### PR TITLE
Added a naive version for joints methods

### DIFF
--- a/src/high-level/include/iDynTree/HighLevel/DynamicsComputations.h
+++ b/src/high-level/include/iDynTree/HighLevel/DynamicsComputations.h
@@ -415,7 +415,7 @@ public:
 
      /**
      * Get the index corresponding to a given link name.
-     * @return a integer greater or equal then zero if the frame exist,
+     * @return a integer greater or equal then zero if the link exist,
      *         a negative integer otherwise.
      */
     int getLinkIndex(const std::string & linkName) const;
@@ -436,6 +436,32 @@ public:
      */
     iDynTree::SpatialInertia getLinkInertia(const std::string & linkName) const;
 
+    //@}
+
+
+    /**
+     * @name Methods to get joint information
+     */
+    //@{
+
+
+    /**
+     * Get the index corresponding to a given joint name.
+     * @note: the current implementation is slow.
+     * @return a integer greater or equal then zero if the joint exist,
+     *         a negative integer otherwise.
+     */
+    int getJointIndex(const std::string & linkName);
+
+    /**
+     * Get the name corresponding to a given joint index
+     * @note: not marked const 
+     * @param jointIndex the index of the joint which name is required
+     *
+     * @return the name of the joint at index jointIndex
+     */
+    std::string getJointName(const unsigned int jointIndex);
+    
     //@}
 
 

--- a/src/high-level/src/DynamicsComputations.cpp
+++ b/src/high-level/src/DynamicsComputations.cpp
@@ -924,8 +924,29 @@ bool DynamicsComputations::getCenterOfMassJacobian(iDynTree::MatrixDynSize & out
     return true;
 }
 
+//////////////////////////////////////////////////////////////////////////////
+///// JOINT METHODS
+//////////////////////////////////////////////////////////////////////////////
+int DynamicsComputations::getJointIndex(const std::string &linkName)
+{
+    int index = -1;
+    for (int i = 0; i < getNrOfDegreesOfFreedom(); i++) {
+        if (this->getDescriptionOfDegreeOfFreedom(i) == linkName) {
+            index = i;
+            break;
+        }
+    }
+    return index;
+}
+
+std::string DynamicsComputations::getJointName(const unsigned int jointIndex)
+{
+    return this->getDescriptionOfDegreeOfFreedom(jointIndex);
+}
+
 
 }
 
 }
+
 


### PR DESCRIPTION
Added:
- getJointIndex
- getJointName

They should be marked const, but it is not possible because they use non-const methods
Furthermore `getJointIndex` is slow: it internally iterates on all the joints comparing their name with the given one