### PR TITLE
Improvement in Doxygen documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,7 +23,7 @@ if(DOXYGEN_FOUND)
 
     # search mscgen program
     # for setting the MSCGEN_PATH variable in the Doxyfile
-    find_program(MSCGEN_EXECUTABLE mscgens)
+    find_program(MSCGEN_EXECUTABLE mscgen)
 
     if( MSCGEN_EXECUTABLE STREQUAL "MSCGEN_EXECUTABLE-NOTFOUND" )
         message(STATUS "mscgen program not found")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -34,6 +34,19 @@ if(DOXYGEN_FOUND)
         string(REGEX REPLACE "mscgen$" "" MSCGEN_PATH ${MSCGEN_EXECUTABLE})
     endif()
 
+    # search dot program
+    # for setting the DOT_PATH variable in the Doxyfile
+    find_program(DOT_EXECUTABLE dot)
+
+    if( DOT_EXECUTABLE STREQUAL "DOT_EXECUTABLE-NOTFOUND" )
+        message(STATUS "dot program not found")
+        set(DOT_PATH "")
+    else()
+        # set the DOT_PATH variable by stripping the name (dot)
+        # from the DOT_EXECUTABLE
+        string(REGEX REPLACE "dot$" "" DOT_PATH ${DOT_EXECUTABLE})
+    endif()
+
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
                    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
     add_custom_target(dox COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,6 +20,20 @@ if(DOXYGEN_FOUND)
     set(DOX_EXTRA_DIR src conf doc/spec)
     set(DOX_PATTERNS "*.h *.dox *.cpp *.hpp")
     set(DOX_GENERATE_MAN NO)
+
+    # search mscgen program
+    # for setting the MSCGEN_PATH variable in the Doxyfile
+    find_program(MSCGEN_EXECUTABLE mscgens)
+
+    if( MSCGEN_EXECUTABLE STREQUAL "MSCGEN_EXECUTABLE-NOTFOUND" )
+        message(STATUS "mscgen program not found")
+        set(MSCGEN_PATH "")
+    else()
+        # set the MSCGEN_PATH variable by stripping the name (mscgen)
+        # from the MSCGEN_EXECUTABLE
+        string(REGEX REPLACE "mscgen$" "" MSCGEN_PATH ${MSCGEN_EXECUTABLE})
+    endif()
+
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
                    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
     add_custom_target(dox COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1592,7 +1592,7 @@ CLASS_DIAGRAMS         = YES
 # the mscgen tool resides. If left empty the tool is assumed to be found in the
 # default search path.
 
-MSCGEN_PATH            =
+MSCGEN_PATH            = ${MSCGEN_PATH}
 
 # If set to YES, the inheritance and collaboration graphs will hide
 # inheritance and usage relations if the target is undocumented

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1736,7 +1736,7 @@ INTERACTIVE_SVG        = NO
 # The tag DOT_PATH can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.
 
-DOT_PATH               =
+DOT_PATH               = ${DOT_PATH}
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -705,7 +705,9 @@ EXCLUDE_SYMLINKS       = NO
 
 EXCLUDE_PATTERNS       = */bindings/* \
                          */tests/*    \
-                         */examples/*
+                         */examples/* \ 
+                         */extern/* \ 
+                         */external/* 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
Two improvements:  
  * skip doxygen generation for external libraries includeded in the repo, see https://github.com/robotology/idyntree/issues/110 
  * add support for finding mscgen using CMake [`find_program`](https://cmake.org/cmake/help/v3.0/command/find_program.html) , see https://github.com/robotology/idyntree/issues/114 

@nunoguedelha can you briefly review?