### PR TITLE
select DOT for Doxygen class graph generation

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1133,7 +1133,7 @@ DISABLE_INDEX          = NO
 # Since the tree basically has the same information as the tab index you
 # could consider to set DISABLE_INDEX to NO when enabling this option.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values
 # (range [0,1..20]) that doxygen will group on one line in the generated HTML
@@ -1605,7 +1605,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # toolkit from AT&T and Lucent Bell Labs. The other options in this section
 # have no effect if this option is set to NO (the default)
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is
 # allowed to run in parallel. When set to 0 (the default) doxygen will
@@ -1672,7 +1672,7 @@ UML_LIMIT_NUM_FIELDS   = 10
 # If set to YES, the inheritance and collaboration graphs will show the
 # relations between templates and their instances.
 
-TEMPLATE_RELATIONS     = NO
+TEMPLATE_RELATIONS     = YES
 
 # If the ENABLE_PREPROCESSING, SEARCH_INCLUDES, INCLUDE_GRAPH, and HAVE_DOT
 # tags are set to YES then doxygen will generate a graph for each documented
@@ -1694,7 +1694,7 @@ INCLUDED_BY_GRAPH      = YES
 # the time of a run. So in most cases it will be better to enable call graphs
 # for selected functions only using the \callgraph command.
 
-CALL_GRAPH             = NO
+CALL_GRAPH             = YES
 
 # If the CALLER_GRAPH and HAVE_DOT tags are set to YES then
 # doxygen will generate a caller dependency graph for every global function
@@ -1702,7 +1702,7 @@ CALL_GRAPH             = NO
 # the time of a run. So in most cases it will be better to enable caller
 # graphs for selected functions only using the \callergraph command.
 
-CALLER_GRAPH           = NO
+CALLER_GRAPH           = YES
 
 # If the GRAPHICAL_HIERARCHY and HAVE_DOT tags are set to YES then doxygen
 # will generate a graphical hierarchy of all classes instead of a textual one.


### PR DESCRIPTION
Doxygen can be configured to use the `dot` tool from GraphViz to generate diagrams more advanced than the inheritance diagrams generated through the default built-in tool (refer to https://github.com/robotology/idyntree/issues/114). The present change sets the correct flags in `Doxygen.in` file for activating and tuning the `dot` tool:
  * `DOT_PATH` has been updated in https://github.com/robotology/idyntree/pull/115, for `Doxygen` to find the `dot` program.
  * the additional following flags have been updated with the current PR:

Tag | Value | Description
------|---------|----------------
GENERATE_TREEVIEW | YES | generate a tree-like index structure to display hierarchical information
HAVE_DOT | YES | use dot tool to generate graphs
TEMPLATE_RELATIONS | YES | inheritance and collaboration graphs show the relations between templates and their instances
CALL_GRAPH | YES | generate a call dependency graph for every global function or class method
CALLER_GRAPH | YES | generate a caller dependency graph for every global function or class method

This improves a lot the documentation of the class hierarchy, global functions and class methods call trees, as well as the illustration of template class instantiation.