### PR TITLE
Change for simplifying matlab calibration of F/T sensors 

### DIFF
--- a/bindings/matlab/+iDynTree/AccelerometerSensor.m
+++ b/bindings/matlab/+iDynTree/AccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef AccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1020, varargin{:});
+        tmp = iDynTreeMEX(1030, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1021, self);
+        iDynTreeMEX(1031, self);
         self.swigPtr=[];
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
-    end
-    function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
-    end
-    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1032, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1033, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
+    end
+    function varargout = setParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
+    end
+    function varargout = getName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
+    end
+    function varargout = getSensorType(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
+    end
+    function varargout = getParentLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1038, self, varargin{:});
+    end
+    function varargout = getParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1041, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithm.m
+++ b/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = ArticulatedBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(953, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(956, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
+++ b/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
@@ -9,110 +9,110 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(931, varargin{:});
+        tmp = iDynTreeMEX(934, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(935, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(936, self, varargin{:});
     end
     function varargout = S(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(934, self);
+        varargout{1} = iDynTreeMEX(937, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(935, self, varargin{1});
+        iDynTreeMEX(938, self, varargin{1});
       end
     end
     function varargout = U(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(936, self);
+        varargout{1} = iDynTreeMEX(939, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(937, self, varargin{1});
+        iDynTreeMEX(940, self, varargin{1});
       end
     end
     function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(938, self);
+        varargout{1} = iDynTreeMEX(941, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(939, self, varargin{1});
+        iDynTreeMEX(942, self, varargin{1});
       end
     end
     function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(940, self);
+        varargout{1} = iDynTreeMEX(943, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(941, self, varargin{1});
+        iDynTreeMEX(944, self, varargin{1});
       end
     end
     function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(942, self);
+        varargout{1} = iDynTreeMEX(945, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(943, self, varargin{1});
+        iDynTreeMEX(946, self, varargin{1});
       end
     end
     function varargout = linksBiasAcceleration(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(944, self);
+        varargout{1} = iDynTreeMEX(947, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(945, self, varargin{1});
+        iDynTreeMEX(948, self, varargin{1});
       end
     end
     function varargout = linksAccelerations(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(946, self);
+        varargout{1} = iDynTreeMEX(949, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(947, self, varargin{1});
+        iDynTreeMEX(950, self, varargin{1});
       end
     end
     function varargout = linkABIs(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(948, self);
+        varargout{1} = iDynTreeMEX(951, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(949, self, varargin{1});
+        iDynTreeMEX(952, self, varargin{1});
       end
     end
     function varargout = linksBiasWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(950, self);
+        varargout{1} = iDynTreeMEX(953, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(951, self, varargin{1});
+        iDynTreeMEX(954, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(952, self);
+        iDynTreeMEX(955, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/CompositeRigidBodyAlgorithm.m
+++ b/bindings/matlab/+iDynTree/CompositeRigidBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = CompositeRigidBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(930, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(933, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ContactWrench.m
+++ b/bindings/matlab/+iDynTree/ContactWrench.m
@@ -4,13 +4,13 @@ classdef ContactWrench < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = contactPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(915, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(916, self, varargin{:});
     end
     function varargout = contactId(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
     end
     function self = ContactWrench(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -18,14 +18,14 @@ classdef ContactWrench < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(915, varargin{:});
+        tmp = iDynTreeMEX(918, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(916, self);
+        iDynTreeMEX(919, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DOFSpatialForceArray.m
+++ b/bindings/matlab/+iDynTree/DOFSpatialForceArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialForceArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(875, varargin{:});
+        tmp = iDynTreeMEX(878, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(876, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(880, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(881, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(879, self);
+        iDynTreeMEX(882, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DOFSpatialMotionArray.m
+++ b/bindings/matlab/+iDynTree/DOFSpatialMotionArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialMotionArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(880, varargin{:});
+        tmp = iDynTreeMEX(883, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(881, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(882, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(885, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(886, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(884, self);
+        iDynTreeMEX(887, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DynamicsComputations.m
+++ b/bindings/matlab/+iDynTree/DynamicsComputations.m
@@ -9,115 +9,115 @@ classdef DynamicsComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1176, varargin{:});
+        tmp = iDynTreeMEX(1189, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1177, self);
+        iDynTreeMEX(1190, self);
         self.swigPtr=[];
       end
     end
     function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
-    end
-    function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
-    end
-    function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
-    end
-    function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
-    end
-    function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
-    end
-    function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
-    end
-    function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
-    end
-    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1191, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1192, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1193, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1196, self, varargin{:});
     end
-    function varargout = getFrameTwist(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1197, self, varargin{:});
     end
-    function varargout = getFrameTwistInWorldOrient(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
     end
-    function varargout = getFrameProperSpatialAcceleration(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
     end
-    function varargout = getLinkIndex(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1200, self, varargin{:});
     end
-    function varargout = getLinkInertia(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1201, self, varargin{:});
     end
-    function varargout = getJointIndex(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1202, self, varargin{:});
     end
-    function varargout = getJointName(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1203, self, varargin{:});
     end
-    function varargout = getJointLimits(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1205, self, varargin{:});
     end
-    function varargout = getFrameJacobian(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1206, self, varargin{:});
     end
-    function varargout = getDynamicsRegressor(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1207, self, varargin{:});
     end
-    function varargout = getModelDynamicsParameters(self,varargin)
+    function varargout = getWorldTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
     end
-    function varargout = getCenterOfMass(self,varargin)
+    function varargout = getRelativeTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = getFrameTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1210, self, varargin{:});
+    end
+    function varargout = getFrameTwistInWorldOrient(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1211, self, varargin{:});
+    end
+    function varargout = getFrameProperSpatialAcceleration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1212, self, varargin{:});
+    end
+    function varargout = getLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
+    end
+    function varargout = getLinkInertia(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1214, self, varargin{:});
+    end
+    function varargout = getJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1215, self, varargin{:});
+    end
+    function varargout = getJointName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1216, self, varargin{:});
+    end
+    function varargout = getJointLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1217, self, varargin{:});
+    end
+    function varargout = inverseDynamics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1218, self, varargin{:});
+    end
+    function varargout = getFrameJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1219, self, varargin{:});
+    end
+    function varargout = getDynamicsRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1220, self, varargin{:});
+    end
+    function varargout = getModelDynamicsParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1221, self, varargin{:});
+    end
+    function varargout = getCenterOfMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1222, self, varargin{:});
+    end
+    function varargout = getCenterOfMassJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1223, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/DynamicsRegressorGenerator.m
+++ b/bindings/matlab/+iDynTree/DynamicsRegressorGenerator.m
@@ -9,82 +9,82 @@ classdef DynamicsRegressorGenerator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1128, varargin{:});
+        tmp = iDynTreeMEX(1141, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1129, self);
+        iDynTreeMEX(1142, self);
         self.swigPtr=[];
       end
     end
     function varargout = loadRobotAndSensorsModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1130, self, varargin{:});
-    end
-    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1131, self, varargin{:});
-    end
-    function varargout = loadRegressorStructureFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1132, self, varargin{:});
-    end
-    function varargout = loadRegressorStructureFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1133, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1134, self, varargin{:});
-    end
-    function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1135, self, varargin{:});
-    end
-    function varargout = getNrOfOutputs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1136, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1137, self, varargin{:});
-    end
-    function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1138, self, varargin{:});
-    end
-    function varargout = getDescriptionOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
-    end
-    function varargout = getDescriptionOfOutput(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1140, self, varargin{:});
-    end
-    function varargout = getDescriptionOfOutputs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1141, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1142, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1143, self, varargin{:});
     end
-    function varargout = getBaseLinkName(self,varargin)
+    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1144, self, varargin{:});
     end
-    function varargout = getSensorsModel(self,varargin)
+    function varargout = loadRegressorStructureFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1145, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = loadRegressorStructureFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1146, self, varargin{:});
     end
-    function varargout = getSensorsMeasurements(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1147, self, varargin{:});
     end
-    function varargout = computeRegressor(self,varargin)
+    function varargout = getNrOfParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1148, self, varargin{:});
     end
-    function varargout = getModelParameters(self,varargin)
+    function varargout = getNrOfOutputs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1149, self, varargin{:});
     end
-    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1150, self, varargin{:});
     end
-    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+    function varargout = getDescriptionOfParameter(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1151, self, varargin{:});
+    end
+    function varargout = getDescriptionOfParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1152, self, varargin{:});
+    end
+    function varargout = getDescriptionOfOutput(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1153, self, varargin{:});
+    end
+    function varargout = getDescriptionOfOutputs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1154, self, varargin{:});
+    end
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1155, self, varargin{:});
+    end
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
+    end
+    function varargout = getBaseLinkName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1157, self, varargin{:});
+    end
+    function varargout = getSensorsModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1158, self, varargin{:});
+    end
+    function varargout = setRobotState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
+    end
+    function varargout = getSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1160, self, varargin{:});
+    end
+    function varargout = computeRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1161, self, varargin{:});
+    end
+    function varargout = getModelParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1162, self, varargin{:});
+    end
+    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
+    end
+    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/DynamicsRegressorParameter.m
+++ b/bindings/matlab/+iDynTree/DynamicsRegressorParameter.m
@@ -7,40 +7,40 @@ classdef DynamicsRegressorParameter < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1108, self);
+        varargout{1} = iDynTreeMEX(1121, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1109, self, varargin{1});
+        iDynTreeMEX(1122, self, varargin{1});
       end
     end
     function varargout = elemIndex(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1110, self);
+        varargout{1} = iDynTreeMEX(1123, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1111, self, varargin{1});
+        iDynTreeMEX(1124, self, varargin{1});
       end
     end
     function varargout = type(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1112, self);
+        varargout{1} = iDynTreeMEX(1125, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1113, self, varargin{1});
+        iDynTreeMEX(1126, self, varargin{1});
       end
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1114, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1127, self, varargin{:});
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1115, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1128, self, varargin{:});
     end
     function varargout = ne(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1129, self, varargin{:});
     end
     function self = DynamicsRegressorParameter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -48,14 +48,14 @@ classdef DynamicsRegressorParameter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1117, varargin{:});
+        tmp = iDynTreeMEX(1130, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1118, self);
+        iDynTreeMEX(1131, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DynamicsRegressorParametersList.m
+++ b/bindings/matlab/+iDynTree/DynamicsRegressorParametersList.m
@@ -7,26 +7,26 @@ classdef DynamicsRegressorParametersList < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1119, self);
+        varargout{1} = iDynTreeMEX(1132, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1120, self, varargin{1});
+        iDynTreeMEX(1133, self, varargin{1});
       end
     end
     function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1121, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1134, self, varargin{:});
     end
     function varargout = addParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1122, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1135, self, varargin{:});
     end
     function varargout = addList(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1123, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1136, self, varargin{:});
     end
     function varargout = findParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1124, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1137, self, varargin{:});
     end
     function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1125, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1138, self, varargin{:});
     end
     function self = DynamicsRegressorParametersList(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -34,14 +34,14 @@ classdef DynamicsRegressorParametersList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1126, varargin{:});
+        tmp = iDynTreeMEX(1139, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1127, self);
+        iDynTreeMEX(1140, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
+++ b/bindings/matlab/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
@@ -9,49 +9,52 @@ classdef ExtWrenchesAndJointTorquesEstimator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1095, varargin{:});
+        tmp = iDynTreeMEX(1107, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1096, self);
+        iDynTreeMEX(1108, self);
         self.swigPtr=[];
       end
     end
     function varargout = setModelAndSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1097, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1109, self, varargin{:});
     end
     function varargout = loadModelAndSensorsFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1110, self, varargin{:});
     end
     function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1099, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1101, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1113, self, varargin{:});
     end
     function varargout = submodels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1102, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1114, self, varargin{:});
     end
     function varargout = updateKinematicsFromFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1115, self, varargin{:});
     end
     function varargout = updateKinematicsFromFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
     end
     function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1105, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1117, self, varargin{:});
     end
     function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1106, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1118, self, varargin{:});
     end
     function varargout = checkThatTheModelIsStill(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1107, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1119, self, varargin{:});
+    end
+    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1120, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/ForwardPosVelAccKinematics.m
+++ b/bindings/matlab/+iDynTree/ForwardPosVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(928, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(931, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ForwardPositionKinematics.m
+++ b/bindings/matlab/+iDynTree/ForwardPositionKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPositionKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(926, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(929, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ForwardVelAccKinematics.m
+++ b/bindings/matlab/+iDynTree/ForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(927, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(930, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/FreeFloatingAcc.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingAcc.m
@@ -9,26 +9,26 @@ classdef FreeFloatingAcc < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(906, varargin{:});
+        tmp = iDynTreeMEX(909, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
     end
     function varargout = baseAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
     end
     function varargout = jointAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(911, self);
+        iDynTreeMEX(914, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingGeneralizedTorques.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingGeneralizedTorques.m
@@ -9,26 +9,26 @@ classdef FreeFloatingGeneralizedTorques < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(894, varargin{:});
+        tmp = iDynTreeMEX(897, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
     end
     function varargout = baseWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(899, self, varargin{:});
     end
     function varargout = jointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(899, self);
+        iDynTreeMEX(902, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingMassMatrix.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingMassMatrix.m
@@ -7,17 +7,17 @@ classdef FreeFloatingMassMatrix < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(885, varargin{:});
+        tmp = iDynTreeMEX(888, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(886, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(887, self);
+        iDynTreeMEX(890, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingPos.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingPos.m
@@ -9,26 +9,26 @@ classdef FreeFloatingPos < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(888, varargin{:});
+        tmp = iDynTreeMEX(891, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(892, self, varargin{:});
     end
     function varargout = worldBasePos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
     end
     function varargout = jointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(891, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(892, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(893, self);
+        iDynTreeMEX(896, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingVel.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingVel.m
@@ -9,26 +9,26 @@ classdef FreeFloatingVel < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(900, varargin{:});
+        tmp = iDynTreeMEX(903, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
     end
     function varargout = baseVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(905, self, varargin{:});
     end
     function varargout = jointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(906, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(905, self);
+        iDynTreeMEX(908, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/GyroscopeSensor.m
+++ b/bindings/matlab/+iDynTree/GyroscopeSensor.m
@@ -7,55 +7,55 @@ classdef GyroscopeSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1035, varargin{:});
+        tmp = iDynTreeMEX(1045, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1036, self);
+        iDynTreeMEX(1046, self);
         self.swigPtr=[];
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1038, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1041, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
-    end
-    function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
-    end
-    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1047, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
+    end
+    function varargout = setParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
+    end
+    function varargout = getName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
+    end
+    function varargout = getSensorType(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
+    end
+    function varargout = getParentLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
+    end
+    function varargout = getParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1057, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1058, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/JointDOFsDoubleArray.m
+++ b/bindings/matlab/+iDynTree/JointDOFsDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointDOFsDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(871, varargin{:});
+        tmp = iDynTreeMEX(874, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(875, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(873, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(876, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(874, self);
+        iDynTreeMEX(877, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/JointPosDoubleArray.m
+++ b/bindings/matlab/+iDynTree/JointPosDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointPosDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(867, varargin{:});
+        tmp = iDynTreeMEX(870, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(870, self);
+        iDynTreeMEX(873, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/JointSensor.m
+++ b/bindings/matlab/+iDynTree/JointSensor.m
@@ -2,21 +2,21 @@ classdef JointSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(964, self);
+        iDynTreeMEX(973, self);
         self.swigPtr=[];
       end
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
     end
     function varargout = getParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(966, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
     end
     function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
     end
     function varargout = setParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
     end
     function self = JointSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/+iDynTree/KinDynComputations.m
@@ -9,82 +9,82 @@ classdef KinDynComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1152, varargin{:});
+        tmp = iDynTreeMEX(1165, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1153, self);
+        iDynTreeMEX(1166, self);
         self.swigPtr=[];
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1154, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1155, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1157, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1158, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1160, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1161, self, varargin{:});
-    end
-    function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1162, self, varargin{:});
-    end
-    function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
-    end
-    function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
-    end
-    function varargout = getRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1165, self, varargin{:});
-    end
-    function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1166, self, varargin{:});
-    end
-    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1167, self, varargin{:});
     end
-    function varargout = getBaseTwist(self,varargin)
+    function varargout = loadRobotModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1168, self, varargin{:});
     end
-    function varargout = getJointPos(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1169, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1170, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1171, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
     end
-    function varargout = getRelativeTransformExplicit(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1174, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1175, self, varargin{:});
+    end
+    function varargout = getFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1176, self, varargin{:});
+    end
+    function varargout = setFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1177, self, varargin{:});
+    end
+    function varargout = getRobotModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
+    end
+    function varargout = setRobotState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
+    end
+    function varargout = getWorldBaseTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
+    end
+    function varargout = getBaseTwist(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
+    end
+    function varargout = getJointPos(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
+    end
+    function varargout = getJointVel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
+    end
+    function varargout = getFrameIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
+    end
+    function varargout = getFrameName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
+    end
+    function varargout = getWorldTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
+    end
+    function varargout = getRelativeTransformExplicit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
+    end
+    function varargout = getRelativeTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/LinkContactWrenches.m
+++ b/bindings/matlab/+iDynTree/LinkContactWrenches.m
@@ -9,35 +9,35 @@ classdef LinkContactWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(917, varargin{:});
+        tmp = iDynTreeMEX(920, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
-    end
-    function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
-    end
-    function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(921, self, varargin{:});
     end
-    function varargout = contactWrench(self,varargin)
+    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(922, self, varargin{:});
     end
-    function varargout = computeNetWrenches(self,varargin)
+    function varargout = setNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
+    end
+    function varargout = contactWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(925, self, varargin{:});
+    end
+    function varargout = computeNetWrenches(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(925, self);
+        iDynTreeMEX(928, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkSensor.m
+++ b/bindings/matlab/+iDynTree/LinkSensor.m
@@ -2,21 +2,24 @@ classdef LinkSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(969, self);
+        iDynTreeMEX(978, self);
         self.swigPtr=[];
       end
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
     end
     function self = LinkSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/LinkUnknownWrenchContacts.m
+++ b/bindings/matlab/+iDynTree/LinkUnknownWrenchContacts.m
@@ -9,38 +9,41 @@ classdef LinkUnknownWrenchContacts < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1064, varargin{:});
+        tmp = iDynTreeMEX(1074, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
     end
     function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
     end
     function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
     end
     function varargout = addNewContactForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
     end
     function varargout = addNewContactInFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
+    end
+    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1082, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1083, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1073, self);
+        iDynTreeMEX(1084, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Model.m
+++ b/bindings/matlab/+iDynTree/Model.m
@@ -53,53 +53,62 @@ classdef Model < SwigRef
     function varargout = isValidJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(850, self, varargin{:});
     end
-    function varargout = addJoint(self,varargin)
+    function varargout = isLinkNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(851, self, varargin{:});
     end
-    function varargout = getNrOfPosCoords(self,varargin)
+    function varargout = isJointNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(852, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = isFrameNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(853, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = addJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(854, self, varargin{:});
     end
-    function varargout = addAdditionalFrameToLink(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(855, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(856, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(857, self, varargin{:});
     end
-    function varargout = isValidFrameIndex(self,varargin)
+    function varargout = addAdditionalFrameToLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(858, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(859, self, varargin{:});
     end
-    function varargout = getFrameLink(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(860, self, varargin{:});
     end
-    function varargout = getNrOfNeighbors(self,varargin)
+    function varargout = isValidFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(861, self, varargin{:});
     end
-    function varargout = getNeighbor(self,varargin)
+    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
     end
-    function varargout = setDefaultBaseLink(self,varargin)
+    function varargout = getFrameLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
     end
-    function varargout = getDefaultBaseLink(self,varargin)
+    function varargout = getNrOfNeighbors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(864, self, varargin{:});
     end
-    function varargout = computeFullTreeTraversal(self,varargin)
+    function varargout = getNeighbor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = setDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
+    end
+    function varargout = getDefaultBaseLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(867, self, varargin{:});
+    end
+    function varargout = computeFullTreeTraversal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/NR_OF_SENSOR_TYPES.m
+++ b/bindings/matlab/+iDynTree/NR_OF_SENSOR_TYPES.m
@@ -1,3 +1,3 @@
 function v = NR_OF_SENSOR_TYPES()
-  v = iDynTreeMEX(956);
+  v = iDynTreeMEX(963);
 end

--- a/bindings/matlab/+iDynTree/RNEADynamicPhase.m
+++ b/bindings/matlab/+iDynTree/RNEADynamicPhase.m
@@ -1,3 +1,3 @@
 function varargout = RNEADynamicPhase(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(929, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(932, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/Sensor.m
+++ b/bindings/matlab/+iDynTree/Sensor.m
@@ -5,27 +5,27 @@ classdef Sensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(957, self);
+        iDynTreeMEX(966, self);
         self.swigPtr=[];
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
     end
     function varargout = updateIndeces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
     end
     function self = Sensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/+iDynTree/SensorsList.m
+++ b/bindings/matlab/+iDynTree/SensorsList.m
@@ -9,43 +9,43 @@ classdef SensorsList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(974, varargin{:});
+        tmp = iDynTreeMEX(984, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(975, self);
+        iDynTreeMEX(985, self);
         self.swigPtr=[];
       end
     end
     function varargout = addSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
     end
     function varargout = setSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
     end
     function varargout = getSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(978, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
     end
     function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
     end
     function varargout = getSensorIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
     end
     function varargout = getSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
     end
     function varargout = getSixAxisForceTorqueSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
     end
     function varargout = getAccelerometerSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
     end
     function varargout = getGyroscopeSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SensorsMeasurements.m
+++ b/bindings/matlab/+iDynTree/SensorsMeasurements.m
@@ -9,34 +9,34 @@ classdef SensorsMeasurements < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(985, varargin{:});
+        tmp = iDynTreeMEX(995, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(986, self);
+        iDynTreeMEX(996, self);
         self.swigPtr=[];
       end
     end
     function varargout = setNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
     end
     function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
     end
     function varargout = toVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
     end
     function varargout = setMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
     end
     function varargout = getMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SixAxisForceTorqueSensor.m
+++ b/bindings/matlab/+iDynTree/SixAxisForceTorqueSensor.m
@@ -7,91 +7,91 @@ classdef SixAxisForceTorqueSensor < iDynTree.JointSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(993, varargin{:});
+        tmp = iDynTreeMEX(1003, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(994, self);
+        iDynTreeMEX(1004, self);
         self.swigPtr=[];
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
-    end
-    function varargout = setFirstLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(996, self, varargin{:});
-    end
-    function varargout = setSecondLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
-    end
-    function varargout = getFirstLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
-    end
-    function varargout = getSecondLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
-    end
-    function varargout = setFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
-    end
-    function varargout = setSecondLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
-    end
-    function varargout = getFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
-    end
-    function varargout = getSecondLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1003, self, varargin{:});
-    end
-    function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
-    end
-    function varargout = setParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
     end
-    function varargout = setAppliedWrenchLink(self,varargin)
+    function varargout = setFirstLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = setSecondLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = getFirstLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1008, self, varargin{:});
     end
-    function varargout = getParentJoint(self,varargin)
+    function varargout = getSecondLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
     end
-    function varargout = getParentJointIndex(self,varargin)
+    function varargout = setFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
     end
-    function varargout = getAppliedWrenchLink(self,varargin)
+    function varargout = setParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
     end
-    function varargout = isLinkAttachedToSensor(self,varargin)
+    function varargout = setParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLink(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
+    end
+    function varargout = getParentJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
+    end
+    function varargout = getAppliedWrenchLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
+    end
+    function varargout = isLinkAttachedToSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/URDFParserOptions.m
+++ b/bindings/matlab/+iDynTree/URDFParserOptions.m
@@ -1,0 +1,36 @@
+classdef URDFParserOptions < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = addSensorFramesAsAdditionalFrames(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(957, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(958, self, varargin{1});
+      end
+    end
+    function self = URDFParserOptions(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(959, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.swigPtr = [];
+      end
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(960, self);
+        self.swigPtr=[];
+      end
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/+iDynTree/UnknownWrenchContact.m
+++ b/bindings/matlab/+iDynTree/UnknownWrenchContact.m
@@ -9,7 +9,7 @@ classdef UnknownWrenchContact < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1054, varargin{:});
+        tmp = iDynTreeMEX(1064, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
@@ -18,45 +18,45 @@ classdef UnknownWrenchContact < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1055, self);
+        varargout{1} = iDynTreeMEX(1065, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1056, self, varargin{1});
+        iDynTreeMEX(1066, self, varargin{1});
       end
     end
     function varargout = contactPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1057, self);
+        varargout{1} = iDynTreeMEX(1067, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1058, self, varargin{1});
+        iDynTreeMEX(1068, self, varargin{1});
       end
     end
     function varargout = forceDirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1059, self);
+        varargout{1} = iDynTreeMEX(1069, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1060, self, varargin{1});
+        iDynTreeMEX(1070, self, varargin{1});
       end
     end
     function varargout = contactId(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1061, self);
+        varargout{1} = iDynTreeMEX(1071, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1062, self, varargin{1});
+        iDynTreeMEX(1072, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1063, self);
+        iDynTreeMEX(1073, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
+++ b/bindings/matlab/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
@@ -1,0 +1,3 @@
+function varargout = computeLinkNetWrenchesWithoutGravity(varargin)
+  [varargout{1:nargout}] = iDynTreeMEX(1106, varargin{:});
+end

--- a/bindings/matlab/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
+++ b/bindings/matlab/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1094, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1105, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/estimateExternalWrenches.m
+++ b/bindings/matlab/+iDynTree/estimateExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1093, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1104, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/estimateExternalWrenchesBuffers.m
+++ b/bindings/matlab/+iDynTree/estimateExternalWrenchesBuffers.m
@@ -9,86 +9,86 @@ classdef estimateExternalWrenchesBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1074, varargin{:});
+        tmp = iDynTreeMEX(1085, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
     end
     function varargout = getNrOfSubModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1087, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1088, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1079, self);
+        varargout{1} = iDynTreeMEX(1090, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1080, self, varargin{1});
+        iDynTreeMEX(1091, self, varargin{1});
       end
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1081, self);
+        varargout{1} = iDynTreeMEX(1092, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1082, self, varargin{1});
+        iDynTreeMEX(1093, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1083, self);
+        varargout{1} = iDynTreeMEX(1094, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1084, self, varargin{1});
+        iDynTreeMEX(1095, self, varargin{1});
       end
     end
     function varargout = pinvA(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1085, self);
+        varargout{1} = iDynTreeMEX(1096, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1086, self, varargin{1});
+        iDynTreeMEX(1097, self, varargin{1});
       end
     end
     function varargout = b_contacts_subtree(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1087, self);
+        varargout{1} = iDynTreeMEX(1098, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1088, self, varargin{1});
+        iDynTreeMEX(1099, self, varargin{1});
       end
     end
     function varargout = subModelBase_H_link(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1089, self);
+        varargout{1} = iDynTreeMEX(1100, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1090, self, varargin{1});
+        iDynTreeMEX(1101, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1091, self);
+        iDynTreeMEX(1102, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
+++ b/bindings/matlab/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenchesWithoutInternalFT(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1092, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1103, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/isJointSensor.m
+++ b/bindings/matlab/+iDynTree/isJointSensor.m
@@ -1,0 +1,3 @@
+function varargout = isJointSensor(varargin)
+  [varargout{1:nargout}] = iDynTreeMEX(965, varargin{:});
+end

--- a/bindings/matlab/+iDynTree/isLinkSensor.m
+++ b/bindings/matlab/+iDynTree/isLinkSensor.m
@@ -1,0 +1,3 @@
+function varargout = isLinkSensor(varargin)
+  [varargout{1:nargout}] = iDynTreeMEX(964, varargin{:});
+end

--- a/bindings/matlab/+iDynTree/modelFromURDF.m
+++ b/bindings/matlab/+iDynTree/modelFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(954, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(961, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/modelFromURDFString.m
+++ b/bindings/matlab/+iDynTree/modelFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(955, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(962, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/predictSensorsMeasurements.m
+++ b/bindings/matlab/+iDynTree/predictSensorsMeasurements.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurements(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1050, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1060, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
+++ b/bindings/matlab/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurementsFromRawBuffers(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1051, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1061, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/sensorsListFromURDF.m
+++ b/bindings/matlab/+iDynTree/sensorsListFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = sensorsListFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1052, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1062, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/sensorsListFromURDFString.m
+++ b/bindings/matlab/+iDynTree/sensorsListFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = sensorsListFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1053, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1063, varargin{:});
 end

--- a/bindings/matlab/iDynTreeMATLAB_wrap.cxx
+++ b/bindings/matlab/iDynTreeMATLAB_wrap.cxx
@@ -1313,29 +1313,30 @@ namespace swig {
 #define SWIGTYPE_p_iDynTree__TransformSemantics swig_types[122]
 #define SWIGTYPE_p_iDynTree__Traversal swig_types[123]
 #define SWIGTYPE_p_iDynTree__Twist swig_types[124]
-#define SWIGTYPE_p_iDynTree__UnknownWrenchContact swig_types[125]
-#define SWIGTYPE_p_iDynTree__VectorDynSize swig_types[126]
-#define SWIGTYPE_p_iDynTree__VectorFixSizeT_10_t swig_types[127]
-#define SWIGTYPE_p_iDynTree__VectorFixSizeT_16_t swig_types[128]
-#define SWIGTYPE_p_iDynTree__VectorFixSizeT_3_t swig_types[129]
-#define SWIGTYPE_p_iDynTree__VectorFixSizeT_4_t swig_types[130]
-#define SWIGTYPE_p_iDynTree__VectorFixSizeT_6_t swig_types[131]
-#define SWIGTYPE_p_iDynTree__Wrench swig_types[132]
-#define SWIGTYPE_p_iDynTree__estimateExternalWrenchesBuffers swig_types[133]
-#define SWIGTYPE_p_int swig_types[134]
-#define SWIGTYPE_p_size_type swig_types[135]
-#define SWIGTYPE_p_std__allocatorT_std__string_t swig_types[136]
-#define SWIGTYPE_p_std__vectorT_iDynTree__MatrixDynSize_std__allocatorT_iDynTree__MatrixDynSize_t_t swig_types[137]
-#define SWIGTYPE_p_std__vectorT_iDynTree__Regressors__DynamicsRegressorParameter_std__allocatorT_iDynTree__Regressors__DynamicsRegressorParameter_t_t swig_types[138]
-#define SWIGTYPE_p_std__vectorT_iDynTree__VectorDynSize_std__allocatorT_iDynTree__VectorDynSize_t_t swig_types[139]
-#define SWIGTYPE_p_std__vectorT_iDynTree__VectorFixSizeT_6_t_std__allocatorT_iDynTree__VectorFixSizeT_6_t_t_t swig_types[140]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[141]
-#define SWIGTYPE_p_swig__MatlabSwigIterator swig_types[142]
-#define SWIGTYPE_p_unsigned_int swig_types[143]
-#define SWIGTYPE_p_unsigned_long swig_types[144]
-#define SWIGTYPE_p_value_type swig_types[145]
-static swig_type_info *swig_types[147];
-static swig_module_info swig_module = {swig_types, 146, 0, 0, 0, 0};
+#define SWIGTYPE_p_iDynTree__URDFParserOptions swig_types[125]
+#define SWIGTYPE_p_iDynTree__UnknownWrenchContact swig_types[126]
+#define SWIGTYPE_p_iDynTree__VectorDynSize swig_types[127]
+#define SWIGTYPE_p_iDynTree__VectorFixSizeT_10_t swig_types[128]
+#define SWIGTYPE_p_iDynTree__VectorFixSizeT_16_t swig_types[129]
+#define SWIGTYPE_p_iDynTree__VectorFixSizeT_3_t swig_types[130]
+#define SWIGTYPE_p_iDynTree__VectorFixSizeT_4_t swig_types[131]
+#define SWIGTYPE_p_iDynTree__VectorFixSizeT_6_t swig_types[132]
+#define SWIGTYPE_p_iDynTree__Wrench swig_types[133]
+#define SWIGTYPE_p_iDynTree__estimateExternalWrenchesBuffers swig_types[134]
+#define SWIGTYPE_p_int swig_types[135]
+#define SWIGTYPE_p_size_type swig_types[136]
+#define SWIGTYPE_p_std__allocatorT_std__string_t swig_types[137]
+#define SWIGTYPE_p_std__vectorT_iDynTree__MatrixDynSize_std__allocatorT_iDynTree__MatrixDynSize_t_t swig_types[138]
+#define SWIGTYPE_p_std__vectorT_iDynTree__Regressors__DynamicsRegressorParameter_std__allocatorT_iDynTree__Regressors__DynamicsRegressorParameter_t_t swig_types[139]
+#define SWIGTYPE_p_std__vectorT_iDynTree__VectorDynSize_std__allocatorT_iDynTree__VectorDynSize_t_t swig_types[140]
+#define SWIGTYPE_p_std__vectorT_iDynTree__VectorFixSizeT_6_t_std__allocatorT_iDynTree__VectorFixSizeT_6_t_t_t swig_types[141]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[142]
+#define SWIGTYPE_p_swig__MatlabSwigIterator swig_types[143]
+#define SWIGTYPE_p_unsigned_int swig_types[144]
+#define SWIGTYPE_p_unsigned_long swig_types[145]
+#define SWIGTYPE_p_value_type swig_types[146]
+static swig_type_info *swig_types[148];
+static swig_module_info swig_module = {swig_types, 147, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3291,6 +3292,15 @@ SWIGINTERN iDynTree::FixedJoint *iDynTree_IJoint_asFixedJoint(iDynTree::IJoint *
             static_cast<iDynTree::FixedJoint*>(self);
         return p;
     }
+
+SWIGINTERN int
+SWIG_AsVal_bool (mxArray* pm, bool *val)
+{
+   if(!mxIsLogicalScalar(pm)) return SWIG_TypeError;
+   if (val) *val = mxIsLogicalScalarTrue(pm);
+   return SWIG_OK;
+}
+
 SWIGINTERN iDynTree::SixAxisForceTorqueSensor *iDynTree_SensorsList_getSixAxisForceTorqueSensor(iDynTree::SensorsList const *self,int sensor_index){
         iDynTree::SixAxisForceTorqueSensor* p =
             static_cast<iDynTree::SixAxisForceTorqueSensor*>(self->getSensor(iDynTree::SIX_AXIS_FORCE_TORQUE,sensor_index));
@@ -3306,15 +3316,6 @@ SWIGINTERN iDynTree::GyroscopeSensor *iDynTree_SensorsList_getGyroscopeSensor(iD
             static_cast<iDynTree::GyroscopeSensor*>(self->getSensor(iDynTree::GYROSCOPE,sensor_index));
         return p;
     }
-
-SWIGINTERN int
-SWIG_AsVal_bool (mxArray* pm, bool *val)
-{
-   if(!mxIsLogicalScalar(pm)) return SWIG_TypeError;
-   if (val) *val = mxIsLogicalScalarTrue(pm);
-   return SWIG_OK;
-}
-
 int _wrap_delete_MatlabSwigIterator (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   swig::MatlabSwigIterator *arg1 = (swig::MatlabSwigIterator *) 0 ;
   void *argp1 = 0 ;
@@ -41058,6 +41059,108 @@ fail:
 }
 
 
+int _wrap_Model_isLinkNameUsed (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::Model *arg1 = (iDynTree::Model *) 0 ;
+  std::string arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("Model_isLinkNameUsed",argc,2,2,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__Model, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Model_isLinkNameUsed" "', argument " "1"" of type '" "iDynTree::Model *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::Model * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(argv[1], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "Model_isLinkNameUsed" "', argument " "2"" of type '" "std::string const""'"); 
+    }
+    arg2 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  result = (bool)(arg1)->isLinkNameUsed(arg2);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_Model_isJointNameUsed (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::Model *arg1 = (iDynTree::Model *) 0 ;
+  std::string arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("Model_isJointNameUsed",argc,2,2,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__Model, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Model_isJointNameUsed" "', argument " "1"" of type '" "iDynTree::Model *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::Model * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(argv[1], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "Model_isJointNameUsed" "', argument " "2"" of type '" "std::string const""'"); 
+    }
+    arg2 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  result = (bool)(arg1)->isJointNameUsed(arg2);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_Model_isFrameNameUsed (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::Model *arg1 = (iDynTree::Model *) 0 ;
+  std::string arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("Model_isFrameNameUsed",argc,2,2,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__Model, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Model_isFrameNameUsed" "', argument " "1"" of type '" "iDynTree::Model *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::Model * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(argv[1], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "Model_isFrameNameUsed" "', argument " "2"" of type '" "std::string const""'"); 
+    }
+    arg2 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  result = (bool)(arg1)->isFrameNameUsed(arg2);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
 int _wrap_Model_addJoint (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   iDynTree::Model *arg1 = (iDynTree::Model *) 0 ;
   std::string *arg2 = 0 ;
@@ -46414,7 +46517,161 @@ fail:
 }
 
 
-int _wrap_modelFromURDF (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+int _wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_set (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::URDFParserOptions *arg1 = (iDynTree::URDFParserOptions *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  mxArray * _out;
+  
+  if (!SWIG_check_num_args("URDFParserOptions_addSensorFramesAsAdditionalFrames_set",argc,2,2,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__URDFParserOptions, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "URDFParserOptions_addSensorFramesAsAdditionalFrames_set" "', argument " "1"" of type '" "iDynTree::URDFParserOptions *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::URDFParserOptions * >(argp1);
+  ecode2 = SWIG_AsVal_bool(argv[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "URDFParserOptions_addSensorFramesAsAdditionalFrames_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->addSensorFramesAsAdditionalFrames = arg2;
+  _out = (mxArray*)0;
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_get (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::URDFParserOptions *arg1 = (iDynTree::URDFParserOptions *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("URDFParserOptions_addSensorFramesAsAdditionalFrames_get",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__URDFParserOptions, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "URDFParserOptions_addSensorFramesAsAdditionalFrames_get" "', argument " "1"" of type '" "iDynTree::URDFParserOptions *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::URDFParserOptions * >(argp1);
+  result = (bool) ((arg1)->addSensorFramesAsAdditionalFrames);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_new_URDFParserOptions (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  mxArray * _out;
+  iDynTree::URDFParserOptions *result = 0 ;
+  
+  if (!SWIG_check_num_args("new_URDFParserOptions",argc,0,0,0)) {
+    SWIG_fail;
+  }
+  result = (iDynTree::URDFParserOptions *)new iDynTree::URDFParserOptions();
+  _out = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_iDynTree__URDFParserOptions, 1 |  0 );
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_delete_URDFParserOptions (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::URDFParserOptions *arg1 = (iDynTree::URDFParserOptions *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  
+  int is_owned;
+  if (!SWIG_check_num_args("delete_URDFParserOptions",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  is_owned = SWIG_Matlab_isOwned(argv[0]);
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__URDFParserOptions, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_URDFParserOptions" "', argument " "1"" of type '" "iDynTree::URDFParserOptions *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::URDFParserOptions * >(argp1);
+  if (is_owned) {
+    delete arg1;
+  }
+  _out = (mxArray*)0;
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_modelFromURDF__SWIG_0 (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  std::string *arg1 = 0 ;
+  iDynTree::Model *arg2 = 0 ;
+  iDynTree::URDFParserOptions arg3 ;
+  int res1 = SWIG_OLDOBJ ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 ;
+  int res3 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("modelFromURDF",argc,3,3,0)) {
+    SWIG_fail;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    res1 = SWIG_AsPtr_std_string(argv[0], &ptr);
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "modelFromURDF" "', argument " "1"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "modelFromURDF" "', argument " "1"" of type '" "std::string const &""'"); 
+    }
+    arg1 = ptr;
+  }
+  res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__Model,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "modelFromURDF" "', argument " "2"" of type '" "iDynTree::Model &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "modelFromURDF" "', argument " "2"" of type '" "iDynTree::Model &""'"); 
+  }
+  arg2 = reinterpret_cast< iDynTree::Model * >(argp2);
+  {
+    res3 = SWIG_ConvertPtr(argv[2], &argp3, SWIGTYPE_p_iDynTree__URDFParserOptions,  0 );
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "modelFromURDF" "', argument " "3"" of type '" "iDynTree::URDFParserOptions const""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "modelFromURDF" "', argument " "3"" of type '" "iDynTree::URDFParserOptions const""'");
+    } else {
+      arg3 = *(reinterpret_cast< iDynTree::URDFParserOptions * >(argp3));
+    }
+  }
+  result = (bool)iDynTree::modelFromURDF((std::string const &)*arg1,*arg2,arg3);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  if (SWIG_IsNewObj(res1)) delete arg1;
+  return 0;
+fail:
+  if (SWIG_IsNewObj(res1)) delete arg1;
+  return 1;
+}
+
+
+int _wrap_modelFromURDF__SWIG_1 (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   std::string *arg1 = 0 ;
   iDynTree::Model *arg2 = 0 ;
   int res1 = SWIG_OLDOBJ ;
@@ -46456,7 +46713,104 @@ fail:
 }
 
 
-int _wrap_modelFromURDFString (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+int _wrap_modelFromURDF (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_AsPtr_std_string(argv[0], (std::string**)(0));
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_iDynTree__Model, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_modelFromURDF__SWIG_1(resc,resv,argc,argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    int res = SWIG_AsPtr_std_string(argv[0], (std::string**)(0));
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_iDynTree__Model, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_iDynTree__URDFParserOptions, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_modelFromURDF__SWIG_0(resc,resv,argc,argv);
+        }
+      }
+    }
+  }
+  
+  SWIG_Error(SWIG_RuntimeError, "No matching function for overload function 'modelFromURDF'."
+    "  Possible C/C++ prototypes are:\n"
+    "    iDynTree::modelFromURDF(std::string const &,iDynTree::Model &,iDynTree::URDFParserOptions const)\n"
+    "    iDynTree::modelFromURDF(std::string const &,iDynTree::Model &)\n");
+  return 1;
+}
+
+
+int _wrap_modelFromURDFString__SWIG_0 (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  std::string *arg1 = 0 ;
+  iDynTree::Model *arg2 = 0 ;
+  iDynTree::URDFParserOptions arg3 ;
+  int res1 = SWIG_OLDOBJ ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 ;
+  int res3 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("modelFromURDFString",argc,3,3,0)) {
+    SWIG_fail;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    res1 = SWIG_AsPtr_std_string(argv[0], &ptr);
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "modelFromURDFString" "', argument " "1"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "modelFromURDFString" "', argument " "1"" of type '" "std::string const &""'"); 
+    }
+    arg1 = ptr;
+  }
+  res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__Model,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "modelFromURDFString" "', argument " "2"" of type '" "iDynTree::Model &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "modelFromURDFString" "', argument " "2"" of type '" "iDynTree::Model &""'"); 
+  }
+  arg2 = reinterpret_cast< iDynTree::Model * >(argp2);
+  {
+    res3 = SWIG_ConvertPtr(argv[2], &argp3, SWIGTYPE_p_iDynTree__URDFParserOptions,  0 );
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "modelFromURDFString" "', argument " "3"" of type '" "iDynTree::URDFParserOptions const""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "modelFromURDFString" "', argument " "3"" of type '" "iDynTree::URDFParserOptions const""'");
+    } else {
+      arg3 = *(reinterpret_cast< iDynTree::URDFParserOptions * >(argp3));
+    }
+  }
+  result = (bool)iDynTree::modelFromURDFString((std::string const &)*arg1,*arg2,arg3);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  if (SWIG_IsNewObj(res1)) delete arg1;
+  return 0;
+fail:
+  if (SWIG_IsNewObj(res1)) delete arg1;
+  return 1;
+}
+
+
+int _wrap_modelFromURDFString__SWIG_1 (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   std::string *arg1 = 0 ;
   iDynTree::Model *arg2 = 0 ;
   int res1 = SWIG_OLDOBJ ;
@@ -46498,6 +46852,47 @@ fail:
 }
 
 
+int _wrap_modelFromURDFString (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_AsPtr_std_string(argv[0], (std::string**)(0));
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_iDynTree__Model, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_modelFromURDFString__SWIG_1(resc,resv,argc,argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    int res = SWIG_AsPtr_std_string(argv[0], (std::string**)(0));
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_iDynTree__Model, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_iDynTree__URDFParserOptions, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_modelFromURDFString__SWIG_0(resc,resv,argc,argv);
+        }
+      }
+    }
+  }
+  
+  SWIG_Error(SWIG_RuntimeError, "No matching function for overload function 'modelFromURDFString'."
+    "  Possible C/C++ prototypes are:\n"
+    "    iDynTree::modelFromURDFString(std::string const &,iDynTree::Model &,iDynTree::URDFParserOptions const)\n"
+    "    iDynTree::modelFromURDFString(std::string const &,iDynTree::Model &)\n");
+  return 1;
+}
+
+
 int _wrap_NR_OF_SENSOR_TYPES_get (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   mxArray * _out;
   int result;
@@ -46507,6 +46902,54 @@ int _wrap_NR_OF_SENSOR_TYPES_get (int resc, mxArray *resv[], int argc, mxArray *
   }
   result = (int)(int)iDynTree::NR_OF_SENSOR_TYPES;
   _out = SWIG_From_int(static_cast< int >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_isLinkSensor (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::SensorType arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("isLinkSensor",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "isLinkSensor" "', argument " "1"" of type '" "iDynTree::SensorType""'");
+  } 
+  arg1 = static_cast< iDynTree::SensorType >(val1);
+  result = (bool)iDynTree::isLinkSensor(arg1);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_isJointSensor (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::SensorType arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("isJointSensor",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "isJointSensor" "', argument " "1"" of type '" "iDynTree::SensorType""'");
+  } 
+  arg1 = static_cast< iDynTree::SensorType >(val1);
+  result = (bool)iDynTree::isJointSensor(arg1);
+  _out = SWIG_From_bool(static_cast< bool >(result));
   if (_out) --resc, *resv++ = _out;
   return 0;
 fail:
@@ -46927,6 +47370,30 @@ int _wrap_LinkSensor_getParentLinkIndex (int resc, mxArray *resv[], int argc, mx
   arg1 = reinterpret_cast< iDynTree::LinkSensor * >(argp1);
   result = (iDynTree::LinkIndex)((iDynTree::LinkSensor const *)arg1)->getParentLinkIndex();
   _out = SWIG_From_int(static_cast< int >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_LinkSensor_getLinkSensorTransform (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::LinkSensor *arg1 = (iDynTree::LinkSensor *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  iDynTree::Transform result;
+  
+  if (!SWIG_check_num_args("LinkSensor_getLinkSensorTransform",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__LinkSensor, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "LinkSensor_getLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::LinkSensor const *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::LinkSensor * >(argp1);
+  result = ((iDynTree::LinkSensor const *)arg1)->getLinkSensorTransform();
+  _out = SWIG_NewPointerObj((new iDynTree::Transform(static_cast< const iDynTree::Transform& >(result))), SWIGTYPE_p_iDynTree__Transform, SWIG_POINTER_OWN |  0 );
   if (_out) --resc, *resv++ = _out;
   return 0;
 fail:
@@ -49414,7 +49881,7 @@ int _wrap_AccelerometerSensor_setLinkSensorTransform (int resc, mxArray *resv[],
   }
   res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__AccelerometerSensor, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "AccelerometerSensor_setLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::AccelerometerSensor const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "AccelerometerSensor_setLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::AccelerometerSensor *""'"); 
   }
   arg1 = reinterpret_cast< iDynTree::AccelerometerSensor * >(argp1);
   res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__Transform,  0 );
@@ -49425,7 +49892,7 @@ int _wrap_AccelerometerSensor_setLinkSensorTransform (int resc, mxArray *resv[],
     SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "AccelerometerSensor_setLinkSensorTransform" "', argument " "2"" of type '" "iDynTree::Transform const &""'"); 
   }
   arg2 = reinterpret_cast< iDynTree::Transform * >(argp2);
-  result = (bool)((iDynTree::AccelerometerSensor const *)arg1)->setLinkSensorTransform((iDynTree::Transform const &)*arg2);
+  result = (bool)(arg1)->setLinkSensorTransform((iDynTree::Transform const &)*arg2);
   _out = SWIG_From_bool(static_cast< bool >(result));
   if (_out) --resc, *resv++ = _out;
   return 0;
@@ -49603,6 +50070,30 @@ fail:
 }
 
 
+int _wrap_AccelerometerSensor_getLinkSensorTransform (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::AccelerometerSensor *arg1 = (iDynTree::AccelerometerSensor *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  iDynTree::Transform result;
+  
+  if (!SWIG_check_num_args("AccelerometerSensor_getLinkSensorTransform",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__AccelerometerSensor, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "AccelerometerSensor_getLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::AccelerometerSensor const *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::AccelerometerSensor * >(argp1);
+  result = ((iDynTree::AccelerometerSensor const *)arg1)->getLinkSensorTransform();
+  _out = SWIG_NewPointerObj((new iDynTree::Transform(static_cast< const iDynTree::Transform& >(result))), SWIGTYPE_p_iDynTree__Transform, SWIG_POINTER_OWN |  0 );
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
 int _wrap_AccelerometerSensor_isValid (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   iDynTree::AccelerometerSensor *arg1 = (iDynTree::AccelerometerSensor *) 0 ;
   void *argp1 = 0 ;
@@ -49679,30 +50170,6 @@ int _wrap_AccelerometerSensor_updateIndeces (int resc, mxArray *resv[], int argc
   arg2 = reinterpret_cast< iDynTree::Model * >(argp2);
   result = (bool)(arg1)->updateIndeces((iDynTree::Model const &)*arg2);
   _out = SWIG_From_bool(static_cast< bool >(result));
-  if (_out) --resc, *resv++ = _out;
-  return 0;
-fail:
-  return 1;
-}
-
-
-int _wrap_AccelerometerSensor_getLinkSensorTransform (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
-  iDynTree::AccelerometerSensor *arg1 = (iDynTree::AccelerometerSensor *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  mxArray * _out;
-  iDynTree::Transform result;
-  
-  if (!SWIG_check_num_args("AccelerometerSensor_getLinkSensorTransform",argc,1,1,0)) {
-    SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__AccelerometerSensor, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "AccelerometerSensor_getLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::AccelerometerSensor *""'"); 
-  }
-  arg1 = reinterpret_cast< iDynTree::AccelerometerSensor * >(argp1);
-  result = (arg1)->getLinkSensorTransform();
-  _out = SWIG_NewPointerObj((new iDynTree::Transform(static_cast< const iDynTree::Transform& >(result))), SWIGTYPE_p_iDynTree__Transform, SWIG_POINTER_OWN |  0 );
   if (_out) --resc, *resv++ = _out;
   return 0;
 fail:
@@ -49902,7 +50369,7 @@ int _wrap_GyroscopeSensor_setLinkSensorTransform (int resc, mxArray *resv[], int
   }
   res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__GyroscopeSensor, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GyroscopeSensor_setLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::GyroscopeSensor const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GyroscopeSensor_setLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::GyroscopeSensor *""'"); 
   }
   arg1 = reinterpret_cast< iDynTree::GyroscopeSensor * >(argp1);
   res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__Transform,  0 );
@@ -49913,7 +50380,7 @@ int _wrap_GyroscopeSensor_setLinkSensorTransform (int resc, mxArray *resv[], int
     SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GyroscopeSensor_setLinkSensorTransform" "', argument " "2"" of type '" "iDynTree::Transform const &""'"); 
   }
   arg2 = reinterpret_cast< iDynTree::Transform * >(argp2);
-  result = (bool)((iDynTree::GyroscopeSensor const *)arg1)->setLinkSensorTransform((iDynTree::Transform const &)*arg2);
+  result = (bool)(arg1)->setLinkSensorTransform((iDynTree::Transform const &)*arg2);
   _out = SWIG_From_bool(static_cast< bool >(result));
   if (_out) --resc, *resv++ = _out;
   return 0;
@@ -50091,6 +50558,30 @@ fail:
 }
 
 
+int _wrap_GyroscopeSensor_getLinkSensorTransform (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::GyroscopeSensor *arg1 = (iDynTree::GyroscopeSensor *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  iDynTree::Transform result;
+  
+  if (!SWIG_check_num_args("GyroscopeSensor_getLinkSensorTransform",argc,1,1,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__GyroscopeSensor, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GyroscopeSensor_getLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::GyroscopeSensor const *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::GyroscopeSensor * >(argp1);
+  result = ((iDynTree::GyroscopeSensor const *)arg1)->getLinkSensorTransform();
+  _out = SWIG_NewPointerObj((new iDynTree::Transform(static_cast< const iDynTree::Transform& >(result))), SWIGTYPE_p_iDynTree__Transform, SWIG_POINTER_OWN |  0 );
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
 int _wrap_GyroscopeSensor_isValid (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   iDynTree::GyroscopeSensor *arg1 = (iDynTree::GyroscopeSensor *) 0 ;
   void *argp1 = 0 ;
@@ -50167,30 +50658,6 @@ int _wrap_GyroscopeSensor_updateIndeces (int resc, mxArray *resv[], int argc, mx
   arg2 = reinterpret_cast< iDynTree::Model * >(argp2);
   result = (bool)(arg1)->updateIndeces((iDynTree::Model const &)*arg2);
   _out = SWIG_From_bool(static_cast< bool >(result));
-  if (_out) --resc, *resv++ = _out;
-  return 0;
-fail:
-  return 1;
-}
-
-
-int _wrap_GyroscopeSensor_getLinkSensorTransform (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
-  iDynTree::GyroscopeSensor *arg1 = (iDynTree::GyroscopeSensor *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  mxArray * _out;
-  iDynTree::Transform result;
-  
-  if (!SWIG_check_num_args("GyroscopeSensor_getLinkSensorTransform",argc,1,1,0)) {
-    SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__GyroscopeSensor, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GyroscopeSensor_getLinkSensorTransform" "', argument " "1"" of type '" "iDynTree::GyroscopeSensor *""'"); 
-  }
-  arg1 = reinterpret_cast< iDynTree::GyroscopeSensor * >(argp1);
-  result = (arg1)->getLinkSensorTransform();
-  _out = SWIG_NewPointerObj((new iDynTree::Transform(static_cast< const iDynTree::Transform& >(result))), SWIGTYPE_p_iDynTree__Transform, SWIG_POINTER_OWN |  0 );
   if (_out) --resc, *resv++ = _out;
   return 0;
 fail:
@@ -51461,6 +51928,49 @@ fail:
 }
 
 
+int _wrap_LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::LinkUnknownWrenchContacts *arg1 = (iDynTree::LinkUnknownWrenchContacts *) 0 ;
+  iDynTree::Model *arg2 = 0 ;
+  iDynTree::FrameIndex arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin",argc,3,3,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__LinkUnknownWrenchContacts, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin" "', argument " "1"" of type '" "iDynTree::LinkUnknownWrenchContacts *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::LinkUnknownWrenchContacts * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__Model,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin" "', argument " "2"" of type '" "iDynTree::Model const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin" "', argument " "2"" of type '" "iDynTree::Model const &""'"); 
+  }
+  arg2 = reinterpret_cast< iDynTree::Model * >(argp2);
+  ecode3 = SWIG_AsVal_int(argv[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin" "', argument " "3"" of type '" "iDynTree::FrameIndex""'");
+  } 
+  arg3 = static_cast< iDynTree::FrameIndex >(val3);
+  result = (bool)(arg1)->addNewUnknownFullWrenchInFrameOrigin((iDynTree::Model const &)*arg2,arg3);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
 int _wrap_LinkUnknownWrenchContacts_contactWrench__SWIG_0 (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   iDynTree::LinkUnknownWrenchContacts *arg1 = (iDynTree::LinkUnknownWrenchContacts *) 0 ;
   iDynTree::LinkIndex arg2 ;
@@ -52683,6 +53193,66 @@ fail:
 }
 
 
+int _wrap_computeLinkNetWrenchesWithoutGravity (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::Model *arg1 = 0 ;
+  iDynTree::LinkVelArray *arg2 = 0 ;
+  iDynTree::LinkAccArray *arg3 = 0 ;
+  iDynTree::LinkNetWrenchesWithoutGravity *arg4 = 0 ;
+  void *argp1 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  void *argp3 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("computeLinkNetWrenchesWithoutGravity",argc,4,4,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1, SWIGTYPE_p_iDynTree__Model,  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "1"" of type '" "iDynTree::Model const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "1"" of type '" "iDynTree::Model const &""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::Model * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__LinkVelArray,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "2"" of type '" "iDynTree::LinkVelArray const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "2"" of type '" "iDynTree::LinkVelArray const &""'"); 
+  }
+  arg2 = reinterpret_cast< iDynTree::LinkVelArray * >(argp2);
+  res3 = SWIG_ConvertPtr(argv[2], &argp3, SWIGTYPE_p_iDynTree__LinkAccArray,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "3"" of type '" "iDynTree::LinkAccArray const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "3"" of type '" "iDynTree::LinkAccArray const &""'"); 
+  }
+  arg3 = reinterpret_cast< iDynTree::LinkAccArray * >(argp3);
+  res4 = SWIG_ConvertPtr(argv[3], &argp4, SWIGTYPE_p_iDynTree__LinkWrenches,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "4"" of type '" "iDynTree::LinkNetWrenchesWithoutGravity &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "computeLinkNetWrenchesWithoutGravity" "', argument " "4"" of type '" "iDynTree::LinkNetWrenchesWithoutGravity &""'"); 
+  }
+  arg4 = reinterpret_cast< iDynTree::LinkNetWrenchesWithoutGravity * >(argp4);
+  result = (bool)iDynTree::computeLinkNetWrenchesWithoutGravity((iDynTree::Model const &)*arg1,(iDynTree::LinkVelArray const &)*arg2,(iDynTree::LinkAccArray const &)*arg3,*arg4);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
 int _wrap_new_ExtWrenchesAndJointTorquesEstimator (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
   mxArray * _out;
   iDynTree::ExtWrenchesAndJointTorquesEstimator *result = 0 ;
@@ -53472,6 +54042,41 @@ int _wrap_ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill (int resc
   } 
   arg4 = static_cast< double >(val4);
   result = (bool)(arg1)->checkThatTheModelIsStill(arg2,arg3,arg4);
+  _out = SWIG_From_bool(static_cast< bool >(result));
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::ExtWrenchesAndJointTorquesEstimator *arg1 = (iDynTree::ExtWrenchesAndJointTorquesEstimator *) 0 ;
+  iDynTree::LinkNetWrenchesWithoutGravity *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  mxArray * _out;
+  bool result;
+  
+  if (!SWIG_check_num_args("ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity",argc,2,2,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__ExtWrenchesAndJointTorquesEstimator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity" "', argument " "1"" of type '" "iDynTree::ExtWrenchesAndJointTorquesEstimator *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::ExtWrenchesAndJointTorquesEstimator * >(argp1);
+  res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_iDynTree__LinkWrenches,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity" "', argument " "2"" of type '" "iDynTree::LinkNetWrenchesWithoutGravity &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity" "', argument " "2"" of type '" "iDynTree::LinkNetWrenchesWithoutGravity &""'"); 
+  }
+  arg2 = reinterpret_cast< iDynTree::LinkNetWrenchesWithoutGravity * >(argp2);
+  result = (bool)(arg1)->estimateLinkNetWrenchesWithoutGravity(*arg2);
   _out = SWIG_From_bool(static_cast< bool >(result));
   if (_out) --resc, *resv++ = _out;
   return 0;
@@ -59327,7 +59932,7 @@ static swig_type_info _swigt__p_iDynTree__LinkPositions = {"_p_iDynTree__LinkPos
 static swig_type_info _swigt__p_iDynTree__LinkSensor = {"_p_iDynTree__LinkSensor", "iDynTree::LinkSensor *", 0, 0, (void*)"iDynTree.LinkSensor", 0};
 static swig_type_info _swigt__p_iDynTree__LinkUnknownWrenchContacts = {"_p_iDynTree__LinkUnknownWrenchContacts", "iDynTree::LinkUnknownWrenchContacts *", 0, 0, (void*)"iDynTree.LinkUnknownWrenchContacts", 0};
 static swig_type_info _swigt__p_iDynTree__LinkVelArray = {"_p_iDynTree__LinkVelArray", "iDynTree::LinkVelArray *", 0, 0, (void*)"iDynTree.LinkVelArray", 0};
-static swig_type_info _swigt__p_iDynTree__LinkWrenches = {"_p_iDynTree__LinkWrenches", "iDynTree::LinkWrenches *|iDynTree::LinkNetExternalWrenches *|iDynTree::LinkInternalWrenches *", 0, 0, (void*)"iDynTree.LinkWrenches", 0};
+static swig_type_info _swigt__p_iDynTree__LinkWrenches = {"_p_iDynTree__LinkWrenches", "iDynTree::LinkWrenches *|iDynTree::LinkNetExternalWrenches *|iDynTree::LinkInternalWrenches *|iDynTree::LinkNetWrenchesWithoutGravity *", 0, 0, (void*)"iDynTree.LinkWrenches", 0};
 static swig_type_info _swigt__p_iDynTree__MatrixDynSize = {"_p_iDynTree__MatrixDynSize", "iDynTree::MatrixDynSize *", 0, 0, (void*)"iDynTree.MatrixDynSize", 0};
 static swig_type_info _swigt__p_iDynTree__MatrixFixSizeT_10_16_t = {"_p_iDynTree__MatrixFixSizeT_10_16_t", "iDynTree::MatrixFixSize< 10,16 > *|iDynTree::Matrix10x16 *", 0, 0, (void*)"iDynTree.Matrix10x16", 0};
 static swig_type_info _swigt__p_iDynTree__MatrixFixSizeT_1_6_t = {"_p_iDynTree__MatrixFixSizeT_1_6_t", "iDynTree::Matrix1x6 *|iDynTree::MatrixFixSize< 1,6 > *", 0, 0, (void*)0, 0};
@@ -59377,6 +59982,7 @@ static swig_type_info _swigt__p_iDynTree__TransformDerivative = {"_p_iDynTree__T
 static swig_type_info _swigt__p_iDynTree__TransformSemantics = {"_p_iDynTree__TransformSemantics", "iDynTree::TransformSemantics *", 0, 0, (void*)"iDynTree.TransformSemantics", 0};
 static swig_type_info _swigt__p_iDynTree__Traversal = {"_p_iDynTree__Traversal", "iDynTree::Traversal *", 0, 0, (void*)"iDynTree.Traversal", 0};
 static swig_type_info _swigt__p_iDynTree__Twist = {"_p_iDynTree__Twist", "iDynTree::Twist *", 0, 0, (void*)"iDynTree.Twist", 0};
+static swig_type_info _swigt__p_iDynTree__URDFParserOptions = {"_p_iDynTree__URDFParserOptions", "iDynTree::URDFParserOptions *", 0, 0, (void*)"iDynTree.URDFParserOptions", 0};
 static swig_type_info _swigt__p_iDynTree__UnknownWrenchContact = {"_p_iDynTree__UnknownWrenchContact", "iDynTree::UnknownWrenchContact *", 0, 0, (void*)"iDynTree.UnknownWrenchContact", 0};
 static swig_type_info _swigt__p_iDynTree__VectorDynSize = {"_p_iDynTree__VectorDynSize", "iDynTree::VectorDynSize *", 0, 0, (void*)"iDynTree.VectorDynSize", 0};
 static swig_type_info _swigt__p_iDynTree__VectorFixSizeT_10_t = {"_p_iDynTree__VectorFixSizeT_10_t", "iDynTree::VectorFixSize< 10 > *|iDynTree::Vector10 *", 0, 0, (void*)"iDynTree.Vector10", 0};
@@ -59525,6 +60131,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_iDynTree__TransformSemantics,
   &_swigt__p_iDynTree__Traversal,
   &_swigt__p_iDynTree__Twist,
+  &_swigt__p_iDynTree__URDFParserOptions,
   &_swigt__p_iDynTree__UnknownWrenchContact,
   &_swigt__p_iDynTree__VectorDynSize,
   &_swigt__p_iDynTree__VectorFixSizeT_10_t,
@@ -59673,6 +60280,7 @@ static swig_cast_info _swigc__p_iDynTree__TransformDerivative[] = {  {&_swigt__p
 static swig_cast_info _swigc__p_iDynTree__TransformSemantics[] = {  {&_swigt__p_iDynTree__TransformSemantics, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_iDynTree__Traversal[] = {  {&_swigt__p_iDynTree__Traversal, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_iDynTree__Twist[] = {  {&_swigt__p_iDynTree__Twist, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_iDynTree__URDFParserOptions[] = {  {&_swigt__p_iDynTree__URDFParserOptions, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_iDynTree__UnknownWrenchContact[] = {  {&_swigt__p_iDynTree__UnknownWrenchContact, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_iDynTree__VectorDynSize[] = {  {&_swigt__p_iDynTree__VectorDynSize, 0, 0, 0},  {&_swigt__p_iDynTree__JointPosDoubleArray, _p_iDynTree__JointPosDoubleArrayTo_p_iDynTree__VectorDynSize, 0, 0},  {&_swigt__p_iDynTree__JointDOFsDoubleArray, _p_iDynTree__JointDOFsDoubleArrayTo_p_iDynTree__VectorDynSize, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_iDynTree__VectorFixSizeT_10_t[] = {  {&_swigt__p_iDynTree__VectorFixSizeT_10_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -59821,6 +60429,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_iDynTree__TransformSemantics,
   _swigc__p_iDynTree__Traversal,
   _swigc__p_iDynTree__Twist,
+  _swigc__p_iDynTree__URDFParserOptions,
   _swigc__p_iDynTree__UnknownWrenchContact,
   _swigc__p_iDynTree__VectorDynSize,
   _swigc__p_iDynTree__VectorFixSizeT_10_t,
@@ -61039,366 +61648,379 @@ const char* swigFunctionName_(int fcn_id) {
   case 848: return "Model_getJointIndex";
   case 849: return "Model_getJoint";
   case 850: return "Model_isValidJointIndex";
-  case 851: return "Model_addJoint";
-  case 852: return "Model_getNrOfPosCoords";
-  case 853: return "Model_getNrOfDOFs";
-  case 854: return "Model_getNrOfFrames";
-  case 855: return "Model_addAdditionalFrameToLink";
-  case 856: return "Model_getFrameName";
-  case 857: return "Model_getFrameIndex";
-  case 858: return "Model_isValidFrameIndex";
-  case 859: return "Model_getFrameTransform";
-  case 860: return "Model_getFrameLink";
-  case 861: return "Model_getNrOfNeighbors";
-  case 862: return "Model_getNeighbor";
-  case 863: return "Model_setDefaultBaseLink";
-  case 864: return "Model_getDefaultBaseLink";
-  case 865: return "Model_computeFullTreeTraversal";
-  case 866: return "Model_toString";
-  case 867: return "new_JointPosDoubleArray";
-  case 868: return "JointPosDoubleArray_resize";
-  case 869: return "JointPosDoubleArray_isConsistent";
-  case 870: return "delete_JointPosDoubleArray";
-  case 871: return "new_JointDOFsDoubleArray";
-  case 872: return "JointDOFsDoubleArray_resize";
-  case 873: return "JointDOFsDoubleArray_isConsistent";
-  case 874: return "delete_JointDOFsDoubleArray";
-  case 875: return "new_DOFSpatialForceArray";
-  case 876: return "DOFSpatialForceArray_resize";
-  case 877: return "DOFSpatialForceArray_isConsistent";
-  case 878: return "DOFSpatialForceArray_paren";
-  case 879: return "delete_DOFSpatialForceArray";
-  case 880: return "new_DOFSpatialMotionArray";
-  case 881: return "DOFSpatialMotionArray_resize";
-  case 882: return "DOFSpatialMotionArray_isConsistent";
-  case 883: return "DOFSpatialMotionArray_paren";
-  case 884: return "delete_DOFSpatialMotionArray";
-  case 885: return "new_FreeFloatingMassMatrix";
-  case 886: return "FreeFloatingMassMatrix_resize";
-  case 887: return "delete_FreeFloatingMassMatrix";
-  case 888: return "new_FreeFloatingPos";
-  case 889: return "FreeFloatingPos_resize";
-  case 890: return "FreeFloatingPos_worldBasePos";
-  case 891: return "FreeFloatingPos_jointPos";
-  case 892: return "FreeFloatingPos_getNrOfPosCoords";
-  case 893: return "delete_FreeFloatingPos";
-  case 894: return "new_FreeFloatingGeneralizedTorques";
-  case 895: return "FreeFloatingGeneralizedTorques_resize";
-  case 896: return "FreeFloatingGeneralizedTorques_baseWrench";
-  case 897: return "FreeFloatingGeneralizedTorques_jointTorques";
-  case 898: return "FreeFloatingGeneralizedTorques_getNrOfDOFs";
-  case 899: return "delete_FreeFloatingGeneralizedTorques";
-  case 900: return "new_FreeFloatingVel";
-  case 901: return "FreeFloatingVel_resize";
-  case 902: return "FreeFloatingVel_baseVel";
-  case 903: return "FreeFloatingVel_jointVel";
-  case 904: return "FreeFloatingVel_getNrOfDOFs";
-  case 905: return "delete_FreeFloatingVel";
-  case 906: return "new_FreeFloatingAcc";
-  case 907: return "FreeFloatingAcc_resize";
-  case 908: return "FreeFloatingAcc_baseAcc";
-  case 909: return "FreeFloatingAcc_jointAcc";
-  case 910: return "FreeFloatingAcc_getNrOfDOFs";
-  case 911: return "delete_FreeFloatingAcc";
-  case 912: return "ContactWrench_contactPoint";
-  case 913: return "ContactWrench_contactWrench";
-  case 914: return "ContactWrench_contactId";
-  case 915: return "new_ContactWrench";
-  case 916: return "delete_ContactWrench";
-  case 917: return "new_LinkContactWrenches";
-  case 918: return "LinkContactWrenches_resize";
-  case 919: return "LinkContactWrenches_getNrOfContactsForLink";
-  case 920: return "LinkContactWrenches_setNrOfContactsForLink";
-  case 921: return "LinkContactWrenches_getNrOfLinks";
-  case 922: return "LinkContactWrenches_contactWrench";
-  case 923: return "LinkContactWrenches_computeNetWrenches";
-  case 924: return "LinkContactWrenches_toString";
-  case 925: return "delete_LinkContactWrenches";
-  case 926: return "_wrap_ForwardPositionKinematics";
-  case 927: return "_wrap_ForwardVelAccKinematics";
-  case 928: return "_wrap_ForwardPosVelAccKinematics";
-  case 929: return "_wrap_RNEADynamicPhase";
-  case 930: return "_wrap_CompositeRigidBodyAlgorithm";
-  case 931: return "new_ArticulatedBodyAlgorithmInternalBuffers";
-  case 932: return "ArticulatedBodyAlgorithmInternalBuffers_resize";
-  case 933: return "ArticulatedBodyAlgorithmInternalBuffers_isConsistent";
-  case 934: return "ArticulatedBodyAlgorithmInternalBuffers_S_get";
-  case 935: return "ArticulatedBodyAlgorithmInternalBuffers_S_set";
-  case 936: return "ArticulatedBodyAlgorithmInternalBuffers_U_get";
-  case 937: return "ArticulatedBodyAlgorithmInternalBuffers_U_set";
-  case 938: return "ArticulatedBodyAlgorithmInternalBuffers_D_get";
-  case 939: return "ArticulatedBodyAlgorithmInternalBuffers_D_set";
-  case 940: return "ArticulatedBodyAlgorithmInternalBuffers_u_get";
-  case 941: return "ArticulatedBodyAlgorithmInternalBuffers_u_set";
-  case 942: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_get";
-  case 943: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_set";
-  case 944: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get";
-  case 945: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set";
-  case 946: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get";
-  case 947: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set";
-  case 948: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get";
-  case 949: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set";
-  case 950: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get";
-  case 951: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set";
-  case 952: return "delete_ArticulatedBodyAlgorithmInternalBuffers";
-  case 953: return "_wrap_ArticulatedBodyAlgorithm";
-  case 954: return "_wrap_modelFromURDF";
-  case 955: return "_wrap_modelFromURDFString";
-  case 956: return "NR_OF_SENSOR_TYPES_get";
-  case 957: return "delete_Sensor";
-  case 958: return "Sensor_getName";
-  case 959: return "Sensor_getSensorType";
-  case 960: return "Sensor_isValid";
-  case 961: return "Sensor_setName";
-  case 962: return "Sensor_clone";
-  case 963: return "Sensor_updateIndeces";
-  case 964: return "delete_JointSensor";
-  case 965: return "JointSensor_getParentJoint";
-  case 966: return "JointSensor_getParentJointIndex";
-  case 967: return "JointSensor_setParentJoint";
-  case 968: return "JointSensor_setParentJointIndex";
-  case 969: return "delete_LinkSensor";
-  case 970: return "LinkSensor_getParentLink";
-  case 971: return "LinkSensor_getParentLinkIndex";
-  case 972: return "LinkSensor_setParentLink";
-  case 973: return "LinkSensor_setParentLinkIndex";
-  case 974: return "new_SensorsList";
-  case 975: return "delete_SensorsList";
-  case 976: return "SensorsList_addSensor";
-  case 977: return "SensorsList_setSerialization";
-  case 978: return "SensorsList_getSerialization";
-  case 979: return "SensorsList_getNrOfSensors";
-  case 980: return "SensorsList_getSensorIndex";
-  case 981: return "SensorsList_getSensor";
-  case 982: return "SensorsList_getSixAxisForceTorqueSensor";
-  case 983: return "SensorsList_getAccelerometerSensor";
-  case 984: return "SensorsList_getGyroscopeSensor";
-  case 985: return "new_SensorsMeasurements";
-  case 986: return "delete_SensorsMeasurements";
-  case 987: return "SensorsMeasurements_setNrOfSensors";
-  case 988: return "SensorsMeasurements_getNrOfSensors";
-  case 989: return "SensorsMeasurements_resize";
-  case 990: return "SensorsMeasurements_toVector";
-  case 991: return "SensorsMeasurements_setMeasurement";
-  case 992: return "SensorsMeasurements_getMeasurement";
-  case 993: return "new_SixAxisForceTorqueSensor";
-  case 994: return "delete_SixAxisForceTorqueSensor";
-  case 995: return "SixAxisForceTorqueSensor_setName";
-  case 996: return "SixAxisForceTorqueSensor_setFirstLinkSensorTransform";
-  case 997: return "SixAxisForceTorqueSensor_setSecondLinkSensorTransform";
-  case 998: return "SixAxisForceTorqueSensor_getFirstLinkIndex";
-  case 999: return "SixAxisForceTorqueSensor_getSecondLinkIndex";
-  case 1000: return "SixAxisForceTorqueSensor_setFirstLinkName";
-  case 1001: return "SixAxisForceTorqueSensor_setSecondLinkName";
-  case 1002: return "SixAxisForceTorqueSensor_getFirstLinkName";
-  case 1003: return "SixAxisForceTorqueSensor_getSecondLinkName";
-  case 1004: return "SixAxisForceTorqueSensor_setParentJoint";
-  case 1005: return "SixAxisForceTorqueSensor_setParentJointIndex";
-  case 1006: return "SixAxisForceTorqueSensor_setAppliedWrenchLink";
-  case 1007: return "SixAxisForceTorqueSensor_getName";
-  case 1008: return "SixAxisForceTorqueSensor_getSensorType";
-  case 1009: return "SixAxisForceTorqueSensor_getParentJoint";
-  case 1010: return "SixAxisForceTorqueSensor_getParentJointIndex";
-  case 1011: return "SixAxisForceTorqueSensor_isValid";
-  case 1012: return "SixAxisForceTorqueSensor_clone";
-  case 1013: return "SixAxisForceTorqueSensor_updateIndeces";
-  case 1014: return "SixAxisForceTorqueSensor_getAppliedWrenchLink";
-  case 1015: return "SixAxisForceTorqueSensor_isLinkAttachedToSensor";
-  case 1016: return "SixAxisForceTorqueSensor_getLinkSensorTransform";
-  case 1017: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLink";
-  case 1018: return "SixAxisForceTorqueSensor_predictMeasurement";
-  case 1019: return "SixAxisForceTorqueSensor_toString";
-  case 1020: return "new_AccelerometerSensor";
-  case 1021: return "delete_AccelerometerSensor";
-  case 1022: return "AccelerometerSensor_setName";
-  case 1023: return "AccelerometerSensor_setLinkSensorTransform";
-  case 1024: return "AccelerometerSensor_setParentLink";
-  case 1025: return "AccelerometerSensor_setParentLinkIndex";
-  case 1026: return "AccelerometerSensor_getName";
-  case 1027: return "AccelerometerSensor_getSensorType";
-  case 1028: return "AccelerometerSensor_getParentLink";
-  case 1029: return "AccelerometerSensor_getParentLinkIndex";
-  case 1030: return "AccelerometerSensor_isValid";
-  case 1031: return "AccelerometerSensor_clone";
-  case 1032: return "AccelerometerSensor_updateIndeces";
-  case 1033: return "AccelerometerSensor_getLinkSensorTransform";
-  case 1034: return "AccelerometerSensor_predictMeasurement";
-  case 1035: return "new_GyroscopeSensor";
-  case 1036: return "delete_GyroscopeSensor";
-  case 1037: return "GyroscopeSensor_setName";
-  case 1038: return "GyroscopeSensor_setLinkSensorTransform";
-  case 1039: return "GyroscopeSensor_setParentLink";
-  case 1040: return "GyroscopeSensor_setParentLinkIndex";
-  case 1041: return "GyroscopeSensor_getName";
-  case 1042: return "GyroscopeSensor_getSensorType";
-  case 1043: return "GyroscopeSensor_getParentLink";
-  case 1044: return "GyroscopeSensor_getParentLinkIndex";
-  case 1045: return "GyroscopeSensor_isValid";
-  case 1046: return "GyroscopeSensor_clone";
-  case 1047: return "GyroscopeSensor_updateIndeces";
-  case 1048: return "GyroscopeSensor_getLinkSensorTransform";
-  case 1049: return "GyroscopeSensor_predictMeasurement";
-  case 1050: return "_wrap_predictSensorsMeasurements";
-  case 1051: return "_wrap_predictSensorsMeasurementsFromRawBuffers";
-  case 1052: return "_wrap_sensorsListFromURDF";
-  case 1053: return "_wrap_sensorsListFromURDFString";
-  case 1054: return "new_UnknownWrenchContact";
-  case 1055: return "UnknownWrenchContact_unknownType_get";
-  case 1056: return "UnknownWrenchContact_unknownType_set";
-  case 1057: return "UnknownWrenchContact_contactPoint_get";
-  case 1058: return "UnknownWrenchContact_contactPoint_set";
-  case 1059: return "UnknownWrenchContact_forceDirection_get";
-  case 1060: return "UnknownWrenchContact_forceDirection_set";
-  case 1061: return "UnknownWrenchContact_contactId_get";
-  case 1062: return "UnknownWrenchContact_contactId_set";
-  case 1063: return "delete_UnknownWrenchContact";
-  case 1064: return "new_LinkUnknownWrenchContacts";
-  case 1065: return "LinkUnknownWrenchContacts_clear";
-  case 1066: return "LinkUnknownWrenchContacts_resize";
-  case 1067: return "LinkUnknownWrenchContacts_getNrOfContactsForLink";
-  case 1068: return "LinkUnknownWrenchContacts_setNrOfContactsForLink";
-  case 1069: return "LinkUnknownWrenchContacts_addNewContactForLink";
-  case 1070: return "LinkUnknownWrenchContacts_addNewContactInFrame";
-  case 1071: return "LinkUnknownWrenchContacts_contactWrench";
-  case 1072: return "LinkUnknownWrenchContacts_toString";
-  case 1073: return "delete_LinkUnknownWrenchContacts";
-  case 1074: return "new_estimateExternalWrenchesBuffers";
-  case 1075: return "estimateExternalWrenchesBuffers_resize";
-  case 1076: return "estimateExternalWrenchesBuffers_getNrOfSubModels";
-  case 1077: return "estimateExternalWrenchesBuffers_getNrOfLinks";
-  case 1078: return "estimateExternalWrenchesBuffers_isConsistent";
-  case 1079: return "estimateExternalWrenchesBuffers_A_get";
-  case 1080: return "estimateExternalWrenchesBuffers_A_set";
-  case 1081: return "estimateExternalWrenchesBuffers_x_get";
-  case 1082: return "estimateExternalWrenchesBuffers_x_set";
-  case 1083: return "estimateExternalWrenchesBuffers_b_get";
-  case 1084: return "estimateExternalWrenchesBuffers_b_set";
-  case 1085: return "estimateExternalWrenchesBuffers_pinvA_get";
-  case 1086: return "estimateExternalWrenchesBuffers_pinvA_set";
-  case 1087: return "estimateExternalWrenchesBuffers_b_contacts_subtree_get";
-  case 1088: return "estimateExternalWrenchesBuffers_b_contacts_subtree_set";
-  case 1089: return "estimateExternalWrenchesBuffers_subModelBase_H_link_get";
-  case 1090: return "estimateExternalWrenchesBuffers_subModelBase_H_link_set";
-  case 1091: return "delete_estimateExternalWrenchesBuffers";
-  case 1092: return "_wrap_estimateExternalWrenchesWithoutInternalFT";
-  case 1093: return "_wrap_estimateExternalWrenches";
-  case 1094: return "_wrap_dynamicsEstimationForwardVelAccKinematics";
-  case 1095: return "new_ExtWrenchesAndJointTorquesEstimator";
-  case 1096: return "delete_ExtWrenchesAndJointTorquesEstimator";
-  case 1097: return "ExtWrenchesAndJointTorquesEstimator_setModelAndSensors";
-  case 1098: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile";
-  case 1099: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs";
-  case 1100: return "ExtWrenchesAndJointTorquesEstimator_model";
-  case 1101: return "ExtWrenchesAndJointTorquesEstimator_sensors";
-  case 1102: return "ExtWrenchesAndJointTorquesEstimator_submodels";
-  case 1103: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase";
-  case 1104: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase";
-  case 1105: return "ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements";
-  case 1106: return "ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques";
-  case 1107: return "ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill";
-  case 1108: return "DynamicsRegressorParameter_category_get";
-  case 1109: return "DynamicsRegressorParameter_category_set";
-  case 1110: return "DynamicsRegressorParameter_elemIndex_get";
-  case 1111: return "DynamicsRegressorParameter_elemIndex_set";
-  case 1112: return "DynamicsRegressorParameter_type_get";
-  case 1113: return "DynamicsRegressorParameter_type_set";
-  case 1114: return "DynamicsRegressorParameter_lt";
-  case 1115: return "DynamicsRegressorParameter_eq";
-  case 1116: return "DynamicsRegressorParameter_ne";
-  case 1117: return "new_DynamicsRegressorParameter";
-  case 1118: return "delete_DynamicsRegressorParameter";
-  case 1119: return "DynamicsRegressorParametersList_parameters_get";
-  case 1120: return "DynamicsRegressorParametersList_parameters_set";
-  case 1121: return "DynamicsRegressorParametersList_getDescriptionOfParameter";
-  case 1122: return "DynamicsRegressorParametersList_addParam";
-  case 1123: return "DynamicsRegressorParametersList_addList";
-  case 1124: return "DynamicsRegressorParametersList_findParam";
-  case 1125: return "DynamicsRegressorParametersList_getNrOfParameters";
-  case 1126: return "new_DynamicsRegressorParametersList";
-  case 1127: return "delete_DynamicsRegressorParametersList";
-  case 1128: return "new_DynamicsRegressorGenerator";
-  case 1129: return "delete_DynamicsRegressorGenerator";
-  case 1130: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile";
-  case 1131: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString";
-  case 1132: return "DynamicsRegressorGenerator_loadRegressorStructureFromFile";
-  case 1133: return "DynamicsRegressorGenerator_loadRegressorStructureFromString";
-  case 1134: return "DynamicsRegressorGenerator_isValid";
-  case 1135: return "DynamicsRegressorGenerator_getNrOfParameters";
-  case 1136: return "DynamicsRegressorGenerator_getNrOfOutputs";
-  case 1137: return "DynamicsRegressorGenerator_getNrOfDegreesOfFreedom";
-  case 1138: return "DynamicsRegressorGenerator_getDescriptionOfParameter";
-  case 1139: return "DynamicsRegressorGenerator_getDescriptionOfParameters";
-  case 1140: return "DynamicsRegressorGenerator_getDescriptionOfOutput";
-  case 1141: return "DynamicsRegressorGenerator_getDescriptionOfOutputs";
-  case 1142: return "DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom";
-  case 1143: return "DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom";
-  case 1144: return "DynamicsRegressorGenerator_getBaseLinkName";
-  case 1145: return "DynamicsRegressorGenerator_getSensorsModel";
-  case 1146: return "DynamicsRegressorGenerator_setRobotState";
-  case 1147: return "DynamicsRegressorGenerator_getSensorsMeasurements";
-  case 1148: return "DynamicsRegressorGenerator_computeRegressor";
-  case 1149: return "DynamicsRegressorGenerator_getModelParameters";
-  case 1150: return "DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace";
-  case 1151: return "DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace";
-  case 1152: return "new_KinDynComputations";
-  case 1153: return "delete_KinDynComputations";
-  case 1154: return "KinDynComputations_loadRobotModel";
-  case 1155: return "KinDynComputations_loadRobotModelFromFile";
-  case 1156: return "KinDynComputations_loadRobotModelFromString";
-  case 1157: return "KinDynComputations_isValid";
-  case 1158: return "KinDynComputations_getNrOfDegreesOfFreedom";
-  case 1159: return "KinDynComputations_getDescriptionOfDegreeOfFreedom";
-  case 1160: return "KinDynComputations_getDescriptionOfDegreesOfFreedom";
-  case 1161: return "KinDynComputations_getNrOfLinks";
-  case 1162: return "KinDynComputations_getNrOfFrames";
-  case 1163: return "KinDynComputations_getFloatingBase";
-  case 1164: return "KinDynComputations_setFloatingBase";
-  case 1165: return "KinDynComputations_getRobotModel";
-  case 1166: return "KinDynComputations_setRobotState";
-  case 1167: return "KinDynComputations_getWorldBaseTransform";
-  case 1168: return "KinDynComputations_getBaseTwist";
-  case 1169: return "KinDynComputations_getJointPos";
-  case 1170: return "KinDynComputations_getJointVel";
-  case 1171: return "KinDynComputations_getFrameIndex";
-  case 1172: return "KinDynComputations_getFrameName";
-  case 1173: return "KinDynComputations_getWorldTransform";
-  case 1174: return "KinDynComputations_getRelativeTransformExplicit";
-  case 1175: return "KinDynComputations_getRelativeTransform";
-  case 1176: return "new_DynamicsComputations";
-  case 1177: return "delete_DynamicsComputations";
-  case 1178: return "DynamicsComputations_loadRobotModelFromFile";
-  case 1179: return "DynamicsComputations_loadRobotModelFromString";
-  case 1180: return "DynamicsComputations_isValid";
-  case 1181: return "DynamicsComputations_getNrOfDegreesOfFreedom";
-  case 1182: return "DynamicsComputations_getDescriptionOfDegreeOfFreedom";
-  case 1183: return "DynamicsComputations_getDescriptionOfDegreesOfFreedom";
-  case 1184: return "DynamicsComputations_getNrOfLinks";
-  case 1185: return "DynamicsComputations_getNrOfFrames";
-  case 1186: return "DynamicsComputations_getFloatingBase";
-  case 1187: return "DynamicsComputations_setFloatingBase";
-  case 1188: return "DynamicsComputations_setRobotState";
-  case 1189: return "DynamicsComputations_getWorldBaseTransform";
-  case 1190: return "DynamicsComputations_getBaseTwist";
-  case 1191: return "DynamicsComputations_getJointPos";
-  case 1192: return "DynamicsComputations_getJointVel";
-  case 1193: return "DynamicsComputations_getFrameIndex";
-  case 1194: return "DynamicsComputations_getFrameName";
-  case 1195: return "DynamicsComputations_getWorldTransform";
-  case 1196: return "DynamicsComputations_getRelativeTransform";
-  case 1197: return "DynamicsComputations_getFrameTwist";
-  case 1198: return "DynamicsComputations_getFrameTwistInWorldOrient";
-  case 1199: return "DynamicsComputations_getFrameProperSpatialAcceleration";
-  case 1200: return "DynamicsComputations_getLinkIndex";
-  case 1201: return "DynamicsComputations_getLinkInertia";
-  case 1202: return "DynamicsComputations_getJointIndex";
-  case 1203: return "DynamicsComputations_getJointName";
-  case 1204: return "DynamicsComputations_getJointLimits";
-  case 1205: return "DynamicsComputations_inverseDynamics";
-  case 1206: return "DynamicsComputations_getFrameJacobian";
-  case 1207: return "DynamicsComputations_getDynamicsRegressor";
-  case 1208: return "DynamicsComputations_getModelDynamicsParameters";
-  case 1209: return "DynamicsComputations_getCenterOfMass";
-  case 1210: return "DynamicsComputations_getCenterOfMassJacobian";
+  case 851: return "Model_isLinkNameUsed";
+  case 852: return "Model_isJointNameUsed";
+  case 853: return "Model_isFrameNameUsed";
+  case 854: return "Model_addJoint";
+  case 855: return "Model_getNrOfPosCoords";
+  case 856: return "Model_getNrOfDOFs";
+  case 857: return "Model_getNrOfFrames";
+  case 858: return "Model_addAdditionalFrameToLink";
+  case 859: return "Model_getFrameName";
+  case 860: return "Model_getFrameIndex";
+  case 861: return "Model_isValidFrameIndex";
+  case 862: return "Model_getFrameTransform";
+  case 863: return "Model_getFrameLink";
+  case 864: return "Model_getNrOfNeighbors";
+  case 865: return "Model_getNeighbor";
+  case 866: return "Model_setDefaultBaseLink";
+  case 867: return "Model_getDefaultBaseLink";
+  case 868: return "Model_computeFullTreeTraversal";
+  case 869: return "Model_toString";
+  case 870: return "new_JointPosDoubleArray";
+  case 871: return "JointPosDoubleArray_resize";
+  case 872: return "JointPosDoubleArray_isConsistent";
+  case 873: return "delete_JointPosDoubleArray";
+  case 874: return "new_JointDOFsDoubleArray";
+  case 875: return "JointDOFsDoubleArray_resize";
+  case 876: return "JointDOFsDoubleArray_isConsistent";
+  case 877: return "delete_JointDOFsDoubleArray";
+  case 878: return "new_DOFSpatialForceArray";
+  case 879: return "DOFSpatialForceArray_resize";
+  case 880: return "DOFSpatialForceArray_isConsistent";
+  case 881: return "DOFSpatialForceArray_paren";
+  case 882: return "delete_DOFSpatialForceArray";
+  case 883: return "new_DOFSpatialMotionArray";
+  case 884: return "DOFSpatialMotionArray_resize";
+  case 885: return "DOFSpatialMotionArray_isConsistent";
+  case 886: return "DOFSpatialMotionArray_paren";
+  case 887: return "delete_DOFSpatialMotionArray";
+  case 888: return "new_FreeFloatingMassMatrix";
+  case 889: return "FreeFloatingMassMatrix_resize";
+  case 890: return "delete_FreeFloatingMassMatrix";
+  case 891: return "new_FreeFloatingPos";
+  case 892: return "FreeFloatingPos_resize";
+  case 893: return "FreeFloatingPos_worldBasePos";
+  case 894: return "FreeFloatingPos_jointPos";
+  case 895: return "FreeFloatingPos_getNrOfPosCoords";
+  case 896: return "delete_FreeFloatingPos";
+  case 897: return "new_FreeFloatingGeneralizedTorques";
+  case 898: return "FreeFloatingGeneralizedTorques_resize";
+  case 899: return "FreeFloatingGeneralizedTorques_baseWrench";
+  case 900: return "FreeFloatingGeneralizedTorques_jointTorques";
+  case 901: return "FreeFloatingGeneralizedTorques_getNrOfDOFs";
+  case 902: return "delete_FreeFloatingGeneralizedTorques";
+  case 903: return "new_FreeFloatingVel";
+  case 904: return "FreeFloatingVel_resize";
+  case 905: return "FreeFloatingVel_baseVel";
+  case 906: return "FreeFloatingVel_jointVel";
+  case 907: return "FreeFloatingVel_getNrOfDOFs";
+  case 908: return "delete_FreeFloatingVel";
+  case 909: return "new_FreeFloatingAcc";
+  case 910: return "FreeFloatingAcc_resize";
+  case 911: return "FreeFloatingAcc_baseAcc";
+  case 912: return "FreeFloatingAcc_jointAcc";
+  case 913: return "FreeFloatingAcc_getNrOfDOFs";
+  case 914: return "delete_FreeFloatingAcc";
+  case 915: return "ContactWrench_contactPoint";
+  case 916: return "ContactWrench_contactWrench";
+  case 917: return "ContactWrench_contactId";
+  case 918: return "new_ContactWrench";
+  case 919: return "delete_ContactWrench";
+  case 920: return "new_LinkContactWrenches";
+  case 921: return "LinkContactWrenches_resize";
+  case 922: return "LinkContactWrenches_getNrOfContactsForLink";
+  case 923: return "LinkContactWrenches_setNrOfContactsForLink";
+  case 924: return "LinkContactWrenches_getNrOfLinks";
+  case 925: return "LinkContactWrenches_contactWrench";
+  case 926: return "LinkContactWrenches_computeNetWrenches";
+  case 927: return "LinkContactWrenches_toString";
+  case 928: return "delete_LinkContactWrenches";
+  case 929: return "_wrap_ForwardPositionKinematics";
+  case 930: return "_wrap_ForwardVelAccKinematics";
+  case 931: return "_wrap_ForwardPosVelAccKinematics";
+  case 932: return "_wrap_RNEADynamicPhase";
+  case 933: return "_wrap_CompositeRigidBodyAlgorithm";
+  case 934: return "new_ArticulatedBodyAlgorithmInternalBuffers";
+  case 935: return "ArticulatedBodyAlgorithmInternalBuffers_resize";
+  case 936: return "ArticulatedBodyAlgorithmInternalBuffers_isConsistent";
+  case 937: return "ArticulatedBodyAlgorithmInternalBuffers_S_get";
+  case 938: return "ArticulatedBodyAlgorithmInternalBuffers_S_set";
+  case 939: return "ArticulatedBodyAlgorithmInternalBuffers_U_get";
+  case 940: return "ArticulatedBodyAlgorithmInternalBuffers_U_set";
+  case 941: return "ArticulatedBodyAlgorithmInternalBuffers_D_get";
+  case 942: return "ArticulatedBodyAlgorithmInternalBuffers_D_set";
+  case 943: return "ArticulatedBodyAlgorithmInternalBuffers_u_get";
+  case 944: return "ArticulatedBodyAlgorithmInternalBuffers_u_set";
+  case 945: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_get";
+  case 946: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_set";
+  case 947: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get";
+  case 948: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set";
+  case 949: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get";
+  case 950: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set";
+  case 951: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get";
+  case 952: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set";
+  case 953: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get";
+  case 954: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set";
+  case 955: return "delete_ArticulatedBodyAlgorithmInternalBuffers";
+  case 956: return "_wrap_ArticulatedBodyAlgorithm";
+  case 957: return "URDFParserOptions_addSensorFramesAsAdditionalFrames_get";
+  case 958: return "URDFParserOptions_addSensorFramesAsAdditionalFrames_set";
+  case 959: return "new_URDFParserOptions";
+  case 960: return "delete_URDFParserOptions";
+  case 961: return "_wrap_modelFromURDF";
+  case 962: return "_wrap_modelFromURDFString";
+  case 963: return "NR_OF_SENSOR_TYPES_get";
+  case 964: return "_wrap_isLinkSensor";
+  case 965: return "_wrap_isJointSensor";
+  case 966: return "delete_Sensor";
+  case 967: return "Sensor_getName";
+  case 968: return "Sensor_getSensorType";
+  case 969: return "Sensor_isValid";
+  case 970: return "Sensor_setName";
+  case 971: return "Sensor_clone";
+  case 972: return "Sensor_updateIndeces";
+  case 973: return "delete_JointSensor";
+  case 974: return "JointSensor_getParentJoint";
+  case 975: return "JointSensor_getParentJointIndex";
+  case 976: return "JointSensor_setParentJoint";
+  case 977: return "JointSensor_setParentJointIndex";
+  case 978: return "delete_LinkSensor";
+  case 979: return "LinkSensor_getParentLink";
+  case 980: return "LinkSensor_getParentLinkIndex";
+  case 981: return "LinkSensor_getLinkSensorTransform";
+  case 982: return "LinkSensor_setParentLink";
+  case 983: return "LinkSensor_setParentLinkIndex";
+  case 984: return "new_SensorsList";
+  case 985: return "delete_SensorsList";
+  case 986: return "SensorsList_addSensor";
+  case 987: return "SensorsList_setSerialization";
+  case 988: return "SensorsList_getSerialization";
+  case 989: return "SensorsList_getNrOfSensors";
+  case 990: return "SensorsList_getSensorIndex";
+  case 991: return "SensorsList_getSensor";
+  case 992: return "SensorsList_getSixAxisForceTorqueSensor";
+  case 993: return "SensorsList_getAccelerometerSensor";
+  case 994: return "SensorsList_getGyroscopeSensor";
+  case 995: return "new_SensorsMeasurements";
+  case 996: return "delete_SensorsMeasurements";
+  case 997: return "SensorsMeasurements_setNrOfSensors";
+  case 998: return "SensorsMeasurements_getNrOfSensors";
+  case 999: return "SensorsMeasurements_resize";
+  case 1000: return "SensorsMeasurements_toVector";
+  case 1001: return "SensorsMeasurements_setMeasurement";
+  case 1002: return "SensorsMeasurements_getMeasurement";
+  case 1003: return "new_SixAxisForceTorqueSensor";
+  case 1004: return "delete_SixAxisForceTorqueSensor";
+  case 1005: return "SixAxisForceTorqueSensor_setName";
+  case 1006: return "SixAxisForceTorqueSensor_setFirstLinkSensorTransform";
+  case 1007: return "SixAxisForceTorqueSensor_setSecondLinkSensorTransform";
+  case 1008: return "SixAxisForceTorqueSensor_getFirstLinkIndex";
+  case 1009: return "SixAxisForceTorqueSensor_getSecondLinkIndex";
+  case 1010: return "SixAxisForceTorqueSensor_setFirstLinkName";
+  case 1011: return "SixAxisForceTorqueSensor_setSecondLinkName";
+  case 1012: return "SixAxisForceTorqueSensor_getFirstLinkName";
+  case 1013: return "SixAxisForceTorqueSensor_getSecondLinkName";
+  case 1014: return "SixAxisForceTorqueSensor_setParentJoint";
+  case 1015: return "SixAxisForceTorqueSensor_setParentJointIndex";
+  case 1016: return "SixAxisForceTorqueSensor_setAppliedWrenchLink";
+  case 1017: return "SixAxisForceTorqueSensor_getName";
+  case 1018: return "SixAxisForceTorqueSensor_getSensorType";
+  case 1019: return "SixAxisForceTorqueSensor_getParentJoint";
+  case 1020: return "SixAxisForceTorqueSensor_getParentJointIndex";
+  case 1021: return "SixAxisForceTorqueSensor_isValid";
+  case 1022: return "SixAxisForceTorqueSensor_clone";
+  case 1023: return "SixAxisForceTorqueSensor_updateIndeces";
+  case 1024: return "SixAxisForceTorqueSensor_getAppliedWrenchLink";
+  case 1025: return "SixAxisForceTorqueSensor_isLinkAttachedToSensor";
+  case 1026: return "SixAxisForceTorqueSensor_getLinkSensorTransform";
+  case 1027: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLink";
+  case 1028: return "SixAxisForceTorqueSensor_predictMeasurement";
+  case 1029: return "SixAxisForceTorqueSensor_toString";
+  case 1030: return "new_AccelerometerSensor";
+  case 1031: return "delete_AccelerometerSensor";
+  case 1032: return "AccelerometerSensor_setName";
+  case 1033: return "AccelerometerSensor_setLinkSensorTransform";
+  case 1034: return "AccelerometerSensor_setParentLink";
+  case 1035: return "AccelerometerSensor_setParentLinkIndex";
+  case 1036: return "AccelerometerSensor_getName";
+  case 1037: return "AccelerometerSensor_getSensorType";
+  case 1038: return "AccelerometerSensor_getParentLink";
+  case 1039: return "AccelerometerSensor_getParentLinkIndex";
+  case 1040: return "AccelerometerSensor_getLinkSensorTransform";
+  case 1041: return "AccelerometerSensor_isValid";
+  case 1042: return "AccelerometerSensor_clone";
+  case 1043: return "AccelerometerSensor_updateIndeces";
+  case 1044: return "AccelerometerSensor_predictMeasurement";
+  case 1045: return "new_GyroscopeSensor";
+  case 1046: return "delete_GyroscopeSensor";
+  case 1047: return "GyroscopeSensor_setName";
+  case 1048: return "GyroscopeSensor_setLinkSensorTransform";
+  case 1049: return "GyroscopeSensor_setParentLink";
+  case 1050: return "GyroscopeSensor_setParentLinkIndex";
+  case 1051: return "GyroscopeSensor_getName";
+  case 1052: return "GyroscopeSensor_getSensorType";
+  case 1053: return "GyroscopeSensor_getParentLink";
+  case 1054: return "GyroscopeSensor_getParentLinkIndex";
+  case 1055: return "GyroscopeSensor_getLinkSensorTransform";
+  case 1056: return "GyroscopeSensor_isValid";
+  case 1057: return "GyroscopeSensor_clone";
+  case 1058: return "GyroscopeSensor_updateIndeces";
+  case 1059: return "GyroscopeSensor_predictMeasurement";
+  case 1060: return "_wrap_predictSensorsMeasurements";
+  case 1061: return "_wrap_predictSensorsMeasurementsFromRawBuffers";
+  case 1062: return "_wrap_sensorsListFromURDF";
+  case 1063: return "_wrap_sensorsListFromURDFString";
+  case 1064: return "new_UnknownWrenchContact";
+  case 1065: return "UnknownWrenchContact_unknownType_get";
+  case 1066: return "UnknownWrenchContact_unknownType_set";
+  case 1067: return "UnknownWrenchContact_contactPoint_get";
+  case 1068: return "UnknownWrenchContact_contactPoint_set";
+  case 1069: return "UnknownWrenchContact_forceDirection_get";
+  case 1070: return "UnknownWrenchContact_forceDirection_set";
+  case 1071: return "UnknownWrenchContact_contactId_get";
+  case 1072: return "UnknownWrenchContact_contactId_set";
+  case 1073: return "delete_UnknownWrenchContact";
+  case 1074: return "new_LinkUnknownWrenchContacts";
+  case 1075: return "LinkUnknownWrenchContacts_clear";
+  case 1076: return "LinkUnknownWrenchContacts_resize";
+  case 1077: return "LinkUnknownWrenchContacts_getNrOfContactsForLink";
+  case 1078: return "LinkUnknownWrenchContacts_setNrOfContactsForLink";
+  case 1079: return "LinkUnknownWrenchContacts_addNewContactForLink";
+  case 1080: return "LinkUnknownWrenchContacts_addNewContactInFrame";
+  case 1081: return "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin";
+  case 1082: return "LinkUnknownWrenchContacts_contactWrench";
+  case 1083: return "LinkUnknownWrenchContacts_toString";
+  case 1084: return "delete_LinkUnknownWrenchContacts";
+  case 1085: return "new_estimateExternalWrenchesBuffers";
+  case 1086: return "estimateExternalWrenchesBuffers_resize";
+  case 1087: return "estimateExternalWrenchesBuffers_getNrOfSubModels";
+  case 1088: return "estimateExternalWrenchesBuffers_getNrOfLinks";
+  case 1089: return "estimateExternalWrenchesBuffers_isConsistent";
+  case 1090: return "estimateExternalWrenchesBuffers_A_get";
+  case 1091: return "estimateExternalWrenchesBuffers_A_set";
+  case 1092: return "estimateExternalWrenchesBuffers_x_get";
+  case 1093: return "estimateExternalWrenchesBuffers_x_set";
+  case 1094: return "estimateExternalWrenchesBuffers_b_get";
+  case 1095: return "estimateExternalWrenchesBuffers_b_set";
+  case 1096: return "estimateExternalWrenchesBuffers_pinvA_get";
+  case 1097: return "estimateExternalWrenchesBuffers_pinvA_set";
+  case 1098: return "estimateExternalWrenchesBuffers_b_contacts_subtree_get";
+  case 1099: return "estimateExternalWrenchesBuffers_b_contacts_subtree_set";
+  case 1100: return "estimateExternalWrenchesBuffers_subModelBase_H_link_get";
+  case 1101: return "estimateExternalWrenchesBuffers_subModelBase_H_link_set";
+  case 1102: return "delete_estimateExternalWrenchesBuffers";
+  case 1103: return "_wrap_estimateExternalWrenchesWithoutInternalFT";
+  case 1104: return "_wrap_estimateExternalWrenches";
+  case 1105: return "_wrap_dynamicsEstimationForwardVelAccKinematics";
+  case 1106: return "_wrap_computeLinkNetWrenchesWithoutGravity";
+  case 1107: return "new_ExtWrenchesAndJointTorquesEstimator";
+  case 1108: return "delete_ExtWrenchesAndJointTorquesEstimator";
+  case 1109: return "ExtWrenchesAndJointTorquesEstimator_setModelAndSensors";
+  case 1110: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile";
+  case 1111: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs";
+  case 1112: return "ExtWrenchesAndJointTorquesEstimator_model";
+  case 1113: return "ExtWrenchesAndJointTorquesEstimator_sensors";
+  case 1114: return "ExtWrenchesAndJointTorquesEstimator_submodels";
+  case 1115: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase";
+  case 1116: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase";
+  case 1117: return "ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements";
+  case 1118: return "ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques";
+  case 1119: return "ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill";
+  case 1120: return "ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity";
+  case 1121: return "DynamicsRegressorParameter_category_get";
+  case 1122: return "DynamicsRegressorParameter_category_set";
+  case 1123: return "DynamicsRegressorParameter_elemIndex_get";
+  case 1124: return "DynamicsRegressorParameter_elemIndex_set";
+  case 1125: return "DynamicsRegressorParameter_type_get";
+  case 1126: return "DynamicsRegressorParameter_type_set";
+  case 1127: return "DynamicsRegressorParameter_lt";
+  case 1128: return "DynamicsRegressorParameter_eq";
+  case 1129: return "DynamicsRegressorParameter_ne";
+  case 1130: return "new_DynamicsRegressorParameter";
+  case 1131: return "delete_DynamicsRegressorParameter";
+  case 1132: return "DynamicsRegressorParametersList_parameters_get";
+  case 1133: return "DynamicsRegressorParametersList_parameters_set";
+  case 1134: return "DynamicsRegressorParametersList_getDescriptionOfParameter";
+  case 1135: return "DynamicsRegressorParametersList_addParam";
+  case 1136: return "DynamicsRegressorParametersList_addList";
+  case 1137: return "DynamicsRegressorParametersList_findParam";
+  case 1138: return "DynamicsRegressorParametersList_getNrOfParameters";
+  case 1139: return "new_DynamicsRegressorParametersList";
+  case 1140: return "delete_DynamicsRegressorParametersList";
+  case 1141: return "new_DynamicsRegressorGenerator";
+  case 1142: return "delete_DynamicsRegressorGenerator";
+  case 1143: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile";
+  case 1144: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString";
+  case 1145: return "DynamicsRegressorGenerator_loadRegressorStructureFromFile";
+  case 1146: return "DynamicsRegressorGenerator_loadRegressorStructureFromString";
+  case 1147: return "DynamicsRegressorGenerator_isValid";
+  case 1148: return "DynamicsRegressorGenerator_getNrOfParameters";
+  case 1149: return "DynamicsRegressorGenerator_getNrOfOutputs";
+  case 1150: return "DynamicsRegressorGenerator_getNrOfDegreesOfFreedom";
+  case 1151: return "DynamicsRegressorGenerator_getDescriptionOfParameter";
+  case 1152: return "DynamicsRegressorGenerator_getDescriptionOfParameters";
+  case 1153: return "DynamicsRegressorGenerator_getDescriptionOfOutput";
+  case 1154: return "DynamicsRegressorGenerator_getDescriptionOfOutputs";
+  case 1155: return "DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom";
+  case 1156: return "DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom";
+  case 1157: return "DynamicsRegressorGenerator_getBaseLinkName";
+  case 1158: return "DynamicsRegressorGenerator_getSensorsModel";
+  case 1159: return "DynamicsRegressorGenerator_setRobotState";
+  case 1160: return "DynamicsRegressorGenerator_getSensorsMeasurements";
+  case 1161: return "DynamicsRegressorGenerator_computeRegressor";
+  case 1162: return "DynamicsRegressorGenerator_getModelParameters";
+  case 1163: return "DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace";
+  case 1164: return "DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace";
+  case 1165: return "new_KinDynComputations";
+  case 1166: return "delete_KinDynComputations";
+  case 1167: return "KinDynComputations_loadRobotModel";
+  case 1168: return "KinDynComputations_loadRobotModelFromFile";
+  case 1169: return "KinDynComputations_loadRobotModelFromString";
+  case 1170: return "KinDynComputations_isValid";
+  case 1171: return "KinDynComputations_getNrOfDegreesOfFreedom";
+  case 1172: return "KinDynComputations_getDescriptionOfDegreeOfFreedom";
+  case 1173: return "KinDynComputations_getDescriptionOfDegreesOfFreedom";
+  case 1174: return "KinDynComputations_getNrOfLinks";
+  case 1175: return "KinDynComputations_getNrOfFrames";
+  case 1176: return "KinDynComputations_getFloatingBase";
+  case 1177: return "KinDynComputations_setFloatingBase";
+  case 1178: return "KinDynComputations_getRobotModel";
+  case 1179: return "KinDynComputations_setRobotState";
+  case 1180: return "KinDynComputations_getWorldBaseTransform";
+  case 1181: return "KinDynComputations_getBaseTwist";
+  case 1182: return "KinDynComputations_getJointPos";
+  case 1183: return "KinDynComputations_getJointVel";
+  case 1184: return "KinDynComputations_getFrameIndex";
+  case 1185: return "KinDynComputations_getFrameName";
+  case 1186: return "KinDynComputations_getWorldTransform";
+  case 1187: return "KinDynComputations_getRelativeTransformExplicit";
+  case 1188: return "KinDynComputations_getRelativeTransform";
+  case 1189: return "new_DynamicsComputations";
+  case 1190: return "delete_DynamicsComputations";
+  case 1191: return "DynamicsComputations_loadRobotModelFromFile";
+  case 1192: return "DynamicsComputations_loadRobotModelFromString";
+  case 1193: return "DynamicsComputations_isValid";
+  case 1194: return "DynamicsComputations_getNrOfDegreesOfFreedom";
+  case 1195: return "DynamicsComputations_getDescriptionOfDegreeOfFreedom";
+  case 1196: return "DynamicsComputations_getDescriptionOfDegreesOfFreedom";
+  case 1197: return "DynamicsComputations_getNrOfLinks";
+  case 1198: return "DynamicsComputations_getNrOfFrames";
+  case 1199: return "DynamicsComputations_getFloatingBase";
+  case 1200: return "DynamicsComputations_setFloatingBase";
+  case 1201: return "DynamicsComputations_setRobotState";
+  case 1202: return "DynamicsComputations_getWorldBaseTransform";
+  case 1203: return "DynamicsComputations_getBaseTwist";
+  case 1204: return "DynamicsComputations_getJointPos";
+  case 1205: return "DynamicsComputations_getJointVel";
+  case 1206: return "DynamicsComputations_getFrameIndex";
+  case 1207: return "DynamicsComputations_getFrameName";
+  case 1208: return "DynamicsComputations_getWorldTransform";
+  case 1209: return "DynamicsComputations_getRelativeTransform";
+  case 1210: return "DynamicsComputations_getFrameTwist";
+  case 1211: return "DynamicsComputations_getFrameTwistInWorldOrient";
+  case 1212: return "DynamicsComputations_getFrameProperSpatialAcceleration";
+  case 1213: return "DynamicsComputations_getLinkIndex";
+  case 1214: return "DynamicsComputations_getLinkInertia";
+  case 1215: return "DynamicsComputations_getJointIndex";
+  case 1216: return "DynamicsComputations_getJointName";
+  case 1217: return "DynamicsComputations_getJointLimits";
+  case 1218: return "DynamicsComputations_inverseDynamics";
+  case 1219: return "DynamicsComputations_getFrameJacobian";
+  case 1220: return "DynamicsComputations_getDynamicsRegressor";
+  case 1221: return "DynamicsComputations_getModelDynamicsParameters";
+  case 1222: return "DynamicsComputations_getCenterOfMass";
+  case 1223: return "DynamicsComputations_getCenterOfMassJacobian";
   default: return 0;
   }
 }
@@ -62306,366 +62928,379 @@ void mexFunction(int resc, mxArray *resv[], int argc, const mxArray *argv[]) {
   case 848: flag=_wrap_Model_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
   case 849: flag=_wrap_Model_getJoint(resc,resv,argc,(mxArray**)(argv)); break;
   case 850: flag=_wrap_Model_isValidJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 851: flag=_wrap_Model_addJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 852: flag=_wrap_Model_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 853: flag=_wrap_Model_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 854: flag=_wrap_Model_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
-  case 855: flag=_wrap_Model_addAdditionalFrameToLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 856: flag=_wrap_Model_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 857: flag=_wrap_Model_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 858: flag=_wrap_Model_isValidFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 859: flag=_wrap_Model_getFrameTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 860: flag=_wrap_Model_getFrameLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 861: flag=_wrap_Model_getNrOfNeighbors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 862: flag=_wrap_Model_getNeighbor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 863: flag=_wrap_Model_setDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 864: flag=_wrap_Model_getDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 865: flag=_wrap_Model_computeFullTreeTraversal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 866: flag=_wrap_Model_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 867: flag=_wrap_new_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 868: flag=_wrap_JointPosDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 869: flag=_wrap_JointPosDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 870: flag=_wrap_delete_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 871: flag=_wrap_new_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 872: flag=_wrap_JointDOFsDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 873: flag=_wrap_JointDOFsDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 874: flag=_wrap_delete_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 875: flag=_wrap_new_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 876: flag=_wrap_DOFSpatialForceArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 877: flag=_wrap_DOFSpatialForceArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 878: flag=_wrap_DOFSpatialForceArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 879: flag=_wrap_delete_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 880: flag=_wrap_new_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 881: flag=_wrap_DOFSpatialMotionArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 882: flag=_wrap_DOFSpatialMotionArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 883: flag=_wrap_DOFSpatialMotionArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 884: flag=_wrap_delete_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 885: flag=_wrap_new_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 886: flag=_wrap_FreeFloatingMassMatrix_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 887: flag=_wrap_delete_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 888: flag=_wrap_new_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 889: flag=_wrap_FreeFloatingPos_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 890: flag=_wrap_FreeFloatingPos_worldBasePos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 891: flag=_wrap_FreeFloatingPos_jointPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 892: flag=_wrap_FreeFloatingPos_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 893: flag=_wrap_delete_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 894: flag=_wrap_new_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 895: flag=_wrap_FreeFloatingGeneralizedTorques_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 896: flag=_wrap_FreeFloatingGeneralizedTorques_baseWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 897: flag=_wrap_FreeFloatingGeneralizedTorques_jointTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 898: flag=_wrap_FreeFloatingGeneralizedTorques_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 899: flag=_wrap_delete_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 900: flag=_wrap_new_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 901: flag=_wrap_FreeFloatingVel_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 902: flag=_wrap_FreeFloatingVel_baseVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 903: flag=_wrap_FreeFloatingVel_jointVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 904: flag=_wrap_FreeFloatingVel_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 905: flag=_wrap_delete_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 906: flag=_wrap_new_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 907: flag=_wrap_FreeFloatingAcc_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 908: flag=_wrap_FreeFloatingAcc_baseAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 909: flag=_wrap_FreeFloatingAcc_jointAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 910: flag=_wrap_FreeFloatingAcc_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 911: flag=_wrap_delete_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 912: flag=_wrap_ContactWrench_contactPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 913: flag=_wrap_ContactWrench_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 914: flag=_wrap_ContactWrench_contactId(resc,resv,argc,(mxArray**)(argv)); break;
-  case 915: flag=_wrap_new_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 916: flag=_wrap_delete_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 917: flag=_wrap_new_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 918: flag=_wrap_LinkContactWrenches_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 919: flag=_wrap_LinkContactWrenches_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 920: flag=_wrap_LinkContactWrenches_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 921: flag=_wrap_LinkContactWrenches_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 922: flag=_wrap_LinkContactWrenches_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 923: flag=_wrap_LinkContactWrenches_computeNetWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 924: flag=_wrap_LinkContactWrenches_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 925: flag=_wrap_delete_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 926: flag=_wrap_ForwardPositionKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 927: flag=_wrap_ForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 928: flag=_wrap_ForwardPosVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 929: flag=_wrap_RNEADynamicPhase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 930: flag=_wrap_CompositeRigidBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
-  case 931: flag=_wrap_new_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 932: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 933: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 934: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 935: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 936: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 937: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 938: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 939: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 940: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 941: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 942: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 943: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 944: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 945: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 946: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 947: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 948: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 949: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 950: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 951: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 952: flag=_wrap_delete_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 953: flag=_wrap_ArticulatedBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
-  case 954: flag=_wrap_modelFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
-  case 955: flag=_wrap_modelFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 956: flag=_wrap_NR_OF_SENSOR_TYPES_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 957: flag=_wrap_delete_Sensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 958: flag=_wrap_Sensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 959: flag=_wrap_Sensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 960: flag=_wrap_Sensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 961: flag=_wrap_Sensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 962: flag=_wrap_Sensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 963: flag=_wrap_Sensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 964: flag=_wrap_delete_JointSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 965: flag=_wrap_JointSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 966: flag=_wrap_JointSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 967: flag=_wrap_JointSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 968: flag=_wrap_JointSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 969: flag=_wrap_delete_LinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 970: flag=_wrap_LinkSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 971: flag=_wrap_LinkSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 972: flag=_wrap_LinkSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 973: flag=_wrap_LinkSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 974: flag=_wrap_new_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 975: flag=_wrap_delete_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 976: flag=_wrap_SensorsList_addSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 977: flag=_wrap_SensorsList_setSerialization(resc,resv,argc,(mxArray**)(argv)); break;
-  case 978: flag=_wrap_SensorsList_getSerialization(resc,resv,argc,(mxArray**)(argv)); break;
-  case 979: flag=_wrap_SensorsList_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 980: flag=_wrap_SensorsList_getSensorIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 981: flag=_wrap_SensorsList_getSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 982: flag=_wrap_SensorsList_getSixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 983: flag=_wrap_SensorsList_getAccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 984: flag=_wrap_SensorsList_getGyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 985: flag=_wrap_new_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 986: flag=_wrap_delete_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 987: flag=_wrap_SensorsMeasurements_setNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 988: flag=_wrap_SensorsMeasurements_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 989: flag=_wrap_SensorsMeasurements_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 990: flag=_wrap_SensorsMeasurements_toVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 991: flag=_wrap_SensorsMeasurements_setMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 992: flag=_wrap_SensorsMeasurements_getMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 993: flag=_wrap_new_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 994: flag=_wrap_delete_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 995: flag=_wrap_SixAxisForceTorqueSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 996: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 997: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 998: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 999: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1000: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1001: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1002: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1003: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1004: flag=_wrap_SixAxisForceTorqueSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1005: flag=_wrap_SixAxisForceTorqueSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1006: flag=_wrap_SixAxisForceTorqueSensor_setAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1007: flag=_wrap_SixAxisForceTorqueSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1008: flag=_wrap_SixAxisForceTorqueSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1009: flag=_wrap_SixAxisForceTorqueSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1010: flag=_wrap_SixAxisForceTorqueSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1011: flag=_wrap_SixAxisForceTorqueSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1012: flag=_wrap_SixAxisForceTorqueSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1013: flag=_wrap_SixAxisForceTorqueSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1014: flag=_wrap_SixAxisForceTorqueSensor_getAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1015: flag=_wrap_SixAxisForceTorqueSensor_isLinkAttachedToSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1016: flag=_wrap_SixAxisForceTorqueSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1017: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1018: flag=_wrap_SixAxisForceTorqueSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1019: flag=_wrap_SixAxisForceTorqueSensor_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1020: flag=_wrap_new_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1021: flag=_wrap_delete_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1022: flag=_wrap_AccelerometerSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1023: flag=_wrap_AccelerometerSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1024: flag=_wrap_AccelerometerSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1025: flag=_wrap_AccelerometerSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1026: flag=_wrap_AccelerometerSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1027: flag=_wrap_AccelerometerSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1028: flag=_wrap_AccelerometerSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1029: flag=_wrap_AccelerometerSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1030: flag=_wrap_AccelerometerSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1031: flag=_wrap_AccelerometerSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1032: flag=_wrap_AccelerometerSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1033: flag=_wrap_AccelerometerSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1034: flag=_wrap_AccelerometerSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1035: flag=_wrap_new_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1036: flag=_wrap_delete_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1037: flag=_wrap_GyroscopeSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1038: flag=_wrap_GyroscopeSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1039: flag=_wrap_GyroscopeSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1040: flag=_wrap_GyroscopeSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1041: flag=_wrap_GyroscopeSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1042: flag=_wrap_GyroscopeSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1043: flag=_wrap_GyroscopeSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1044: flag=_wrap_GyroscopeSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1045: flag=_wrap_GyroscopeSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1046: flag=_wrap_GyroscopeSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1047: flag=_wrap_GyroscopeSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1048: flag=_wrap_GyroscopeSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1049: flag=_wrap_GyroscopeSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1050: flag=_wrap_predictSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1051: flag=_wrap_predictSensorsMeasurementsFromRawBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1052: flag=_wrap_sensorsListFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1053: flag=_wrap_sensorsListFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1054: flag=_wrap_new_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1055: flag=_wrap_UnknownWrenchContact_unknownType_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1056: flag=_wrap_UnknownWrenchContact_unknownType_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1057: flag=_wrap_UnknownWrenchContact_contactPoint_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1058: flag=_wrap_UnknownWrenchContact_contactPoint_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1059: flag=_wrap_UnknownWrenchContact_forceDirection_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1060: flag=_wrap_UnknownWrenchContact_forceDirection_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1061: flag=_wrap_UnknownWrenchContact_contactId_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1062: flag=_wrap_UnknownWrenchContact_contactId_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1063: flag=_wrap_delete_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1064: flag=_wrap_new_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1065: flag=_wrap_LinkUnknownWrenchContacts_clear(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1066: flag=_wrap_LinkUnknownWrenchContacts_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1067: flag=_wrap_LinkUnknownWrenchContacts_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1068: flag=_wrap_LinkUnknownWrenchContacts_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1069: flag=_wrap_LinkUnknownWrenchContacts_addNewContactForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1070: flag=_wrap_LinkUnknownWrenchContacts_addNewContactInFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1071: flag=_wrap_LinkUnknownWrenchContacts_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1072: flag=_wrap_LinkUnknownWrenchContacts_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1073: flag=_wrap_delete_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1074: flag=_wrap_new_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1075: flag=_wrap_estimateExternalWrenchesBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1076: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfSubModels(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1077: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1078: flag=_wrap_estimateExternalWrenchesBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1079: flag=_wrap_estimateExternalWrenchesBuffers_A_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1080: flag=_wrap_estimateExternalWrenchesBuffers_A_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1081: flag=_wrap_estimateExternalWrenchesBuffers_x_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1082: flag=_wrap_estimateExternalWrenchesBuffers_x_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1083: flag=_wrap_estimateExternalWrenchesBuffers_b_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1084: flag=_wrap_estimateExternalWrenchesBuffers_b_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1085: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1086: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1087: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1088: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1089: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1090: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1091: flag=_wrap_delete_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1092: flag=_wrap_estimateExternalWrenchesWithoutInternalFT(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1093: flag=_wrap_estimateExternalWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1094: flag=_wrap_dynamicsEstimationForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1095: flag=_wrap_new_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1096: flag=_wrap_delete_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1097: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_setModelAndSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1098: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1099: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1100: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1101: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_sensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1102: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_submodels(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1103: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1104: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1105: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1106: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1107: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1108: flag=_wrap_DynamicsRegressorParameter_category_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1109: flag=_wrap_DynamicsRegressorParameter_category_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1110: flag=_wrap_DynamicsRegressorParameter_elemIndex_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1111: flag=_wrap_DynamicsRegressorParameter_elemIndex_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1112: flag=_wrap_DynamicsRegressorParameter_type_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1113: flag=_wrap_DynamicsRegressorParameter_type_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1114: flag=_wrap_DynamicsRegressorParameter_lt(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1115: flag=_wrap_DynamicsRegressorParameter_eq(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1116: flag=_wrap_DynamicsRegressorParameter_ne(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1117: flag=_wrap_new_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1118: flag=_wrap_delete_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1119: flag=_wrap_DynamicsRegressorParametersList_parameters_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1120: flag=_wrap_DynamicsRegressorParametersList_parameters_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1121: flag=_wrap_DynamicsRegressorParametersList_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1122: flag=_wrap_DynamicsRegressorParametersList_addParam(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1123: flag=_wrap_DynamicsRegressorParametersList_addList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1124: flag=_wrap_DynamicsRegressorParametersList_findParam(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1125: flag=_wrap_DynamicsRegressorParametersList_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1126: flag=_wrap_new_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1127: flag=_wrap_delete_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1128: flag=_wrap_new_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1129: flag=_wrap_delete_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1130: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1131: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1132: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1133: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1134: flag=_wrap_DynamicsRegressorGenerator_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1135: flag=_wrap_DynamicsRegressorGenerator_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1136: flag=_wrap_DynamicsRegressorGenerator_getNrOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1137: flag=_wrap_DynamicsRegressorGenerator_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1138: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1139: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1140: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutput(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1141: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1142: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1143: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1144: flag=_wrap_DynamicsRegressorGenerator_getBaseLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1145: flag=_wrap_DynamicsRegressorGenerator_getSensorsModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1146: flag=_wrap_DynamicsRegressorGenerator_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1147: flag=_wrap_DynamicsRegressorGenerator_getSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1148: flag=_wrap_DynamicsRegressorGenerator_computeRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1149: flag=_wrap_DynamicsRegressorGenerator_getModelParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1150: flag=_wrap_DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1151: flag=_wrap_DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1152: flag=_wrap_new_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1153: flag=_wrap_delete_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1154: flag=_wrap_KinDynComputations_loadRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1155: flag=_wrap_KinDynComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1156: flag=_wrap_KinDynComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1157: flag=_wrap_KinDynComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1158: flag=_wrap_KinDynComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1159: flag=_wrap_KinDynComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1160: flag=_wrap_KinDynComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1161: flag=_wrap_KinDynComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1162: flag=_wrap_KinDynComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1163: flag=_wrap_KinDynComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1164: flag=_wrap_KinDynComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1165: flag=_wrap_KinDynComputations_getRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1166: flag=_wrap_KinDynComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1167: flag=_wrap_KinDynComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1168: flag=_wrap_KinDynComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1169: flag=_wrap_KinDynComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1170: flag=_wrap_KinDynComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1171: flag=_wrap_KinDynComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1172: flag=_wrap_KinDynComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1173: flag=_wrap_KinDynComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1174: flag=_wrap_KinDynComputations_getRelativeTransformExplicit(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1175: flag=_wrap_KinDynComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1176: flag=_wrap_new_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1177: flag=_wrap_delete_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1178: flag=_wrap_DynamicsComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1179: flag=_wrap_DynamicsComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1180: flag=_wrap_DynamicsComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1181: flag=_wrap_DynamicsComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1182: flag=_wrap_DynamicsComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1183: flag=_wrap_DynamicsComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1184: flag=_wrap_DynamicsComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1185: flag=_wrap_DynamicsComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1186: flag=_wrap_DynamicsComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1187: flag=_wrap_DynamicsComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1188: flag=_wrap_DynamicsComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1189: flag=_wrap_DynamicsComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1190: flag=_wrap_DynamicsComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1191: flag=_wrap_DynamicsComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1192: flag=_wrap_DynamicsComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1193: flag=_wrap_DynamicsComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1194: flag=_wrap_DynamicsComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1195: flag=_wrap_DynamicsComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1196: flag=_wrap_DynamicsComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1197: flag=_wrap_DynamicsComputations_getFrameTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1198: flag=_wrap_DynamicsComputations_getFrameTwistInWorldOrient(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1199: flag=_wrap_DynamicsComputations_getFrameProperSpatialAcceleration(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1200: flag=_wrap_DynamicsComputations_getLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1201: flag=_wrap_DynamicsComputations_getLinkInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1202: flag=_wrap_DynamicsComputations_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1203: flag=_wrap_DynamicsComputations_getJointName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1204: flag=_wrap_DynamicsComputations_getJointLimits(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1205: flag=_wrap_DynamicsComputations_inverseDynamics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1206: flag=_wrap_DynamicsComputations_getFrameJacobian(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1207: flag=_wrap_DynamicsComputations_getDynamicsRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1208: flag=_wrap_DynamicsComputations_getModelDynamicsParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1209: flag=_wrap_DynamicsComputations_getCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1210: flag=_wrap_DynamicsComputations_getCenterOfMassJacobian(resc,resv,argc,(mxArray**)(argv)); break;
+  case 851: flag=_wrap_Model_isLinkNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
+  case 852: flag=_wrap_Model_isJointNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
+  case 853: flag=_wrap_Model_isFrameNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
+  case 854: flag=_wrap_Model_addJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 855: flag=_wrap_Model_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 856: flag=_wrap_Model_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 857: flag=_wrap_Model_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
+  case 858: flag=_wrap_Model_addAdditionalFrameToLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 859: flag=_wrap_Model_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 860: flag=_wrap_Model_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 861: flag=_wrap_Model_isValidFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 862: flag=_wrap_Model_getFrameTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 863: flag=_wrap_Model_getFrameLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 864: flag=_wrap_Model_getNrOfNeighbors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 865: flag=_wrap_Model_getNeighbor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 866: flag=_wrap_Model_setDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 867: flag=_wrap_Model_getDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 868: flag=_wrap_Model_computeFullTreeTraversal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 869: flag=_wrap_Model_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 870: flag=_wrap_new_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 871: flag=_wrap_JointPosDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 872: flag=_wrap_JointPosDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 873: flag=_wrap_delete_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 874: flag=_wrap_new_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 875: flag=_wrap_JointDOFsDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 876: flag=_wrap_JointDOFsDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 877: flag=_wrap_delete_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 878: flag=_wrap_new_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 879: flag=_wrap_DOFSpatialForceArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 880: flag=_wrap_DOFSpatialForceArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 881: flag=_wrap_DOFSpatialForceArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 882: flag=_wrap_delete_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 883: flag=_wrap_new_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 884: flag=_wrap_DOFSpatialMotionArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 885: flag=_wrap_DOFSpatialMotionArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 886: flag=_wrap_DOFSpatialMotionArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 887: flag=_wrap_delete_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 888: flag=_wrap_new_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 889: flag=_wrap_FreeFloatingMassMatrix_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 890: flag=_wrap_delete_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 891: flag=_wrap_new_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 892: flag=_wrap_FreeFloatingPos_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 893: flag=_wrap_FreeFloatingPos_worldBasePos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 894: flag=_wrap_FreeFloatingPos_jointPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 895: flag=_wrap_FreeFloatingPos_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 896: flag=_wrap_delete_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 897: flag=_wrap_new_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 898: flag=_wrap_FreeFloatingGeneralizedTorques_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 899: flag=_wrap_FreeFloatingGeneralizedTorques_baseWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 900: flag=_wrap_FreeFloatingGeneralizedTorques_jointTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 901: flag=_wrap_FreeFloatingGeneralizedTorques_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 902: flag=_wrap_delete_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 903: flag=_wrap_new_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 904: flag=_wrap_FreeFloatingVel_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 905: flag=_wrap_FreeFloatingVel_baseVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 906: flag=_wrap_FreeFloatingVel_jointVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 907: flag=_wrap_FreeFloatingVel_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 908: flag=_wrap_delete_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 909: flag=_wrap_new_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 910: flag=_wrap_FreeFloatingAcc_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 911: flag=_wrap_FreeFloatingAcc_baseAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 912: flag=_wrap_FreeFloatingAcc_jointAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 913: flag=_wrap_FreeFloatingAcc_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 914: flag=_wrap_delete_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 915: flag=_wrap_ContactWrench_contactPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 916: flag=_wrap_ContactWrench_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 917: flag=_wrap_ContactWrench_contactId(resc,resv,argc,(mxArray**)(argv)); break;
+  case 918: flag=_wrap_new_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 919: flag=_wrap_delete_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 920: flag=_wrap_new_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 921: flag=_wrap_LinkContactWrenches_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 922: flag=_wrap_LinkContactWrenches_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 923: flag=_wrap_LinkContactWrenches_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 924: flag=_wrap_LinkContactWrenches_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 925: flag=_wrap_LinkContactWrenches_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 926: flag=_wrap_LinkContactWrenches_computeNetWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 927: flag=_wrap_LinkContactWrenches_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 928: flag=_wrap_delete_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 929: flag=_wrap_ForwardPositionKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 930: flag=_wrap_ForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 931: flag=_wrap_ForwardPosVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 932: flag=_wrap_RNEADynamicPhase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 933: flag=_wrap_CompositeRigidBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
+  case 934: flag=_wrap_new_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 935: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 936: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 937: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 938: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 939: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 940: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 941: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 942: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 943: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 944: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 945: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 946: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 947: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 948: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 949: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 950: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 951: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 952: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 953: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 954: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 955: flag=_wrap_delete_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 956: flag=_wrap_ArticulatedBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
+  case 957: flag=_wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 958: flag=_wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 959: flag=_wrap_new_URDFParserOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 960: flag=_wrap_delete_URDFParserOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 961: flag=_wrap_modelFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
+  case 962: flag=_wrap_modelFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 963: flag=_wrap_NR_OF_SENSOR_TYPES_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 964: flag=_wrap_isLinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 965: flag=_wrap_isJointSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 966: flag=_wrap_delete_Sensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 967: flag=_wrap_Sensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 968: flag=_wrap_Sensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 969: flag=_wrap_Sensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 970: flag=_wrap_Sensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 971: flag=_wrap_Sensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 972: flag=_wrap_Sensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 973: flag=_wrap_delete_JointSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 974: flag=_wrap_JointSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 975: flag=_wrap_JointSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 976: flag=_wrap_JointSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 977: flag=_wrap_JointSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 978: flag=_wrap_delete_LinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 979: flag=_wrap_LinkSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 980: flag=_wrap_LinkSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 981: flag=_wrap_LinkSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 982: flag=_wrap_LinkSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 983: flag=_wrap_LinkSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 984: flag=_wrap_new_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 985: flag=_wrap_delete_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 986: flag=_wrap_SensorsList_addSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 987: flag=_wrap_SensorsList_setSerialization(resc,resv,argc,(mxArray**)(argv)); break;
+  case 988: flag=_wrap_SensorsList_getSerialization(resc,resv,argc,(mxArray**)(argv)); break;
+  case 989: flag=_wrap_SensorsList_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 990: flag=_wrap_SensorsList_getSensorIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 991: flag=_wrap_SensorsList_getSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 992: flag=_wrap_SensorsList_getSixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 993: flag=_wrap_SensorsList_getAccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 994: flag=_wrap_SensorsList_getGyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 995: flag=_wrap_new_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 996: flag=_wrap_delete_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 997: flag=_wrap_SensorsMeasurements_setNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 998: flag=_wrap_SensorsMeasurements_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 999: flag=_wrap_SensorsMeasurements_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1000: flag=_wrap_SensorsMeasurements_toVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1001: flag=_wrap_SensorsMeasurements_setMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1002: flag=_wrap_SensorsMeasurements_getMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1003: flag=_wrap_new_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1004: flag=_wrap_delete_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1005: flag=_wrap_SixAxisForceTorqueSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1006: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1007: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1008: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1009: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1010: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1011: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1012: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1013: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1014: flag=_wrap_SixAxisForceTorqueSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1015: flag=_wrap_SixAxisForceTorqueSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1016: flag=_wrap_SixAxisForceTorqueSensor_setAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1017: flag=_wrap_SixAxisForceTorqueSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1018: flag=_wrap_SixAxisForceTorqueSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1019: flag=_wrap_SixAxisForceTorqueSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1020: flag=_wrap_SixAxisForceTorqueSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1021: flag=_wrap_SixAxisForceTorqueSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1022: flag=_wrap_SixAxisForceTorqueSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1023: flag=_wrap_SixAxisForceTorqueSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1024: flag=_wrap_SixAxisForceTorqueSensor_getAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1025: flag=_wrap_SixAxisForceTorqueSensor_isLinkAttachedToSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1026: flag=_wrap_SixAxisForceTorqueSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1027: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1028: flag=_wrap_SixAxisForceTorqueSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1029: flag=_wrap_SixAxisForceTorqueSensor_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1030: flag=_wrap_new_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1031: flag=_wrap_delete_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1032: flag=_wrap_AccelerometerSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1033: flag=_wrap_AccelerometerSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1034: flag=_wrap_AccelerometerSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1035: flag=_wrap_AccelerometerSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1036: flag=_wrap_AccelerometerSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1037: flag=_wrap_AccelerometerSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1038: flag=_wrap_AccelerometerSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1039: flag=_wrap_AccelerometerSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1040: flag=_wrap_AccelerometerSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1041: flag=_wrap_AccelerometerSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1042: flag=_wrap_AccelerometerSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1043: flag=_wrap_AccelerometerSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1044: flag=_wrap_AccelerometerSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1045: flag=_wrap_new_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1046: flag=_wrap_delete_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1047: flag=_wrap_GyroscopeSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1048: flag=_wrap_GyroscopeSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1049: flag=_wrap_GyroscopeSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1050: flag=_wrap_GyroscopeSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1051: flag=_wrap_GyroscopeSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1052: flag=_wrap_GyroscopeSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1053: flag=_wrap_GyroscopeSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1054: flag=_wrap_GyroscopeSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1055: flag=_wrap_GyroscopeSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1056: flag=_wrap_GyroscopeSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1057: flag=_wrap_GyroscopeSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1058: flag=_wrap_GyroscopeSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1059: flag=_wrap_GyroscopeSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1060: flag=_wrap_predictSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1061: flag=_wrap_predictSensorsMeasurementsFromRawBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1062: flag=_wrap_sensorsListFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1063: flag=_wrap_sensorsListFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1064: flag=_wrap_new_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1065: flag=_wrap_UnknownWrenchContact_unknownType_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1066: flag=_wrap_UnknownWrenchContact_unknownType_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1067: flag=_wrap_UnknownWrenchContact_contactPoint_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1068: flag=_wrap_UnknownWrenchContact_contactPoint_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1069: flag=_wrap_UnknownWrenchContact_forceDirection_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1070: flag=_wrap_UnknownWrenchContact_forceDirection_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1071: flag=_wrap_UnknownWrenchContact_contactId_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1072: flag=_wrap_UnknownWrenchContact_contactId_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1073: flag=_wrap_delete_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1074: flag=_wrap_new_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1075: flag=_wrap_LinkUnknownWrenchContacts_clear(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1076: flag=_wrap_LinkUnknownWrenchContacts_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1077: flag=_wrap_LinkUnknownWrenchContacts_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1078: flag=_wrap_LinkUnknownWrenchContacts_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1079: flag=_wrap_LinkUnknownWrenchContacts_addNewContactForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1080: flag=_wrap_LinkUnknownWrenchContacts_addNewContactInFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1081: flag=_wrap_LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1082: flag=_wrap_LinkUnknownWrenchContacts_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1083: flag=_wrap_LinkUnknownWrenchContacts_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1084: flag=_wrap_delete_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1085: flag=_wrap_new_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1086: flag=_wrap_estimateExternalWrenchesBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1087: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfSubModels(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1088: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1089: flag=_wrap_estimateExternalWrenchesBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1090: flag=_wrap_estimateExternalWrenchesBuffers_A_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1091: flag=_wrap_estimateExternalWrenchesBuffers_A_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1092: flag=_wrap_estimateExternalWrenchesBuffers_x_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1093: flag=_wrap_estimateExternalWrenchesBuffers_x_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1094: flag=_wrap_estimateExternalWrenchesBuffers_b_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1095: flag=_wrap_estimateExternalWrenchesBuffers_b_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1096: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1097: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1098: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1099: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1100: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1101: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1102: flag=_wrap_delete_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1103: flag=_wrap_estimateExternalWrenchesWithoutInternalFT(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1104: flag=_wrap_estimateExternalWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1105: flag=_wrap_dynamicsEstimationForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1106: flag=_wrap_computeLinkNetWrenchesWithoutGravity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1107: flag=_wrap_new_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1108: flag=_wrap_delete_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1109: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_setModelAndSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1110: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1111: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1112: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1113: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_sensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1114: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_submodels(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1115: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1116: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1117: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1118: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1119: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1120: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1121: flag=_wrap_DynamicsRegressorParameter_category_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1122: flag=_wrap_DynamicsRegressorParameter_category_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1123: flag=_wrap_DynamicsRegressorParameter_elemIndex_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1124: flag=_wrap_DynamicsRegressorParameter_elemIndex_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1125: flag=_wrap_DynamicsRegressorParameter_type_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1126: flag=_wrap_DynamicsRegressorParameter_type_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1127: flag=_wrap_DynamicsRegressorParameter_lt(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1128: flag=_wrap_DynamicsRegressorParameter_eq(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1129: flag=_wrap_DynamicsRegressorParameter_ne(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1130: flag=_wrap_new_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1131: flag=_wrap_delete_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1132: flag=_wrap_DynamicsRegressorParametersList_parameters_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1133: flag=_wrap_DynamicsRegressorParametersList_parameters_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1134: flag=_wrap_DynamicsRegressorParametersList_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1135: flag=_wrap_DynamicsRegressorParametersList_addParam(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1136: flag=_wrap_DynamicsRegressorParametersList_addList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1137: flag=_wrap_DynamicsRegressorParametersList_findParam(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1138: flag=_wrap_DynamicsRegressorParametersList_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1139: flag=_wrap_new_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1140: flag=_wrap_delete_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1141: flag=_wrap_new_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1142: flag=_wrap_delete_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1143: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1144: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1145: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1146: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1147: flag=_wrap_DynamicsRegressorGenerator_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1148: flag=_wrap_DynamicsRegressorGenerator_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1149: flag=_wrap_DynamicsRegressorGenerator_getNrOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1150: flag=_wrap_DynamicsRegressorGenerator_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1151: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1152: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1153: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutput(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1154: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1155: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1156: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1157: flag=_wrap_DynamicsRegressorGenerator_getBaseLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1158: flag=_wrap_DynamicsRegressorGenerator_getSensorsModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1159: flag=_wrap_DynamicsRegressorGenerator_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1160: flag=_wrap_DynamicsRegressorGenerator_getSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1161: flag=_wrap_DynamicsRegressorGenerator_computeRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1162: flag=_wrap_DynamicsRegressorGenerator_getModelParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1163: flag=_wrap_DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1164: flag=_wrap_DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1165: flag=_wrap_new_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1166: flag=_wrap_delete_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1167: flag=_wrap_KinDynComputations_loadRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1168: flag=_wrap_KinDynComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1169: flag=_wrap_KinDynComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1170: flag=_wrap_KinDynComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1171: flag=_wrap_KinDynComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1172: flag=_wrap_KinDynComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1173: flag=_wrap_KinDynComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1174: flag=_wrap_KinDynComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1175: flag=_wrap_KinDynComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1176: flag=_wrap_KinDynComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1177: flag=_wrap_KinDynComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1178: flag=_wrap_KinDynComputations_getRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1179: flag=_wrap_KinDynComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1180: flag=_wrap_KinDynComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1181: flag=_wrap_KinDynComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1182: flag=_wrap_KinDynComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1183: flag=_wrap_KinDynComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1184: flag=_wrap_KinDynComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1185: flag=_wrap_KinDynComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1186: flag=_wrap_KinDynComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1187: flag=_wrap_KinDynComputations_getRelativeTransformExplicit(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1188: flag=_wrap_KinDynComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1189: flag=_wrap_new_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1190: flag=_wrap_delete_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1191: flag=_wrap_DynamicsComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1192: flag=_wrap_DynamicsComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1193: flag=_wrap_DynamicsComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1194: flag=_wrap_DynamicsComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1195: flag=_wrap_DynamicsComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1196: flag=_wrap_DynamicsComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1197: flag=_wrap_DynamicsComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1198: flag=_wrap_DynamicsComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1199: flag=_wrap_DynamicsComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1200: flag=_wrap_DynamicsComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1201: flag=_wrap_DynamicsComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1202: flag=_wrap_DynamicsComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1203: flag=_wrap_DynamicsComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1204: flag=_wrap_DynamicsComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1205: flag=_wrap_DynamicsComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1206: flag=_wrap_DynamicsComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1207: flag=_wrap_DynamicsComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1208: flag=_wrap_DynamicsComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1209: flag=_wrap_DynamicsComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1210: flag=_wrap_DynamicsComputations_getFrameTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1211: flag=_wrap_DynamicsComputations_getFrameTwistInWorldOrient(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1212: flag=_wrap_DynamicsComputations_getFrameProperSpatialAcceleration(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1213: flag=_wrap_DynamicsComputations_getLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1214: flag=_wrap_DynamicsComputations_getLinkInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1215: flag=_wrap_DynamicsComputations_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1216: flag=_wrap_DynamicsComputations_getJointName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1217: flag=_wrap_DynamicsComputations_getJointLimits(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1218: flag=_wrap_DynamicsComputations_inverseDynamics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1219: flag=_wrap_DynamicsComputations_getFrameJacobian(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1220: flag=_wrap_DynamicsComputations_getDynamicsRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1221: flag=_wrap_DynamicsComputations_getModelDynamicsParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1222: flag=_wrap_DynamicsComputations_getCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1223: flag=_wrap_DynamicsComputations_getCenterOfMassJacobian(resc,resv,argc,(mxArray**)(argv)); break;
   default: flag=1, SWIG_Error(SWIG_RuntimeError, "No function id %d.", fcn_id);
   }
   if (flag) {

--- a/src/core/include/iDynTree/Core/Utils.h
+++ b/src/core/include/iDynTree/Core/Utils.h
@@ -43,6 +43,12 @@ namespace iDynTree
     bool reportErrorIf(bool condition, const char * className_methodName, const char * errorMessage);
 
     /**
+     * Helper function for reporting warnings in iDynTree
+     *
+     */
+    void reportWarning(const char * className, const char* methodName, const char * errorMessage);
+
+    /**
      * Convert a double from degrees to radians.
      */
     double deg2rad(const double valueInDeg);

--- a/src/core/src/Utils.cpp
+++ b/src/core/src/Utils.cpp
@@ -55,6 +55,11 @@ namespace iDynTree
         return !condition;
     }
 
+    void reportWarning(const char* className, const char* methodName, const char* errorMessage)
+    {
+        std::cerr << "[WARNING] " << className << " :: " << methodName << " : " << errorMessage <<  "\n";
+    }
+
     double deg2rad(const double valueInDeg)
     {
         return IDYNTREE_DEG2RAD*valueInDeg;

--- a/src/estimation/include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
+++ b/src/estimation/include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
@@ -245,7 +245,11 @@ public:
      * Contact force estimations using tactile sensors and force/torque sensors.
      * URL : http://www.researchgate.net/profile/Andrea_Del_Prete/publication/236152161_Contact_Force_Estimations_Using_Tactile_Sensors_and_Force__Torque_Sensors/links/00b495166e74a5369d000000.pdf
      *
-     * @param[in] unknowns the unknown external wrenches.
+     * \note There should be at least 6 unknowns variables for each submodel for which the estimation of
+     *       external wrenches is performed (i.e. usually 1 unknown wrench for each submodel).
+     *       If is not the case, undefined results could occur in the estimation.
+     *
+     * @param[in] unknowns the unknown external wrenches
      * @param[in] ftSensorsMeasures the measurements for the FT sensors.
      * @param[out] estimatedContactWrenches the estimated contact wrenches.
      * @param[out] estimatedJointTorques the estimated joint torques.

--- a/src/estimation/include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
+++ b/src/estimation/include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
@@ -276,6 +276,19 @@ public:
                                   const double properAccTol,
                                   const double verbose);
 
+
+    /**
+     * Compute the vector of the sum of all the wrenches (both internal and external, excluding gravity) acting on
+     * link i, expressed (both orientation and point) with respect to the reference frame of link i,
+     * using the articulated body model and the kinematics information provided by the updateKinematics* methods.
+     *
+     * This is tipically computed as I*a+v*(I*v) , where a is the proper acceleration.
+     *
+     * @param[out] netWrenches the vector of link net wrenches.
+     * @return true if all went ok, false otherwise.
+     */
+    bool estimateLinkNetWrenchesWithoutGravity(LinkNetWrenchesWithoutGravity & netWrenches);
+
 };
 
 }

--- a/src/estimation/include/iDynTree/Estimation/ExternalWrenchesEstimation.h
+++ b/src/estimation/include/iDynTree/Estimation/ExternalWrenchesEstimation.h
@@ -337,6 +337,18 @@ bool dynamicsEstimationForwardVelAccKinematics(const iDynTree::Model & model,
                                                      iDynTree::LinkVelArray & linkVel,
                                                      iDynTree::LinkAccArray  & linkProperAcc);
 
+/**
+ * \brief Compute the net external wrenches (excluding gravity forces) acting on the links.
+ * @param[in] model the input model
+ * @param[in] linkVel a vector of link twists, expressed w.r.t to the link orientation and the link origin
+ * @param[in] linkProperAcc a vector of link spatial (in the Featherstone sense) and proper accelerations, expressed w.r.t to the link orientation and the link origin
+ * @param[in] linkNetWrenchesWithoutGravity the vector of the sum of all the wrenches (both internal and external, excluding gravity) acting on link i, expressed (both orientation and point) with respect to the reference frame of link i
+ */
+bool computeLinkNetWrenchesWithoutGravity(const Model& model,
+                                          const LinkVelArray & linkVel,
+                                          const LinkAccArray & linkProperAcc,
+                                                LinkNetWrenchesWithoutGravity& linkNetWrenchesWithoutGravity);
+
 
 }
 

--- a/src/estimation/include/iDynTree/Estimation/ExternalWrenchesEstimation.h
+++ b/src/estimation/include/iDynTree/Estimation/ExternalWrenchesEstimation.h
@@ -178,6 +178,21 @@ public:
                               const UnknownWrenchContact& newContact);
 
     /**
+     * Add a full wrench unknown at the origin of the specified frame.
+     * Simplified version of a addNewContactInFrame, in which the contact
+     * point is the origin of the frame and the unknown type is FULL_WRENCH.
+     *
+     * Equivalent to
+     *   addNewContactInFrame(model,frame,UnknownWrenchContact(FULL_WRENCH,Position::Zero()))
+     *
+     * @param[in] model the model class for getting frame information.
+     * @param[in] frameIndex the index of the frame in which you are expressing the new unknown wrench.
+     * @return true if all went well, false otherwise
+     */
+    bool addNewUnknownFullWrenchInFrameOrigin(const Model& model,
+                                              const FrameIndex frame);
+
+    /**
      * Get a specific ContactWrench
      *
      * @param[in] linkIndex the index of the link for which the contact is retrieved

--- a/src/estimation/src/ExtWrenchesAndJointTorquesEstimator.cpp
+++ b/src/estimation/src/ExtWrenchesAndJointTorquesEstimator.cpp
@@ -508,6 +508,28 @@ bool ExtWrenchesAndJointTorquesEstimator::checkThatTheModelIsStill(const double 
     return isStill;
 }
 
+bool ExtWrenchesAndJointTorquesEstimator::estimateLinkNetWrenchesWithoutGravity(LinkNetWrenchesWithoutGravity& netWrenches)
+{
+   if( !m_isModelValid )
+    {
+        reportError("ExtWrenchesAndJointTorquesEstimator","estimateLinkNetWrenchesWithoutGravity",
+                    "Model and sensors information not set.");
+        return false;
+    }
+
+    if( !m_isKinematicsUpdated )
+    {
+        reportError("ExtWrenchesAndJointTorquesEstimator","estimateLinkNetWrenchesWithoutGravity",
+                    "Kinematic information not set.");
+        return false;
+    }
+
+    netWrenches.resize(m_model);
+
+    return computeLinkNetWrenchesWithoutGravity(m_model,m_linkVels,m_linkProperAccs,netWrenches);
+}
+
+
 
 
 

--- a/src/estimation/src/ExternalWrenchesEstimation.cpp
+++ b/src/estimation/src/ExternalWrenchesEstimation.cpp
@@ -374,6 +374,7 @@ Wrench computeKnownTermsOfEstimationEquationWithInternalFT(const Model& model,
          }
      }
 
+     // If we reach this point of the code, something is really really wrong
      assert(false);
      return Wrench::Zero();
 }
@@ -716,6 +717,28 @@ bool dynamicsEstimationForwardVelAccKinematics(const iDynTree::Model & model,
     return retValue;
 
 }
+
+bool computeLinkNetWrenchesWithoutGravity(const Model& model,
+                                          const LinkVelArray& linkVel,
+                                          const LinkAccArray& linkProperAcc,
+                                                LinkNetWrenchesWithoutGravity& linkNetWrenchesWithoutGravity)
+{
+     // Note that we are not using a Traversal here: the main reason
+     // is that given that the computation that we are doing (once we have the linkVel and linkProperAcc
+     // does not depend on the topology, so we can visit the links in any possible order
+     for(LinkIndex visitedLinkIndex = 0; visitedLinkIndex < model.getNrOfLinks(); visitedLinkIndex++)
+     {
+         LinkConstPtr visitedLink = model.getLink(visitedLinkIndex);
+
+         const iDynTree::SpatialInertia & I = visitedLink->getInertia();
+         const iDynTree::SpatialAcc     & properAcc = linkProperAcc(visitedLinkIndex);
+         const iDynTree::Twist          & v = linkVel(visitedLinkIndex);
+         linkNetWrenchesWithoutGravity(visitedLinkIndex) = I*properAcc + v*(I*v);
+     }
+
+     return true;
+}
+
 
 
 

--- a/src/estimation/src/ExternalWrenchesEstimation.cpp
+++ b/src/estimation/src/ExternalWrenchesEstimation.cpp
@@ -139,6 +139,12 @@ bool LinkUnknownWrenchContacts::addNewContactInFrame(const Model & model,
     return true;
 }
 
+bool LinkUnknownWrenchContacts::addNewUnknownFullWrenchInFrameOrigin(const Model& model, const FrameIndex frame)
+{
+    return this->addNewContactInFrame(model,frame,UnknownWrenchContact(FULL_WRENCH,Position::Zero()));
+}
+
+
 
 
 std::string LinkUnknownWrenchContacts::toString(const Model& model) const
@@ -650,7 +656,6 @@ bool estimateExternalWrenches(const Model& model,
         // Note that the logic of conversion between input/output contacts should be
         // the same used before in computeMatrixOfEstimationEquation
         storeResultsOfEstimation(subModelTraversal,unknownWrenches,sm,bufs,outputContactWrenches);
-
     }
 
     return true;

--- a/src/estimation/tests/ExtWrenchesAndJointTorquesEstimatorUnitTest.cpp
+++ b/src/estimation/tests/ExtWrenchesAndJointTorquesEstimatorUnitTest.cpp
@@ -176,7 +176,7 @@ int main()
     ASSERT_IS_TRUE(ok);
 
 
-    LinkPositions base_H_link;
+    LinkPositions base_H_link(estimatorIMU.model());
     // Compute the transform from each link to the base
     Traversal defaultTraversal;
     estimatorIMU.model().computeFullTreeTraversal(defaultTraversal);
@@ -189,6 +189,15 @@ int main()
     momentumDerivative.zero();
     iDynTree::Wrench externalForces;
     externalForces.zero();
+
+    for(LinkIndex idx = 0; idx < estimatorIMU.model().getNrOfLinks(); idx++)
+    {
+        momentumDerivative = momentumDerivative + base_H_link(idx)*netWrenchesWithoutGravity(idx);
+        externalForces     = externalForces + base_H_link(idx)*externalWrenches(idx);
+    }
+
+    // The sum of the netWrenchesWithoutGravity of all the links should be equal to the sum of the external wrenches
+    ASSERT_EQUAL_SPATIAL_FORCE_TOL(momentumDerivative,externalForces,1e-8);
 
 
     return EXIT_SUCCESS;

--- a/src/estimation/tests/ExtWrenchesAndJointTorquesEstimatorUnitTest.cpp
+++ b/src/estimation/tests/ExtWrenchesAndJointTorquesEstimatorUnitTest.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <iDynTree/Model/ForwardKinematics.h>
 #include <iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h>
 
 #include "testModels.h"
@@ -162,6 +163,33 @@ int main()
 
         ASSERT_EQUAL_SPATIAL_FORCE_TOL(ftIMU,ftFixedBase,1e-9);
     }
+
+    // Add a test on net external wrenches
+    // Compute the net wrenches acting on a link
+    LinkNetWrenchesWithoutGravity netWrenchesWithoutGravity(estimatorIMU.model());
+    bool ok = estimatorIMU.estimateLinkNetWrenchesWithoutGravity(netWrenchesWithoutGravity);
+    ASSERT_IS_TRUE(ok);
+
+    // Compute the external wrenches
+    LinkNetExternalWrenches externalWrenches(estimatorIMU.model());
+    ok = estimatedContactWrenchesFixedBase.computeNetWrenches(externalWrenches);
+    ASSERT_IS_TRUE(ok);
+
+
+    LinkPositions base_H_link;
+    // Compute the transform from each link to the base
+    Traversal defaultTraversal;
+    estimatorIMU.model().computeFullTreeTraversal(defaultTraversal);
+    ok = iDynTree::ForwardPositionKinematics(estimatorIMU.model(),
+                                             defaultTraversal,
+                                             Transform::Identity(),
+                                             qj,base_H_link);
+
+    iDynTree::Wrench momentumDerivative;
+    momentumDerivative.zero();
+    iDynTree::Wrench externalForces;
+    externalForces.zero();
+
 
     return EXIT_SUCCESS;
 }

--- a/src/model/include/iDynTree/Model/LinkState.h
+++ b/src/model/include/iDynTree/Model/LinkState.h
@@ -113,6 +113,15 @@ namespace iDynTree
      */
     typedef LinkWrenches LinkInternalWrenches;
 
+
+    /**
+     * Vector of the sum of all the wrenches (both internal and external, excluding gravity) acting on
+     * link i, expressed (both orientation and point) with respect to the reference frame of link i.
+     *
+     * This is tipically computed as I*a+v*(I*v) , where a is the proper acceleration.
+     */
+    typedef LinkWrenches LinkNetWrenchesWithoutGravity;
+
     /**
      * Class for storing a vector of SpatialInertia objects , one for each link in a model.
      */

--- a/src/model/include/iDynTree/Model/Model.h
+++ b/src/model/include/iDynTree/Model/Model.h
@@ -126,28 +126,6 @@ namespace iDynTree
         unsigned int nrOfDOFs;
 
         /**
-         * Check if a name is already used for a link in the model.
-         *
-         * @return true if a name is used by a link in a model, false otherwise.
-         */
-        bool isLinkNameUsed(const std::string linkName);
-
-        /**
-         * Check if a name is already used for a joint in the model.
-         *
-         * @return true if a name is used by a joint in a model, false otherwise.
-         */
-        bool isJointNameUsed(const std::string jointName);
-
-        /**
-         * Check if a name is already used for a frame in the model.
-         *
-         * \note this function will check the name of the links and the names of the additional frames.
-         * @return true if a name is used by a frame in a model, false otherwise.
-         */
-        bool isFrameNameUsed(const std::string frameName);
-
-        /**
          * Copy the structure of the model from another instance of a model.
          */
         void copy(const Model & model);
@@ -240,6 +218,28 @@ namespace iDynTree
          * @return true if the index is valid, false otherwise.
          */
         bool isValidJointIndex(const JointIndex index) const;
+
+        /**
+         * Check if a name is already used for a link in the model.
+         *
+         * @return true if a name is used by a link in a model, false otherwise.
+         */
+        bool isLinkNameUsed(const std::string linkName);
+
+        /**
+         * Check if a name is already used for a joint in the model.
+         *
+         * @return true if a name is used by a joint in a model, false otherwise.
+         */
+        bool isJointNameUsed(const std::string jointName);
+
+        /**
+         * Check if a name is already used for a frame in the model.
+         *
+         * \note this function will check the name of the links and the names of the additional frames.
+         * @return true if a name is used by a frame in a model, false otherwise.
+         */
+        bool isFrameNameUsed(const std::string frameName);
 
         /**
          *

--- a/src/model_io/urdf/include/iDynTree/ModelIO/URDFGenericSensorsImport.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/URDFGenericSensorsImport.h
@@ -19,18 +19,25 @@ class Model;
 /**
  * Load a iDynTree::SensorsList object from a URDF file.
  *
- * Supported sensors:
+ * The URDF syntax and the sensor supported are documented in
+ * https://github.com/robotology/idyntree/blob/master/doc/model_loading.md .
  *
- * * Gyroscope :
- *
- * \note Experimental version for a more generic set of sensors
- *  other than gazebo extension F/T.
  *
  * @return true if all went ok, false otherwise.
  */
 bool sensorsFromURDF(const std::string & urdf_filename,
                      iDynTree::SensorsList & output);
 
+/**
+ * Load a iDynTree::SensorsList object from a URDF file, using a previous loaded
+ * iDynTree::Model from the same URDF.
+ *
+ * The URDF syntax and the sensor supported are documented in
+ * https://github.com/robotology/idyntree/blob/master/doc/model_loading.md .
+ *
+ *
+ * @return true if all went ok, false otherwise.
+ */
 bool sensorsFromURDF(const std::string & urdf_filename,
                      const Model & model,
                      iDynTree::SensorsList & output);
@@ -38,13 +45,26 @@ bool sensorsFromURDF(const std::string & urdf_filename,
 /**
  * Load a iDynTree::SensorsList object from a URDF string.
  *
- * \note Experimental version for a more generic set of sensors
- *  other than gazebo extension F/T.
+ * The URDF syntax and the sensor supported are documented in
+ * https://github.com/robotology/idyntree/blob/master/doc/model_loading.md .
  *
  * @return true if all went ok, false otherwise.
  */
 bool sensorsFromURDFString(const std::string & urdf_string,
-                       iDynTree::SensorsList & output);
+                           iDynTree::SensorsList & output);
+
+/**
+ * Load a iDynTree::SensorsList object from a URDF string, using a previous loaded
+ * iDynTree::Model from the same URDF.
+ *
+ * The URDF syntax and the sensor supported are documented in
+ * https://github.com/robotology/idyntree/blob/master/doc/model_loading.md .
+ *
+ * @return true if all went ok, false otherwise.
+ */
+bool sensorsFromURDFString(const std::string & urdf_string,
+                           const Model & model,
+                           iDynTree::SensorsList & output);
 
 }
 

--- a/src/model_io/urdf/include/iDynTree/ModelIO/URDFModelImport.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/URDFModelImport.h
@@ -18,6 +18,29 @@ class Model;
 /**
  * \ingroup iDynTreeModelIO
  *
+ * Options for the iDynTree URDF parser.
+ */
+struct URDFParserOptions
+{
+    /**
+     * If true, add to the model the sensor frames
+     * as additional frames with the same name of the sensor.
+     * If there is already a link or additional frame with the same
+     * name of the sensor, a warning is printed and no frame is added.
+     */
+    bool addSensorFramesAsAdditionalFrames;
+
+    /**
+     * Constructor, containing default values.
+     */
+    URDFParserOptions(): addSensorFramesAsAdditionalFrames(true)
+    {
+    }
+};
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
  * Load a iDynTree::Model object from a URDF file.
  *
  * Loading the URDF with this function, the  "fake links"
@@ -26,10 +49,12 @@ class Model;
  * function, that is called inside this function before
  * returning the model.
  *
+ * @param[in] options the URDFParserOptions struct of options passed to the parser
  * @return true if all went ok, false otherwise.
  */
 bool modelFromURDF(const std::string & urdf_filename,
-                   iDynTree::Model & output);
+                   iDynTree::Model & output,
+                   const URDFParserOptions options=URDFParserOptions());
 
 /**
  * \ingroup iDynTreeModelIO
@@ -40,10 +65,12 @@ bool modelFromURDF(const std::string & urdf_filename,
  * function, that is called inside this function before
  * returning the model. .
  *
+ * @param[in] options the URDFParserOptions struct of options passed to the parser
  * @return true if all went ok, false otherwise.
  */
 bool modelFromURDFString(const std::string & urdf_string,
-                         iDynTree::Model & output);
+                         iDynTree::Model & output,
+                         const URDFParserOptions options=URDFParserOptions());
 
 
 }

--- a/src/model_io/urdf/src/URDFGenericSensorsImport.cpp
+++ b/src/model_io/urdf/src/URDFGenericSensorsImport.cpp
@@ -519,7 +519,7 @@ bool sensorsFromURDF(const std::string & urdf_filename,
 }
 
 bool sensorsFromURDFString(const std::string& urdf_string,
-                                     iDynTree::SensorsList& output)
+                           iDynTree::SensorsList& output)
 {
     iDynTree::Model model;
     bool ok = modelFromURDFString(urdf_string,model);

--- a/src/model_io/urdf/tests/PredictSensorsMeasurementUnitTest.cpp
+++ b/src/model_io/urdf/tests/PredictSensorsMeasurementUnitTest.cpp
@@ -37,7 +37,7 @@ void init(std::string fileName, Model &model, Traversal &traversal,
     ASSERT_EQUAL_DOUBLE(model.getNrOfLinks(),2);
     ASSERT_EQUAL_DOUBLE(model.getNrOfJoints(),1);
     ASSERT_EQUAL_DOUBLE(model.getNrOfDOFs(),1);
-    ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(),3);
+    ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(),6);
     ASSERT_EQUAL_STRING(model.getLinkName(model.getDefaultBaseLink()),"link1");
 
     ok = model.computeFullTreeTraversal(traversal);

--- a/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
+++ b/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
@@ -73,7 +73,7 @@ void checkURDF(std::string fileName,
 
 
     ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfLinks(),expectedNrOfLinks);
-    ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfJoints(),expectedNrOfJoints);
+      (modelCopyAssigned.getNrOfJoints(),expectedNrOfJoints);
     ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfDOFs(),expectedNrOfDOFs);
     ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfFrames(),expectedNrOfFrames);
     ASSERT_EQUAL_STRING(modelCopyAssigned.getLinkName(modelCopyAssigned.getDefaultBaseLink()),expectedDefaultBase);
@@ -82,10 +82,10 @@ void checkURDF(std::string fileName,
 
 int main()
 {
-    checkURDF(getAbsModelPath("/oneLink.urdf"),1,0,0,4,"link1");
-    checkURDF(getAbsModelPath("twoLinks.urdf"),2,1,1,3,"link1");
-    checkURDF(getAbsModelPath("icub_skin_frames.urdf"),39,38,32,56,"root_link");
-    checkURDF(getAbsModelPath("iCubGenova02.urdf"),33,32,26,105,"root_link");
+    checkURDF(getAbsModelPath("/oneLink.urdf"),1,0,0,7,"link1");
+    checkURDF(getAbsModelPath("twoLinks.urdf"),2,1,1,6,"link1");
+    checkURDF(getAbsModelPath("icub_skin_frames.urdf"),39,38,32,62,"root_link");
+    checkURDF(getAbsModelPath("iCubGenova02.urdf"),33,32,26,111,"root_link");
 
 
     return EXIT_SUCCESS;

--- a/src/model_io/urdf/tests/icubSensorURDFUnitTest.cpp
+++ b/src/model_io/urdf/tests/icubSensorURDFUnitTest.cpp
@@ -25,7 +25,8 @@ using namespace iDynTree;
 void checkURDF(std::string fileName,
                unsigned int expectedNrOfAccelerometers,
                unsigned int expectedNrOfGyroscopes,
-               unsigned int expectedNrOfFTSensors
+               unsigned int expectedNrOfFTSensors,
+               const std::string nameOfASensorFrame
               )
 {
     std::cout<<"Tying to load model from URDF"<<std::endl;
@@ -57,6 +58,11 @@ void checkURDF(std::string fileName,
      ASSERT_EQUAL_DOUBLE(sensorList.getNrOfSensors(iDynTree::ACCELEROMETER),expectedNrOfAccelerometers);
      ASSERT_EQUAL_DOUBLE(sensorList.getNrOfSensors(iDynTree::GYROSCOPE),expectedNrOfGyroscopes);
      ASSERT_EQUAL_DOUBLE(sensorList.getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE),expectedNrOfFTSensors);
+
+     // The default behavior is to load the sensor frame as additional frames, so we check
+     // if at least one sensor frame has been correctly loaded
+     ASSERT_IS_TRUE(model.isFrameNameUsed(nameOfASensorFrame));
+
 }
 
 
@@ -64,7 +70,7 @@ void checkURDF(std::string fileName,
 int main()
 {
     std::cout<<"iCub Sensor test running:\n";
-    checkURDF(getAbsModelPath("/icub_sensorised.urdf"),55,11,6);
+    checkURDF(getAbsModelPath("/icub_sensorised.urdf"),55,11,6,"root_link_ems_acc_eb5");
 
     std::cout <<"iCub Sensor test just ran\n";
     return 0;

--- a/src/sensors/include/iDynTree/Sensors/AccelerometerSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/AccelerometerSensor.h
@@ -79,7 +79,7 @@ namespace iDynTree {
          *
          * @return true if link_index is parent link attached to the accelerometer sensor, false otherwise.
          */
-        bool setLinkSensorTransform(const iDynTree::Transform & link_H_sensor) const;
+        bool setLinkSensorTransform(const iDynTree::Transform & link_H_sensor);
 
         /*
          * Documented in Sensor
@@ -91,34 +91,37 @@ namespace iDynTree {
          */
         bool setParentLinkIndex(const LinkIndex & parent_index);
 
-        /**
+        /*
          * Documented in the sensor
          *
          */
         std::string getName() const;
 
-        /**
+        /*
          * Documented in Sensor
          */
         SensorType getSensorType() const;
 
 
-        /**
+        /*
          * Documented in Sensor
          */
         std::string getParentLink() const;
 
-        /**
+        /*
          * Documented in Sensor
          */
         LinkIndex getParentLinkIndex() const;
 
-        /**
+        // Documented in LinkSensor
+        Transform getLinkSensorTransform() const;
+
+        /*
          * Documented in Sensor
          */
         bool isValid() const;
 
-        /**
+        /*
          * Documented in Sensor
          */
         Sensor * clone() const;
@@ -128,12 +131,6 @@ namespace iDynTree {
          */
         bool updateIndeces(const Model & model);
 
-        /**
-         * Get the transform from the sensor to the specified link.
-         *
-         * @return Transform associated with the link Frame and the sensor
-         */
-       Transform getLinkSensorTransform(void);
 
 
       /**

--- a/src/sensors/include/iDynTree/Sensors/GyroscopeSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/GyroscopeSensor.h
@@ -76,8 +76,7 @@ namespace iDynTree {
          *
          * @return true if link_index is the link attached to the Gyroscope, false otherwise.
          */
-        bool setLinkSensorTransform(const iDynTree::Transform & link_H_sensor) const;
-
+        bool setLinkSensorTransform(const iDynTree::Transform & link_H_sensor);
 
         /**
          * Documented in Sensor
@@ -112,6 +111,9 @@ namespace iDynTree {
          */
         LinkIndex getParentLinkIndex() const;
 
+        // Documented in LinkSensor
+        Transform getLinkSensorTransform() const;
+
         /**
          * Documented in Sensor
          */
@@ -126,13 +128,6 @@ namespace iDynTree {
          * Documented in Sensor
          */
         bool updateIndeces(const Model & model);
-
-        /**
-         * Get the transform from the sensor to the parent link.
-         *
-         * @return Transform associated with the link frame and the sensor
-         */
-        Transform getLinkSensorTransform(void);
 
         /**
          * Predict sensor measurement when given the parent link spatial velocity, expressed

--- a/src/sensors/include/iDynTree/Sensors/Sensors.h
+++ b/src/sensors/include/iDynTree/Sensors/Sensors.h
@@ -49,6 +49,28 @@ namespace iDynTree {
     //  in the SensorType enum
     const int NR_OF_SENSOR_TYPES = 3;
 
+    /**
+     * Short function to check if a SensorType is a LinkSensor
+     */
+    inline bool isLinkSensor(const SensorType type)
+    {
+        switch(type)
+        {
+        case SIX_AXIS_FORCE_TORQUE:
+            return false;
+        case ACCELEROMETER:
+        case GYROSCOPE:
+            return true;
+        }
+    }
+
+    /**
+     * Short function to check if a SensorType is
+     */
+    inline bool isJointSensor(const SensorType type)
+    {
+        return !isLinkSensor(type);
+    }
 
     /**
      * Interface for Sensor classes in iDynTree .
@@ -169,6 +191,16 @@ namespace iDynTree {
          * @return the index of the parent Link of the sensor.
          */
         virtual LinkIndex getParentLinkIndex() const = 0;
+
+        /**
+         * Return the transform that applied on a element
+         * expressed in sensor frames it transform it
+         * in one expressed in the link frame (\f[ {}^l H_s \f]).
+         *
+         * @return the link_H_sensor transform
+         */
+        virtual Transform getLinkSensorTransform() const = 0;
+
 
         /**
          * Set the name of the parent Link.

--- a/src/sensors/src/AccelerometerSensor.cpp
+++ b/src/sensors/src/AccelerometerSensor.cpp
@@ -80,7 +80,7 @@ bool AccelerometerSensor::setName(const std::string& _name)
 }
 
 
-bool AccelerometerSensor::setLinkSensorTransform(const iDynTree::Transform& link_H_sensor) const
+bool AccelerometerSensor::setLinkSensorTransform(const iDynTree::Transform& link_H_sensor)
 {
       this->pimpl->link_H_sensor = link_H_sensor;
       return true;
@@ -156,7 +156,7 @@ SensorType AccelerometerSensor::getSensorType() const
     return ACCELEROMETER;
 }
 
-Transform AccelerometerSensor::getLinkSensorTransform(void)
+Transform AccelerometerSensor::getLinkSensorTransform() const
 {
     return(this->pimpl->link_H_sensor);
 }

--- a/src/sensors/src/GyroscopeSensor.cpp
+++ b/src/sensors/src/GyroscopeSensor.cpp
@@ -76,7 +76,7 @@ bool GyroscopeSensor::setName(const std::string& _name)
 }
 
 
-bool GyroscopeSensor::setLinkSensorTransform(const iDynTree::Transform& link_H_sensor) const
+bool GyroscopeSensor::setLinkSensorTransform(const iDynTree::Transform& link_H_sensor)
 {
     this->pimpl->link_H_sensor = link_H_sensor;
     return true;
@@ -154,7 +154,7 @@ LinkIndex GyroscopeSensor::getParentLinkIndex() const
 }
 
 
-Transform GyroscopeSensor::getLinkSensorTransform(void)
+Transform GyroscopeSensor::getLinkSensorTransform() const
 {
     return(this->pimpl->link_H_sensor);
 

--- a/src/tools/idyntree-model-info.cpp
+++ b/src/tools/idyntree-model-info.cpp
@@ -16,6 +16,9 @@ void addOptions(cmdline::parser &cmd)
                          "Model to load.",
                          true);
 
+    cmd.add("print", 'p',
+            "Print the model.");
+
     cmd.add("total-mass", '\0',
             "Get the total mass of a model.");
 
@@ -24,12 +27,22 @@ void addOptions(cmdline::parser &cmd)
 
     cmd.add<std::string>("link-com-frame", '\0',
                          "If link-com is passed, link-com-frame specifies the frame in which the inertia information is printed (assuming that the model is in zero position)",false);
-    
+
     cmd.add<std::string>("frame-pose", '\0',
-                         "Print t",false);
+                         "Print the referenceFrame_H_frame transform.",false);
 
     cmd.add<std::string>("frame-pose-reference-frame", '\0',
                          "If frame-pose is passed, frame-pose-reference-frame specifies the reference frame in which the frame pose is expressed (assuming that the model is in zero position)",false);
+}
+
+void handlePrintOption(iDynTree::KinDynComputations & comp, cmdline::parser & cmd)
+{
+    if( !cmd.exist("print") )
+    {
+        return;
+    }
+
+    std::cout << comp.getRobotModel().toString() << std::endl;
 }
 
 void handleTotalMassOptions(iDynTree::KinDynComputations & comp, cmdline::parser & cmd)
@@ -55,7 +68,7 @@ void handleTotalMassOptions(iDynTree::KinDynComputations & comp, cmdline::parser
 void handleFramePoseOptions(iDynTree::KinDynComputations & comp, cmdline::parser & cmd)
 {
     using namespace iDynTree;
-    
+
     const Model & model = comp.getRobotModel();
 
     if( !cmd.exist("frame-pose") )
@@ -74,13 +87,13 @@ void handleFramePoseOptions(iDynTree::KinDynComputations & comp, cmdline::parser
     {
         referenceFrameName = model.getFrameName(comp.getRobotModel().getDefaultBaseLink());
     }
-    
+
     if( !model.isValidFrameIndex(model.getFrameIndex(frameName)) )
     {
         std::cerr << "Frame " << frameName << " not found in the model" << std::endl;
 	return;
     }
-    
+
     if( !model.isValidFrameIndex(model.getFrameIndex(referenceFrameName)) )
     {
         std::cerr << "Frame " << referenceFrameName << " not found in the model" << std::endl;
@@ -149,13 +162,16 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // Handle print option
+    handlePrintOption(model,cmd);
+
     // Handle total mass option
     handleTotalMassOptions(model,cmd);
 
     // Handle link com
     handleLinkCOMOptions(model,cmd);
-    
-    // Handle frame pose 
+
+    // Handle frame pose
     handleFramePoseOptions(model,cmd);
 
 


### PR DESCRIPTION
* [ https://github.com/robotology/idyntree/commit/aeddd0f8f4d3a091853218931bf249323f255ca1 , https://github.com/robotology/idyntree/commit/34fcbf85769405e83116efff0de933a1c02b3ca9 ] [estimation] Exposed momentum derivative of the link (i.e. net wrench minus gravitatinal effect) information in estimator 
* [ https://github.com/robotology/idyntree/commit/ca27f6906c4787df49bee134eb7563d3a8a42245 ]  	Added option in urdf parser to treat sensor frames as additional frames 