### PR TITLE
Fixed acceleration projection to sensor frame in predictMeasurements

### DIFF
--- a/src/model_io/urdf/tests/PredictSensorsMeasurementUnitTest.cpp
+++ b/src/model_io/urdf/tests/PredictSensorsMeasurementUnitTest.cpp
@@ -131,7 +131,7 @@ void runTest(const int& expID,const Model& model,const Traversal& traversal,
                 ASSERT_EQUAL_DOUBLE(gyro1(1),0);
                 ASSERT_EQUAL_DOUBLE(gyro1(2),0);
                 ASSERT_EQUAL_DOUBLE(accl2(0),0);
-                ASSERT_EQUAL_DOUBLE(accl2(1),-0.1*acclTestVal);
+                ASSERT_EQUAL_DOUBLE(accl2(1),0.1*acclTestVal);
                 ASSERT_EQUAL_DOUBLE(accl2(2),0);
                 break;
     }

--- a/src/sensors/src/AccelerometerSensor.cpp
+++ b/src/sensors/src/AccelerometerSensor.cpp
@@ -166,8 +166,8 @@ LinAcceleration AccelerometerSensor::predictMeasurement(const SpatialAcc& linkAc
     LinAcceleration returnAcc(0,0,0);
     if( this->pimpl->parent_link_index >= 0)
     {
-        iDynTree::Twist localVelocity = this->pimpl->link_H_sensor * linkTwist;
-        returnAcc = ((this->pimpl->link_H_sensor* linkAcc).getLinearVec3() + (localVelocity.getAngularVec3()).cross(localVelocity.getLinearVec3()));
+        iDynTree::Twist localVelocity = this->pimpl->link_H_sensor.inverse() * linkTwist;
+        returnAcc = ((this->pimpl->link_H_sensor.inverse() * linkAcc).getLinearVec3() + (localVelocity.getAngularVec3()).cross(localVelocity.getLinearVec3()));
     }
 
     return(returnAcc);

--- a/src/sensors/src/GyroscopeSensor.cpp
+++ b/src/sensors/src/GyroscopeSensor.cpp
@@ -165,7 +165,7 @@ AngVelocity GyroscopeSensor::predictMeasurement(const Twist& linkVel)
     AngVelocity angVel(0,0,0);
     if(this->pimpl->parent_link_index>=0)
     {
-        angVel = ((this->pimpl->link_H_sensor * linkVel).getAngularVec3());
+        angVel = ((this->pimpl->link_H_sensor.inverse() * linkVel).getAngularVec3());
     }
     return(angVel);
 }


### PR DESCRIPTION
This change fixes issue https://github.com/robotology/idyntree/issues/162.
Below, the IMU predicted measurement matching the real measurement, after the fix was integrated:
![v3daccestvsaccmeas](https://cloud.githubusercontent.com/assets/6848872/16241454/004e5df0-37ee-11e6-9623-27ff064888e7.png)
