### PR TITLE
Fixed regressor size in last code ex. of DynamicsComputations tutorial

### DIFF
--- a/doc/dcTutorialCpp.md
+++ b/doc/dcTutorialCpp.md
@@ -87,7 +87,7 @@ parameters vector, please check https://hal.archives-ouvertes.fr/hal-01137215/do
 
 ~~~cpp
     unsigned int links = dynComp.getNrOfLinks();
-    MatrixDynSize regr(6+dofs,6+10*links);
+    MatrixDynSize regr(6+dofs,10*links);
     ok = dynComp.getDynamicsRegressor(regr);
     
     if( !ok )


### PR DESCRIPTION
The `pi` vector is a `10 * nrOfLinks` inertial parameters vector, as per tutorial explanation and paper https://hal.archives-ouvertes.fr/hal-01137215/document. Corrected typo in example code.