### PR TITLE
[sensors] compile sensors even without kdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,10 @@ endif()
 
 add_subdirectory(core-experimental)
 add_subdirectory(model)
+add_subdirectory(sensors)
 
 if(IDYNTREE_USES_KDL)
     add_subdirectory(core)
-    add_subdirectory(sensors)
     add_subdirectory(model_io)
     add_subdirectory(regressors)
     if(IDYNTREE_USES_YARP)

--- a/sensors/src/Sensors.cpp
+++ b/sensors/src/Sensors.cpp
@@ -28,7 +28,6 @@
 #include <iostream>
 
 namespace iDynTree {
-//namespace CoDyCo {
 
 Sensor::~Sensor()
 {
@@ -284,8 +283,4 @@ unsigned int SensorsMeasurements::getNrOfSensors(const SensorType& sensor_type) 
     return 0;
 }
 
-
-
-
-//}
 }

--- a/sensors/src/Sensors.cpp
+++ b/sensors/src/Sensors.cpp
@@ -22,9 +22,6 @@
 #include <vector>
 #include <map>
 
-
-//#include <kdl/frames.hpp>
-#include "kdl_codyco/KDLConversions.h"
 #include <iDynTree/Core/Wrench.h>
 
 

--- a/sensors/src/SixAxisFTSensor.cpp
+++ b/sensors/src/SixAxisFTSensor.cpp
@@ -17,8 +17,6 @@
 
 #include "iDynTree/Sensors/SixAxisFTSensor.hpp"
 
-#include "kdl_codyco/undirectedtree.hpp"
-
 #include "iDynTree/Core/Transform.h"
 #include "iDynTree/Core/Wrench.h"
 

--- a/sensors/src/SixAxisFTSensor.cpp
+++ b/sensors/src/SixAxisFTSensor.cpp
@@ -19,9 +19,6 @@
 
 #include "kdl_codyco/undirectedtree.hpp"
 
-//#include <kdl/frames.hpp>
-#include "kdl_codyco/KDLConversions.h"
-//#include <iDynTree/Core/KDLConversions.h>
 #include "iDynTree/Core/Transform.h"
 #include "iDynTree/Core/Wrench.h"
 

--- a/sensors/src/SixAxisFTSensor.cpp
+++ b/sensors/src/SixAxisFTSensor.cpp
@@ -20,6 +20,8 @@
 #include "iDynTree/Core/Transform.h"
 #include "iDynTree/Core/Wrench.h"
 
+#include <cassert>
+
 
 namespace iDynTree {
 


### PR DESCRIPTION
Sensors does not depend any more on kdl, so they can be compiled even if the `IDYNTREE_USES_KDL` option is set to false (as we currently do on AppVeyor). 