### PR TITLE
CMake cleanup

### DIFF
--- a/examples/fixedBaseGravityCompensation/CMakeLists.txt
+++ b/examples/fixedBaseGravityCompensation/CMakeLists.txt
@@ -3,30 +3,20 @@
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 #
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.11)
 
-SET(PROJECTNAME fixedBaseGravityCompensation)
+project(fixedBaseGravityCompensation)
 
-PROJECT(${PROJECTNAME})
+find_package(YARP REQUIRED)
+find_package(iDynTree REQUIRED)
 
-FIND_PACKAGE(YARP REQUIRED)
-FIND_PACKAGE(iDynTree REQUIRED)
+set(folder_source main.cpp)
 
-SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${YARP_MODULE_PATH})
+source_group("Source Files" FILES ${folder_source})
 
-SET(folder_source main.cpp)
+add_executable(${PROJECT_NAME} ${folder_source})
 
-SOURCE_GROUP("Source Files" FILES ${folder_source})
-
-message(STATUS "iDynTree_INCLUDE_DIRS is ${iDynTree_INCLUDE_DIRS}")
-
-INCLUDE_DIRECTORIES(${iDynTree_INCLUDE_DIRS}
-                    ${YARP_INCLUDE_DIRS})
-
-
-ADD_EXECUTABLE(${PROJECTNAME} ${folder_source})
-
-TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES}
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES}
                                      ${iDynTree_LIBRARIES})
 
 

--- a/examples/icubArmRegressor/CMakeLists.txt
+++ b/examples/icubArmRegressor/CMakeLists.txt
@@ -3,30 +3,20 @@
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 #
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.11)
 
-SET(PROJECTNAME icubArmRegressor)
+project(icubArmRegressor)
 
-PROJECT(${PROJECTNAME})
-
-FIND_PACKAGE(YARP REQUIRED)
-FIND_PACKAGE(iDynTree REQUIRED)
-
-SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${YARP_MODULE_PATH})
+find_package(YARP REQUIRED)
+find_package(iDynTree REQUIRED)
 
 SET(folder_source main.cpp)
 
-SOURCE_GROUP("Source Files" FILES ${folder_source})
+source_group("Source Files" FILES ${folder_source})
 
-message(STATUS "iDynTree_INCLUDE_DIRS is ${iDynTree_INCLUDE_DIRS}")
+add_executable(${PROJECT_NAME} ${folder_source})
 
-INCLUDE_DIRECTORIES(${iDynTree_INCLUDE_DIRS}
-                    ${YARP_INCLUDE_DIRS})
-
-
-ADD_EXECUTABLE(${PROJECTNAME} ${folder_source})
-
-TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES}
-                                     ${iDynTree_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES}
+                                      ${iDynTree_LIBRARIES})
 
 

--- a/examples/walkmanLimbJTSRegressor/CMakeLists.txt
+++ b/examples/walkmanLimbJTSRegressor/CMakeLists.txt
@@ -3,30 +3,20 @@
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 #
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.11)
 
-SET(PROJECTNAME walkmanLimbJTSRegressor)
+project(walkmanLimbJTSRegressor)
 
-PROJECT(${PROJECTNAME})
+find_package(YARP REQUIRED)
+find_package(iDynTree REQUIRED)
 
-FIND_PACKAGE(YARP REQUIRED)
-FIND_PACKAGE(iDynTree REQUIRED)
+set(folder_source main.cpp)
 
-SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${YARP_MODULE_PATH})
+source_group("Source Files" FILES ${folder_source})
 
-SET(folder_source main.cpp)
+add_executable(${PROJECT_NAME} ${folder_source})
 
-SOURCE_GROUP("Source Files" FILES ${folder_source})
-
-message(STATUS "iDynTree_INCLUDE_DIRS is ${iDynTree_INCLUDE_DIRS}")
-
-INCLUDE_DIRECTORIES(${iDynTree_INCLUDE_DIRS}
-                    ${YARP_INCLUDE_DIRS})
-
-
-ADD_EXECUTABLE(${PROJECTNAME} ${folder_source})
-
-TARGET_LINK_LIBRARIES(${PROJECTNAME} ${YARP_LIBRARIES}
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES}
                                      ${iDynTree_LIBRARIES})
 
 

--- a/iDynTreeConfig.cmake.in
+++ b/iDynTreeConfig.cmake.in
@@ -1,21 +1,3 @@
-find_package(orocos_kdl QUIET)
-#support also for the old version of kdl cmake package
-if(NOT orocos_kdl_FOUND)
-   find_package(Orocos-KDL QUIET)
-   if(NOT Orocos-KDL_FOUND)
-      message(WARNING "KDL not found: neither orocos_kdl or Orocos-KDL cmake packages are available")
-   else(NOT Orocos-KDL_FOUND)
-      set(orocos_kdl_INCLUDE_DIRS ${Orocos-KDL_INCLUDE_DIRS})
-      set(orocos_kdl_LIBRARY_DIRS ${Orocos-KDL_LIBRARY_DIRS})
-      set(orocos_kdl_LIBRARIES ${Orocos-KDL_LIBRARIES})
-      set(orocos_kdl_FOUND true)
-   endif(NOT Orocos-KDL_FOUND)
-endif(NOT orocos_kdl_FOUND)
-
-find_package(YARP QUIET)
-find_package(ICUB QUIET)
-find_package(TinyXML QUIET)
-
 set(iDynTree_VERSION @iDynTree_VERSION@)
 
 @PACKAGE_INIT@
@@ -24,6 +6,29 @@ if(NOT TARGET iDynTree::idyntree-core)
   include("${CMAKE_CURRENT_LIST_DIR}/iDynTreeTargets.cmake")
 endif()
 
-# Compatibility
+if(TARGET iDynTree::idyntree-kdl)
+    find_package(orocos_kdl QUIET)
+    #support also for the old version of kdl cmake package
+    if(NOT orocos_kdl_FOUND)
+        find_package(Orocos-KDL QUIET)
+        if(NOT Orocos-KDL_FOUND)
+            message(WARNING "KDL not found: neither orocos_kdl or Orocos-KDL cmake packages are available")
+        else()
+            set(orocos_kdl_INCLUDE_DIRS ${Orocos-KDL_INCLUDE_DIRS})
+            set(orocos_kdl_LIBRARY_DIRS ${Orocos-KDL_LIBRARY_DIRS})
+            set(orocos_kdl_LIBRARIES ${Orocos-KDL_LIBRARIES})
+            set(orocos_kdl_FOUND true)
+        endif()
+endif()
+
+if(TARGET iDynTree::idyntree-yarp)
+    find_package(YARP QUIET)
+endif()
+
+if(TARGET iDynTree::idyntree-icub)
+    find_package(ICUB QUIET)
+endif()
+
+# Provide an iDynTree_LIBRARIES variable containing all the
+# targets exported by iDynTree
 set(iDynTree_LIBRARIES "@iDynTree_TARGETS@")
-set(iDynTree_INCLUDE_DIRS "@EIGEN3_INCLUDE_DIR@" "@Boost_INCLUDE_DIRS@")


### PR DESCRIPTION
[ https://github.com/robotology/idyntree/commit/f8e761a551bc95d8dc89c26a36e5478b7847b7b4 ]  Cleanup iDynTreeConfig.cmake to only search for necessary dependencies (see https://github.com/robotology-playground/iDynTree-superbuild/issues/1 ) 
[ https://github.com/robotology/idyntree/commit/9747e0c70a1afe657ccb5131d4107b92f14c01d3 ]  	Remove references to iDynTree_INCLUDE_DIRS (see https://github.com/robotology/codyco-superbuild/issues/117 )