### PR TITLE
Fix Rotation::getRPY method and introduce KDL-free SimpleLeggedOdometry

### DIFF
--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -150,7 +150,9 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponing to this rotation.
          *
-         * \todo TODO Add detailed docs .
+         * Get r \in [-180,180] , p \in [-90,90], y \in [-180,180]
+         * such that
+         * *this == RotZ(y)*RotY(p)*RotX(r) 
          *
          */
         void getRPY(double & r, double & p, double &y);

--- a/src/core/include/iDynTree/Core/TestUtils.h
+++ b/src/core/include/iDynTree/Core/TestUtils.h
@@ -38,6 +38,7 @@ namespace iDynTree
 #define ASSERT_IS_FALSE(prop) iDynTree::assertTrue(!(prop),__FILE__,__LINE__)
 #define ASSERT_EQUAL_STRING(val1,val2) iDynTree::assertStringAreEqual(val1,val2,iDynTree::DEFAULT_TOL,__FILE__,__LINE__)
 #define ASSERT_EQUAL_DOUBLE(val1,val2) iDynTree::assertDoubleAreEqual(val1,val2,iDynTree::DEFAULT_TOL,__FILE__,__LINE__)
+#define ASSERT_EQUAL_DOUBLE_TOL(val1,val2,tol) iDynTree::assertDoubleAreEqual(val1,val2,tol,__FILE__,__LINE__)
 #define ASSERT_EQUAL_VECTOR(val1,val2) assertVectorAreEqual(val1,val2,iDynTree::DEFAULT_TOL,__FILE__,__LINE__)
 #define ASSERT_EQUAL_VECTOR_TOL(val1,val2,tol) assertVectorAreEqual(val1,val2,tol,__FILE__,__LINE__)
 #define ASSERT_EQUAL_SPATIAL_MOTION(val1,val2) assertSpatialMotionAreEqual(val1,val2,iDynTree::DEFAULT_TOL,__FILE__,__LINE__)

--- a/src/core/src/Rotation.cpp
+++ b/src/core/src/Rotation.cpp
@@ -258,13 +258,32 @@ namespace iDynTree
 
     void Rotation::getRPY(double& r, double& p, double& y)
     {
-        Eigen::Map<const Matrix3dRowMajor> dataEigen(this->data());
+        Eigen::Map<const Matrix3dRowMajor> R(m_data);
 
-        Eigen::Vector3d rpy = dataEigen.eulerAngles(0,1,2);
 
-        r = rpy(0);
-        p = rpy(1);
-        y = rpy(2);
+        if (R(2,0)<1.0)
+        {
+            if (R(2,0)>-1.0)
+            {
+                r=atan2(R(2,1),R(2,2));
+                p=asin(-R(2,0));
+                y=atan2(R(1,0),R(0,0));
+            }
+            else
+            {
+                // Not a unique solution
+                r=0.0;
+                p=M_PI/2.0;
+                y=-atan2(-R(1,2),R(1,1));
+            }
+        }
+        else
+        {
+            // Not a unique solution
+            r=0.0;
+            p=-M_PI/2.0;
+            y=atan2(-R(1,2),R(1,1));
+        }
     }
 
 

--- a/src/core/src/TestUtils.cpp
+++ b/src/core/src/TestUtils.cpp
@@ -95,7 +95,7 @@ Position getRandomPosition()
 
 Rotation getRandomRotation()
 {
-    return Rotation::RPY(getRandomDouble(),getRandomDouble(-1,1),getRandomDouble());
+    return Rotation::RPY(getRandomDouble(-10,10),getRandomDouble(-10,10),getRandomDouble(-10,10));
 }
 
 Transform getRandomTransform()

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -5,12 +5,14 @@
 project(iDynTree_Estimation CXX)
 
 set(IDYNTREE_ESTIMATION_HEADERS include/iDynTree/Estimation/ExternalWrenchesEstimation.h
-                                include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h)
+                                include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
+                                include/iDynTree/Estimation/SimpleLeggedOdometry.h)
 
 set(IDYNTREE_ESTIMATION_PRIVATE_INCLUDES )
 
 set(IDYNTREE_ESTIMATION_SOURCES src/ExternalWrenchesEstimation.cpp
-                                src/ExtWrenchesAndJointTorquesEstimator.cpp)
+                                src/ExtWrenchesAndJointTorquesEstimator.cpp
+                                src/SimpleLeggedOdometry.cpp)
 
 SOURCE_GROUP("Source Files" FILES ${IDYNTREE_ESTIMATION_SOURCES})
 SOURCE_GROUP("Header Files" FILES ${IDYNTREE_ESTIMATION_HEADERS})

--- a/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
+++ b/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2015 Robotics, Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
+ * Author: Silvio Traversaro
+ * email: silvio.traversaro@iit.it
+ *
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+ */
+
+#ifndef IDYNTREE_SIMPLE_LEGGED_ODOMETRY2_
+#define IDYNTREE_SIMPLE_LEGGED_ODOMETRY2_
+
+#include <iDynTree/Core/Transform.h>
+#include <iDynTree/Model/Indeces.h>
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/Traversal.h>
+#include <iDynTree/Model/JointState.h>
+#include <iDynTree/Model/LinkState.h>
+
+namespace iDynTree
+{
+
+/**
+ * \ingroup iDynTreeEstimation
+ *
+ * A simple legged odometry for a legged robot.
+ *
+ * Under the assumption that at least a link of the robot at the time is
+ * not moving (no slippage), it computes the estimate of the transform
+ * between a inertial/world frame and the robot floating base.
+ *
+ * The algorithm implemented is the following :
+ *
+ * -# During initialization  the user of the class specifies (through init()):
+ *       * a frame that is rigidly attached to a link that is not moving (`initialFixedFrame`)
+ *       * an optional transform between the desired location of the world and the fixed frame (`world_H_initialFixedFrame`)
+ *    At the beginning, the `world_H_fixed` is the one specified (default is the identity)
+ *
+ * -# At this point, the `getWorldFrameTransform(iDynTree::FrameIndex frame_id)` will return the `world_H_frame`
+ *      ( \f${}^{world} H_{frame}\f$ ) transform simply by computing the forward kinematics from the fixed frame
+ *     to the frame specified by `frame_id` : `world_H_frame = world_H_fixed * fixed_H_frame(qj)`, i.e.
+ *                                          \f${}^{world} H_{frame} = {}^{world} H_{fixed} \cdot {}^{fixed} H_{frame}(q_j)\f$
+ *
+ * -# If the fixed frame changes, we can simply change the frame used as "fixed" (changeFixedLink()), and consistently update the
+ *      `world_H_fixed` transform to be equal to `world_H_new_fixed =  world_H_old_fixed * old_fixed_H_new_fixed(qj)`, i.e.
+ *      \f${}^{world} H_{new\_fixed} = {}^{world} H_{old\_fixed} \cdot {}^{old\_fixed} H_{new\_fixed}(q_j)\f$
+ *
+ * -# After the update, the `getWorldFrameTransform(iDynTree::FrameIndex frame_id)` can be obtained as in point 1b .
+ *
+ * To reset the location of the world, init can simply be called again.
+ *
+ */
+class SimpleLeggedOdometry
+{
+    /**
+     * Model used in odometry.
+     */
+    Model m_model;
+
+    /**
+     * Traversal used for the dynamics computations
+     */
+    Traversal m_traversal;
+
+    /**
+     * False initially, true after a valid model has been loaded.
+     */
+    bool m_isModelValid;
+
+      /**
+     * False initially, true after updateKinematics was successfully called.
+     */
+    bool m_kinematicsUpdated;
+
+    /**
+     * False initially, true after init was successfully called.
+     */
+    bool m_isOdometryInitialized;
+
+    /**
+     * The link index of the link considered fixed.
+     */
+    LinkIndex m_fixedLinkIndex;
+
+    /**
+     * Position of each link with respect to the base
+     * link of the traversal (i.e. output
+     * of the relative forward kinematics).
+     */
+    LinkPositions m_base_H_link;
+
+    /**
+     * Transform between the link currently considered fixed
+     * and the world/inertial frame.
+     * This is initialized in the init method and update
+     * by the changeFixedLink method.
+     */
+    Transform m_world_H_fixedLink;
+
+public:
+    /**
+     * Constructor
+     */
+    SimpleLeggedOdometry();
+
+    /**
+     * Destructor
+     */
+    ~SimpleLeggedOdometry();
+
+    /**
+     * \brief Set model used for the odometry.
+     * The model is copied inside the class, to be used for the odometry estimation.
+     *
+     * @param[in] _model the kinematic and dynamic model used for the estimation.
+     * @return true if all went well (model is well formed), false otherwise.
+     */
+    bool setModel(const Model & _model);
+
+    /**
+     * Load model from file.
+     *
+     * @param[in] filename path to the file to load.
+     * @param[in] filetype (optional) explicit definiton of the filetype to load.
+     *                     Only "urdf" is supported at the moment.
+     * @return true if all went well (files were correctly loaded and consistent), false otherwise.
+     *
+     */
+    bool loadModelFromFile(const std::string filename, const std::string filetype="");
+
+    /**
+     * Load model from file, specifieng the dof considered for the estimation.
+     *
+     * @param[in] filename path to the file to load.
+     * @param[in] consideredDOFs list of dof to consider in the model.
+     * @param[in] filetype (optional) explicit definiton of the filetype to load.
+     *                     Only "urdf" is supported at the moment.
+     * @return true if all went well (files were correctly loaded and consistent), false otherwise.
+     *
+     *
+     * \note this will create e a reduced model only with the joint specified in consideredDOFs
+     */
+    bool loadModelFromFileWithSpecifiedDOFs(const std::string filename,
+                                            const std::vector<std::string> & consideredDOFs,
+                                            const std::string filetype="");
+
+    /**
+     * Get used model.
+     *
+     * @return the kinematic and dynamic model used for estimation.
+     */
+    const Model & model() const;
+
+    /**
+     * Set the measured joint positions.
+     *
+     * This is used to update the joints positions used by the odometry.
+     *
+     */
+    bool updateKinematics(JointPosDoubleArray & jointPos);
+
+    /**
+     * Initialize the odometry.
+     */
+    bool init(const std::string & initialFixedFrame,
+              const Transform & world_H_initialFixedFrame);
+
+    /**
+     * Initialize the odometry.
+     */
+    bool init(const FrameIndex initialFixedFrameIndex,
+              const Transform & world_H_initialFixedFrame);
+
+    /**
+     * Change the link that the odometry assumes to be fixed with
+     * respect to the inertial/world frame.
+     */
+    bool changeFixedFrame(const std::string & newFixedFrame);
+
+    /**
+     * Change the link that the odometry assumes to be fixed
+     * with respect to the inertial/world frame.
+     */
+    bool changeFixedFrame(const FrameIndex newFixedFrame);
+
+    /**
+     * Get the link currently considered fixed with respect to the inertial frame.
+     *
+     * \note This can be diffent from what was set with changeFixedFrame, because
+     *       multiple frames can belong to the same link.
+     *
+     * @return the name of the link currently considered fixed.
+     */
+    std::string getCurrentFixedLink();
+
+    /**
+     * Get the world_H_link transform for an arbitrary link.
+     *
+     * \note this method works only for link, not for arbitrary frames.
+     */
+    iDynTree::Transform getWorldLinkTransform(const LinkIndex frame_index);
+};
+
+
+} // End namespace iDynTree
+
+#endif // IDYNTREE_SIMPLE_LEGGED_ODOMETRY2_
+
+

--- a/src/estimation/src/ExtWrenchesAndJointTorquesEstimator.cpp
+++ b/src/estimation/src/ExtWrenchesAndJointTorquesEstimator.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h>
-
 #include <iDynTree/Estimation/ExternalWrenchesEstimation.h>
 
 #include <iDynTree/Core/EigenHelpers.h>
@@ -101,8 +100,6 @@ bool ExtWrenchesAndJointTorquesEstimator::setModelAndSensors(const Model& _model
                                                              const SensorsList& _sensors)
 {
     // \todo TODO add isConsistent methods to Model and SensorList class
-
-
     m_model = _model;
     m_sensors = _sensors;
 

--- a/src/estimation/src/ExtWrenchesAndJointTorquesEstimator.cpp
+++ b/src/estimation/src/ExtWrenchesAndJointTorquesEstimator.cpp
@@ -484,7 +484,7 @@ bool ExtWrenchesAndJointTorquesEstimator::checkThatTheModelIsStill(const double 
         return false;
     }
 
-    bool ok = true;
+    bool isStill = true;
 
     for(iDynTree::LinkIndex link = 0; link < this->m_model.getNrOfLinks(); link++)
     {
@@ -492,7 +492,7 @@ bool ExtWrenchesAndJointTorquesEstimator::checkThatTheModelIsStill(const double 
 
         if( fabs(properAccNorm-gravityNorm) >= properAccTol )
         {
-            ok = false;
+            isStill = false;
 
             if( verbose )
             {
@@ -504,6 +504,8 @@ bool ExtWrenchesAndJointTorquesEstimator::checkThatTheModelIsStill(const double 
             }
         }
     }
+
+    return isStill;
 }
 
 

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2016 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+
+#include <iDynTree/Core/EigenHelpers.h>
+
+#include <iDynTree/Estimation/SimpleLeggedOdometry.h>
+
+#include <iDynTree/Model/ForwardKinematics.h>
+#include <iDynTree/Model/Indeces.h>
+#include <iDynTree/Model/ModelTransformers.h>
+
+#include <iDynTree/ModelIO/URDFModelImport.h>
+#include <iDynTree/ModelIO/URDFGenericSensorsImport.h>
+
+#include <sstream>
+
+namespace iDynTree
+{
+
+SimpleLeggedOdometry::SimpleLeggedOdometry(): m_model(),
+                                              m_traversal(),
+                                              m_isModelValid(false),
+                                              m_kinematicsUpdated(false),
+                                              m_isOdometryInitialized(false),
+                                              m_fixedLinkIndex(iDynTree::LINK_INVALID_INDEX),
+                                              m_world_H_fixedLink(Transform::Identity())
+{
+}
+
+SimpleLeggedOdometry::~SimpleLeggedOdometry()
+{
+}
+
+bool SimpleLeggedOdometry::init(const std::string& initialFixedFrame,
+                                const Transform& world_H_initialFixedFrame)
+{
+    FrameIndex initialFixedFrameIndex = this->m_model.getFrameIndex(initialFixedFrame);
+
+    return init(initialFixedFrameIndex,world_H_initialFixedFrame);
+}
+
+
+bool SimpleLeggedOdometry::init(const FrameIndex initialFixedFrameIndex,
+                                const Transform& world_H_initialFixedFrame)
+{
+    if( !m_isModelValid )
+    {
+         reportError("SimpleLeggedOdometry",
+                     "init",
+                     "Model not initialised.");
+         return false;
+    }
+
+    if( !m_model.isValidFrameIndex(initialFixedFrameIndex) )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "init","invalid frame passed");
+        return false;
+    }
+
+
+
+    m_fixedLinkIndex = m_model.getFrameLink(initialFixedFrameIndex);
+    Transform initialFixedFrame_H_fixedLink = m_model.getFrameTransform(initialFixedFrameIndex).inverse();
+    m_world_H_fixedLink = world_H_initialFixedFrame*initialFixedFrame_H_fixedLink;
+
+    m_isOdometryInitialized = true;
+}
+
+bool SimpleLeggedOdometry::updateKinematics(JointPosDoubleArray& jointPos)
+{
+    if( !m_isModelValid )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "updateKinematics","model not valid");
+        return false;
+    }
+
+    if( !jointPos.isConsistent(m_model) )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "updateKinematics","error in size of input jointPos");
+        return false;
+    }
+
+    bool ok = ForwardPositionKinematics(m_model,m_traversal,
+                                        Transform::Identity(),jointPos,
+                                        m_base_H_link);
+
+    m_kinematicsUpdated = ok;
+
+    return ok;
+}
+
+
+const Model& SimpleLeggedOdometry::model() const
+{
+    return m_model;
+}
+
+bool SimpleLeggedOdometry::setModel(const Model& _model)
+{
+    m_model = _model;
+
+    // resize the data structures
+    m_model.computeFullTreeTraversal(m_traversal);
+
+    // set that the model is valid
+    m_isModelValid = true;
+
+    // Set the kinematics and the odometry is not initialized
+    m_isOdometryInitialized          = false;
+    m_kinematicsUpdated              = false;
+
+    // Resize the linkPositions
+    m_base_H_link.resize(m_model);
+
+    return true;
+}
+
+
+bool SimpleLeggedOdometry::loadModelFromFile(const std::string filename,
+                                             const std::string /*filetype*/)
+{
+    Model _model;
+
+    bool parsingCorrect = false;
+
+    parsingCorrect = modelFromURDF(filename,_model);
+
+    if( !parsingCorrect )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "loadModelFromFile",
+                    "Error in parsing model from URDF.");
+        return false;
+    }
+
+    return setModel(_model);
+}
+
+bool SimpleLeggedOdometry::loadModelFromFileWithSpecifiedDOFs(const std::string filename,
+                                                              const std::vector< std::string >& consideredDOFs,
+                                                              const std::string filetype)
+{
+    Model _modelFull;
+
+    bool parsingCorrect = false;
+
+    parsingCorrect = modelFromURDF(filename,_modelFull);
+
+    if( !parsingCorrect )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "loadModelFromFileWithSpecifiedDOFs",
+                    "Error in parsing model from URDF.");
+        return false;
+    }
+
+
+    Model _modelReduced;
+
+    // Create a reduced model: this will lump all not considered joints
+    iDynTree::createReducedModel(_modelFull,consideredDOFs,_modelReduced);
+
+    return setModel(_modelReduced);
+}
+
+
+
+std::string SimpleLeggedOdometry::getCurrentFixedLink()
+{
+    if( this->m_isModelValid && this->m_isOdometryInitialized )
+    {
+        return this->m_model.getLinkName(this->m_fixedLinkIndex);
+    }
+    else
+    {
+        reportError("SimpleLeggedOdometry",
+                    "getCurrentFixedLink",
+                    "getCurrentFixedLink was called, but no model is available or the odometry is not initialized.");
+        return "";
+    }
+}
+
+bool SimpleLeggedOdometry::changeFixedFrame(const FrameIndex newFixedFrame)
+{
+    if( !this->m_kinematicsUpdated )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "changeFixedFrame",
+                    "changeFixedFrame was called, but the kinematics info was never setted.");
+        return false;
+    }
+
+    LinkIndex newFixedLink = this->m_model.getFrameLink(newFixedFrame);
+
+    if( newFixedLink == LINK_INVALID_INDEX )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "changeFixedFrame",
+                    "changeFixedFrame was called, but the provided new fixed frame is unknown.");
+        return false;
+    }
+
+    Transform world_H_oldFixed = this->m_world_H_fixedLink;
+    LinkIndex oldFixedLink = m_fixedLinkIndex;
+    Transform oldFixed_H_newFixed = m_base_H_link(oldFixedLink).inverse()*m_base_H_link(newFixedLink);
+    Transform world_H_newFixed = world_H_oldFixed*oldFixed_H_newFixed;
+    this->m_world_H_fixedLink = world_H_newFixed;
+    this->m_fixedLinkIndex = newFixedLink;
+
+    return true;
+}
+
+bool SimpleLeggedOdometry::changeFixedFrame(const std::string& newFixedFrame)
+{
+    iDynTree::FrameIndex newFixedFrameIndex = this->m_model.getFrameIndex(newFixedFrame);
+
+    if( newFixedFrameIndex == FRAME_INVALID_INDEX )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "changeFixedFrame",
+                    "changeFixedFrame was called, but the provided new fixed frame is unknown.");
+        return false;
+    }
+
+    return this->changeFixedFrame(newFixedFrameIndex);
+}
+
+Transform SimpleLeggedOdometry::getWorldLinkTransform(const LinkIndex link_index)
+{
+    if( !this->m_kinematicsUpdated || !this->m_isOdometryInitialized  )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "getWorldLinkTransform",
+                    "getWorldLinkTransform was called, but the kinematics update or the odometry init was never setted.");
+        return Transform::Identity();
+    }
+
+    if( !this->m_model.isValidLinkIndex(link_index) )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "getWorldLinkTransform",
+                    "getWorldLinkTransform was called, but the request linkindex is not part of the model");
+        return Transform::Identity();
+    }
+
+    std::cerr << m_fixedLinkIndex << std::endl;
+    std::cerr << m_base_H_link.getNrOfLinks() << std::endl;
+
+    assert(m_fixedLinkIndex < m_base_H_link.getNrOfLinks());
+    Transform base_H_fixed = m_base_H_link(m_fixedLinkIndex);
+    Transform base_H_link =  m_base_H_link(link_index);
+
+    std::cerr << "base_H_fixed " << base_H_fixed.toString() << std::endl;
+    std::cerr << "base_H_link " << base_H_link.toString() << std::endl;
+    std::cerr << "m_world_H_fixedLink " << m_world_H_fixedLink.toString() << std::endl;
+
+
+    return m_world_H_fixedLink*base_H_fixed.inverse()*base_H_link;
+}
+
+
+}
+

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -63,13 +63,13 @@ bool SimpleLeggedOdometry::init(const FrameIndex initialFixedFrameIndex,
         return false;
     }
 
-
-
     m_fixedLinkIndex = m_model.getFrameLink(initialFixedFrameIndex);
     Transform initialFixedFrame_H_fixedLink = m_model.getFrameTransform(initialFixedFrameIndex).inverse();
     m_world_H_fixedLink = world_H_initialFixedFrame*initialFixedFrame_H_fixedLink;
 
     m_isOdometryInitialized = true;
+
+    return true;
 }
 
 bool SimpleLeggedOdometry::updateKinematics(JointPosDoubleArray& jointPos)

--- a/src/estimation/tests/CMakeLists.txt
+++ b/src/estimation/tests/CMakeLists.txt
@@ -15,3 +15,4 @@ endmacro()
 
 add_estimation_test(ExternalWrenchesEstimation)
 add_estimation_test(ExtWrenchesAndJointTorquesEstimator)
+add_estimation_test(SimpleLeggedOdometry)

--- a/src/estimation/tests/SimpleLeggedOdometryUnitTest.cpp
+++ b/src/estimation/tests/SimpleLeggedOdometryUnitTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <iDynTree/Estimation/SimpleLeggedOdometry.h>
+
+#include "testModels.h"
+
+#include <iDynTree/Core/TestUtils.h>
+
+
+using namespace iDynTree;
+
+std::vector<std::string> getCanonical_iCubJoints()
+{
+    std::vector<std::string> consideredJoints;
+
+    consideredJoints.push_back("torso_pitch");
+    consideredJoints.push_back("torso_roll");
+    consideredJoints.push_back("torso_yaw");
+    consideredJoints.push_back("neck_pitch");
+    consideredJoints.push_back("neck_roll");
+    consideredJoints.push_back("neck_yaw");
+    consideredJoints.push_back("l_shoulder_pitch");
+    consideredJoints.push_back("l_shoulder_roll");
+    consideredJoints.push_back("l_shoulder_yaw");
+    consideredJoints.push_back("l_elbow");
+    consideredJoints.push_back("r_shoulder_pitch");
+    consideredJoints.push_back("r_shoulder_roll");
+    consideredJoints.push_back("r_shoulder_yaw");
+    consideredJoints.push_back("r_elbow");
+    consideredJoints.push_back("l_hip_pitch");
+    consideredJoints.push_back("l_hip_roll");
+    consideredJoints.push_back("l_hip_yaw");
+    consideredJoints.push_back("l_knee");
+    consideredJoints.push_back("l_ankle_pitch");
+    consideredJoints.push_back("l_ankle_roll");
+    consideredJoints.push_back("r_hip_pitch");
+    consideredJoints.push_back("r_hip_roll");
+    consideredJoints.push_back("r_hip_yaw");
+    consideredJoints.push_back("r_knee");
+    consideredJoints.push_back("r_ankle_pitch");
+    consideredJoints.push_back("r_ankle_roll");
+
+    return consideredJoints;
+}
+
+void setDOFsSubSetPositionsInDegrees(const iDynTree::Model & model,
+                                     const std::vector<std::string> & dofNames,
+                                     const std::vector<double> & dofPositionsInDegrees,
+                                     JointPosDoubleArray & qj)
+{
+    for(int i=0; i < dofNames.size(); i++)
+    {
+        iDynTree::JointIndex jntIdx = model.getJointIndex(dofNames[i]);
+        size_t dofOffset = model.getJoint(jntIdx)->getDOFsOffset();
+        qj(dofOffset) = deg2rad(dofPositionsInDegrees[i]);
+    }
+}
+
+
+int main()
+{
+    SimpleLeggedOdometry simpleOdometry;
+
+    std::vector<std::string> consideredJoints = getCanonical_iCubJoints();
+
+    bool ok = simpleOdometry.loadModelFromFileWithSpecifiedDOFs(getAbsModelPath("iCubDarmstadt01.urdf"),consideredJoints);
+
+    ASSERT_IS_TRUE(ok);
+
+    JointPosDoubleArray qj(simpleOdometry.model());
+
+    qj.zero();
+
+    // Initialize the odometry
+    Transform world_H_l_sole = iDynTree::getRandomTransform();
+
+    ok = simpleOdometry.init("l_sole",world_H_l_sole);
+
+    ok = simpleOdometry.updateKinematics(qj);
+
+    ASSERT_IS_TRUE(ok);
+
+    Transform world_H_rootLink1 = simpleOdometry.getWorldLinkTransform(simpleOdometry.model().getLinkIndex("root_link"));
+
+    ASSERT_IS_TRUE(simpleOdometry.changeFixedFrame("r_sole"));
+
+    Transform world_H_rootLink2 = simpleOdometry.getWorldLinkTransform(simpleOdometry.model().getLinkIndex("root_link"));
+
+    ASSERT_IS_TRUE(simpleOdometry.changeFixedFrame("head"));
+
+    Transform world_H_rootLink3 = simpleOdometry.getWorldLinkTransform(simpleOdometry.model().getLinkIndex("root_link"));
+
+    ASSERT_EQUAL_TRANSFORM(world_H_rootLink1,world_H_rootLink2);
+    ASSERT_EQUAL_TRANSFORM(world_H_rootLink1,world_H_rootLink3);
+
+    // Set a desired configuration
+    std::vector<std::string> dofNames;
+    std::vector<double> dofPositionsInDegrees;
+
+
+    return EXIT_SUCCESS;
+}

--- a/src/kdl/include/kdl_codyco/KDLConversions.h
+++ b/src/kdl/include/kdl_codyco/KDLConversions.h
@@ -54,7 +54,7 @@ namespace iDynTree
     KDL::Twist    ToKDL(const iDynTree::ClassicalAcc & idyntree_classical_acc);
     KDL::Wrench   ToKDL(const iDynTree::SpatialMomentum    & idyntree_spatial_momentum);
     bool          ToKDL(const iDynTree::VectorDynSize & idyntree_jntarray,
-                        KDL::JntArray             & kdl_jntarray);
+                               KDL::JntArray             & kdl_jntarray);
 
     /**
      * Convert the configuration of a free floating robot from iDynTree.

--- a/src/model/include/iDynTree/Model/ForwardKinematics.h
+++ b/src/model/include/iDynTree/Model/ForwardKinematics.h
@@ -14,19 +14,37 @@ namespace iDynTree
 {
     class Model;
     class Traversal;
+    class Transform;
     class FreeFloatingPos;
     class FreeFloatingVel;
     class FreeFloatingAcc;
     class LinkPositions;
     class LinkVelArray;
     class LinkAccArray;
+    class JointPosDoubleArray;
 
     /**
-     * Function that computes, given a traversal
-     * the position forward kinematics of a FreeFloating robot.
-     *
      * \ingroup iDynTreeModel
      *
+     * Given a robot floating base configuration (i.e. world_H_base and the joint positions)
+     * compute for each link the world_H_link transform.
+     *
+     * @param[in]  model the used model,
+     * @param[in]  traversal the used traversal,
+     * @param[in]  worldHbase the world_H_base transform,
+     * @param[in]  jointPositions the vector of (internal) joint positions,
+     * @param[out] linkPositions linkPositions(l) contains the world_H_link transform.
+     * @return true if all went well, false otherwise.
+     */
+    bool ForwardPositionKinematics(const Model& model,
+                                   const Traversal& traversal,
+                                   const Transform& worldHbase,
+                                   const JointPosDoubleArray& jointPositions,
+                                         LinkPositions& linkPositions);
+
+    /**
+     * Variant of ForwardPositionKinematics that takes in input a FreeFloatingPos
+     * object instead of a separate couple of (worldHbase,jointPositions)
      *
      */
     bool ForwardPositionKinematics(const Model & model,

--- a/src/model/include/iDynTree/Model/LinkState.h
+++ b/src/model/include/iDynTree/Model/LinkState.h
@@ -36,8 +36,12 @@ namespace iDynTree
 
         bool isConsistent(const Model& model) const;
 
+        size_t getNrOfLinks() const;
+
         iDynTree::Transform & operator()(const LinkIndex link);
         const iDynTree::Transform & operator()(const LinkIndex link) const;
+
+        std::string toString(const Model & model) const;
 
         ~LinkPositions();
     };

--- a/src/model/src/ForwardKinematics.cpp
+++ b/src/model/src/ForwardKinematics.cpp
@@ -19,7 +19,18 @@ namespace iDynTree
 
 bool ForwardPositionKinematics(const Model& model,
                                const Traversal& traversal,
-                               const FreeFloatingPos& jointPositions,
+                               const FreeFloatingPos& robotPosition,
+                                     LinkPositions& linkPositions)
+{
+    return ForwardPositionKinematics(model,traversal,
+                                     robotPosition.worldBasePos(),robotPosition.jointPos(),
+                                     linkPositions);
+}
+
+bool ForwardPositionKinematics(const Model& model,
+                               const Traversal& traversal,
+                               const Transform& worldHbase,
+                               const JointPosDoubleArray& jointPositions,
                                      LinkPositions& linkPositions)
 {
     bool retValue = true;
@@ -35,7 +46,7 @@ bool ForwardPositionKinematics(const Model& model,
             // If the visited link is the base, the base has no parent.
             // In this case the position of the base with respect to the world is simply
             // the worldBase transform contained in the jointPos input object
-            linkPositions(visitedLink->getIndex()) = jointPositions.worldBasePos();
+            linkPositions(visitedLink->getIndex()) =worldHbase;
         }
         else
         {
@@ -43,7 +54,7 @@ bool ForwardPositionKinematics(const Model& model,
             // world_H_link = world_H_parentLink * parentLink_H_link
             linkPositions(visitedLink->getIndex()) =
                 linkPositions(parentLink->getIndex())*
-                    toParentJoint->getTransform(jointPositions.jointPos(),parentLink->getIndex(),visitedLink->getIndex());
+                    toParentJoint->getTransform(jointPositions,parentLink->getIndex(),visitedLink->getIndex());
         }
     }
 
@@ -54,9 +65,9 @@ bool ForwardPosVelAccKinematics(const Model& model, const Traversal& traversal,
                                 const FreeFloatingPos& robotPos,
                                 const FreeFloatingVel& robotVel,
                                 const FreeFloatingAcc& robotAcc,
-                                LinkPositions& linkPos,
-                                LinkVelArray & linkVel,
-                                LinkAccArray & linkAcc)
+                                      LinkPositions& linkPos,
+                                      LinkVelArray & linkVel,
+                                      LinkAccArray & linkAcc)
 {
     bool retValue = true;
 
@@ -124,7 +135,8 @@ bool ForwardVelAccKinematics(const Model& model, const Traversal& traversal,
                                               robotVel.jointVel(),
                                               robotAcc.jointAcc(),
                                               linkVel, linkAcc,
-                                              visitedLink->getIndex(),parentLink->getIndex());
+                                              visitedLink->getIndex(),
+                                              parentLink->getIndex());
         }
 
     }

--- a/src/model/src/FreeFloatingMassMatrix.cpp
+++ b/src/model/src/FreeFloatingMassMatrix.cpp
@@ -16,12 +16,14 @@ namespace iDynTree
 
 FreeFloatingMassMatrix::FreeFloatingMassMatrix(size_t nrOfDofs): MatrixDynSize(6+nrOfDofs,6+nrOfDofs)
 {
+    MatrixDynSize::zero();
 }
 
 
 FreeFloatingMassMatrix::FreeFloatingMassMatrix(const Model& model)
 {
     MatrixDynSize::resize(6+model.getNrOfDOFs(),6+model.getNrOfDOFs());
+    MatrixDynSize::zero();
 }
 
 void FreeFloatingMassMatrix::resize(const Model& model)

--- a/src/model/src/JointState.cpp
+++ b/src/model/src/JointState.cpp
@@ -37,7 +37,7 @@ void JointPosDoubleArray::resize(unsigned int nrOfPosCoords)
 
 bool JointPosDoubleArray::isConsistent(const Model& model)
 {
-    return (this->size() != model.getNrOfPosCoords());
+    return (this->size() == model.getNrOfPosCoords());
 }
 
 JointPosDoubleArray::~JointPosDoubleArray()
@@ -69,7 +69,7 @@ void JointDOFsDoubleArray::resize(unsigned int nrOfDOFs)
 
 bool JointDOFsDoubleArray::isConsistent(const Model& model)
 {
-    return (this->size() != model.getNrOfDOFs());
+    return (this->size() == model.getNrOfDOFs());
 }
 
 JointDOFsDoubleArray::~JointDOFsDoubleArray()

--- a/src/model/src/LinkState.cpp
+++ b/src/model/src/LinkState.cpp
@@ -44,6 +44,11 @@ bool LinkPositions::isConsistent(const Model& model) const
     return (this->m_linkPos.size() == model.getNrOfLinks());
 }
 
+size_t LinkPositions::getNrOfLinks() const
+{
+    return this->m_linkPos.size();
+}
+
 const Transform& LinkPositions::operator()(const LinkIndex link) const
 {
     return this->m_linkPos[link];
@@ -53,6 +58,19 @@ Transform& LinkPositions::operator()(const LinkIndex link)
 {
     return this->m_linkPos[link];
 }
+
+std::string LinkPositions::toString(const Model& model) const
+{
+   std::stringstream ss;
+
+    size_t nrOfLinks = this->getNrOfLinks();
+    for(size_t l=0; l < nrOfLinks; l++)
+    {
+        ss << "Position for link " << model.getLinkName(l) << ":" << this->operator()(l).toString() << std::endl;
+    }
+    return ss.str();
+}
+
 
 LinkPositions::~LinkPositions()
 {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,8 +6,16 @@ if(IDYNTREE_USES_KDL)
     # Integration tests of old kdl_codyco project
     add_subdirectory(kdl_tests)
 
+    # Consistency tests with kdl stuff
+    add_subdirectory(kdl_consistency)
+
     # Benchmarks against old RNEA & CRBA based on kdl
     add_subdirectory(benchmark)
+
+    # Test implementations of RPY in iDynTree, Eigen, KDL and YARP
+    if( IDYNTREE_USES_YARP )
+        add_subdirectory(yarp_kdl_rpy)
+    endif()
 
     if(IDYNTREE_USES_ICUB_MAIN)
         # Add benchmark test against yarp/icub functions

--- a/src/tests/kdl_consistency/GeometryConsistencyTest.cpp
+++ b/src/tests/kdl_consistency/GeometryConsistencyTest.cpp
@@ -36,6 +36,8 @@ void checkGetSetRPYIsIdempotent(double r, double p, double y)
     rotIDT.getRPY(roll, pitch, yaw);
 
     iDynTree::Rotation rotIDTchecl = iDynTree::Rotation::RPY(roll,pitch,yaw);
+
+    ASSERT_EQUAL_MATRIX(rotIDT,rotIDTchecl);
 }
 
 void checkSetRPYIsConsistentWithKDL(double r, double p, double y)

--- a/src/tests/yarp_kdl_rpy/CMakeLists.txt
+++ b/src/tests/yarp_kdl_rpy/CMakeLists.txt
@@ -1,0 +1,6 @@
+get_property(IDYNTREE_TREE_INCLUDE_DIRS GLOBAL PROPERTY IDYNTREE_TREE_INCLUDE_DIRS)
+
+add_executable(RPYConsistencyTest RPYConsistency.cpp)
+target_include_directories(RPYConsistencyTest PRIVATE ${IDYNTREE_TREE_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR})
+target_link_libraries(RPYConsistencyTest idyntree-modelio-urdf-kdl idyntree-yarp-kdl idyntree-icub idyntree-core idyntree-kdl idyntree-model)
+add_test(NAME RPYConsistencyTest COMMAND RPYConsistencyTest)

--- a/src/tests/yarp_kdl_rpy/RPYConsistency.cpp
+++ b/src/tests/yarp_kdl_rpy/RPYConsistency.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include <iDynTree/Core/VectorFixSize.h>
+#include <iDynTree/Core/Rotation.h>
+#include <iDynTree/Core/Utils.h>
+#include <iDynTree/Core/TestUtils.h>
+
+#include <kdl_codyco/KDLConversions.h>
+#include <kdl/frames.hpp>
+
+#include <iDynTree/yarp/YARPConversions.h>
+
+#include <yarp/sig/Matrix.h>
+#include <yarp/math/Math.h>
+
+#include <cstdlib>
+#include <limits>
+#include <iostream>
+#include <sstream>
+
+class MaxMin
+{
+public:
+    double min;
+    double max;
+
+    MaxMin()
+    {
+        min = std::numeric_limits<double>::max();
+        max = -std::numeric_limits<double>::max();
+    }
+
+    void update(const double newValue)
+    {
+        if( newValue > max )
+        {
+            max = newValue;
+        }
+
+        if( newValue < min )
+        {
+            min = newValue;
+        }
+    }
+};
+
+class RPYMaxMin
+{
+public:
+    MaxMin help[3];
+
+    void update(const iDynTree::Vector3 & rpy)
+    {
+        help[0].update(rpy(0));
+        help[1].update(rpy(1));
+        help[2].update(rpy(2));
+    }
+
+    std::string toString()
+    {
+        std::stringstream ss;
+        ss << "Roll is in (" << iDynTree::rad2deg(help[0].min) << " , " << iDynTree::rad2deg(help[0].max) << ")" << std::endl;
+        ss << "Pitch is in (" << iDynTree::rad2deg(help[1].min) << " , " << iDynTree::rad2deg(help[1].max) << ")" << std::endl;
+        ss << "Yaw is in (" << iDynTree::rad2deg(help[2].min) << " , " << iDynTree::rad2deg(help[2].max) << ")" << std::endl;
+
+        return ss.str();
+    }
+};
+
+void getRPY(iDynTree::Rotation & rot,
+            iDynTree::Vector3 & rpy_idyntree,
+            iDynTree::Vector3 & rpy_kdl,
+            iDynTree::Vector3 & rpy_yarp)
+{
+    rot.getRPY(rpy_idyntree(0),rpy_idyntree(1),rpy_idyntree(2));
+
+    iDynTree::ToKDL(rot).GetRPY(rpy_kdl(0),rpy_kdl(1),rpy_kdl(2));
+
+    yarp::sig::Matrix rotYarp(3,3);
+    iDynTree::toYarp(rot,rotYarp);
+
+    yarp::sig::Vector rpy_yarp_yarp(3);
+
+    rpy_yarp_yarp = yarp::math::dcm2rpy(rotYarp);
+
+    iDynTree::toiDynTree(rpy_yarp_yarp,rpy_yarp);
+}
+
+int main()
+{
+    std::cerr << "RPY Consistency check " << std::endl;
+
+    RPYMaxMin kdl, idyntree, yarp;
+
+    int nrOfTrials = 1000;
+
+    for(int i=0; i < nrOfTrials;i++)
+    {
+        // Create random rotation
+        iDynTree::Rotation randRot = iDynTree::getRandomRotation();
+
+        iDynTree::Vector3 rpy_idyntree, rpy_kdl, rpy_yarp;
+        getRPY(randRot,rpy_idyntree,rpy_kdl,rpy_yarp);
+
+        idyntree.update(rpy_idyntree);
+        kdl.update(rpy_kdl);
+        yarp.update(rpy_yarp);
+
+        ASSERT_EQUAL_VECTOR(rpy_kdl,rpy_kdl);
+
+
+        iDynTree::Rotation rotCheck_idyntree = iDynTree::Rotation::RPY(rpy_idyntree(0),rpy_idyntree(1),rpy_idyntree(2));
+        iDynTree::Rotation rotCheck_kdl = iDynTree::Rotation::RPY(rpy_kdl(0),rpy_kdl(1),rpy_kdl(2));
+        iDynTree::Rotation rotCheck_yarp = iDynTree::Rotation::RPY(rpy_yarp(0),rpy_yarp(1),rpy_yarp(2));
+
+        ASSERT_EQUAL_MATRIX(rotCheck_idyntree,rotCheck_kdl);
+        ASSERT_EQUAL_MATRIX(rotCheck_idyntree,rotCheck_yarp);
+
+    }
+
+    // this should be r \in [-180,180], p \in [-90,90], y \in [-180,180]
+    // this parametrization is consistent with YARP, KDL and XSens sensors
+    std::cerr << "Check the range of RPY in iDynTree, YARP and KDL: " << std::endl;
+    std::cerr << "iDynTree: " << std::endl;
+    std::cerr << idyntree.toString();
+    std::cerr << "KDL: " << std::endl;
+    std::cerr << kdl.toString();
+    std::cerr << "YARP: " << std::endl;
+    std::cerr << yarp.toString();
+
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Several improvements, please see the individual commits. 
Most important modifications: 
* [ https://github.com/robotology/idyntree/commit/cdcfe75caddcde493a0cad24eb31fe3b2e007733 ] : `[core] Fix getRPY method to actually return a RPY triple consistent with YARP, KDL and XSens`
* [ https://github.com/robotology/idyntree/commit/944e3178bb813d7d95bbbb83435a031e08be9633 ]  :  `[estimation] Added KDL-free and YARP-free SimpleLeggedOdometry class` 