### PR TITLE
[Sensors] Create function to extract a reduced model and relative reduced sensors list

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -98,6 +98,10 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
 
 set_property(TARGET ${libraryname} PROPERTY PUBLIC_HEADER ${IDYNTREE_CORE_EXP_HEADERS})
 
+if(MSVC)
+   add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 install(TARGETS ${libraryname}
         EXPORT iDynTree
         COMPONENT runtime

--- a/src/estimation/include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
+++ b/src/estimation/include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
@@ -129,6 +129,24 @@ public:
     bool loadModelAndSensorsFromFile(const std::string filename, const std::string filetype="");
 
     /**
+     * Load model and sensors from file, specifieng the dof considered for the estimation.
+     *
+     * @param[in] filename path to the file to load.
+     * @param[in] consideredDOFs list of dof to consider in the model.
+     * @param[in] filetype (optional) explicit definiton of the filetype to load.
+     *                     Only "urdf" is supported at the moment.
+     * @return true if all went well (files were correctly loaded and consistent), false otherwise.
+     *
+     *
+     * \note this will create e a reduced model only with the joint specified in consideredDOFs and  the
+     *       fixed joints in which FT sensor are mounted.
+     */
+    bool loadModelAndSensorsFromFileWithSpecifiedDOFs(const std::string filename,
+                                                      const std::vector<std::string> & consideredDOFs,
+                                                      const std::string filetype="");
+
+
+    /**
      * Get used model.
      *
      * @return the kinematic and dynamic model used for estimation.

--- a/src/estimation/include/iDynTree/Estimation/ExternalWrenchesEstimation.h
+++ b/src/estimation/include/iDynTree/Estimation/ExternalWrenchesEstimation.h
@@ -77,6 +77,19 @@ enum UnknownWrenchContactType
 struct UnknownWrenchContact
 {
     /**
+     * Constructor
+     */
+    UnknownWrenchContact()
+    {}
+
+    UnknownWrenchContact(const UnknownWrenchContactType _unknownType,
+                         const Position & _contactPoint,
+                         const Direction & _forceDirection = iDynTree::Direction::Default()): unknownType(_unknownType),
+                                                                                              contactPoint(_contactPoint),
+                                                                                              forceDirection(_forceDirection)
+    {}
+
+    /**
      * Type of the unknown contact.
      */
     UnknownWrenchContactType unknownType;

--- a/src/icub-kdl/src/TorqueEstimationTree.cpp
+++ b/src/icub-kdl/src/TorqueEstimationTree.cpp
@@ -202,12 +202,12 @@ void TorqueEstimationTree::TorqueEstimationConstructor(KDL::Tree & icub_kdl,
     //Setting a custom dof serialization (\todo TODO FIXME : quite an hack, substitute with proper)
     if( dof_serialization.size() != 0 )
     {
-        YARP_ASSERT(dof_serialization.size() == serial.getNrOfDOFs());
+        yAssert(dof_serialization.size() == serial.getNrOfDOFs());
         for(std::size_t dof=0; dof < dof_serialization.size(); dof++)
         {
             std::string dof_string = dof_serialization[dof];
-            YARP_ASSERT(serial.getDOFID(dof_string) != -1);
-            YARP_ASSERT(serial.getJunctionID(dof_string) != -1);
+            yAssert(serial.getDOFID(dof_string) != -1);
+            yAssert(serial.getJunctionID(dof_string) != -1);
         }
 
         for(std::size_t dof=0; dof < dof_serialization.size(); dof++)

--- a/src/icub-kdl/src/idyn2kdl_icub.cpp
+++ b/src/icub-kdl/src/idyn2kdl_icub.cpp
@@ -443,16 +443,16 @@ bool toKDL(const iCub::iDyn::iCubWholeBody & icub_idyn,
 
     KDL::Frame root_link_H_l_foot_dh_frame, root_link_H_l_foot,l_foot_dh_frame_H_l_foot;
     int ret = pos_solv.JntToCart(pos,root_link_H_l_foot_dh_frame,"l_foot_dh_frame");
-    YARP_ASSERT(ret == 0);
+    yAssert(ret == 0);
     ret = pos_solv.JntToCart(pos,root_link_H_l_foot,"l_foot");
-    YARP_ASSERT(ret == 0);
+    yAssert(ret == 0);
     l_foot_dh_frame_H_l_foot = root_link_H_l_foot_dh_frame.Inverse()*root_link_H_l_foot;
 
     KDL::Frame root_link_H_r_foot_dh_frame, root_link_H_r_foot,r_foot_dh_frame_H_r_foot;
     ret = pos_solv.JntToCart(pos,root_link_H_r_foot_dh_frame,"r_foot_dh_frame");
-    YARP_ASSERT(ret == 0);
+    yAssert(ret == 0);
     ret = pos_solv.JntToCart(pos,root_link_H_r_foot,"r_foot");
-    YARP_ASSERT(ret == 0);
+    yAssert(ret == 0);
     r_foot_dh_frame_H_r_foot = root_link_H_r_foot_dh_frame.Inverse()*root_link_H_r_foot;
 
 
@@ -488,13 +488,13 @@ bool toKDL(const iCub::iDyn::iCubWholeBody & icub_idyn,
     // Export chest_skin_frame, see https://github.com/robotology/icub-main/issues/124 for more info
     KDL::Frame root_link_H_chest;
     int retChest = pos_solv.JntToCart(pos,root_link_H_chest,"chest");
-    YARP_ASSERT(retChest == 0);
+    yAssert(retChest == 0);
     KDL::Frame root_link_H_chest_skin_frame;
     iCub::iKin::iCubTorso chest_skin_frame_chest;
     yarp::sig::Vector qTorso(chest_skin_frame_chest.getN());
     qTorso.zero();
     chest_skin_frame_chest.setAng(qTorso);
-    YARP_ASSERT(YarptoKDL(chest_skin_frame_chest.getH(),root_link_H_chest_skin_frame));
+    yAssert(YarptoKDL(chest_skin_frame_chest.getH(),root_link_H_chest_skin_frame));
 
     std::cout << "root_link_H_chest_skin_frame is " << root_link_H_chest_skin_frame << std::endl;
 

--- a/src/model/include/iDynTree/Model/ModelTransformers.h
+++ b/src/model/include/iDynTree/Model/ModelTransformers.h
@@ -21,6 +21,7 @@
 namespace iDynTree
 {
 class Model;
+class SensorsList;
 
 /**
  * \function Remove all fake links in the model, transforming them in frames.
@@ -47,15 +48,15 @@ bool removeFakeLinks(const Model& modelWithFakeLinks,
                      Model& modelWithoutFakeLinks);
 
 /**
- * This function will take in input a iDynTree::Model and
- * an ordered list of joints and will return a model with
+ * This function takes in input a iDynTree::Model and
+ * an ordered list of joints and returns a model with
  * just the joint specified in the list, with that exact order.
  *
- * All other joints will be removed by lumping (i.e. fusing together)
+ * All other joints are be removed by lumping (i.e. fusing together)
  * the inertia of the links that are connected by that joint, assuming the joint
  * to be in "rest" position (i.e. zero for revolute joints). The links eliminated
- * with this process will be added back to the reduced model as "frames",
- * and will be copied in the same way all the additional frames of the lumped links.
+ * with this process are be added back to the reduced model as "frames",
+ * and are copied in the same way all the additional frames of the lumped links.
  * 
  */
 bool createReducedModel(const Model& fullModel,

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -373,7 +373,7 @@ bool createReducedModel(const Model& fullModel,
         Transform newLink1_X_oldLink1 = subModelBase_X_link(oldLink1);
         Transform newLink2_X_oldLink2 = subModelBase_X_link(oldLink2);
 
-        // \todo handle this in a joint-agnostic way,
+        // \todo TODO handle this in a joint-agnostic way,
         // possibly extending the joint interface
         IJointPtr newJoint = 0;
         if( dynamic_cast<const FixedJoint*>(oldJoint) )
@@ -417,7 +417,6 @@ bool createReducedModel(const Model& fullModel,
 
     return ok;
 }
-
 
 
 }

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -14,13 +14,15 @@ set(IDYNTREE_SENSORS_HEADERS include/iDynTree/Sensors/Sensors.h
                              include/iDynTree/Sensors/SixAxisFTSensor.h
                              include/iDynTree/Sensors/GyroscopeSensor.h
                              include/iDynTree/Sensors/AccelerometerSensor.h
-                             include/iDynTree/Sensors/PredictSensorsMeasurements.h)
+                             include/iDynTree/Sensors/PredictSensorsMeasurements.h
+                             include/iDynTree/Sensors/ModelSensorsTransformers.h)
 
 set(IDYNTREE_SENSORS_SOURCES src/Sensors.cpp
                              src/SixAxisFTSensor.cpp
                              src/AccelerometerSensor.cpp
                              src/GyroscopeSensor.cpp
-                             src/PredictSensorsMeasurements.cpp)
+                             src/PredictSensorsMeasurements.cpp
+                             src/ModelSensorsTransformers.cpp)
 
 
 SOURCE_GROUP("Source Files" FILES ${IDYNTREE_SENSORS_SOURCES})

--- a/src/sensors/include/iDynTree/Sensors/AccelerometerSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/AccelerometerSensor.h
@@ -123,6 +123,11 @@ namespace iDynTree {
          */
         Sensor * clone() const;
 
+        /*
+         * Documented in Sensor
+         */
+        bool updateIndeces(const Model & model);
+
         /**
          * Get the transform from the sensor to the specified link.
          *

--- a/src/sensors/include/iDynTree/Sensors/GyroscopeSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/GyroscopeSensor.h
@@ -122,6 +122,10 @@ namespace iDynTree {
          */
         Sensor * clone() const;
 
+        /*
+         * Documented in Sensor
+         */
+        bool updateIndeces(const Model & model);
 
         /**
          * Get the transform from the sensor to the parent link.

--- a/src/sensors/include/iDynTree/Sensors/ModelSensorsTransformers.h
+++ b/src/sensors/include/iDynTree/Sensors/ModelSensorsTransformers.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+/**
+ * \file ModelSensorsTransformers.h
+ *  \brief Collection of function to modify model and sensors in various ways
+ *
+ *
+ */
+
+
+#ifndef IDYNTREE_MODEL_SENSORS_TRANSFORMERS_H
+#define IDYNTREE_MODEL_SENSORS_TRANSFORMERS_H
+
+namespace iDynTree
+{
+class Model;
+class SensorsList;
+
+/**
+ * Variant of createReducedModel function that also process the sensorList .
+ *
+ *
+ */
+bool createReducedModelAndSensors(const Model& fullModel,
+                                  const SensorsList& fullSensors,
+                                  const std::vector<std::string>& jointsInReducedModel,
+                                        Model& reducedModel,
+                                        SensorsList& reducedSensors);
+
+
+}
+
+#endif

--- a/src/sensors/include/iDynTree/Sensors/Sensors.h
+++ b/src/sensors/include/iDynTree/Sensors/Sensors.h
@@ -33,6 +33,7 @@ namespace iDynTree {
 
 #include <iDynTree/Core/VectorDynSize.h>
 
+#include <iDynTree/Model/Model.h>
 #include <iDynTree/Model/Indeces.h>
 
 namespace iDynTree {
@@ -84,10 +85,6 @@ namespace iDynTree {
         virtual bool isValid() const = 0;
 
         /**
-         *  Return a pointer to a copy of this sensor.
-         *
-         */
-                /**
          * Set the id (name) of sensor.
          */
         virtual bool setName(const std::string &) = 0;
@@ -97,6 +94,11 @@ namespace iDynTree {
          *
          */
         virtual Sensor* clone() const = 0;
+
+        /**
+         * Update all the indeces (link/frames) contained in this sensor.
+         */
+        virtual bool updateIndeces(const Model & model) = 0;
     };
 
     /**

--- a/src/sensors/include/iDynTree/Sensors/SixAxisFTSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/SixAxisFTSensor.h
@@ -153,15 +153,20 @@ namespace iDynTree {
         // Documented in JointSensor
         JointIndex getParentJointIndex() const;
 
-        /**
+        /*
          * Documented in Sensor
          */
         bool isValid() const;
 
-        /**
+        /*
          * Documented in Sensor
          */
         Sensor * clone() const;
+
+        /*
+         * Documented in Sensor
+         */
+        bool updateIndeces(const Model & model);
 
         /**
          * The Six Axis Force Torque sensor measure the Force Torque (wrench)

--- a/src/sensors/src/AccelerometerSensor.cpp
+++ b/src/sensors/src/AccelerometerSensor.cpp
@@ -131,6 +131,20 @@ Sensor* AccelerometerSensor::clone() const
     return (Sensor *)new AccelerometerSensor(*this);
 }
 
+bool AccelerometerSensor::updateIndeces(const Model& model)
+{
+    iDynTree::LinkIndex linkNewIndex = model.getLinkIndex(this->pimpl->parent_link_name);
+
+    if( (linkNewIndex == iDynTree::LINK_INVALID_INDEX) )
+    {
+        return false;
+    }
+
+    this->pimpl->parent_link_name = linkNewIndex;
+
+    return true;
+}
+
 
 std::string AccelerometerSensor::getName() const
 {

--- a/src/sensors/src/GyroscopeSensor.cpp
+++ b/src/sensors/src/GyroscopeSensor.cpp
@@ -116,6 +116,21 @@ Sensor* GyroscopeSensor::clone() const
     return (Sensor *)new GyroscopeSensor(*this);
 }
 
+bool GyroscopeSensor::updateIndeces(const Model& model)
+{
+    iDynTree::LinkIndex linkNewIndex = model.getLinkIndex(this->pimpl->parent_link_name);
+
+    if( (linkNewIndex == iDynTree::LINK_INVALID_INDEX) )
+    {
+        return false;
+    }
+
+    this->pimpl->parent_link_name = linkNewIndex;
+
+    return true;
+}
+
+
 
 std::string GyroscopeSensor::getName() const
 {

--- a/src/sensors/src/ModelSensorsTransformers.cpp
+++ b/src/sensors/src/ModelSensorsTransformers.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/ModelTransformers.h>
+
+#include <iDynTree/Sensors/Sensors.h>
+#include <iDynTree/Sensors/ModelSensorsTransformers.h>
+
+#include <iDynTree/Sensors/SixAxisFTSensor.h>
+
+
+#include <cassert>
+#include <set>
+
+
+namespace iDynTree
+{
+
+bool createReducedModelAndSensors(const Model& fullModel,
+                        const SensorsList& fullSensors,
+                        const std::vector<std::string>& jointsInReducedModel,
+                              Model& reducedModel,
+                              SensorsList& reducedSensors)
+{
+    bool ok = createReducedModel(fullModel,jointsInReducedModel,reducedModel);
+
+    // make sure that reducedSensors is empty
+    assert(fullSensors.getNrOfSensors(SIX_AXIS_FORCE_TORQUE) == 0);
+
+    if( !ok ) return false;
+
+    // \todo currently only FT sensors are processed, extend to all sensors
+    for(size_t sens=0; sens < fullSensors.getNrOfSensors(SIX_AXIS_FORCE_TORQUE); sens++)
+    {
+        SixAxisForceTorqueSensor* pSens = static_cast<SixAxisForceTorqueSensor*>(fullSensors.getSensor(SIX_AXIS_FORCE_TORQUE,sens));
+        std::string parentJointName = pSens->getParentJoint();
+        iDynTree::JointIndex parentJointIndex = reducedModel.getJointIndex(parentJointName);
+
+        // If the sensor at which the sensor is attached is not in the reduced model, drop the sensor
+        if( parentJointIndex != iDynTree::JOINT_INVALID_INDEX )
+        {
+            // If we add the sensor to the new sensors list, we have to upgrade the indeces
+            SixAxisForceTorqueSensor* sensorCopy = (SixAxisForceTorqueSensor*)pSens->clone();
+
+            // For now we assume that the two links at which the FT sensors is attached are not reduced.
+            // A more advanced version of this function could properly handle that case \todo TODO
+            std::string firstLinkName  = sensorCopy->getFirstLinkName();
+            std::string secondLinkName = sensorCopy->getSecondLinkName();
+
+            iDynTree::LinkIndex firstLinkIndex = reducedModel.getLinkIndex(firstLinkName);
+            if( firstLinkIndex == iDynTree::LINK_INVALID_INDEX )
+            {
+                std::cerr << "[ERROR] createReducedModelAndSensors : " << firstLinkName << " is not in the reduced model, reducing sensors failed" << std::endl;
+                return false;
+            }
+
+            iDynTree::LinkIndex secondLinkIndex = reducedModel.getLinkIndex(secondLinkName);
+            if( secondLinkIndex == iDynTree::LINK_INVALID_INDEX )
+            {
+                std::cerr << "[ERROR] createReducedModelAndSensors : " << secondLinkName << " is not in the reduced model, reducing sensors failed" << std::endl;
+                return false;
+            }
+
+            // Update indeces
+            sensorCopy->updateIndeces(reducedModel);
+
+            reducedSensors.addSensor(*sensorCopy);
+
+            delete sensorCopy;
+        }
+    }
+}
+
+
+}

--- a/src/sensors/src/SixAxisFTSensor.cpp
+++ b/src/sensors/src/SixAxisFTSensor.cpp
@@ -145,6 +145,44 @@ Sensor* SixAxisForceTorqueSensor::clone() const
     return (Sensor *)new SixAxisForceTorqueSensor(*this);
 }
 
+bool SixAxisForceTorqueSensor::updateIndeces(const Model& model)
+{
+    if( !( (this->pimpl->appliedWrenchLink == this->pimpl->link1) ||
+           (this->pimpl->appliedWrenchLink == this->pimpl->link2) ) )
+    {
+        return false;
+    }
+
+    std::string appliedWrenchLinkName;
+    if( this->pimpl->appliedWrenchLink == this->pimpl->link1 )
+    {
+        appliedWrenchLinkName = this->pimpl->link1Name;
+    }
+
+    if( this->pimpl->appliedWrenchLink == this->pimpl->link2 )
+    {
+        appliedWrenchLinkName = this->pimpl->link2Name;
+    }
+
+    iDynTree::LinkIndex link1NewIndex = model.getLinkIndex(this->pimpl->link1Name);
+    iDynTree::LinkIndex link2NewIndex = model.getLinkIndex(this->pimpl->link2Name);
+    iDynTree::LinkIndex appliedWrenchLinkNewIndex = model.getLinkIndex(appliedWrenchLinkName);
+
+    if( (link1NewIndex == iDynTree::LINK_INVALID_INDEX) ||
+        (link2NewIndex == iDynTree::LINK_INVALID_INDEX) ||
+        (appliedWrenchLinkNewIndex == iDynTree::LINK_INVALID_INDEX) )
+    {
+        return false;
+    }
+
+    this->pimpl->link1 = link1NewIndex;
+    this->pimpl->link2 = link2NewIndex;
+    this->pimpl->appliedWrenchLink = appliedWrenchLinkNewIndex;
+
+    return true;
+}
+
+
 
 std::string SixAxisForceTorqueSensor::getName() const
 {


### PR DESCRIPTION
Furthermore, fix various issues around in the code.

The spreading of code related to this in the library is suboptimal,
and mostly due to the fact that model functions can't depend on sensors data structure.
The definite fix for this is to merge the model and sensors libraries, but
this require that first we solve this issue: https://github.com/robotology/idyntree/issues/132 .