### PR TITLE
Support to Matlab sparse matrices

### DIFF
--- a/bindings/matlab/+iDynTree/AccelerometerSensor.m
+++ b/bindings/matlab/+iDynTree/AccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef AccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1078, varargin{:});
+        tmp = iDynTreeMEX(1079, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1079, self);
+        iDynTreeMEX(1080, self);
         self.swigPtr=[];
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
     end
-    function varargout = setParentLink(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1082, self, varargin{:});
     end
-    function varargout = setParentLinkIndex(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1083, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1084, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1087, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1088, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1091, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1092, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1093, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/AngularForceVector3.m
+++ b/bindings/matlab/+iDynTree/AngularForceVector3.m
@@ -7,17 +7,17 @@ classdef AngularForceVector3 < iDynTree.ForceVector3__AngularForceVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(415, varargin{:});
+        tmp = iDynTreeMEX(416, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(416, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(417, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(417, self);
+        iDynTreeMEX(418, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/AngularForceVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/AngularForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef AngularForceVector3Semantics < iDynTree.ForceVector3Semantics__AngularF
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(411, varargin{:});
+        tmp = iDynTreeMEX(412, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(412, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(413, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(414, self);
+        iDynTreeMEX(415, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(413, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(414, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/AngularMotionVector3.m
+++ b/bindings/matlab/+iDynTree/AngularMotionVector3.m
@@ -7,17 +7,17 @@ classdef AngularMotionVector3 < iDynTree.MotionVector3__AngularMotionVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(404, varargin{:});
+        tmp = iDynTreeMEX(405, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = exp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(405, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(406, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(406, self);
+        iDynTreeMEX(407, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/AngularMotionVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/AngularMotionVector3Semantics.m
@@ -7,14 +7,14 @@ classdef AngularMotionVector3Semantics < iDynTree.GeomVector3Semantics__AngularM
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(402, varargin{:});
+        tmp = iDynTreeMEX(403, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(403, self);
+        iDynTreeMEX(404, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithm.m
+++ b/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = ArticulatedBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1003, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1004, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
+++ b/bindings/matlab/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
@@ -9,110 +9,110 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(981, varargin{:});
+        tmp = iDynTreeMEX(982, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
     end
     function varargout = S(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(984, self);
+        varargout{1} = iDynTreeMEX(985, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(985, self, varargin{1});
+        iDynTreeMEX(986, self, varargin{1});
       end
     end
     function varargout = U(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(986, self);
+        varargout{1} = iDynTreeMEX(987, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(987, self, varargin{1});
+        iDynTreeMEX(988, self, varargin{1});
       end
     end
     function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(988, self);
+        varargout{1} = iDynTreeMEX(989, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(989, self, varargin{1});
+        iDynTreeMEX(990, self, varargin{1});
       end
     end
     function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(990, self);
+        varargout{1} = iDynTreeMEX(991, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(991, self, varargin{1});
+        iDynTreeMEX(992, self, varargin{1});
       end
     end
     function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(992, self);
+        varargout{1} = iDynTreeMEX(993, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(993, self, varargin{1});
+        iDynTreeMEX(994, self, varargin{1});
       end
     end
     function varargout = linksBiasAcceleration(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(994, self);
+        varargout{1} = iDynTreeMEX(995, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(995, self, varargin{1});
+        iDynTreeMEX(996, self, varargin{1});
       end
     end
     function varargout = linksAccelerations(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(996, self);
+        varargout{1} = iDynTreeMEX(997, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(997, self, varargin{1});
+        iDynTreeMEX(998, self, varargin{1});
       end
     end
     function varargout = linkABIs(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(998, self);
+        varargout{1} = iDynTreeMEX(999, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(999, self, varargin{1});
+        iDynTreeMEX(1000, self, varargin{1});
       end
     end
     function varargout = linksBiasWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1000, self);
+        varargout{1} = iDynTreeMEX(1001, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1001, self, varargin{1});
+        iDynTreeMEX(1002, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1002, self);
+        iDynTreeMEX(1003, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ArticulatedBodyInertia.m
+++ b/bindings/matlab/+iDynTree/ArticulatedBodyInertia.m
@@ -9,57 +9,57 @@ classdef ArticulatedBodyInertia < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(563, varargin{:});
+        tmp = iDynTreeMEX(564, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getLinearLinearSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(564, self, varargin{:});
-    end
-    function varargout = getLinearAngularSubmatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(565, self, varargin{:});
     end
-    function varargout = getAngularAngularSubmatrix(self,varargin)
+    function varargout = getLinearAngularSubmatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(566, self, varargin{:});
     end
-    function varargout = applyInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(568, self, varargin{:});
+    function varargout = getAngularAngularSubmatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(567, self, varargin{:});
     end
-    function varargout = asMatrix(self,varargin)
+    function varargout = applyInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(569, self, varargin{:});
     end
-    function varargout = getInverse(self,varargin)
+    function varargout = asMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(570, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = getInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(571, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(572, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(573, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(574, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(575, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(577, self);
+        iDynTreeMEX(578, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(567, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(568, varargin{:});
     end
     function varargout = ABADyadHelper(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(575, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(576, varargin{:});
     end
     function varargout = ABADyadHelperLin(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(576, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(577, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/Axis.m
+++ b/bindings/matlab/+iDynTree/Axis.m
@@ -9,44 +9,44 @@ classdef Axis < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(523, varargin{:});
+        tmp = iDynTreeMEX(524, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(524, self, varargin{:});
-    end
-    function varargout = getOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(525, self, varargin{:});
     end
-    function varargout = setDirection(self,varargin)
+    function varargout = getOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(526, self, varargin{:});
     end
-    function varargout = setOrigin(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(527, self, varargin{:});
     end
-    function varargout = getRotationTransform(self,varargin)
+    function varargout = setOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(528, self, varargin{:});
     end
-    function varargout = getRotationTransformDerivative(self,varargin)
+    function varargout = getRotationTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(529, self, varargin{:});
     end
-    function varargout = getRotationTwist(self,varargin)
+    function varargout = getRotationTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(530, self, varargin{:});
     end
-    function varargout = getRotationSpatialAcc(self,varargin)
+    function varargout = getRotationTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(531, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getRotationSpatialAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(532, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(533, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(534, self);
+        iDynTreeMEX(535, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/+iDynTree/BerdyDynamicVariable.m
@@ -7,30 +7,30 @@ classdef BerdyDynamicVariable < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1230, self);
+        varargout{1} = iDynTreeMEX(1231, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1231, self, varargin{1});
+        iDynTreeMEX(1232, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1232, self);
+        varargout{1} = iDynTreeMEX(1233, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1233, self, varargin{1});
+        iDynTreeMEX(1234, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1234, self);
+        varargout{1} = iDynTreeMEX(1235, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1235, self, varargin{1});
+        iDynTreeMEX(1236, self, varargin{1});
       end
     end
     function self = BerdyDynamicVariable(varargin)
@@ -39,14 +39,14 @@ classdef BerdyDynamicVariable < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1236, varargin{:});
+        tmp = iDynTreeMEX(1237, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1237, self);
+        iDynTreeMEX(1238, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/+iDynTree/BerdyHelper.m
@@ -9,68 +9,68 @@ classdef BerdyHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1238, varargin{:});
+        tmp = iDynTreeMEX(1239, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1239, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1240, self, varargin{:});
     end
-    function varargout = sensors(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1241, self, varargin{:});
     end
-    function varargout = init(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
     end
-    function varargout = getOptions(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
     end
-    function varargout = getNrOfDynamicVariables(self,varargin)
+    function varargout = getOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
     end
-    function varargout = getNrOfDynamicEquations(self,varargin)
+    function varargout = getNrOfDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1245, self, varargin{:});
     end
-    function varargout = getNrOfSensorsMeasurements(self,varargin)
+    function varargout = getNrOfDynamicEquations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
     end
-    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
+    function varargout = getNrOfSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
     end
-    function varargout = getBerdyMatrices(self,varargin)
+    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
     end
-    function varargout = getSensorsOrdering(self,varargin)
+    function varargout = getBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1249, self, varargin{:});
     end
-    function varargout = getDynamicVariablesOrdering(self,varargin)
+    function varargout = getSensorsOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
     end
-    function varargout = serializeDynamicVariables(self,varargin)
+    function varargout = getDynamicVariablesOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1251, self, varargin{:});
     end
-    function varargout = serializeSensorVariables(self,varargin)
+    function varargout = serializeDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
     end
-    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
+    function varargout = serializeSensorVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1255, self, varargin{:});
     end
-    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1256, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1257, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1257, self);
+        iDynTreeMEX(1258, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/+iDynTree/BerdyOptions.m
@@ -9,7 +9,7 @@ classdef BerdyOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1204, varargin{:});
+        tmp = iDynTreeMEX(1205, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
@@ -18,78 +18,78 @@ classdef BerdyOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1205, self);
+        varargout{1} = iDynTreeMEX(1206, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1206, self, varargin{1});
+        iDynTreeMEX(1207, self, varargin{1});
       end
     end
     function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1207, self);
+        varargout{1} = iDynTreeMEX(1208, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1208, self, varargin{1});
+        iDynTreeMEX(1209, self, varargin{1});
       end
     end
     function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1209, self);
+        varargout{1} = iDynTreeMEX(1210, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1210, self, varargin{1});
+        iDynTreeMEX(1211, self, varargin{1});
       end
     end
     function varargout = includeAllJointTorquesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1211, self);
+        varargout{1} = iDynTreeMEX(1212, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1212, self, varargin{1});
+        iDynTreeMEX(1213, self, varargin{1});
       end
     end
     function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1213, self);
+        varargout{1} = iDynTreeMEX(1214, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1214, self, varargin{1});
+        iDynTreeMEX(1215, self, varargin{1});
       end
     end
     function varargout = includeFixedBaseExternalWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1215, self);
+        varargout{1} = iDynTreeMEX(1216, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1216, self, varargin{1});
+        iDynTreeMEX(1217, self, varargin{1});
       end
     end
     function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1217, self);
+        varargout{1} = iDynTreeMEX(1218, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1218, self, varargin{1});
+        iDynTreeMEX(1219, self, varargin{1});
       end
     end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1219, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1220, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1220, self);
+        iDynTreeMEX(1221, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/+iDynTree/BerdySensor.m
@@ -7,34 +7,34 @@ classdef BerdySensor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1221, self);
+        varargout{1} = iDynTreeMEX(1222, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1222, self, varargin{1});
+        iDynTreeMEX(1223, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1223, self);
+        varargout{1} = iDynTreeMEX(1224, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1224, self, varargin{1});
+        iDynTreeMEX(1225, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1225, self);
+        varargout{1} = iDynTreeMEX(1226, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1226, self, varargin{1});
+        iDynTreeMEX(1227, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1227, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1228, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -42,14 +42,14 @@ classdef BerdySensor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1228, varargin{:});
+        tmp = iDynTreeMEX(1229, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1229, self);
+        iDynTreeMEX(1230, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ClassicalAcc.m
+++ b/bindings/matlab/+iDynTree/ClassicalAcc.m
@@ -7,30 +7,30 @@ classdef ClassicalAcc < iDynTree.Vector6
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(511, varargin{:});
+        tmp = iDynTreeMEX(512, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(512, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(513, self, varargin{:});
     end
     function varargout = fromSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(514, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(515, self, varargin{:});
     end
     function varargout = toSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(515, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(516, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(516, self);
+        iDynTreeMEX(517, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(513, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(514, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/CompositeRigidBodyAlgorithm.m
+++ b/bindings/matlab/+iDynTree/CompositeRigidBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = CompositeRigidBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(980, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(981, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ContactWrench.m
+++ b/bindings/matlab/+iDynTree/ContactWrench.m
@@ -4,13 +4,13 @@ classdef ContactWrench < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = contactId(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
-    end
-    function varargout = contactPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
     end
-    function varargout = contactWrench(self,varargin)
+    function varargout = contactPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(964, self, varargin{:});
+    end
+    function varargout = contactWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
     end
     function self = ContactWrench(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -18,14 +18,14 @@ classdef ContactWrench < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(965, varargin{:});
+        tmp = iDynTreeMEX(966, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(966, self);
+        iDynTreeMEX(967, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DOFSpatialForceArray.m
+++ b/bindings/matlab/+iDynTree/DOFSpatialForceArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialForceArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(925, varargin{:});
+        tmp = iDynTreeMEX(926, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(928, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(929, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(929, self);
+        iDynTreeMEX(930, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DOFSpatialMotionArray.m
+++ b/bindings/matlab/+iDynTree/DOFSpatialMotionArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialMotionArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(930, varargin{:});
+        tmp = iDynTreeMEX(931, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(931, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(934, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(934, self);
+        iDynTreeMEX(935, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DOF_INVALID_INDEX.m
+++ b/bindings/matlab/+iDynTree/DOF_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(686);
+    varargout{1} = iDynTreeMEX(687);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(687,varargin{1});
+    iDynTreeMEX(688,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/DOF_INVALID_NAME.m
+++ b/bindings/matlab/+iDynTree/DOF_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(688);
+    varargout{1} = iDynTreeMEX(689);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(689,varargin{1});
+    iDynTreeMEX(690,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/Direction.m
+++ b/bindings/matlab/+iDynTree/Direction.m
@@ -7,30 +7,30 @@ classdef Direction < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(517, varargin{:});
+        tmp = iDynTreeMEX(518, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = Normalize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(518, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(519, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(520, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(521, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(522, self);
+        iDynTreeMEX(523, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = Default(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(521, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(522, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/Dummy.m
+++ b/bindings/matlab/+iDynTree/Dummy.m
@@ -9,14 +9,14 @@ classdef Dummy < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(478, varargin{:});
+        tmp = iDynTreeMEX(479, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(479, self);
+        iDynTreeMEX(480, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DynamicsComputations.m
+++ b/bindings/matlab/+iDynTree/DynamicsComputations.m
@@ -9,115 +9,115 @@ classdef DynamicsComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1326, varargin{:});
+        tmp = iDynTreeMEX(1327, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1327, self);
+        iDynTreeMEX(1328, self);
         self.swigPtr=[];
       end
     end
     function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1328, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1330, self, varargin{:});
     end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1331, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
     end
-    function varargout = getFloatingBase(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
     end
-    function varargout = setFloatingBase(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1338, self, varargin{:});
     end
-    function varargout = getWorldBaseTransform(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1339, self, varargin{:});
     end
-    function varargout = getBaseTwist(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1340, self, varargin{:});
     end
-    function varargout = getJointPos(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1344, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1345, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getWorldTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
     end
-    function varargout = getFrameTwist(self,varargin)
+    function varargout = getRelativeTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1347, self, varargin{:});
     end
-    function varargout = getFrameTwistInWorldOrient(self,varargin)
+    function varargout = getFrameTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1348, self, varargin{:});
     end
-    function varargout = getFrameProperSpatialAcceleration(self,varargin)
+    function varargout = getFrameTwistInWorldOrient(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1349, self, varargin{:});
     end
-    function varargout = getLinkIndex(self,varargin)
+    function varargout = getFrameProperSpatialAcceleration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1350, self, varargin{:});
     end
-    function varargout = getLinkInertia(self,varargin)
+    function varargout = getLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
     end
-    function varargout = getJointIndex(self,varargin)
+    function varargout = getLinkInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
     end
-    function varargout = getJointName(self,varargin)
+    function varargout = getJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1353, self, varargin{:});
     end
-    function varargout = getJointLimits(self,varargin)
+    function varargout = getJointName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1354, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = getJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1355, self, varargin{:});
     end
-    function varargout = getFrameJacobian(self,varargin)
+    function varargout = inverseDynamics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1356, self, varargin{:});
     end
-    function varargout = getDynamicsRegressor(self,varargin)
+    function varargout = getFrameJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1357, self, varargin{:});
     end
-    function varargout = getModelDynamicsParameters(self,varargin)
+    function varargout = getDynamicsRegressor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1358, self, varargin{:});
     end
-    function varargout = getCenterOfMass(self,varargin)
+    function varargout = getModelDynamicsParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1359, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = getCenterOfMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1360, self, varargin{:});
+    end
+    function varargout = getCenterOfMassJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1361, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/DynamicsRegressorGenerator.m
+++ b/bindings/matlab/+iDynTree/DynamicsRegressorGenerator.m
@@ -9,82 +9,82 @@ classdef DynamicsRegressorGenerator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1278, varargin{:});
+        tmp = iDynTreeMEX(1279, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1279, self);
+        iDynTreeMEX(1280, self);
         self.swigPtr=[];
       end
     end
     function varargout = loadRobotAndSensorsModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1280, self, varargin{:});
-    end
-    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1281, self, varargin{:});
     end
-    function varargout = loadRegressorStructureFromFile(self,varargin)
+    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1282, self, varargin{:});
     end
-    function varargout = loadRegressorStructureFromString(self,varargin)
+    function varargout = loadRegressorStructureFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1283, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = loadRegressorStructureFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1284, self, varargin{:});
     end
-    function varargout = getNrOfParameters(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1285, self, varargin{:});
     end
-    function varargout = getNrOfOutputs(self,varargin)
+    function varargout = getNrOfParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1286, self, varargin{:});
     end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
+    function varargout = getNrOfOutputs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1287, self, varargin{:});
     end
-    function varargout = getDescriptionOfParameter(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1288, self, varargin{:});
     end
-    function varargout = getDescriptionOfParameters(self,varargin)
+    function varargout = getDescriptionOfParameter(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1289, self, varargin{:});
     end
-    function varargout = getDescriptionOfOutput(self,varargin)
+    function varargout = getDescriptionOfParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1290, self, varargin{:});
     end
-    function varargout = getDescriptionOfOutputs(self,varargin)
+    function varargout = getDescriptionOfOutput(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1291, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = getDescriptionOfOutputs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1292, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1293, self, varargin{:});
     end
-    function varargout = getBaseLinkName(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1294, self, varargin{:});
     end
-    function varargout = getSensorsModel(self,varargin)
+    function varargout = getBaseLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1295, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = getSensorsModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1296, self, varargin{:});
     end
-    function varargout = getSensorsMeasurements(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1297, self, varargin{:});
     end
-    function varargout = computeRegressor(self,varargin)
+    function varargout = getSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1298, self, varargin{:});
     end
-    function varargout = getModelParameters(self,varargin)
+    function varargout = computeRegressor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1299, self, varargin{:});
     end
-    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
+    function varargout = getModelParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1300, self, varargin{:});
     end
-    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1301, self, varargin{:});
+    end
+    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1302, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/DynamicsRegressorParameter.m
+++ b/bindings/matlab/+iDynTree/DynamicsRegressorParameter.m
@@ -7,40 +7,40 @@ classdef DynamicsRegressorParameter < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1258, self);
+        varargout{1} = iDynTreeMEX(1259, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1259, self, varargin{1});
+        iDynTreeMEX(1260, self, varargin{1});
       end
     end
     function varargout = elemIndex(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1260, self);
+        varargout{1} = iDynTreeMEX(1261, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1261, self, varargin{1});
+        iDynTreeMEX(1262, self, varargin{1});
       end
     end
     function varargout = type(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1262, self);
+        varargout{1} = iDynTreeMEX(1263, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1263, self, varargin{1});
+        iDynTreeMEX(1264, self, varargin{1});
       end
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1264, self, varargin{:});
-    end
-    function varargout = eq(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1265, self, varargin{:});
     end
-    function varargout = ne(self,varargin)
+    function varargout = eq(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1266, self, varargin{:});
+    end
+    function varargout = ne(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1267, self, varargin{:});
     end
     function self = DynamicsRegressorParameter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -48,14 +48,14 @@ classdef DynamicsRegressorParameter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1267, varargin{:});
+        tmp = iDynTreeMEX(1268, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1268, self);
+        iDynTreeMEX(1269, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/DynamicsRegressorParametersList.m
+++ b/bindings/matlab/+iDynTree/DynamicsRegressorParametersList.m
@@ -7,26 +7,26 @@ classdef DynamicsRegressorParametersList < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1269, self);
+        varargout{1} = iDynTreeMEX(1270, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1270, self, varargin{1});
+        iDynTreeMEX(1271, self, varargin{1});
       end
     end
     function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1271, self, varargin{:});
-    end
-    function varargout = addParam(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1272, self, varargin{:});
     end
-    function varargout = addList(self,varargin)
+    function varargout = addParam(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1273, self, varargin{:});
     end
-    function varargout = findParam(self,varargin)
+    function varargout = addList(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1274, self, varargin{:});
     end
-    function varargout = getNrOfParameters(self,varargin)
+    function varargout = findParam(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1275, self, varargin{:});
+    end
+    function varargout = getNrOfParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1276, self, varargin{:});
     end
     function self = DynamicsRegressorParametersList(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -34,14 +34,14 @@ classdef DynamicsRegressorParametersList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1276, varargin{:});
+        tmp = iDynTreeMEX(1277, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1277, self);
+        iDynTreeMEX(1278, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
+++ b/bindings/matlab/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
@@ -9,52 +9,52 @@ classdef ExtWrenchesAndJointTorquesEstimator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1176, varargin{:});
+        tmp = iDynTreeMEX(1177, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1177, self);
+        iDynTreeMEX(1178, self);
         self.swigPtr=[];
       end
     end
     function varargout = setModelAndSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
-    end
-    function varargout = loadModelAndSensorsFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
     end
-    function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
+    function varargout = loadModelAndSensorsFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
     end
-    function varargout = sensors(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
     end
-    function varargout = submodels(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+    function varargout = submodels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
     end
-    function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
     end
-    function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
+    function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
     end
-    function varargout = checkThatTheModelIsStill(self,varargin)
+    function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
     end
-    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+    function varargout = checkThatTheModelIsStill(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
+    end
+    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/FRAME_INVALID_INDEX.m
+++ b/bindings/matlab/+iDynTree/FRAME_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(690);
+    varargout{1} = iDynTreeMEX(691);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(691,varargin{1});
+    iDynTreeMEX(692,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/FRAME_INVALID_NAME.m
+++ b/bindings/matlab/+iDynTree/FRAME_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(692);
+    varargout{1} = iDynTreeMEX(693);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(693,varargin{1});
+    iDynTreeMEX(694,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/FixedJoint.m
+++ b/bindings/matlab/+iDynTree/FixedJoint.m
@@ -7,79 +7,79 @@ classdef FixedJoint < iDynTree.IJoint
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(767, varargin{:});
+        tmp = iDynTreeMEX(768, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(768, self);
+        iDynTreeMEX(769, self);
         self.swigPtr=[];
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(769, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(770, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(771, self, varargin{:});
     end
-    function varargout = setAttachedLinks(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(772, self, varargin{:});
     end
-    function varargout = setRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(773, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(774, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(775, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(776, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(778, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(779, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(780, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(781, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(782, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(783, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(785, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(786, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/ForceVector3Semantics__AngularForceVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/ForceVector3Semantics__AngularForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef ForceVector3Semantics__AngularForceVector3Semantics < iDynTree.GeomVect
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(381, varargin{:});
+        tmp = iDynTreeMEX(382, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(384, self);
+        iDynTreeMEX(385, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(382, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(383, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(383, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(384, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/ForceVector3Semantics__LinearForceVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/ForceVector3Semantics__LinearForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef ForceVector3Semantics__LinearForceVector3Semantics < iDynTree.GeomVecto
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(377, varargin{:});
+        tmp = iDynTreeMEX(378, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(380, self);
+        iDynTreeMEX(381, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(378, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(379, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(379, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(380, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/ForceVector3__AngularForceVector3.m
+++ b/bindings/matlab/+iDynTree/ForceVector3__AngularForceVector3.m
@@ -7,14 +7,14 @@ classdef ForceVector3__AngularForceVector3 < iDynTree.GeomVector3__AngularForceV
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(393, varargin{:});
+        tmp = iDynTreeMEX(394, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(394, self);
+        iDynTreeMEX(395, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ForceVector3__LinearForceVector3.m
+++ b/bindings/matlab/+iDynTree/ForceVector3__LinearForceVector3.m
@@ -7,14 +7,14 @@ classdef ForceVector3__LinearForceVector3 < iDynTree.GeomVector3__LinearForceVec
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(391, varargin{:});
+        tmp = iDynTreeMEX(392, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(392, self);
+        iDynTreeMEX(393, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/ForwardPosVelAccKinematics.m
+++ b/bindings/matlab/+iDynTree/ForwardPosVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(978, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(979, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ForwardPositionKinematics.m
+++ b/bindings/matlab/+iDynTree/ForwardPositionKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPositionKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(976, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(977, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/ForwardVelAccKinematics.m
+++ b/bindings/matlab/+iDynTree/ForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(977, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(978, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/FreeFloatingAcc.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingAcc.m
@@ -9,26 +9,26 @@ classdef FreeFloatingAcc < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(956, varargin{:});
+        tmp = iDynTreeMEX(957, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
-    end
-    function varargout = baseAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
     end
-    function varargout = jointAcc(self,varargin)
+    function varargout = baseAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = jointAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
+    end
+    function varargout = getNrOfDOFs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(961, self);
+        iDynTreeMEX(962, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingGeneralizedTorques.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingGeneralizedTorques.m
@@ -9,26 +9,26 @@ classdef FreeFloatingGeneralizedTorques < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(944, varargin{:});
+        tmp = iDynTreeMEX(945, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(945, self, varargin{:});
-    end
-    function varargout = baseWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(946, self, varargin{:});
     end
-    function varargout = jointTorques(self,varargin)
+    function varargout = baseWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(947, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = jointTorques(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(948, self, varargin{:});
+    end
+    function varargout = getNrOfDOFs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(949, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(949, self);
+        iDynTreeMEX(950, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingMassMatrix.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingMassMatrix.m
@@ -7,17 +7,17 @@ classdef FreeFloatingMassMatrix < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(935, varargin{:});
+        tmp = iDynTreeMEX(936, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(936, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(937, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(937, self);
+        iDynTreeMEX(938, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingPos.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingPos.m
@@ -9,26 +9,26 @@ classdef FreeFloatingPos < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(938, varargin{:});
+        tmp = iDynTreeMEX(939, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(939, self, varargin{:});
-    end
-    function varargout = worldBasePos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(940, self, varargin{:});
     end
-    function varargout = jointPos(self,varargin)
+    function varargout = worldBasePos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(941, self, varargin{:});
     end
-    function varargout = getNrOfPosCoords(self,varargin)
+    function varargout = jointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(942, self, varargin{:});
+    end
+    function varargout = getNrOfPosCoords(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(943, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(943, self);
+        iDynTreeMEX(944, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/FreeFloatingVel.m
+++ b/bindings/matlab/+iDynTree/FreeFloatingVel.m
@@ -9,26 +9,26 @@ classdef FreeFloatingVel < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(950, varargin{:});
+        tmp = iDynTreeMEX(951, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(951, self, varargin{:});
-    end
-    function varargout = baseVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(952, self, varargin{:});
     end
-    function varargout = jointVel(self,varargin)
+    function varargout = baseVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(953, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = jointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(954, self, varargin{:});
+    end
+    function varargout = getNrOfDOFs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(955, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(955, self);
+        iDynTreeMEX(956, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/GeomVector3Semantics__AngularForceVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/GeomVector3Semantics__AngularForceVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__AngularForceVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(318, varargin{:});
+        tmp = iDynTreeMEX(319, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(319, self, varargin{:});
-    end
-    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(320, self, varargin{:});
     end
-    function varargout = getRefBody(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(321, self, varargin{:});
     end
-    function varargout = getCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(322, self, varargin{:});
     end
-    function varargout = isUnknown(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(323, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = isUnknown(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(324, self, varargin{:});
     end
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(325, self, varargin{:});
+    end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(327, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(328, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(328, self);
+        iDynTreeMEX(329, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(325, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(326, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(326, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(327, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3Semantics__AngularMotionVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/GeomVector3Semantics__AngularMotionVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__AngularMotionVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(296, varargin{:});
+        tmp = iDynTreeMEX(297, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(297, self, varargin{:});
-    end
-    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(298, self, varargin{:});
     end
-    function varargout = getRefBody(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(299, self, varargin{:});
     end
-    function varargout = getCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(300, self, varargin{:});
     end
-    function varargout = isUnknown(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(301, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = isUnknown(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(302, self, varargin{:});
     end
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(303, self, varargin{:});
+    end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(305, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(306, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(306, self);
+        iDynTreeMEX(307, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(303, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(304, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(304, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(305, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3Semantics__LinearForceVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/GeomVector3Semantics__LinearForceVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__LinearForceVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(307, varargin{:});
+        tmp = iDynTreeMEX(308, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(308, self, varargin{:});
-    end
-    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(309, self, varargin{:});
     end
-    function varargout = getRefBody(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(310, self, varargin{:});
     end
-    function varargout = getCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(311, self, varargin{:});
     end
-    function varargout = isUnknown(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(312, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = isUnknown(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(313, self, varargin{:});
     end
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(314, self, varargin{:});
+    end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(316, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(317, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(317, self);
+        iDynTreeMEX(318, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(314, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(315, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(315, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(316, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3Semantics__LinearMotionVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/GeomVector3Semantics__LinearMotionVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__LinearMotionVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(285, varargin{:});
+        tmp = iDynTreeMEX(286, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(286, self, varargin{:});
-    end
-    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(287, self, varargin{:});
     end
-    function varargout = getRefBody(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(288, self, varargin{:});
     end
-    function varargout = getCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(289, self, varargin{:});
     end
-    function varargout = isUnknown(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(290, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = isUnknown(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(291, self, varargin{:});
     end
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(292, self, varargin{:});
+    end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(294, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(295, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(295, self);
+        iDynTreeMEX(296, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(292, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(293, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(293, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(294, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3__AngularForceVector3.m
+++ b/bindings/matlab/+iDynTree/GeomVector3__AngularForceVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__AngularForceVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(365, self);
+        varargout{1} = iDynTreeMEX(366, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(366, self, varargin{1});
+        iDynTreeMEX(367, self, varargin{1});
       end
     end
     function self = GeomVector3__AngularForceVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__AngularForceVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(367, varargin{:});
+        tmp = iDynTreeMEX(368, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(368, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(369, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(372, self, varargin{:});
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(370, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(373, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(374, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(375, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(376, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(376, self);
+        iDynTreeMEX(377, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(370, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(371, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(371, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(372, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3__AngularMotionVector3.m
+++ b/bindings/matlab/+iDynTree/GeomVector3__AngularMotionVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__AngularMotionVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(341, self);
+        varargout{1} = iDynTreeMEX(342, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(342, self, varargin{1});
+        iDynTreeMEX(343, self, varargin{1});
       end
     end
     function self = GeomVector3__AngularMotionVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__AngularMotionVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(343, varargin{:});
+        tmp = iDynTreeMEX(344, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(344, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(345, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(348, self, varargin{:});
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(346, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(349, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(350, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(351, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(352, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(352, self);
+        iDynTreeMEX(353, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(346, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(347, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(347, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(348, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3__LinearForceVector3.m
+++ b/bindings/matlab/+iDynTree/GeomVector3__LinearForceVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__LinearForceVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(353, self);
+        varargout{1} = iDynTreeMEX(354, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(354, self, varargin{1});
+        iDynTreeMEX(355, self, varargin{1});
       end
     end
     function self = GeomVector3__LinearForceVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__LinearForceVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(355, varargin{:});
+        tmp = iDynTreeMEX(356, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(356, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(357, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(360, self, varargin{:});
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(358, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(361, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(362, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(363, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(364, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(364, self);
+        iDynTreeMEX(365, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(358, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(359, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(359, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(360, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GeomVector3__LinearMotionVector3.m
+++ b/bindings/matlab/+iDynTree/GeomVector3__LinearMotionVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__LinearMotionVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(329, self);
+        varargout{1} = iDynTreeMEX(330, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(330, self, varargin{1});
+        iDynTreeMEX(331, self, varargin{1});
       end
     end
     function self = GeomVector3__LinearMotionVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__LinearMotionVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(331, varargin{:});
+        tmp = iDynTreeMEX(332, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(332, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(333, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(336, self, varargin{:});
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(334, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(337, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(338, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(339, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(340, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(340, self);
+        iDynTreeMEX(341, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(334, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(335, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(335, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(336, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/GyroscopeSensor.m
+++ b/bindings/matlab/+iDynTree/GyroscopeSensor.m
@@ -7,55 +7,55 @@ classdef GyroscopeSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1093, varargin{:});
+        tmp = iDynTreeMEX(1094, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1094, self);
+        iDynTreeMEX(1095, self);
         self.swigPtr=[];
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1095, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1096, self, varargin{:});
     end
-    function varargout = setParentLink(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1097, self, varargin{:});
     end
-    function varargout = setParentLinkIndex(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1099, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1101, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1102, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1105, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1106, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1107, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1108, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/IJoint.m
+++ b/bindings/matlab/+iDynTree/IJoint.m
@@ -5,84 +5,84 @@ classdef IJoint < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(741, self);
+        iDynTreeMEX(742, self);
         self.swigPtr=[];
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(742, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(743, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(744, self, varargin{:});
     end
-    function varargout = setAttachedLinks(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(745, self, varargin{:});
     end
-    function varargout = setRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(746, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(747, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(748, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(749, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(750, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(751, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(752, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(753, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(754, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(755, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(756, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(757, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(758, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(759, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(760, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(761, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(762, self, varargin{:});
     end
-    function varargout = isRevoluteJoint(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(763, self, varargin{:});
     end
-    function varargout = isFixedJoint(self,varargin)
+    function varargout = isRevoluteJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(764, self, varargin{:});
     end
-    function varargout = asRevoluteJoint(self,varargin)
+    function varargout = isFixedJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(765, self, varargin{:});
     end
-    function varargout = asFixedJoint(self,varargin)
+    function varargout = asRevoluteJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(766, self, varargin{:});
+    end
+    function varargout = asFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(767, self, varargin{:});
     end
     function self = IJoint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/+iDynTree/JOINT_INVALID_INDEX.m
+++ b/bindings/matlab/+iDynTree/JOINT_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(682);
+    varargout{1} = iDynTreeMEX(683);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(683,varargin{1});
+    iDynTreeMEX(684,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/JOINT_INVALID_NAME.m
+++ b/bindings/matlab/+iDynTree/JOINT_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(684);
+    varargout{1} = iDynTreeMEX(685);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(685,varargin{1});
+    iDynTreeMEX(686,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/JointDOFsDoubleArray.m
+++ b/bindings/matlab/+iDynTree/JointDOFsDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointDOFsDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(921, varargin{:});
+        tmp = iDynTreeMEX(922, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(922, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(924, self);
+        iDynTreeMEX(925, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/JointPosDoubleArray.m
+++ b/bindings/matlab/+iDynTree/JointPosDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointPosDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(917, varargin{:});
+        tmp = iDynTreeMEX(918, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(920, self);
+        iDynTreeMEX(921, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/JointSensor.m
+++ b/bindings/matlab/+iDynTree/JointSensor.m
@@ -2,21 +2,21 @@ classdef JointSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1015, self);
+        iDynTreeMEX(1016, self);
         self.swigPtr=[];
       end
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
-    end
-    function varargout = getParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
     end
-    function varargout = setParentJoint(self,varargin)
+    function varargout = getParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
     end
-    function varargout = setParentJointIndex(self,varargin)
+    function varargout = setParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
+    end
+    function varargout = setParentJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
     end
     function self = JointSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/+iDynTree/KinDynComputations.m
@@ -9,82 +9,82 @@ classdef KinDynComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1302, varargin{:});
+        tmp = iDynTreeMEX(1303, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1303, self);
+        iDynTreeMEX(1304, self);
         self.swigPtr=[];
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1304, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1305, self, varargin{:});
     end
-    function varargout = loadRobotModelFromString(self,varargin)
+    function varargout = loadRobotModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1307, self, varargin{:});
     end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
     end
-    function varargout = getFloatingBase(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1313, self, varargin{:});
     end
-    function varargout = setFloatingBase(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
     end
-    function varargout = getRobotModel(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = getRobotModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
     end
-    function varargout = getWorldBaseTransform(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
     end
-    function varargout = getBaseTwist(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
     end
-    function varargout = getJointPos(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1319, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1321, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1322, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
     end
-    function varargout = getRelativeTransformExplicit(self,varargin)
+    function varargout = getWorldTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getRelativeTransformExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
+    end
+    function varargout = getRelativeTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/LINK_INVALID_INDEX.m
+++ b/bindings/matlab/+iDynTree/LINK_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(678);
+    varargout{1} = iDynTreeMEX(679);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(679,varargin{1});
+    iDynTreeMEX(680,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/LINK_INVALID_NAME.m
+++ b/bindings/matlab/+iDynTree/LINK_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(680);
+    varargout{1} = iDynTreeMEX(681);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(681,varargin{1});
+    iDynTreeMEX(682,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/LinearForceVector3.m
+++ b/bindings/matlab/+iDynTree/LinearForceVector3.m
@@ -7,14 +7,14 @@ classdef LinearForceVector3 < iDynTree.ForceVector3__LinearForceVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(409, varargin{:});
+        tmp = iDynTreeMEX(410, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(410, self);
+        iDynTreeMEX(411, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinearForceVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/LinearForceVector3Semantics.m
@@ -7,14 +7,14 @@ classdef LinearForceVector3Semantics < iDynTree.ForceVector3Semantics__LinearFor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(407, varargin{:});
+        tmp = iDynTreeMEX(408, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(408, self);
+        iDynTreeMEX(409, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinearMotionVector3.m
+++ b/bindings/matlab/+iDynTree/LinearMotionVector3.m
@@ -7,17 +7,17 @@ classdef LinearMotionVector3 < iDynTree.MotionVector3__LinearMotionVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(399, varargin{:});
+        tmp = iDynTreeMEX(400, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(400, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(401, self);
+        iDynTreeMEX(402, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinearMotionVector3Semantics.m
+++ b/bindings/matlab/+iDynTree/LinearMotionVector3Semantics.m
@@ -7,24 +7,24 @@ classdef LinearMotionVector3Semantics < iDynTree.GeomVector3Semantics__LinearMot
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(395, varargin{:});
+        tmp = iDynTreeMEX(396, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(396, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(397, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(398, self);
+        iDynTreeMEX(399, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(397, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(398, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/Link.m
+++ b/bindings/matlab/+iDynTree/Link.m
@@ -9,29 +9,29 @@ classdef Link < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(734, varargin{:});
+        tmp = iDynTreeMEX(735, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = inertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(735, self, varargin{:});
-    end
-    function varargout = setInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(736, self, varargin{:});
     end
-    function varargout = getInertia(self,varargin)
+    function varargout = setInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(737, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(738, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(739, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(740, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(740, self);
+        iDynTreeMEX(741, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkAccArray.m
+++ b/bindings/matlab/+iDynTree/LinkAccArray.m
@@ -9,29 +9,29 @@ classdef LinkAccArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(727, varargin{:});
+        tmp = iDynTreeMEX(728, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(728, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(729, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(730, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(731, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(732, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(733, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(733, self);
+        iDynTreeMEX(734, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkArticulatedBodyInertias.m
+++ b/bindings/matlab/+iDynTree/LinkArticulatedBodyInertias.m
@@ -9,23 +9,23 @@ classdef LinkArticulatedBodyInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(715, varargin{:});
+        tmp = iDynTreeMEX(716, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(716, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(717, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(718, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(719, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(719, self);
+        iDynTreeMEX(720, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkContactWrenches.m
+++ b/bindings/matlab/+iDynTree/LinkContactWrenches.m
@@ -9,35 +9,35 @@ classdef LinkContactWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(967, varargin{:});
+        tmp = iDynTreeMEX(968, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
-    end
-    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
     end
-    function varargout = setNrOfContactsForLink(self,varargin)
+    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = setNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
     end
-    function varargout = contactWrench(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
     end
-    function varargout = computeNetWrenches(self,varargin)
+    function varargout = contactWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = computeNetWrenches(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(975, self);
+        iDynTreeMEX(976, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkInertias.m
+++ b/bindings/matlab/+iDynTree/LinkInertias.m
@@ -9,23 +9,23 @@ classdef LinkInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(710, varargin{:});
+        tmp = iDynTreeMEX(711, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(711, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(712, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(713, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(714, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(714, self);
+        iDynTreeMEX(715, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkPositions.m
+++ b/bindings/matlab/+iDynTree/LinkPositions.m
@@ -9,29 +9,29 @@ classdef LinkPositions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(696, varargin{:});
+        tmp = iDynTreeMEX(697, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(697, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(698, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(699, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(700, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(701, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(702, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(702, self);
+        iDynTreeMEX(703, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkSensor.m
+++ b/bindings/matlab/+iDynTree/LinkSensor.m
@@ -2,24 +2,24 @@ classdef LinkSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1020, self);
+        iDynTreeMEX(1021, self);
         self.swigPtr=[];
       end
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
     end
-    function varargout = setParentLink(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
     end
-    function varargout = setParentLinkIndex(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
+    end
+    function varargout = setParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
     end
     function self = LinkSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/LinkTraversalsCache.m
+++ b/bindings/matlab/+iDynTree/LinkTraversalsCache.m
@@ -9,22 +9,22 @@ classdef LinkTraversalsCache < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1149, varargin{:});
+        tmp = iDynTreeMEX(1150, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1150, self);
+        iDynTreeMEX(1151, self);
         self.swigPtr=[];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1151, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1152, self, varargin{:});
     end
     function varargout = getTraversalWithLinkAsBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1152, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1153, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/LinkUnknownWrenchContacts.m
+++ b/bindings/matlab/+iDynTree/LinkUnknownWrenchContacts.m
@@ -9,41 +9,41 @@ classdef LinkUnknownWrenchContacts < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1138, varargin{:});
+        tmp = iDynTreeMEX(1139, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1140, self, varargin{:});
     end
-    function varargout = getNrOfContactsForLink(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1141, self, varargin{:});
     end
-    function varargout = setNrOfContactsForLink(self,varargin)
+    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1142, self, varargin{:});
     end
-    function varargout = addNewContactForLink(self,varargin)
+    function varargout = setNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1143, self, varargin{:});
     end
-    function varargout = addNewContactInFrame(self,varargin)
+    function varargout = addNewContactForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1144, self, varargin{:});
     end
-    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
+    function varargout = addNewContactInFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1145, self, varargin{:});
     end
-    function varargout = contactWrench(self,varargin)
+    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1146, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = contactWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1147, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1148, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1148, self);
+        iDynTreeMEX(1149, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkVelArray.m
+++ b/bindings/matlab/+iDynTree/LinkVelArray.m
@@ -9,29 +9,29 @@ classdef LinkVelArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(720, varargin{:});
+        tmp = iDynTreeMEX(721, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(721, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(722, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(723, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(724, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(725, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(726, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(726, self);
+        iDynTreeMEX(727, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/LinkWrenches.m
+++ b/bindings/matlab/+iDynTree/LinkWrenches.m
@@ -9,29 +9,29 @@ classdef LinkWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(703, varargin{:});
+        tmp = iDynTreeMEX(704, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(704, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(705, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(706, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(707, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(708, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(709, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(709, self);
+        iDynTreeMEX(710, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Matrix10x16.m
+++ b/bindings/matlab/+iDynTree/Matrix10x16.m
@@ -9,53 +9,53 @@ classdef Matrix10x16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(174, varargin{:});
+        tmp = iDynTreeMEX(175, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(175, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(176, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(177, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(178, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(179, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(180, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(181, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(182, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(183, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(184, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(185, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(186, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(187, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(188, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(188, self);
+        iDynTreeMEX(189, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Matrix3x3.m
+++ b/bindings/matlab/+iDynTree/Matrix3x3.m
@@ -9,53 +9,53 @@ classdef Matrix3x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(114, varargin{:});
+        tmp = iDynTreeMEX(115, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(115, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(116, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(117, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(118, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(119, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(120, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(121, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(122, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(123, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(124, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(125, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(126, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(127, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(128, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(128, self);
+        iDynTreeMEX(129, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Matrix4x4.m
+++ b/bindings/matlab/+iDynTree/Matrix4x4.m
@@ -9,53 +9,53 @@ classdef Matrix4x4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(129, varargin{:});
+        tmp = iDynTreeMEX(130, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(130, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(131, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(132, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(133, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(134, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(135, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(136, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(137, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(138, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(139, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(140, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(141, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(142, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(143, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(143, self);
+        iDynTreeMEX(144, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Matrix6x10.m
+++ b/bindings/matlab/+iDynTree/Matrix6x10.m
@@ -9,53 +9,53 @@ classdef Matrix6x10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(159, varargin{:});
+        tmp = iDynTreeMEX(160, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(160, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(161, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(162, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(163, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(164, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(165, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(166, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(167, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(168, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(169, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(170, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(171, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(172, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(173, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(173, self);
+        iDynTreeMEX(174, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Matrix6x6.m
+++ b/bindings/matlab/+iDynTree/Matrix6x6.m
@@ -9,53 +9,53 @@ classdef Matrix6x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(144, varargin{:});
+        tmp = iDynTreeMEX(145, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(145, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(146, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(147, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(148, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(149, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(150, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(151, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(152, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(153, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(154, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(155, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(156, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(157, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(158, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(158, self);
+        iDynTreeMEX(159, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/MatrixDynSize.m
+++ b/bindings/matlab/+iDynTree/MatrixDynSize.m
@@ -68,6 +68,9 @@ classdef MatrixDynSize < SwigRef
     function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(96, self, varargin{:});
     end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(97, self, varargin{:});
+    end
   end
   methods(Static)
   end

--- a/bindings/matlab/+iDynTree/Model.m
+++ b/bindings/matlab/+iDynTree/Model.m
@@ -9,112 +9,112 @@ classdef Model < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(883, varargin{:});
+        tmp = iDynTreeMEX(884, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(884, self);
+        iDynTreeMEX(885, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(885, self, varargin{:});
-    end
-    function varargout = getLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(886, self, varargin{:});
     end
-    function varargout = getLinkIndex(self,varargin)
+    function varargout = getLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(887, self, varargin{:});
     end
-    function varargout = isValidLinkIndex(self,varargin)
+    function varargout = getLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
     end
-    function varargout = getLink(self,varargin)
+    function varargout = isValidLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
     end
-    function varargout = addLink(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
     end
-    function varargout = getNrOfJoints(self,varargin)
+    function varargout = addLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(891, self, varargin{:});
     end
-    function varargout = getJointName(self,varargin)
+    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(892, self, varargin{:});
     end
-    function varargout = getJointIndex(self,varargin)
+    function varargout = getJointName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
     end
-    function varargout = getJoint(self,varargin)
+    function varargout = getJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
     end
-    function varargout = isValidJointIndex(self,varargin)
+    function varargout = getJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
     end
-    function varargout = isLinkNameUsed(self,varargin)
+    function varargout = isValidJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
     end
-    function varargout = isJointNameUsed(self,varargin)
+    function varargout = isLinkNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
     end
-    function varargout = isFrameNameUsed(self,varargin)
+    function varargout = isJointNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
     end
-    function varargout = addJoint(self,varargin)
+    function varargout = isFrameNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(899, self, varargin{:});
     end
-    function varargout = getNrOfPosCoords(self,varargin)
+    function varargout = addJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
     end
-    function varargout = addAdditionalFrameToLink(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = addAdditionalFrameToLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(905, self, varargin{:});
     end
-    function varargout = isValidFrameIndex(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(906, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = isValidFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
     end
-    function varargout = getFrameLink(self,varargin)
+    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
     end
-    function varargout = getNrOfNeighbors(self,varargin)
+    function varargout = getFrameLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
     end
-    function varargout = getNeighbor(self,varargin)
+    function varargout = getNrOfNeighbors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
     end
-    function varargout = setDefaultBaseLink(self,varargin)
+    function varargout = getNeighbor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
     end
-    function varargout = getDefaultBaseLink(self,varargin)
+    function varargout = setDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
     end
-    function varargout = computeFullTreeTraversal(self,varargin)
+    function varargout = getDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
     end
-    function varargout = getInertialParameters(self,varargin)
+    function varargout = computeFullTreeTraversal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
     end
-    function varargout = updateInertialParameters(self,varargin)
+    function varargout = getInertialParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(915, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = updateInertialParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(916, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/ModelLoader.m
+++ b/bindings/matlab/+iDynTree/ModelLoader.m
@@ -9,38 +9,38 @@ classdef ModelLoader < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1118, varargin{:});
+        tmp = iDynTreeMEX(1119, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1119, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1120, self, varargin{:});
     end
-    function varargout = loadReducedModelFromFullModel(self,varargin)
+    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1121, self, varargin{:});
     end
-    function varargout = loadReducedModelFromString(self,varargin)
+    function varargout = loadReducedModelFromFullModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1122, self, varargin{:});
     end
-    function varargout = loadReducedModelFromFile(self,varargin)
+    function varargout = loadReducedModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1123, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = loadReducedModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1124, self, varargin{:});
     end
-    function varargout = sensors(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1125, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1126, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1127, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1127, self);
+        iDynTreeMEX(1128, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/MotionVector3__AngularMotionVector3.m
+++ b/bindings/matlab/+iDynTree/MotionVector3__AngularMotionVector3.m
@@ -7,17 +7,17 @@ classdef MotionVector3__AngularMotionVector3 < iDynTree.GeomVector3__AngularMoti
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(388, varargin{:});
+        tmp = iDynTreeMEX(389, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(389, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(390, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(390, self);
+        iDynTreeMEX(391, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/MotionVector3__LinearMotionVector3.m
+++ b/bindings/matlab/+iDynTree/MotionVector3__LinearMotionVector3.m
@@ -7,17 +7,17 @@ classdef MotionVector3__LinearMotionVector3 < iDynTree.GeomVector3__LinearMotion
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(385, varargin{:});
+        tmp = iDynTreeMEX(386, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(386, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(387, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(387, self);
+        iDynTreeMEX(388, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/MovableJointImpl1.m
+++ b/bindings/matlab/+iDynTree/MovableJointImpl1.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl1 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(790, self);
+        iDynTreeMEX(791, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(791, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(792, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(793, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(794, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(795, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(796, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(797, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(798, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(799, self, varargin{:});
     end
     function self = MovableJointImpl1(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/MovableJointImpl2.m
+++ b/bindings/matlab/+iDynTree/MovableJointImpl2.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl2 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(799, self);
+        iDynTreeMEX(800, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(800, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(801, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(802, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(803, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(804, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(805, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(806, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(807, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(808, self, varargin{:});
     end
     function self = MovableJointImpl2(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/MovableJointImpl3.m
+++ b/bindings/matlab/+iDynTree/MovableJointImpl3.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl3 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(808, self);
+        iDynTreeMEX(809, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(809, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(810, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(812, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(813, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(814, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(815, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(816, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(817, self, varargin{:});
     end
     function self = MovableJointImpl3(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/MovableJointImpl4.m
+++ b/bindings/matlab/+iDynTree/MovableJointImpl4.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl4 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(817, self);
+        iDynTreeMEX(818, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(818, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(819, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(820, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(821, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(825, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(826, self, varargin{:});
     end
     function self = MovableJointImpl4(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/MovableJointImpl5.m
+++ b/bindings/matlab/+iDynTree/MovableJointImpl5.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl5 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(826, self);
+        iDynTreeMEX(827, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(827, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(828, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(829, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(830, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(831, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(832, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(833, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(834, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(835, self, varargin{:});
     end
     function self = MovableJointImpl5(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/MovableJointImpl6.m
+++ b/bindings/matlab/+iDynTree/MovableJointImpl6.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl6 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(835, self);
+        iDynTreeMEX(836, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(836, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(837, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(838, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(839, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(840, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(841, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(842, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(843, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(844, self, varargin{:});
     end
     function self = MovableJointImpl6(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/+iDynTree/NR_OF_SENSOR_TYPES.m
+++ b/bindings/matlab/+iDynTree/NR_OF_SENSOR_TYPES.m
@@ -1,3 +1,3 @@
 function v = NR_OF_SENSOR_TYPES()
-  v = iDynTreeMEX(1004);
+  v = iDynTreeMEX(1005);
 end

--- a/bindings/matlab/+iDynTree/Neighbor.m
+++ b/bindings/matlab/+iDynTree/Neighbor.m
@@ -7,20 +7,20 @@ classdef Neighbor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(877, self);
+        varargout{1} = iDynTreeMEX(878, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(878, self, varargin{1});
+        iDynTreeMEX(879, self, varargin{1});
       end
     end
     function varargout = neighborJoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(879, self);
+        varargout{1} = iDynTreeMEX(880, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(880, self, varargin{1});
+        iDynTreeMEX(881, self, varargin{1});
       end
     end
     function self = Neighbor(varargin)
@@ -29,14 +29,14 @@ classdef Neighbor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(881, varargin{:});
+        tmp = iDynTreeMEX(882, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(882, self);
+        iDynTreeMEX(883, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Position.m
+++ b/bindings/matlab/+iDynTree/Position.m
@@ -7,60 +7,60 @@ classdef Position < iDynTree.PositionRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(269, varargin{:});
+        tmp = iDynTreeMEX(270, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(270, self, varargin{:});
-    end
-    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(271, self, varargin{:});
     end
-    function varargout = changeRefPoint(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(272, self, varargin{:});
     end
-    function varargout = changeCoordinateFrame(self,varargin)
+    function varargout = changeRefPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(273, self, varargin{:});
     end
-    function varargout = changePointOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(276, self, varargin{:});
+    function varargout = changeCoordinateFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(274, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = changePointOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(277, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(278, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(279, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = uminus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(280, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(281, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(282, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(283, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(284, self);
+        iDynTreeMEX(285, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(274, varargin{:});
-    end
-    function varargout = inverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(275, varargin{:});
     end
+    function varargout = inverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(276, varargin{:});
+    end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(283, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(284, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/PositionRaw.m
+++ b/bindings/matlab/+iDynTree/PositionRaw.m
@@ -7,39 +7,39 @@ classdef PositionRaw < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(241, varargin{:});
+        tmp = iDynTreeMEX(242, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(242, self, varargin{:});
-    end
-    function varargout = changeRefPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(243, self, varargin{:});
     end
-    function varargout = changePointOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(246, self, varargin{:});
+    function varargout = changeRefPoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(244, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = changePointOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(247, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(248, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(249, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(249, self);
+        iDynTreeMEX(250, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(244, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(245, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(245, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(246, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/PositionSemantics.m
+++ b/bindings/matlab/+iDynTree/PositionSemantics.m
@@ -9,69 +9,69 @@ classdef PositionSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(250, varargin{:});
+        tmp = iDynTreeMEX(251, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(251, self, varargin{:});
-    end
-    function varargout = getPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(252, self, varargin{:});
     end
-    function varargout = getBody(self,varargin)
+    function varargout = getPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(253, self, varargin{:});
     end
-    function varargout = getReferencePoint(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(254, self, varargin{:});
     end
-    function varargout = getRefBody(self,varargin)
+    function varargout = getReferencePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(255, self, varargin{:});
     end
-    function varargout = getCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(256, self, varargin{:});
     end
-    function varargout = setPoint(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(257, self, varargin{:});
     end
-    function varargout = setBody(self,varargin)
+    function varargout = setPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(258, self, varargin{:});
     end
-    function varargout = setReferencePoint(self,varargin)
+    function varargout = setBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(259, self, varargin{:});
     end
-    function varargout = setRefBody(self,varargin)
+    function varargout = setReferencePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(260, self, varargin{:});
     end
-    function varargout = setCoordinateFrame(self,varargin)
+    function varargout = setRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(261, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = setCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(262, self, varargin{:});
     end
-    function varargout = changeRefPoint(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(263, self, varargin{:});
     end
+    function varargout = changeRefPoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(264, self, varargin{:});
+    end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(266, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(268, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(268, self);
+        iDynTreeMEX(269, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(264, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(265, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(265, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(266, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/RNEADynamicPhase.m
+++ b/bindings/matlab/+iDynTree/RNEADynamicPhase.m
@@ -1,3 +1,3 @@
 function varargout = RNEADynamicPhase(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(979, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(980, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/RevoluteJoint.m
+++ b/bindings/matlab/+iDynTree/RevoluteJoint.m
@@ -7,61 +7,61 @@ classdef RevoluteJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(844, varargin{:});
+        tmp = iDynTreeMEX(845, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(845, self);
+        iDynTreeMEX(846, self);
         self.swigPtr=[];
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(846, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(847, self, varargin{:});
     end
-    function varargout = setRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(848, self, varargin{:});
     end
-    function varargout = setAxis(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(849, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(850, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(851, self, varargin{:});
     end
-    function varargout = getAxis(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(852, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(853, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(854, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(855, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(856, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(857, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(858, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(859, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(860, self, varargin{:});
+    end
+    function varargout = computeJointTorque(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(861, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/Rotation.m
+++ b/bindings/matlab/+iDynTree/Rotation.m
@@ -7,93 +7,93 @@ classdef Rotation < iDynTree.RotationRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(612, varargin{:});
+        tmp = iDynTreeMEX(613, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(613, self, varargin{:});
-    end
-    function varargout = changeOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(614, self, varargin{:});
     end
-    function varargout = changeRefOrientFrame(self,varargin)
+    function varargout = changeOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(615, self, varargin{:});
     end
-    function varargout = changeCoordinateFrame(self,varargin)
+    function varargout = changeRefOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(616, self, varargin{:});
     end
-    function varargout = changeCoordFrameOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(619, self, varargin{:});
+    function varargout = changeCoordinateFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(617, self, varargin{:});
     end
-    function varargout = inverse(self,varargin)
+    function varargout = changeCoordFrameOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(620, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(621, self, varargin{:});
     end
-    function varargout = log(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(622, self, varargin{:});
     end
-    function varargout = fromQuaternion(self,varargin)
+    function varargout = log(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(623, self, varargin{:});
     end
-    function varargout = getRPY(self,varargin)
+    function varargout = fromQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(624, self, varargin{:});
     end
-    function varargout = asRPY(self,varargin)
+    function varargout = getRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(625, self, varargin{:});
     end
-    function varargout = getQuaternion(self,varargin)
+    function varargout = asRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(626, self, varargin{:});
     end
-    function varargout = asQuaternion(self,varargin)
+    function varargout = getQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(627, self, varargin{:});
     end
+    function varargout = asQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(628, self, varargin{:});
+    end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(636, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(637, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(637, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(638, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(638, self);
+        iDynTreeMEX(639, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(617, varargin{:});
-    end
-    function varargout = inverse2(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(618, varargin{:});
     end
-    function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(628, varargin{:});
+    function varargout = inverse2(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(619, varargin{:});
     end
-    function varargout = RotY(varargin)
+    function varargout = RotX(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(629, varargin{:});
     end
-    function varargout = RotZ(varargin)
+    function varargout = RotY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(630, varargin{:});
     end
-    function varargout = RotAxis(varargin)
+    function varargout = RotZ(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(631, varargin{:});
     end
-    function varargout = RotAxisDerivative(varargin)
+    function varargout = RotAxis(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(632, varargin{:});
     end
-    function varargout = RPY(varargin)
+    function varargout = RotAxisDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(633, varargin{:});
     end
-    function varargout = Identity(varargin)
+    function varargout = RPY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(634, varargin{:});
     end
-    function varargout = RotationFromQuaternion(varargin)
+    function varargout = Identity(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(635, varargin{:});
+    end
+    function varargout = RotationFromQuaternion(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(636, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/RotationRaw.m
+++ b/bindings/matlab/+iDynTree/RotationRaw.m
@@ -7,54 +7,54 @@ classdef RotationRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(578, varargin{:});
+        tmp = iDynTreeMEX(579, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(579, self, varargin{:});
-    end
-    function varargout = changeRefOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(580, self, varargin{:});
     end
+    function varargout = changeRefOrientFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(581, self, varargin{:});
+    end
     function varargout = changeCoordFrameOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(583, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(584, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(589, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(590, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(590, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(591, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(591, self);
+        iDynTreeMEX(592, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(581, varargin{:});
-    end
-    function varargout = inverse2(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(582, varargin{:});
     end
-    function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(584, varargin{:});
+    function varargout = inverse2(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(583, varargin{:});
     end
-    function varargout = RotY(varargin)
+    function varargout = RotX(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(585, varargin{:});
     end
-    function varargout = RotZ(varargin)
+    function varargout = RotY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(586, varargin{:});
     end
-    function varargout = RPY(varargin)
+    function varargout = RotZ(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(587, varargin{:});
     end
-    function varargout = Identity(varargin)
+    function varargout = RPY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(588, varargin{:});
+    end
+    function varargout = Identity(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(589, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/RotationSemantics.m
+++ b/bindings/matlab/+iDynTree/RotationSemantics.m
@@ -9,72 +9,72 @@ classdef RotationSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(592, varargin{:});
+        tmp = iDynTreeMEX(593, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(593, self, varargin{:});
-    end
-    function varargout = getOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(594, self, varargin{:});
     end
-    function varargout = getBody(self,varargin)
+    function varargout = getOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(595, self, varargin{:});
     end
-    function varargout = getReferenceOrientationFrame(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(596, self, varargin{:});
     end
-    function varargout = getRefBody(self,varargin)
+    function varargout = getReferenceOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(597, self, varargin{:});
     end
-    function varargout = getCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(598, self, varargin{:});
     end
-    function varargout = setOrientationFrame(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(599, self, varargin{:});
     end
-    function varargout = setBody(self,varargin)
+    function varargout = setOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(600, self, varargin{:});
     end
-    function varargout = setReferenceOrientationFrame(self,varargin)
+    function varargout = setBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(601, self, varargin{:});
     end
-    function varargout = setRefBody(self,varargin)
+    function varargout = setReferenceOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(602, self, varargin{:});
     end
-    function varargout = setCoordinateFrame(self,varargin)
+    function varargout = setRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(603, self, varargin{:});
     end
-    function varargout = changeOrientFrame(self,varargin)
+    function varargout = setCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(604, self, varargin{:});
     end
-    function varargout = changeRefOrientFrame(self,varargin)
+    function varargout = changeOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(605, self, varargin{:});
     end
-    function varargout = changeCoordFrameOf(self,varargin)
+    function varargout = changeRefOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(606, self, varargin{:});
     end
+    function varargout = changeCoordFrameOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(607, self, varargin{:});
+    end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(609, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(610, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(610, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(611, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(611, self);
+        iDynTreeMEX(612, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(607, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(608, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(608, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(609, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/RotationalInertiaRaw.m
+++ b/bindings/matlab/+iDynTree/RotationalInertiaRaw.m
@@ -7,21 +7,21 @@ classdef RotationalInertiaRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(535, varargin{:});
+        tmp = iDynTreeMEX(536, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(537, self);
+        iDynTreeMEX(538, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(536, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(537, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/Sensor.m
+++ b/bindings/matlab/+iDynTree/Sensor.m
@@ -5,27 +5,27 @@ classdef Sensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1008, self);
+        iDynTreeMEX(1009, self);
         self.swigPtr=[];
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
     end
-    function varargout = setName(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
     end
     function self = Sensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/+iDynTree/SensorsList.m
+++ b/bindings/matlab/+iDynTree/SensorsList.m
@@ -9,52 +9,52 @@ classdef SensorsList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1026, varargin{:});
+        tmp = iDynTreeMEX(1027, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1027, self);
+        iDynTreeMEX(1028, self);
         self.swigPtr=[];
       end
     end
     function varargout = addSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
-    end
-    function varargout = setSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
     end
-    function varargout = getSerialization(self,varargin)
+    function varargout = setSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
     end
-    function varargout = getNrOfSensors(self,varargin)
+    function varargout = getSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
     end
-    function varargout = getSensorIndex(self,varargin)
+    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1032, self, varargin{:});
     end
-    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
+    function varargout = getSensorIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1033, self, varargin{:});
     end
-    function varargout = getSensor(self,varargin)
+    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
     end
-    function varargout = removeSensor(self,varargin)
+    function varargout = getSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
     end
-    function varargout = removeAllSensorsOfType(self,varargin)
+    function varargout = removeSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
     end
-    function varargout = getSixAxisForceTorqueSensor(self,varargin)
+    function varargout = removeAllSensorsOfType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
     end
-    function varargout = getAccelerometerSensor(self,varargin)
+    function varargout = getSixAxisForceTorqueSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1038, self, varargin{:});
     end
-    function varargout = getGyroscopeSensor(self,varargin)
+    function varargout = getAccelerometerSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
+    end
+    function varargout = getGyroscopeSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SensorsMeasurements.m
+++ b/bindings/matlab/+iDynTree/SensorsMeasurements.m
@@ -9,37 +9,37 @@ classdef SensorsMeasurements < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1040, varargin{:});
+        tmp = iDynTreeMEX(1041, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1041, self);
+        iDynTreeMEX(1042, self);
         self.swigPtr=[];
       end
     end
     function varargout = setNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
-    end
-    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
     end
-    function varargout = toVector(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
     end
-    function varargout = setMeasurement(self,varargin)
+    function varargout = toVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
     end
-    function varargout = getMeasurement(self,varargin)
+    function varargout = setMeasurement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1047, self, varargin{:});
     end
-    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
+    function varargout = getMeasurement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
+    end
+    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SimpleLeggedOdometry.m
+++ b/bindings/matlab/+iDynTree/SimpleLeggedOdometry.m
@@ -9,43 +9,43 @@ classdef SimpleLeggedOdometry < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1190, varargin{:});
+        tmp = iDynTreeMEX(1191, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1191, self);
+        iDynTreeMEX(1192, self);
         self.swigPtr=[];
       end
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1192, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1193, self, varargin{:});
     end
-    function varargout = loadModelFromFileWithSpecifiedDOFs(self,varargin)
+    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = loadModelFromFileWithSpecifiedDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
     end
-    function varargout = updateKinematics(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1196, self, varargin{:});
     end
-    function varargout = init(self,varargin)
+    function varargout = updateKinematics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1197, self, varargin{:});
     end
-    function varargout = changeFixedFrame(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
     end
-    function varargout = getCurrentFixedLink(self,varargin)
+    function varargout = changeFixedFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = getCurrentFixedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1200, self, varargin{:});
+    end
+    function varargout = getWorldLinkTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1201, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SixAxisForceTorqueSensor.m
+++ b/bindings/matlab/+iDynTree/SixAxisForceTorqueSensor.m
@@ -7,97 +7,97 @@ classdef SixAxisForceTorqueSensor < iDynTree.JointSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1049, varargin{:});
+        tmp = iDynTreeMEX(1050, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1050, self);
+        iDynTreeMEX(1051, self);
         self.swigPtr=[];
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
-    end
-    function varargout = setFirstLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
     end
-    function varargout = setSecondLinkSensorTransform(self,varargin)
+    function varargout = setFirstLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
     end
-    function varargout = getFirstLinkIndex(self,varargin)
+    function varargout = setSecondLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
     end
-    function varargout = getSecondLinkIndex(self,varargin)
+    function varargout = getFirstLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
     end
-    function varargout = setFirstLinkName(self,varargin)
+    function varargout = getSecondLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
     end
-    function varargout = setSecondLinkName(self,varargin)
+    function varargout = setFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1057, self, varargin{:});
     end
-    function varargout = getFirstLinkName(self,varargin)
+    function varargout = setSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1058, self, varargin{:});
     end
-    function varargout = getSecondLinkName(self,varargin)
+    function varargout = getFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
     end
-    function varargout = setParentJoint(self,varargin)
+    function varargout = getSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1060, self, varargin{:});
     end
-    function varargout = setParentJointIndex(self,varargin)
+    function varargout = setParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1061, self, varargin{:});
     end
-    function varargout = setAppliedWrenchLink(self,varargin)
+    function varargout = setParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1062, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = setAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1063, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1064, self, varargin{:});
     end
-    function varargout = getParentJoint(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
     end
-    function varargout = getParentJointIndex(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
     end
-    function varargout = getAppliedWrenchLink(self,varargin)
+    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
     end
-    function varargout = isLinkAttachedToSensor(self,varargin)
+    function varargout = getAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = isLinkAttachedToSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLink(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1073, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+    function varargout = getWrenchAppliedOnLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = predictMeasurement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SpatialAcc.m
+++ b/bindings/matlab/+iDynTree/SpatialAcc.m
@@ -7,23 +7,23 @@ classdef SpatialAcc < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(506, varargin{:});
+        tmp = iDynTreeMEX(507, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(507, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(508, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(509, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(510, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(510, self);
+        iDynTreeMEX(511, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/SpatialForceVector.m
+++ b/bindings/matlab/+iDynTree/SpatialForceVector.m
@@ -7,19 +7,19 @@ classdef SpatialForceVector < iDynTree.SpatialForceVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(487, varargin{:});
+        tmp = iDynTreeMEX(488, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(488, self);
+        iDynTreeMEX(489, self);
         self.swigPtr=[];
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(489, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(490, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/SpatialForceVectorBase.m
+++ b/bindings/matlab/+iDynTree/SpatialForceVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialForceVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(453, varargin{:});
+        tmp = iDynTreeMEX(454, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(454, self, varargin{:});
-    end
-    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(455, self, varargin{:});
     end
-    function varargout = setLinearVec3(self,varargin)
+    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(456, self, varargin{:});
     end
-    function varargout = setAngularVec3(self,varargin)
+    function varargout = setLinearVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(457, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = setAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(458, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(459, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(460, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(462, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(463, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(464, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(467, self, varargin{:});
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(465, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(468, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(469, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(470, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(472, self, varargin{:});
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(471, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = asVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(473, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(474, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(475, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(476, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(477, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(477, self);
+        iDynTreeMEX(478, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(465, varargin{:});
-    end
-    function varargout = inverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(466, varargin{:});
     end
+    function varargout = inverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(467, varargin{:});
+    end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(471, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(472, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/SpatialForceVectorSemanticsBase.m
+++ b/bindings/matlab/+iDynTree/SpatialForceVectorSemanticsBase.m
@@ -9,23 +9,23 @@ classdef SpatialForceVectorSemanticsBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(423, varargin{:});
+        tmp = iDynTreeMEX(424, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = check_linear2angularConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(424, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(425, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(426, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(427, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(427, self);
+        iDynTreeMEX(428, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/SpatialInertia.m
+++ b/bindings/matlab/+iDynTree/SpatialInertia.m
@@ -7,57 +7,57 @@ classdef SpatialInertia < iDynTree.SpatialInertiaRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(548, varargin{:});
+        tmp = iDynTreeMEX(549, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = asMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(550, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(551, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(552, self, varargin{:});
     end
-    function varargout = biasWrench(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(553, self, varargin{:});
     end
-    function varargout = biasWrenchDerivative(self,varargin)
+    function varargout = biasWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(554, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(556, self, varargin{:});
+    function varargout = biasWrenchDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(555, self, varargin{:});
     end
-    function varargout = fromVector(self,varargin)
+    function varargout = asVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(557, self, varargin{:});
     end
-    function varargout = isPhysicallyConsistent(self,varargin)
+    function varargout = fromVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(558, self, varargin{:});
+    end
+    function varargout = isPhysicallyConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(559, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(562, self);
+        iDynTreeMEX(563, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(549, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(550, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(555, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(556, varargin{:});
     end
     function varargout = momentumRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(559, varargin{:});
-    end
-    function varargout = momentumDerivativeRegressor(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(560, varargin{:});
     end
-    function varargout = momentumDerivativeSlotineLiRegressor(varargin)
+    function varargout = momentumDerivativeRegressor(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(561, varargin{:});
+    end
+    function varargout = momentumDerivativeSlotineLiRegressor(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(562, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/SpatialInertiaRaw.m
+++ b/bindings/matlab/+iDynTree/SpatialInertiaRaw.m
@@ -9,42 +9,42 @@ classdef SpatialInertiaRaw < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(538, varargin{:});
+        tmp = iDynTreeMEX(539, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = fromRotationalInertiaWrtCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(539, self, varargin{:});
-    end
-    function varargout = getMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(540, self, varargin{:});
     end
-    function varargout = getCenterOfMass(self,varargin)
+    function varargout = getMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(541, self, varargin{:});
     end
-    function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
+    function varargout = getCenterOfMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(542, self, varargin{:});
     end
-    function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
+    function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(543, self, varargin{:});
     end
+    function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(544, self, varargin{:});
+    end
     function varargout = multiply(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(545, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(546, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(546, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(547, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(547, self);
+        iDynTreeMEX(548, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(544, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(545, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/SpatialMomentum.m
+++ b/bindings/matlab/+iDynTree/SpatialMomentum.m
@@ -7,23 +7,23 @@ classdef SpatialMomentum < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(501, varargin{:});
+        tmp = iDynTreeMEX(502, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(502, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(503, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(504, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(505, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(505, self);
+        iDynTreeMEX(506, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/SpatialMotionVector.m
+++ b/bindings/matlab/+iDynTree/SpatialMotionVector.m
@@ -7,29 +7,29 @@ classdef SpatialMotionVector < iDynTree.SpatialMotionVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(480, varargin{:});
+        tmp = iDynTreeMEX(481, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(481, self, varargin{:});
-    end
-    function varargout = cross(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(482, self, varargin{:});
     end
-    function varargout = asCrossProductMatrix(self,varargin)
+    function varargout = cross(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(483, self, varargin{:});
     end
-    function varargout = asCrossProductMatrixWrench(self,varargin)
+    function varargout = asCrossProductMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(484, self, varargin{:});
     end
-    function varargout = exp(self,varargin)
+    function varargout = asCrossProductMatrixWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(485, self, varargin{:});
+    end
+    function varargout = exp(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(486, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(486, self);
+        iDynTreeMEX(487, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/SpatialMotionVectorBase.m
+++ b/bindings/matlab/+iDynTree/SpatialMotionVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialMotionVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(428, varargin{:});
+        tmp = iDynTreeMEX(429, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(429, self, varargin{:});
-    end
-    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(430, self, varargin{:});
     end
-    function varargout = setLinearVec3(self,varargin)
+    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(431, self, varargin{:});
     end
-    function varargout = setAngularVec3(self,varargin)
+    function varargout = setLinearVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(432, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = setAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(433, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(434, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(435, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(436, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(437, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(438, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(439, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(442, self, varargin{:});
+    function varargout = changeCoordFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(440, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(443, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(444, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(445, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(447, self, varargin{:});
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(446, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = asVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(448, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(449, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(450, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(451, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(452, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(452, self);
+        iDynTreeMEX(453, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(440, varargin{:});
-    end
-    function varargout = inverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(441, varargin{:});
     end
+    function varargout = inverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(442, varargin{:});
+    end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(446, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(447, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/SpatialMotionVectorSemanticsBase.m
+++ b/bindings/matlab/+iDynTree/SpatialMotionVectorSemanticsBase.m
@@ -9,23 +9,23 @@ classdef SpatialMotionVectorSemanticsBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(418, varargin{:});
+        tmp = iDynTreeMEX(419, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = check_linear2angularConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(419, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(420, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(421, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(422, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(422, self);
+        iDynTreeMEX(423, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/TRAVERSAL_INVALID_INDEX.m
+++ b/bindings/matlab/+iDynTree/TRAVERSAL_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = TRAVERSAL_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(694);
+    varargout{1} = iDynTreeMEX(695);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(695,varargin{1});
+    iDynTreeMEX(696,varargin{1});
   end
 end

--- a/bindings/matlab/+iDynTree/Transform.m
+++ b/bindings/matlab/+iDynTree/Transform.m
@@ -9,66 +9,66 @@ classdef Transform < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(647, varargin{:});
+        tmp = iDynTreeMEX(648, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(648, self, varargin{:});
-    end
-    function varargout = getRotation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(649, self, varargin{:});
     end
-    function varargout = getPosition(self,varargin)
+    function varargout = getRotation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(650, self, varargin{:});
     end
-    function varargout = setRotation(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(651, self, varargin{:});
     end
-    function varargout = setPosition(self,varargin)
+    function varargout = setRotation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(652, self, varargin{:});
     end
-    function varargout = inverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(655, self, varargin{:});
+    function varargout = setPosition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(653, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(656, self, varargin{:});
     end
-    function varargout = asHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(658, self, varargin{:});
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(657, self, varargin{:});
     end
-    function varargout = asAdjointTransform(self,varargin)
+    function varargout = asHomogeneousTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(659, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrench(self,varargin)
+    function varargout = asAdjointTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(660, self, varargin{:});
     end
-    function varargout = log(self,varargin)
+    function varargout = asAdjointTransformWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(661, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = log(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(662, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(663, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(664, self);
+        iDynTreeMEX(665, self);
         self.swigPtr=[];
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(653, varargin{:});
-    end
-    function varargout = inverse2(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(654, varargin{:});
     end
+    function varargout = inverse2(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(655, varargin{:});
+    end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(657, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(658, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/TransformDerivative.m
+++ b/bindings/matlab/+iDynTree/TransformDerivative.m
@@ -9,51 +9,51 @@ classdef TransformDerivative < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(665, varargin{:});
+        tmp = iDynTreeMEX(666, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(666, self);
+        iDynTreeMEX(667, self);
         self.swigPtr=[];
       end
     end
     function varargout = getRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(667, self, varargin{:});
-    end
-    function varargout = getPositionDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(668, self, varargin{:});
     end
-    function varargout = setRotationDerivative(self,varargin)
+    function varargout = getPositionDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(669, self, varargin{:});
     end
-    function varargout = setPositionDerivative(self,varargin)
+    function varargout = setRotationDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(670, self, varargin{:});
     end
-    function varargout = asHomogeneousTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(672, self, varargin{:});
+    function varargout = setPositionDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(671, self, varargin{:});
     end
-    function varargout = asAdjointTransformDerivative(self,varargin)
+    function varargout = asHomogeneousTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(673, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+    function varargout = asAdjointTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(674, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(675, self, varargin{:});
     end
-    function varargout = derivativeOfInverse(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(676, self, varargin{:});
     end
-    function varargout = transform(self,varargin)
+    function varargout = derivativeOfInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(677, self, varargin{:});
+    end
+    function varargout = transform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(678, self, varargin{:});
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(671, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(672, varargin{:});
     end
   end
 end

--- a/bindings/matlab/+iDynTree/TransformSemantics.m
+++ b/bindings/matlab/+iDynTree/TransformSemantics.m
@@ -9,32 +9,32 @@ classdef TransformSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(639, varargin{:});
+        tmp = iDynTreeMEX(640, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = getRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(640, self, varargin{:});
-    end
-    function varargout = getPositionSemantics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(641, self, varargin{:});
     end
-    function varargout = setRotationSemantics(self,varargin)
+    function varargout = getPositionSemantics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(642, self, varargin{:});
     end
-    function varargout = setPositionSemantics(self,varargin)
+    function varargout = setRotationSemantics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(643, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = setPositionSemantics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(644, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(645, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(646, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(646, self);
+        iDynTreeMEX(647, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Traversal.m
+++ b/bindings/matlab/+iDynTree/Traversal.m
@@ -9,58 +9,58 @@ classdef Traversal < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(861, varargin{:});
+        tmp = iDynTreeMEX(862, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(862, self);
+        iDynTreeMEX(863, self);
         self.swigPtr=[];
       end
     end
     function varargout = getNrOfVisitedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(864, self, varargin{:});
     end
-    function varargout = getBaseLink(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = getBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
     end
-    function varargout = getParentJoint(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(867, self, varargin{:});
     end
-    function varargout = getParentLinkFromLinkIndex(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
     end
-    function varargout = getParentJointFromLinkIndex(self,varargin)
+    function varargout = getParentLinkFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
     end
-    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
+    function varargout = getParentJointFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
     end
-    function varargout = reset(self,varargin)
+    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
     end
-    function varargout = addTraversalBase(self,varargin)
+    function varargout = reset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
     end
-    function varargout = addTraversalElement(self,varargin)
+    function varargout = addTraversalBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(873, self, varargin{:});
     end
-    function varargout = isParentOf(self,varargin)
+    function varargout = addTraversalElement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(874, self, varargin{:});
     end
-    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+    function varargout = isParentOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(875, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(876, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/Twist.m
+++ b/bindings/matlab/+iDynTree/Twist.m
@@ -7,26 +7,26 @@ classdef Twist < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(490, varargin{:});
+        tmp = iDynTreeMEX(491, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(491, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(492, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(493, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = uminus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(494, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(495, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(495, self);
+        iDynTreeMEX(496, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/URDFParserOptions.m
+++ b/bindings/matlab/+iDynTree/URDFParserOptions.m
@@ -7,10 +7,10 @@ classdef URDFParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1110, self);
+        varargout{1} = iDynTreeMEX(1111, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1111, self, varargin{1});
+        iDynTreeMEX(1112, self, varargin{1});
       end
     end
     function self = URDFParserOptions(varargin)
@@ -19,14 +19,14 @@ classdef URDFParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1112, varargin{:});
+        tmp = iDynTreeMEX(1113, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1113, self);
+        iDynTreeMEX(1114, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/UnknownWrenchContact.m
+++ b/bindings/matlab/+iDynTree/UnknownWrenchContact.m
@@ -9,7 +9,7 @@ classdef UnknownWrenchContact < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1128, varargin{:});
+        tmp = iDynTreeMEX(1129, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
@@ -18,45 +18,45 @@ classdef UnknownWrenchContact < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1129, self);
+        varargout{1} = iDynTreeMEX(1130, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1130, self, varargin{1});
+        iDynTreeMEX(1131, self, varargin{1});
       end
     end
     function varargout = contactPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1131, self);
+        varargout{1} = iDynTreeMEX(1132, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1132, self, varargin{1});
+        iDynTreeMEX(1133, self, varargin{1});
       end
     end
     function varargout = forceDirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1133, self);
+        varargout{1} = iDynTreeMEX(1134, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1134, self, varargin{1});
+        iDynTreeMEX(1135, self, varargin{1});
       end
     end
     function varargout = contactId(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1135, self);
+        varargout{1} = iDynTreeMEX(1136, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1136, self, varargin{1});
+        iDynTreeMEX(1137, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1137, self);
+        iDynTreeMEX(1138, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Vector10.m
+++ b/bindings/matlab/+iDynTree/Vector10.m
@@ -9,47 +9,47 @@ classdef Vector10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(215, varargin{:});
+        tmp = iDynTreeMEX(216, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(216, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(217, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(218, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(219, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(220, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(221, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(222, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(223, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(224, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(225, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(226, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(227, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(227, self);
+        iDynTreeMEX(228, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Vector16.m
+++ b/bindings/matlab/+iDynTree/Vector16.m
@@ -9,47 +9,47 @@ classdef Vector16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(228, varargin{:});
+        tmp = iDynTreeMEX(229, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(229, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(230, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(231, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(232, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(233, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(234, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(235, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(236, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(237, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(238, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(239, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(240, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(240, self);
+        iDynTreeMEX(241, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Vector3.m
+++ b/bindings/matlab/+iDynTree/Vector3.m
@@ -9,47 +9,47 @@ classdef Vector3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(189, varargin{:});
+        tmp = iDynTreeMEX(190, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(190, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(191, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(192, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(193, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(194, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(195, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(196, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(197, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(198, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(199, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(200, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(201, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(201, self);
+        iDynTreeMEX(202, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/Vector6.m
+++ b/bindings/matlab/+iDynTree/Vector6.m
@@ -9,47 +9,47 @@ classdef Vector6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(202, varargin{:});
+        tmp = iDynTreeMEX(203, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(203, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(204, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(205, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(206, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(207, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(208, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(209, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(210, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(211, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(212, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(213, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(214, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(214, self);
+        iDynTreeMEX(215, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/VectorDynSize.m
+++ b/bindings/matlab/+iDynTree/VectorDynSize.m
@@ -9,61 +9,61 @@ classdef VectorDynSize < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(97, varargin{:});
+        tmp = iDynTreeMEX(98, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(98, self);
+        iDynTreeMEX(99, self);
         self.swigPtr=[];
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(99, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(100, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(101, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(102, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(103, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(104, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(105, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(106, self, varargin{:});
     end
-    function varargout = shrink_to_fit(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(107, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = shrink_to_fit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(108, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = capacity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(109, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(110, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(111, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(112, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(113, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(114, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/+iDynTree/Wrench.m
+++ b/bindings/matlab/+iDynTree/Wrench.m
@@ -7,23 +7,23 @@ classdef Wrench < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(496, varargin{:});
+        tmp = iDynTreeMEX(497, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(497, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(498, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(499, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(500, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(500, self);
+        iDynTreeMEX(501, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
+++ b/bindings/matlab/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
@@ -1,3 +1,3 @@
 function varargout = computeLinkNetWrenchesWithoutGravity(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1175, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1176, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
+++ b/bindings/matlab/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1173, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1174, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/dynamicsEstimationForwardVelKinematics.m
+++ b/bindings/matlab/+iDynTree/dynamicsEstimationForwardVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1174, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1175, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/estimateExternalWrenches.m
+++ b/bindings/matlab/+iDynTree/estimateExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1172, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1173, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/estimateExternalWrenchesBuffers.m
+++ b/bindings/matlab/+iDynTree/estimateExternalWrenchesBuffers.m
@@ -9,86 +9,86 @@ classdef estimateExternalWrenchesBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1153, varargin{:});
+        tmp = iDynTreeMEX(1154, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.swigPtr = [];
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1154, self, varargin{:});
-    end
-    function varargout = getNrOfSubModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1155, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = getNrOfSubModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
     end
-    function varargout = isConsistent(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1157, self, varargin{:});
+    end
+    function varargout = isConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1158, self, varargin{:});
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1158, self);
+        varargout{1} = iDynTreeMEX(1159, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1159, self, varargin{1});
+        iDynTreeMEX(1160, self, varargin{1});
       end
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1160, self);
+        varargout{1} = iDynTreeMEX(1161, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1161, self, varargin{1});
+        iDynTreeMEX(1162, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1162, self);
+        varargout{1} = iDynTreeMEX(1163, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1163, self, varargin{1});
+        iDynTreeMEX(1164, self, varargin{1});
       end
     end
     function varargout = pinvA(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1164, self);
+        varargout{1} = iDynTreeMEX(1165, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1165, self, varargin{1});
+        iDynTreeMEX(1166, self, varargin{1});
       end
     end
     function varargout = b_contacts_subtree(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1166, self);
+        varargout{1} = iDynTreeMEX(1167, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1167, self, varargin{1});
+        iDynTreeMEX(1168, self, varargin{1});
       end
     end
     function varargout = subModelBase_H_link(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1168, self);
+        varargout{1} = iDynTreeMEX(1169, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1169, self, varargin{1});
+        iDynTreeMEX(1170, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1170, self);
+        iDynTreeMEX(1171, self);
         self.swigPtr=[];
       end
     end

--- a/bindings/matlab/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
+++ b/bindings/matlab/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenchesWithoutInternalFT(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1171, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1172, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/getSensorTypeSize.m
+++ b/bindings/matlab/+iDynTree/getSensorTypeSize.m
@@ -1,3 +1,3 @@
 function varargout = getSensorTypeSize(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1007, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1008, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/isDOFBerdyDynamicVariable.m
+++ b/bindings/matlab/+iDynTree/isDOFBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isDOFBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1203, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1204, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/isJointBerdyDynamicVariable.m
+++ b/bindings/matlab/+iDynTree/isJointBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isJointBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1202, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1203, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/isJointSensor.m
+++ b/bindings/matlab/+iDynTree/isJointSensor.m
@@ -1,3 +1,3 @@
 function varargout = isJointSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1006, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1007, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/isLinkBerdyDynamicVariable.m
+++ b/bindings/matlab/+iDynTree/isLinkBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isLinkBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1201, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1202, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/isLinkSensor.m
+++ b/bindings/matlab/+iDynTree/isLinkSensor.m
@@ -1,3 +1,3 @@
 function varargout = isLinkSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1005, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1006, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/modelFromURDF.m
+++ b/bindings/matlab/+iDynTree/modelFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1114, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1115, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/modelFromURDFString.m
+++ b/bindings/matlab/+iDynTree/modelFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1115, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1116, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/predictSensorsMeasurements.m
+++ b/bindings/matlab/+iDynTree/predictSensorsMeasurements.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurements(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1108, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1109, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
+++ b/bindings/matlab/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurementsFromRawBuffers(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1109, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1110, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/sensorsFromURDF.m
+++ b/bindings/matlab/+iDynTree/sensorsFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1116, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1117, varargin{:});
 end

--- a/bindings/matlab/+iDynTree/sensorsFromURDFString.m
+++ b/bindings/matlab/+iDynTree/sensorsFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1117, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1118, varargin{:});
 end

--- a/bindings/matlab/iDynTreeMATLAB_wrap.cxx
+++ b/bindings/matlab/iDynTreeMATLAB_wrap.cxx
@@ -3054,21 +3054,57 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_3_Sc_3_Sg__toMatlab(iDynTree::Matr
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_3_Sc_3_Sg__fromMatlab(iDynTree::MatrixFixSize< 3,3 > *self,mxArray *in){
+        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
         size_t fixValCols = self->cols();
-        if( dims[0] == fixValRows && dims[1] == fixValCols )
+        if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            for(size_t row=0; row < fixValRows; row++ )
+            if (mxIsSparse(in)) 
             {
-                for(size_t col=0; col < fixValCols; col++ )
+                //getting pointer to sparse structure
+                mwIndex* ir = mxGetIr(in);
+                mwIndex* jc = mxGetJc(in);
+                double *data = mxGetPr(in);
+
+                //zero the matrix (iDynTree matrix is dense)
+                self->zero();
+                for (mwIndex col = 0; col < fixValCols; col++)
                 {
-                    self->operator()(row,col) = d[col*fixValRows + row];
+                    /*
+                        jc[col] contains information about the nonzero values.
+                        jc[col + 1] - jc[col] = number of nonzero elements in column col
+                        These nonzero elements can be access with a for loop starting at 
+                        jc[col] and ending at jc[col + 1] - 1.
+                        
+                    */
+                    mwIndex startingRowIndex = jc[col];
+                    mwIndex endRowIndex = jc[col + 1];
+                    if (startingRowIndex == endRowIndex)
+                    {
+                        //no elements in this column
+                        continue;
+                    }
+                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+                    {
+                        //access the element
+                        mwIndex row = ir[currentIndex];
+                        self->operator()(row, col) = data[currentIndex];
+                    }
                 }
+
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                for (size_t row = 0; row < fixValRows; row++)
+                {
+                    for (size_t col = 0; col < fixValCols; col++)
+                    {
+                        self->operator()(row,col) = d[col*fixValRows + row];
+                    }
+                }
+                return;
             }
-            return;
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__toMatlab(iDynTree::MatrixFixSize< 4,4 > const *self){
@@ -3078,21 +3114,57 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__toMatlab(iDynTree::Matr
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__fromMatlab(iDynTree::MatrixFixSize< 4,4 > *self,mxArray *in){
+        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
         size_t fixValCols = self->cols();
-        if( dims[0] == fixValRows && dims[1] == fixValCols )
+        if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            for(size_t row=0; row < fixValRows; row++ )
+            if (mxIsSparse(in)) 
             {
-                for(size_t col=0; col < fixValCols; col++ )
+                //getting pointer to sparse structure
+                mwIndex* ir = mxGetIr(in);
+                mwIndex* jc = mxGetJc(in);
+                double *data = mxGetPr(in);
+
+                //zero the matrix (iDynTree matrix is dense)
+                self->zero();
+                for (mwIndex col = 0; col < fixValCols; col++)
                 {
-                    self->operator()(row,col) = d[col*fixValRows + row];
+                    /*
+                        jc[col] contains information about the nonzero values.
+                        jc[col + 1] - jc[col] = number of nonzero elements in column col
+                        These nonzero elements can be access with a for loop starting at 
+                        jc[col] and ending at jc[col + 1] - 1.
+                        
+                    */
+                    mwIndex startingRowIndex = jc[col];
+                    mwIndex endRowIndex = jc[col + 1];
+                    if (startingRowIndex == endRowIndex)
+                    {
+                        //no elements in this column
+                        continue;
+                    }
+                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+                    {
+                        //access the element
+                        mwIndex row = ir[currentIndex];
+                        self->operator()(row, col) = data[currentIndex];
+                    }
                 }
+
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                for (size_t row = 0; row < fixValRows; row++)
+                {
+                    for (size_t col = 0; col < fixValCols; col++)
+                    {
+                        self->operator()(row,col) = d[col*fixValRows + row];
+                    }
+                }
+                return;
             }
-            return;
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__toMatlab(iDynTree::MatrixFixSize< 6,6 > const *self){
@@ -3102,21 +3174,57 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__toMatlab(iDynTree::Matr
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__fromMatlab(iDynTree::MatrixFixSize< 6,6 > *self,mxArray *in){
+        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
         size_t fixValCols = self->cols();
-        if( dims[0] == fixValRows && dims[1] == fixValCols )
+        if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            for(size_t row=0; row < fixValRows; row++ )
+            if (mxIsSparse(in)) 
             {
-                for(size_t col=0; col < fixValCols; col++ )
+                //getting pointer to sparse structure
+                mwIndex* ir = mxGetIr(in);
+                mwIndex* jc = mxGetJc(in);
+                double *data = mxGetPr(in);
+
+                //zero the matrix (iDynTree matrix is dense)
+                self->zero();
+                for (mwIndex col = 0; col < fixValCols; col++)
                 {
-                    self->operator()(row,col) = d[col*fixValRows + row];
+                    /*
+                        jc[col] contains information about the nonzero values.
+                        jc[col + 1] - jc[col] = number of nonzero elements in column col
+                        These nonzero elements can be access with a for loop starting at 
+                        jc[col] and ending at jc[col + 1] - 1.
+                        
+                    */
+                    mwIndex startingRowIndex = jc[col];
+                    mwIndex endRowIndex = jc[col + 1];
+                    if (startingRowIndex == endRowIndex)
+                    {
+                        //no elements in this column
+                        continue;
+                    }
+                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+                    {
+                        //access the element
+                        mwIndex row = ir[currentIndex];
+                        self->operator()(row, col) = data[currentIndex];
+                    }
                 }
+
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                for (size_t row = 0; row < fixValRows; row++)
+                {
+                    for (size_t col = 0; col < fixValCols; col++)
+                    {
+                        self->operator()(row,col) = d[col*fixValRows + row];
+                    }
+                }
+                return;
             }
-            return;
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__toMatlab(iDynTree::MatrixFixSize< 6,10 > const *self){
@@ -3126,21 +3234,57 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__toMatlab(iDynTree::Mat
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__fromMatlab(iDynTree::MatrixFixSize< 6,10 > *self,mxArray *in){
+        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
         size_t fixValCols = self->cols();
-        if( dims[0] == fixValRows && dims[1] == fixValCols )
+        if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            for(size_t row=0; row < fixValRows; row++ )
+            if (mxIsSparse(in)) 
             {
-                for(size_t col=0; col < fixValCols; col++ )
+                //getting pointer to sparse structure
+                mwIndex* ir = mxGetIr(in);
+                mwIndex* jc = mxGetJc(in);
+                double *data = mxGetPr(in);
+
+                //zero the matrix (iDynTree matrix is dense)
+                self->zero();
+                for (mwIndex col = 0; col < fixValCols; col++)
                 {
-                    self->operator()(row,col) = d[col*fixValRows + row];
+                    /*
+                        jc[col] contains information about the nonzero values.
+                        jc[col + 1] - jc[col] = number of nonzero elements in column col
+                        These nonzero elements can be access with a for loop starting at 
+                        jc[col] and ending at jc[col + 1] - 1.
+                        
+                    */
+                    mwIndex startingRowIndex = jc[col];
+                    mwIndex endRowIndex = jc[col + 1];
+                    if (startingRowIndex == endRowIndex)
+                    {
+                        //no elements in this column
+                        continue;
+                    }
+                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+                    {
+                        //access the element
+                        mwIndex row = ir[currentIndex];
+                        self->operator()(row, col) = data[currentIndex];
+                    }
                 }
+
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                for (size_t row = 0; row < fixValRows; row++)
+                {
+                    for (size_t col = 0; col < fixValCols; col++)
+                    {
+                        self->operator()(row,col) = d[col*fixValRows + row];
+                    }
+                }
+                return;
             }
-            return;
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__toMatlab(iDynTree::MatrixFixSize< 10,16 > const *self){
@@ -3150,21 +3294,57 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__toMatlab(iDynTree::Ma
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__fromMatlab(iDynTree::MatrixFixSize< 10,16 > *self,mxArray *in){
+        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
         size_t fixValCols = self->cols();
-        if( dims[0] == fixValRows && dims[1] == fixValCols )
+        if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            for(size_t row=0; row < fixValRows; row++ )
+            if (mxIsSparse(in)) 
             {
-                for(size_t col=0; col < fixValCols; col++ )
+                //getting pointer to sparse structure
+                mwIndex* ir = mxGetIr(in);
+                mwIndex* jc = mxGetJc(in);
+                double *data = mxGetPr(in);
+
+                //zero the matrix (iDynTree matrix is dense)
+                self->zero();
+                for (mwIndex col = 0; col < fixValCols; col++)
                 {
-                    self->operator()(row,col) = d[col*fixValRows + row];
+                    /*
+                        jc[col] contains information about the nonzero values.
+                        jc[col + 1] - jc[col] = number of nonzero elements in column col
+                        These nonzero elements can be access with a for loop starting at 
+                        jc[col] and ending at jc[col + 1] - 1.
+                        
+                    */
+                    mwIndex startingRowIndex = jc[col];
+                    mwIndex endRowIndex = jc[col + 1];
+                    if (startingRowIndex == endRowIndex)
+                    {
+                        //no elements in this column
+                        continue;
+                    }
+                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+                    {
+                        //access the element
+                        mwIndex row = ir[currentIndex];
+                        self->operator()(row, col) = data[currentIndex];
+                    }
                 }
+
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                for (size_t row = 0; row < fixValRows; row++)
+                {
+                    for (size_t col = 0; col < fixValCols; col++)
+                    {
+                        self->operator()(row,col) = d[col*fixValRows + row];
+                    }
+                }
+                return;
             }
-            return;
         }
     }
 SWIGINTERN mxArray *iDynTree_VectorFixSize_Sl_3_Sg__toMatlab(iDynTree::VectorFixSize< 3 > const *self){

--- a/bindings/matlab/iDynTreeMATLAB_wrap.cxx
+++ b/bindings/matlab/iDynTreeMATLAB_wrap.cxx
@@ -3007,6 +3007,63 @@ SWIGINTERN mxArray *iDynTree_MatrixDynSize_toMatlab(iDynTree::MatrixDynSize cons
         self->fillColMajorBuffer(d); // Column-major
         return p;
     }
+SWIGINTERN void iDynTree_MatrixDynSize_fromMatlab(iDynTree::MatrixDynSize *self,mxArray *in){
+        // check size
+        const size_t * dims = mxGetDimensions(in);
+        size_t rows = self->rows();
+        size_t cols = self->cols();
+        if (dims[0] != rows || dims[1] == cols)
+        {
+            self->resize(rows, cols);
+            mexWarnMsgIdAndTxt("iDynTree:Core:perfomance", "Resizing iDynTree vector to (%d,%d)", rows, cols);
+        }
+
+        if (mxIsSparse(in)) 
+        {
+            /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,43,MATRIXSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
+
+    //zero the matrix (iDynTree matrix is dense)
+    self->zero();
+    for (mwIndex col = 0; col < cols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            self->operator()(row, col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
+        } else {
+            double* d = static_cast<double*>(mxGetData(in));
+            for (size_t row = 0; row < rows; row++)
+            {
+                for (size_t col = 0; col < cols; col++)
+                {
+                    self->operator()(row,col) = d[col*rows + row];
+                }
+            }
+            return;
+        }
+    }
 SWIGINTERN mxArray *iDynTree_VectorDynSize_toMatlab(iDynTree::VectorDynSize const *self){
         mxArray *p  = mxCreateDoubleMatrix(self->size(), 1, mxREAL);
         double* d = static_cast<double*>(mxGetData(p));
@@ -3017,7 +3074,7 @@ SWIGINTERN void iDynTree_VectorDynSize_fromMatlab(iDynTree::VectorDynSize *self,
         // check size
         const size_t * dims = mxGetDimensions(in);
         self->size();
-        if( ( dims[0] == 1 || dims[1] == 1) )
+        if (( dims[0] == 1 || dims[1] == 1))
         {
             // Get the size of the input vector
             size_t inSize;
@@ -3036,13 +3093,54 @@ SWIGINTERN void iDynTree_VectorDynSize_fromMatlab(iDynTree::VectorDynSize *self,
             if( self->size() != inSize )
             {
                 self->resize(inSize);
+                mexWarnMsgIdAndTxt("iDynTree:Core:perfomance", "Resizing iDynTree vector to %d", inSize);
             }
 
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = self->data();
-            for(size_t i=0; i < inSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,6,VECTORSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
+    
+    //If dims[1] == 1 assume it is a column vector (or a 1 element vector)
+    bool isColumnVector = (dims[1] == 1);
+
+    //zero the matrix (iDynTree vector is dense)
+    self->zero();
+    for (mwIndex col = 0; col < dims[1]; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+        
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            //iDynTree has only one size.
+            self->operator()(isColumnVector ? row : col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = self->data();
+                for(size_t i=0; i < inSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
         }
@@ -3054,7 +3152,6 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_3_Sc_3_Sg__toMatlab(iDynTree::Matr
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_3_Sc_3_Sg__fromMatlab(iDynTree::MatrixFixSize< 3,3 > *self,mxArray *in){
-        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
@@ -3063,37 +3160,38 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_3_Sc_3_Sg__fromMatlab(iDynTree::Matrix
         {
             if (mxIsSparse(in)) 
             {
-                //getting pointer to sparse structure
-                mwIndex* ir = mxGetIr(in);
-                mwIndex* jc = mxGetJc(in);
-                double *data = mxGetPr(in);
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,43,MATRIXSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
 
-                //zero the matrix (iDynTree matrix is dense)
-                self->zero();
-                for (mwIndex col = 0; col < fixValCols; col++)
-                {
-                    /*
-                        jc[col] contains information about the nonzero values.
-                        jc[col + 1] - jc[col] = number of nonzero elements in column col
-                        These nonzero elements can be access with a for loop starting at 
-                        jc[col] and ending at jc[col + 1] - 1.
-                        
-                    */
-                    mwIndex startingRowIndex = jc[col];
-                    mwIndex endRowIndex = jc[col + 1];
-                    if (startingRowIndex == endRowIndex)
-                    {
-                        //no elements in this column
-                        continue;
-                    }
-                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
-                    {
-                        //access the element
-                        mwIndex row = ir[currentIndex];
-                        self->operator()(row, col) = data[currentIndex];
-                    }
-                }
-
+    //zero the matrix (iDynTree matrix is dense)
+    self->zero();
+    for (mwIndex col = 0; col < fixValCols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            self->operator()(row, col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
             } else {
                 double* d = static_cast<double*>(mxGetData(in));
                 for (size_t row = 0; row < fixValRows; row++)
@@ -3105,6 +3203,9 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_3_Sc_3_Sg__fromMatlab(iDynTree::Matrix
                 }
                 return;
             }
+            } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__toMatlab(iDynTree::MatrixFixSize< 4,4 > const *self){
@@ -3114,7 +3215,6 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__toMatlab(iDynTree::Matr
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__fromMatlab(iDynTree::MatrixFixSize< 4,4 > *self,mxArray *in){
-        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
@@ -3123,37 +3223,38 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__fromMatlab(iDynTree::Matrix
         {
             if (mxIsSparse(in)) 
             {
-                //getting pointer to sparse structure
-                mwIndex* ir = mxGetIr(in);
-                mwIndex* jc = mxGetJc(in);
-                double *data = mxGetPr(in);
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,43,MATRIXSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
 
-                //zero the matrix (iDynTree matrix is dense)
-                self->zero();
-                for (mwIndex col = 0; col < fixValCols; col++)
-                {
-                    /*
-                        jc[col] contains information about the nonzero values.
-                        jc[col + 1] - jc[col] = number of nonzero elements in column col
-                        These nonzero elements can be access with a for loop starting at 
-                        jc[col] and ending at jc[col + 1] - 1.
-                        
-                    */
-                    mwIndex startingRowIndex = jc[col];
-                    mwIndex endRowIndex = jc[col + 1];
-                    if (startingRowIndex == endRowIndex)
-                    {
-                        //no elements in this column
-                        continue;
-                    }
-                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
-                    {
-                        //access the element
-                        mwIndex row = ir[currentIndex];
-                        self->operator()(row, col) = data[currentIndex];
-                    }
-                }
-
+    //zero the matrix (iDynTree matrix is dense)
+    self->zero();
+    for (mwIndex col = 0; col < fixValCols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            self->operator()(row, col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
             } else {
                 double* d = static_cast<double*>(mxGetData(in));
                 for (size_t row = 0; row < fixValRows; row++)
@@ -3165,6 +3266,9 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_4_Sc_4_Sg__fromMatlab(iDynTree::Matrix
                 }
                 return;
             }
+            } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__toMatlab(iDynTree::MatrixFixSize< 6,6 > const *self){
@@ -3174,7 +3278,6 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__toMatlab(iDynTree::Matr
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__fromMatlab(iDynTree::MatrixFixSize< 6,6 > *self,mxArray *in){
-        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
@@ -3183,37 +3286,38 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__fromMatlab(iDynTree::Matrix
         {
             if (mxIsSparse(in)) 
             {
-                //getting pointer to sparse structure
-                mwIndex* ir = mxGetIr(in);
-                mwIndex* jc = mxGetJc(in);
-                double *data = mxGetPr(in);
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,43,MATRIXSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
 
-                //zero the matrix (iDynTree matrix is dense)
-                self->zero();
-                for (mwIndex col = 0; col < fixValCols; col++)
-                {
-                    /*
-                        jc[col] contains information about the nonzero values.
-                        jc[col + 1] - jc[col] = number of nonzero elements in column col
-                        These nonzero elements can be access with a for loop starting at 
-                        jc[col] and ending at jc[col + 1] - 1.
-                        
-                    */
-                    mwIndex startingRowIndex = jc[col];
-                    mwIndex endRowIndex = jc[col + 1];
-                    if (startingRowIndex == endRowIndex)
-                    {
-                        //no elements in this column
-                        continue;
-                    }
-                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
-                    {
-                        //access the element
-                        mwIndex row = ir[currentIndex];
-                        self->operator()(row, col) = data[currentIndex];
-                    }
-                }
-
+    //zero the matrix (iDynTree matrix is dense)
+    self->zero();
+    for (mwIndex col = 0; col < fixValCols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            self->operator()(row, col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
             } else {
                 double* d = static_cast<double*>(mxGetData(in));
                 for (size_t row = 0; row < fixValRows; row++)
@@ -3225,6 +3329,9 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_6_Sg__fromMatlab(iDynTree::Matrix
                 }
                 return;
             }
+            } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__toMatlab(iDynTree::MatrixFixSize< 6,10 > const *self){
@@ -3234,7 +3341,6 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__toMatlab(iDynTree::Mat
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__fromMatlab(iDynTree::MatrixFixSize< 6,10 > *self,mxArray *in){
-        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
@@ -3243,37 +3349,38 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__fromMatlab(iDynTree::Matri
         {
             if (mxIsSparse(in)) 
             {
-                //getting pointer to sparse structure
-                mwIndex* ir = mxGetIr(in);
-                mwIndex* jc = mxGetJc(in);
-                double *data = mxGetPr(in);
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,43,MATRIXSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
 
-                //zero the matrix (iDynTree matrix is dense)
-                self->zero();
-                for (mwIndex col = 0; col < fixValCols; col++)
-                {
-                    /*
-                        jc[col] contains information about the nonzero values.
-                        jc[col + 1] - jc[col] = number of nonzero elements in column col
-                        These nonzero elements can be access with a for loop starting at 
-                        jc[col] and ending at jc[col + 1] - 1.
-                        
-                    */
-                    mwIndex startingRowIndex = jc[col];
-                    mwIndex endRowIndex = jc[col + 1];
-                    if (startingRowIndex == endRowIndex)
-                    {
-                        //no elements in this column
-                        continue;
-                    }
-                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
-                    {
-                        //access the element
-                        mwIndex row = ir[currentIndex];
-                        self->operator()(row, col) = data[currentIndex];
-                    }
-                }
-
+    //zero the matrix (iDynTree matrix is dense)
+    self->zero();
+    for (mwIndex col = 0; col < fixValCols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            self->operator()(row, col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
             } else {
                 double* d = static_cast<double*>(mxGetData(in));
                 for (size_t row = 0; row < fixValRows; row++)
@@ -3285,6 +3392,9 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_6_Sc_10_Sg__fromMatlab(iDynTree::Matri
                 }
                 return;
             }
+            } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
 SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__toMatlab(iDynTree::MatrixFixSize< 10,16 > const *self){
@@ -3294,7 +3404,6 @@ SWIGINTERN mxArray *iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__toMatlab(iDynTree::Ma
         return p;
     }
 SWIGINTERN void iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__fromMatlab(iDynTree::MatrixFixSize< 10,16 > *self,mxArray *in){
-        
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = self->rows();
@@ -3303,37 +3412,38 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__fromMatlab(iDynTree::Matr
         {
             if (mxIsSparse(in)) 
             {
-                //getting pointer to sparse structure
-                mwIndex* ir = mxGetIr(in);
-                mwIndex* jc = mxGetJc(in);
-                double *data = mxGetPr(in);
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,43,MATRIXSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
 
-                //zero the matrix (iDynTree matrix is dense)
-                self->zero();
-                for (mwIndex col = 0; col < fixValCols; col++)
-                {
-                    /*
-                        jc[col] contains information about the nonzero values.
-                        jc[col + 1] - jc[col] = number of nonzero elements in column col
-                        These nonzero elements can be access with a for loop starting at 
-                        jc[col] and ending at jc[col + 1] - 1.
-                        
-                    */
-                    mwIndex startingRowIndex = jc[col];
-                    mwIndex endRowIndex = jc[col + 1];
-                    if (startingRowIndex == endRowIndex)
-                    {
-                        //no elements in this column
-                        continue;
-                    }
-                    for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
-                    {
-                        //access the element
-                        mwIndex row = ir[currentIndex];
-                        self->operator()(row, col) = data[currentIndex];
-                    }
-                }
-
+    //zero the matrix (iDynTree matrix is dense)
+    self->zero();
+    for (mwIndex col = 0; col < fixValCols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            self->operator()(row, col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
             } else {
                 double* d = static_cast<double*>(mxGetData(in));
                 for (size_t row = 0; row < fixValRows; row++)
@@ -3345,6 +3455,9 @@ SWIGINTERN void iDynTree_MatrixFixSize_Sl_10_Sc_16_Sg__fromMatlab(iDynTree::Matr
                 }
                 return;
             }
+            } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
 SWIGINTERN mxArray *iDynTree_VectorFixSize_Sl_3_Sg__toMatlab(iDynTree::VectorFixSize< 3 > const *self){
@@ -3357,16 +3470,60 @@ SWIGINTERN void iDynTree_VectorFixSize_Sl_3_Sg__fromMatlab(iDynTree::VectorFixSi
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValSize = self->size();
-        if( ( dims[0] == fixValSize && dims[1] == 1) ||
-            ( dims[0] == 1 && dims[1] == fixValSize ) )
+        size_t nonSingletonDimension = (dims[0] == 1 ? dims[1] : dims[0]);
+        
+        if (nonSingletonDimension == fixValSize)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = self->data();
-            for(size_t i=0; i < fixValSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,6,VECTORSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
+    
+    //If dims[1] == 1 assume it is a column vector (or a 1 element vector)
+    bool isColumnVector = (dims[1] == 1);
+
+    //zero the matrix (iDynTree vector is dense)
+    self->zero();
+    for (mwIndex col = 0; col < dims[1]; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+        
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            //iDynTree has only one size.
+            self->operator()(isColumnVector ? row : col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = self->data();
+                for(size_t i=0; i < fixValSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
+        } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong vector size. Matlab size: %d. iDynTree size: %d", nonSingletonDimension, fixValSize);
         }
     }
 SWIGINTERN mxArray *iDynTree_VectorFixSize_Sl_6_Sg__toMatlab(iDynTree::VectorFixSize< 6 > const *self){
@@ -3379,16 +3536,60 @@ SWIGINTERN void iDynTree_VectorFixSize_Sl_6_Sg__fromMatlab(iDynTree::VectorFixSi
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValSize = self->size();
-        if( ( dims[0] == fixValSize && dims[1] == 1) ||
-            ( dims[0] == 1 && dims[1] == fixValSize ) )
+        size_t nonSingletonDimension = (dims[0] == 1 ? dims[1] : dims[0]);
+        
+        if (nonSingletonDimension == fixValSize)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = self->data();
-            for(size_t i=0; i < fixValSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,6,VECTORSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
+    
+    //If dims[1] == 1 assume it is a column vector (or a 1 element vector)
+    bool isColumnVector = (dims[1] == 1);
+
+    //zero the matrix (iDynTree vector is dense)
+    self->zero();
+    for (mwIndex col = 0; col < dims[1]; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+        
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            //iDynTree has only one size.
+            self->operator()(isColumnVector ? row : col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = self->data();
+                for(size_t i=0; i < fixValSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
+        } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong vector size. Matlab size: %d. iDynTree size: %d", nonSingletonDimension, fixValSize);
         }
     }
 SWIGINTERN mxArray *iDynTree_VectorFixSize_Sl_10_Sg__toMatlab(iDynTree::VectorFixSize< 10 > const *self){
@@ -3401,16 +3602,60 @@ SWIGINTERN void iDynTree_VectorFixSize_Sl_10_Sg__fromMatlab(iDynTree::VectorFixS
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValSize = self->size();
-        if( ( dims[0] == fixValSize && dims[1] == 1) ||
-            ( dims[0] == 1 && dims[1] == fixValSize ) )
+        size_t nonSingletonDimension = (dims[0] == 1 ? dims[1] : dims[0]);
+        
+        if (nonSingletonDimension == fixValSize)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = self->data();
-            for(size_t i=0; i < fixValSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,6,VECTORSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
+    
+    //If dims[1] == 1 assume it is a column vector (or a 1 element vector)
+    bool isColumnVector = (dims[1] == 1);
+
+    //zero the matrix (iDynTree vector is dense)
+    self->zero();
+    for (mwIndex col = 0; col < dims[1]; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+        
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            //iDynTree has only one size.
+            self->operator()(isColumnVector ? row : col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = self->data();
+                for(size_t i=0; i < fixValSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
+        } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong vector size. Matlab size: %d. iDynTree size: %d", nonSingletonDimension, fixValSize);
         }
     }
 SWIGINTERN mxArray *iDynTree_VectorFixSize_Sl_16_Sg__toMatlab(iDynTree::VectorFixSize< 16 > const *self){
@@ -3423,16 +3668,60 @@ SWIGINTERN void iDynTree_VectorFixSize_Sl_16_Sg__fromMatlab(iDynTree::VectorFixS
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValSize = self->size();
-        if( ( dims[0] == fixValSize && dims[1] == 1) ||
-            ( dims[0] == 1 && dims[1] == fixValSize ) )
+        size_t nonSingletonDimension = (dims[0] == 1 ? dims[1] : dims[0]);
+        
+        if (nonSingletonDimension == fixValSize)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = self->data();
-            for(size_t i=0; i < fixValSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                /*@SWIG:/Users/makaveli/Projects/src/codyco-superbuild/libraries/iDynTree/bindings/./matlab/matlab_matvec.i,6,VECTORSPARSECOPY@*/
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(in);
+    mwIndex* jc = mxGetJc(in);
+    double *data = mxGetPr(in);
+    
+    //If dims[1] == 1 assume it is a column vector (or a 1 element vector)
+    bool isColumnVector = (dims[1] == 1);
+
+    //zero the matrix (iDynTree vector is dense)
+    self->zero();
+    for (mwIndex col = 0; col < dims[1]; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+        
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            //iDynTree has only one size.
+            self->operator()(isColumnVector ? row : col) = data[currentIndex];
+        }
+    }
+/*@SWIG@*/
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = self->data();
+                for(size_t i=0; i < fixValSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
+        } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong vector size. Matlab size: %d. iDynTree size: %d", nonSingletonDimension, fixValSize);
         }
     }
 
@@ -7540,6 +7829,31 @@ int _wrap_MatrixDynSize_toMatlab (int resc, mxArray *resv[], int argc, mxArray *
   arg1 = reinterpret_cast< iDynTree::MatrixDynSize * >(argp1);
   result = (mxArray *)iDynTree_MatrixDynSize_toMatlab((iDynTree::MatrixDynSize const *)arg1);
   _out = result;
+  if (_out) --resc, *resv++ = _out;
+  return 0;
+fail:
+  return 1;
+}
+
+
+int _wrap_MatrixDynSize_fromMatlab (int resc, mxArray *resv[], int argc, mxArray *argv[]) {
+  iDynTree::MatrixDynSize *arg1 = (iDynTree::MatrixDynSize *) 0 ;
+  mxArray *arg2 = (mxArray *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mxArray * _out;
+  
+  if (!SWIG_check_num_args("MatrixDynSize_fromMatlab",argc,2,2,0)) {
+    SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_iDynTree__MatrixDynSize, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixDynSize_fromMatlab" "', argument " "1"" of type '" "iDynTree::MatrixDynSize *""'"); 
+  }
+  arg1 = reinterpret_cast< iDynTree::MatrixDynSize * >(argp1);
+  arg2 = argv[1];
+  iDynTree_MatrixDynSize_fromMatlab(arg1,arg2);
+  _out = (mxArray*)0;
   if (_out) --resc, *resv++ = _out;
   return 0;
 fail:
@@ -67958,1270 +68272,1271 @@ const char* swigFunctionName_(int fcn_id) {
   case 94: return "MatrixDynSize_toString";
   case 95: return "MatrixDynSize_display";
   case 96: return "MatrixDynSize_toMatlab";
-  case 97: return "new_VectorDynSize";
-  case 98: return "delete_VectorDynSize";
-  case 99: return "VectorDynSize_paren";
-  case 100: return "VectorDynSize_getVal";
-  case 101: return "VectorDynSize_setVal";
-  case 102: return "VectorDynSize_size";
-  case 103: return "VectorDynSize_data";
-  case 104: return "VectorDynSize_zero";
-  case 105: return "VectorDynSize_reserve";
-  case 106: return "VectorDynSize_resize";
-  case 107: return "VectorDynSize_shrink_to_fit";
-  case 108: return "VectorDynSize_capacity";
-  case 109: return "VectorDynSize_fillBuffer";
-  case 110: return "VectorDynSize_toString";
-  case 111: return "VectorDynSize_display";
-  case 112: return "VectorDynSize_toMatlab";
-  case 113: return "VectorDynSize_fromMatlab";
-  case 114: return "new_Matrix3x3";
-  case 115: return "Matrix3x3_paren";
-  case 116: return "Matrix3x3_getVal";
-  case 117: return "Matrix3x3_setVal";
-  case 118: return "Matrix3x3_rows";
-  case 119: return "Matrix3x3_cols";
-  case 120: return "Matrix3x3_data";
-  case 121: return "Matrix3x3_zero";
-  case 122: return "Matrix3x3_fillRowMajorBuffer";
-  case 123: return "Matrix3x3_fillColMajorBuffer";
-  case 124: return "Matrix3x3_toString";
-  case 125: return "Matrix3x3_display";
-  case 126: return "Matrix3x3_toMatlab";
-  case 127: return "Matrix3x3_fromMatlab";
-  case 128: return "delete_Matrix3x3";
-  case 129: return "new_Matrix4x4";
-  case 130: return "Matrix4x4_paren";
-  case 131: return "Matrix4x4_getVal";
-  case 132: return "Matrix4x4_setVal";
-  case 133: return "Matrix4x4_rows";
-  case 134: return "Matrix4x4_cols";
-  case 135: return "Matrix4x4_data";
-  case 136: return "Matrix4x4_zero";
-  case 137: return "Matrix4x4_fillRowMajorBuffer";
-  case 138: return "Matrix4x4_fillColMajorBuffer";
-  case 139: return "Matrix4x4_toString";
-  case 140: return "Matrix4x4_display";
-  case 141: return "Matrix4x4_toMatlab";
-  case 142: return "Matrix4x4_fromMatlab";
-  case 143: return "delete_Matrix4x4";
-  case 144: return "new_Matrix6x6";
-  case 145: return "Matrix6x6_paren";
-  case 146: return "Matrix6x6_getVal";
-  case 147: return "Matrix6x6_setVal";
-  case 148: return "Matrix6x6_rows";
-  case 149: return "Matrix6x6_cols";
-  case 150: return "Matrix6x6_data";
-  case 151: return "Matrix6x6_zero";
-  case 152: return "Matrix6x6_fillRowMajorBuffer";
-  case 153: return "Matrix6x6_fillColMajorBuffer";
-  case 154: return "Matrix6x6_toString";
-  case 155: return "Matrix6x6_display";
-  case 156: return "Matrix6x6_toMatlab";
-  case 157: return "Matrix6x6_fromMatlab";
-  case 158: return "delete_Matrix6x6";
-  case 159: return "new_Matrix6x10";
-  case 160: return "Matrix6x10_paren";
-  case 161: return "Matrix6x10_getVal";
-  case 162: return "Matrix6x10_setVal";
-  case 163: return "Matrix6x10_rows";
-  case 164: return "Matrix6x10_cols";
-  case 165: return "Matrix6x10_data";
-  case 166: return "Matrix6x10_zero";
-  case 167: return "Matrix6x10_fillRowMajorBuffer";
-  case 168: return "Matrix6x10_fillColMajorBuffer";
-  case 169: return "Matrix6x10_toString";
-  case 170: return "Matrix6x10_display";
-  case 171: return "Matrix6x10_toMatlab";
-  case 172: return "Matrix6x10_fromMatlab";
-  case 173: return "delete_Matrix6x10";
-  case 174: return "new_Matrix10x16";
-  case 175: return "Matrix10x16_paren";
-  case 176: return "Matrix10x16_getVal";
-  case 177: return "Matrix10x16_setVal";
-  case 178: return "Matrix10x16_rows";
-  case 179: return "Matrix10x16_cols";
-  case 180: return "Matrix10x16_data";
-  case 181: return "Matrix10x16_zero";
-  case 182: return "Matrix10x16_fillRowMajorBuffer";
-  case 183: return "Matrix10x16_fillColMajorBuffer";
-  case 184: return "Matrix10x16_toString";
-  case 185: return "Matrix10x16_display";
-  case 186: return "Matrix10x16_toMatlab";
-  case 187: return "Matrix10x16_fromMatlab";
-  case 188: return "delete_Matrix10x16";
-  case 189: return "new_Vector3";
-  case 190: return "Vector3_paren";
-  case 191: return "Vector3_getVal";
-  case 192: return "Vector3_setVal";
-  case 193: return "Vector3_size";
-  case 194: return "Vector3_data";
-  case 195: return "Vector3_zero";
-  case 196: return "Vector3_fillBuffer";
-  case 197: return "Vector3_toString";
-  case 198: return "Vector3_display";
-  case 199: return "Vector3_toMatlab";
-  case 200: return "Vector3_fromMatlab";
-  case 201: return "delete_Vector3";
-  case 202: return "new_Vector6";
-  case 203: return "Vector6_paren";
-  case 204: return "Vector6_getVal";
-  case 205: return "Vector6_setVal";
-  case 206: return "Vector6_size";
-  case 207: return "Vector6_data";
-  case 208: return "Vector6_zero";
-  case 209: return "Vector6_fillBuffer";
-  case 210: return "Vector6_toString";
-  case 211: return "Vector6_display";
-  case 212: return "Vector6_toMatlab";
-  case 213: return "Vector6_fromMatlab";
-  case 214: return "delete_Vector6";
-  case 215: return "new_Vector10";
-  case 216: return "Vector10_paren";
-  case 217: return "Vector10_getVal";
-  case 218: return "Vector10_setVal";
-  case 219: return "Vector10_size";
-  case 220: return "Vector10_data";
-  case 221: return "Vector10_zero";
-  case 222: return "Vector10_fillBuffer";
-  case 223: return "Vector10_toString";
-  case 224: return "Vector10_display";
-  case 225: return "Vector10_toMatlab";
-  case 226: return "Vector10_fromMatlab";
-  case 227: return "delete_Vector10";
-  case 228: return "new_Vector16";
-  case 229: return "Vector16_paren";
-  case 230: return "Vector16_getVal";
-  case 231: return "Vector16_setVal";
-  case 232: return "Vector16_size";
-  case 233: return "Vector16_data";
-  case 234: return "Vector16_zero";
-  case 235: return "Vector16_fillBuffer";
-  case 236: return "Vector16_toString";
-  case 237: return "Vector16_display";
-  case 238: return "Vector16_toMatlab";
-  case 239: return "Vector16_fromMatlab";
-  case 240: return "delete_Vector16";
-  case 241: return "new_PositionRaw";
-  case 242: return "PositionRaw_changePoint";
-  case 243: return "PositionRaw_changeRefPoint";
-  case 244: return "PositionRaw_compose";
-  case 245: return "PositionRaw_inverse";
-  case 246: return "PositionRaw_changePointOf";
-  case 247: return "PositionRaw_toString";
-  case 248: return "PositionRaw_display";
-  case 249: return "delete_PositionRaw";
-  case 250: return "new_PositionSemantics";
-  case 251: return "PositionSemantics_setToUnknown";
-  case 252: return "PositionSemantics_getPoint";
-  case 253: return "PositionSemantics_getBody";
-  case 254: return "PositionSemantics_getReferencePoint";
-  case 255: return "PositionSemantics_getRefBody";
-  case 256: return "PositionSemantics_getCoordinateFrame";
-  case 257: return "PositionSemantics_setPoint";
-  case 258: return "PositionSemantics_setBody";
-  case 259: return "PositionSemantics_setReferencePoint";
-  case 260: return "PositionSemantics_setRefBody";
-  case 261: return "PositionSemantics_setCoordinateFrame";
-  case 262: return "PositionSemantics_changePoint";
-  case 263: return "PositionSemantics_changeRefPoint";
-  case 264: return "PositionSemantics_compose";
-  case 265: return "PositionSemantics_inverse";
-  case 266: return "PositionSemantics_toString";
-  case 267: return "PositionSemantics_display";
-  case 268: return "delete_PositionSemantics";
-  case 269: return "new_Position";
-  case 270: return "Position_getSemantics";
-  case 271: return "Position_changePoint";
-  case 272: return "Position_changeRefPoint";
-  case 273: return "Position_changeCoordinateFrame";
-  case 274: return "Position_compose";
-  case 275: return "Position_inverse";
-  case 276: return "Position_changePointOf";
-  case 277: return "Position_plus";
-  case 278: return "Position_minus";
-  case 279: return "Position_uminus";
-  case 280: return "Position_mtimes";
-  case 281: return "Position_toString";
-  case 282: return "Position_display";
-  case 283: return "Position_Zero";
-  case 284: return "delete_Position";
-  case 285: return "new_GeomVector3Semantics__LinearMotionVector3Semantics";
-  case 286: return "GeomVector3Semantics__LinearMotionVector3Semantics_setToUnknown";
-  case 287: return "GeomVector3Semantics__LinearMotionVector3Semantics_getBody";
-  case 288: return "GeomVector3Semantics__LinearMotionVector3Semantics_getRefBody";
-  case 289: return "GeomVector3Semantics__LinearMotionVector3Semantics_getCoordinateFrame";
-  case 290: return "GeomVector3Semantics__LinearMotionVector3Semantics_isUnknown";
-  case 291: return "GeomVector3Semantics__LinearMotionVector3Semantics_changeCoordFrame";
-  case 292: return "GeomVector3Semantics__LinearMotionVector3Semantics_compose";
-  case 293: return "GeomVector3Semantics__LinearMotionVector3Semantics_inverse";
-  case 294: return "GeomVector3Semantics__LinearMotionVector3Semantics_dot";
-  case 295: return "delete_GeomVector3Semantics__LinearMotionVector3Semantics";
-  case 296: return "new_GeomVector3Semantics__AngularMotionVector3Semantics";
-  case 297: return "GeomVector3Semantics__AngularMotionVector3Semantics_setToUnknown";
-  case 298: return "GeomVector3Semantics__AngularMotionVector3Semantics_getBody";
-  case 299: return "GeomVector3Semantics__AngularMotionVector3Semantics_getRefBody";
-  case 300: return "GeomVector3Semantics__AngularMotionVector3Semantics_getCoordinateFrame";
-  case 301: return "GeomVector3Semantics__AngularMotionVector3Semantics_isUnknown";
-  case 302: return "GeomVector3Semantics__AngularMotionVector3Semantics_changeCoordFrame";
-  case 303: return "GeomVector3Semantics__AngularMotionVector3Semantics_compose";
-  case 304: return "GeomVector3Semantics__AngularMotionVector3Semantics_inverse";
-  case 305: return "GeomVector3Semantics__AngularMotionVector3Semantics_dot";
-  case 306: return "delete_GeomVector3Semantics__AngularMotionVector3Semantics";
-  case 307: return "new_GeomVector3Semantics__LinearForceVector3Semantics";
-  case 308: return "GeomVector3Semantics__LinearForceVector3Semantics_setToUnknown";
-  case 309: return "GeomVector3Semantics__LinearForceVector3Semantics_getBody";
-  case 310: return "GeomVector3Semantics__LinearForceVector3Semantics_getRefBody";
-  case 311: return "GeomVector3Semantics__LinearForceVector3Semantics_getCoordinateFrame";
-  case 312: return "GeomVector3Semantics__LinearForceVector3Semantics_isUnknown";
-  case 313: return "GeomVector3Semantics__LinearForceVector3Semantics_changeCoordFrame";
-  case 314: return "GeomVector3Semantics__LinearForceVector3Semantics_compose";
-  case 315: return "GeomVector3Semantics__LinearForceVector3Semantics_inverse";
-  case 316: return "GeomVector3Semantics__LinearForceVector3Semantics_dot";
-  case 317: return "delete_GeomVector3Semantics__LinearForceVector3Semantics";
-  case 318: return "new_GeomVector3Semantics__AngularForceVector3Semantics";
-  case 319: return "GeomVector3Semantics__AngularForceVector3Semantics_setToUnknown";
-  case 320: return "GeomVector3Semantics__AngularForceVector3Semantics_getBody";
-  case 321: return "GeomVector3Semantics__AngularForceVector3Semantics_getRefBody";
-  case 322: return "GeomVector3Semantics__AngularForceVector3Semantics_getCoordinateFrame";
-  case 323: return "GeomVector3Semantics__AngularForceVector3Semantics_isUnknown";
-  case 324: return "GeomVector3Semantics__AngularForceVector3Semantics_changeCoordFrame";
-  case 325: return "GeomVector3Semantics__AngularForceVector3Semantics_compose";
-  case 326: return "GeomVector3Semantics__AngularForceVector3Semantics_inverse";
-  case 327: return "GeomVector3Semantics__AngularForceVector3Semantics_dot";
-  case 328: return "delete_GeomVector3Semantics__AngularForceVector3Semantics";
-  case 329: return "GeomVector3__LinearMotionVector3_semantics_get";
-  case 330: return "GeomVector3__LinearMotionVector3_semantics_set";
-  case 331: return "new_GeomVector3__LinearMotionVector3";
-  case 332: return "GeomVector3__LinearMotionVector3_setSemantics";
-  case 333: return "GeomVector3__LinearMotionVector3_changeCoordFrame";
-  case 334: return "GeomVector3__LinearMotionVector3_compose";
-  case 335: return "GeomVector3__LinearMotionVector3_inverse";
-  case 336: return "GeomVector3__LinearMotionVector3_dot";
-  case 337: return "GeomVector3__LinearMotionVector3_plus";
-  case 338: return "GeomVector3__LinearMotionVector3_minus";
-  case 339: return "GeomVector3__LinearMotionVector3_uminus";
-  case 340: return "delete_GeomVector3__LinearMotionVector3";
-  case 341: return "GeomVector3__AngularMotionVector3_semantics_get";
-  case 342: return "GeomVector3__AngularMotionVector3_semantics_set";
-  case 343: return "new_GeomVector3__AngularMotionVector3";
-  case 344: return "GeomVector3__AngularMotionVector3_setSemantics";
-  case 345: return "GeomVector3__AngularMotionVector3_changeCoordFrame";
-  case 346: return "GeomVector3__AngularMotionVector3_compose";
-  case 347: return "GeomVector3__AngularMotionVector3_inverse";
-  case 348: return "GeomVector3__AngularMotionVector3_dot";
-  case 349: return "GeomVector3__AngularMotionVector3_plus";
-  case 350: return "GeomVector3__AngularMotionVector3_minus";
-  case 351: return "GeomVector3__AngularMotionVector3_uminus";
-  case 352: return "delete_GeomVector3__AngularMotionVector3";
-  case 353: return "GeomVector3__LinearForceVector3_semantics_get";
-  case 354: return "GeomVector3__LinearForceVector3_semantics_set";
-  case 355: return "new_GeomVector3__LinearForceVector3";
-  case 356: return "GeomVector3__LinearForceVector3_setSemantics";
-  case 357: return "GeomVector3__LinearForceVector3_changeCoordFrame";
-  case 358: return "GeomVector3__LinearForceVector3_compose";
-  case 359: return "GeomVector3__LinearForceVector3_inverse";
-  case 360: return "GeomVector3__LinearForceVector3_dot";
-  case 361: return "GeomVector3__LinearForceVector3_plus";
-  case 362: return "GeomVector3__LinearForceVector3_minus";
-  case 363: return "GeomVector3__LinearForceVector3_uminus";
-  case 364: return "delete_GeomVector3__LinearForceVector3";
-  case 365: return "GeomVector3__AngularForceVector3_semantics_get";
-  case 366: return "GeomVector3__AngularForceVector3_semantics_set";
-  case 367: return "new_GeomVector3__AngularForceVector3";
-  case 368: return "GeomVector3__AngularForceVector3_setSemantics";
-  case 369: return "GeomVector3__AngularForceVector3_changeCoordFrame";
-  case 370: return "GeomVector3__AngularForceVector3_compose";
-  case 371: return "GeomVector3__AngularForceVector3_inverse";
-  case 372: return "GeomVector3__AngularForceVector3_dot";
-  case 373: return "GeomVector3__AngularForceVector3_plus";
-  case 374: return "GeomVector3__AngularForceVector3_minus";
-  case 375: return "GeomVector3__AngularForceVector3_uminus";
-  case 376: return "delete_GeomVector3__AngularForceVector3";
-  case 377: return "new_ForceVector3Semantics__LinearForceVector3Semantics";
-  case 378: return "ForceVector3Semantics__LinearForceVector3Semantics_compose";
-  case 379: return "ForceVector3Semantics__LinearForceVector3Semantics_inverse";
-  case 380: return "delete_ForceVector3Semantics__LinearForceVector3Semantics";
-  case 381: return "new_ForceVector3Semantics__AngularForceVector3Semantics";
-  case 382: return "ForceVector3Semantics__AngularForceVector3Semantics_compose";
-  case 383: return "ForceVector3Semantics__AngularForceVector3Semantics_inverse";
-  case 384: return "delete_ForceVector3Semantics__AngularForceVector3Semantics";
-  case 385: return "new_MotionVector3__LinearMotionVector3";
-  case 386: return "MotionVector3__LinearMotionVector3_cross";
-  case 387: return "delete_MotionVector3__LinearMotionVector3";
-  case 388: return "new_MotionVector3__AngularMotionVector3";
-  case 389: return "MotionVector3__AngularMotionVector3_cross";
-  case 390: return "delete_MotionVector3__AngularMotionVector3";
-  case 391: return "new_ForceVector3__LinearForceVector3";
-  case 392: return "delete_ForceVector3__LinearForceVector3";
-  case 393: return "new_ForceVector3__AngularForceVector3";
-  case 394: return "delete_ForceVector3__AngularForceVector3";
-  case 395: return "new_LinearMotionVector3Semantics";
-  case 396: return "LinearMotionVector3Semantics_changePoint";
-  case 397: return "LinearMotionVector3Semantics_compose";
-  case 398: return "delete_LinearMotionVector3Semantics";
-  case 399: return "new_LinearMotionVector3";
-  case 400: return "LinearMotionVector3_changePoint";
-  case 401: return "delete_LinearMotionVector3";
-  case 402: return "new_AngularMotionVector3Semantics";
-  case 403: return "delete_AngularMotionVector3Semantics";
-  case 404: return "new_AngularMotionVector3";
-  case 405: return "AngularMotionVector3_exp";
-  case 406: return "delete_AngularMotionVector3";
-  case 407: return "new_LinearForceVector3Semantics";
-  case 408: return "delete_LinearForceVector3Semantics";
-  case 409: return "new_LinearForceVector3";
-  case 410: return "delete_LinearForceVector3";
-  case 411: return "new_AngularForceVector3Semantics";
-  case 412: return "AngularForceVector3Semantics_changePoint";
-  case 413: return "AngularForceVector3Semantics_compose";
-  case 414: return "delete_AngularForceVector3Semantics";
-  case 415: return "new_AngularForceVector3";
-  case 416: return "AngularForceVector3_changePoint";
-  case 417: return "delete_AngularForceVector3";
-  case 418: return "new_SpatialMotionVectorSemanticsBase";
-  case 419: return "SpatialMotionVectorSemanticsBase_check_linear2angularConsistency";
-  case 420: return "SpatialMotionVectorSemanticsBase_toString";
-  case 421: return "SpatialMotionVectorSemanticsBase_display";
-  case 422: return "delete_SpatialMotionVectorSemanticsBase";
-  case 423: return "new_SpatialForceVectorSemanticsBase";
-  case 424: return "SpatialForceVectorSemanticsBase_check_linear2angularConsistency";
-  case 425: return "SpatialForceVectorSemanticsBase_toString";
-  case 426: return "SpatialForceVectorSemanticsBase_display";
-  case 427: return "delete_SpatialForceVectorSemanticsBase";
-  case 428: return "new_SpatialMotionVectorBase";
-  case 429: return "SpatialMotionVectorBase_getLinearVec3";
-  case 430: return "SpatialMotionVectorBase_getAngularVec3";
-  case 431: return "SpatialMotionVectorBase_setLinearVec3";
-  case 432: return "SpatialMotionVectorBase_setAngularVec3";
-  case 433: return "SpatialMotionVectorBase_paren";
-  case 434: return "SpatialMotionVectorBase_getVal";
-  case 435: return "SpatialMotionVectorBase_setVal";
-  case 436: return "SpatialMotionVectorBase_size";
-  case 437: return "SpatialMotionVectorBase_zero";
-  case 438: return "SpatialMotionVectorBase_changePoint";
-  case 439: return "SpatialMotionVectorBase_changeCoordFrame";
-  case 440: return "SpatialMotionVectorBase_compose";
-  case 441: return "SpatialMotionVectorBase_inverse";
-  case 442: return "SpatialMotionVectorBase_dot";
-  case 443: return "SpatialMotionVectorBase_plus";
-  case 444: return "SpatialMotionVectorBase_minus";
-  case 445: return "SpatialMotionVectorBase_uminus";
-  case 446: return "SpatialMotionVectorBase_Zero";
-  case 447: return "SpatialMotionVectorBase_asVector";
-  case 448: return "SpatialMotionVectorBase_toString";
-  case 449: return "SpatialMotionVectorBase_display";
-  case 450: return "SpatialMotionVectorBase_toMatlab";
-  case 451: return "SpatialMotionVectorBase_fromMatlab";
-  case 452: return "delete_SpatialMotionVectorBase";
-  case 453: return "new_SpatialForceVectorBase";
-  case 454: return "SpatialForceVectorBase_getLinearVec3";
-  case 455: return "SpatialForceVectorBase_getAngularVec3";
-  case 456: return "SpatialForceVectorBase_setLinearVec3";
-  case 457: return "SpatialForceVectorBase_setAngularVec3";
-  case 458: return "SpatialForceVectorBase_paren";
-  case 459: return "SpatialForceVectorBase_getVal";
-  case 460: return "SpatialForceVectorBase_setVal";
-  case 461: return "SpatialForceVectorBase_size";
-  case 462: return "SpatialForceVectorBase_zero";
-  case 463: return "SpatialForceVectorBase_changePoint";
-  case 464: return "SpatialForceVectorBase_changeCoordFrame";
-  case 465: return "SpatialForceVectorBase_compose";
-  case 466: return "SpatialForceVectorBase_inverse";
-  case 467: return "SpatialForceVectorBase_dot";
-  case 468: return "SpatialForceVectorBase_plus";
-  case 469: return "SpatialForceVectorBase_minus";
-  case 470: return "SpatialForceVectorBase_uminus";
-  case 471: return "SpatialForceVectorBase_Zero";
-  case 472: return "SpatialForceVectorBase_asVector";
-  case 473: return "SpatialForceVectorBase_toString";
-  case 474: return "SpatialForceVectorBase_display";
-  case 475: return "SpatialForceVectorBase_toMatlab";
-  case 476: return "SpatialForceVectorBase_fromMatlab";
-  case 477: return "delete_SpatialForceVectorBase";
-  case 478: return "new_Dummy";
-  case 479: return "delete_Dummy";
-  case 480: return "new_SpatialMotionVector";
-  case 481: return "SpatialMotionVector_mtimes";
-  case 482: return "SpatialMotionVector_cross";
-  case 483: return "SpatialMotionVector_asCrossProductMatrix";
-  case 484: return "SpatialMotionVector_asCrossProductMatrixWrench";
-  case 485: return "SpatialMotionVector_exp";
-  case 486: return "delete_SpatialMotionVector";
-  case 487: return "new_SpatialForceVector";
-  case 488: return "delete_SpatialForceVector";
-  case 489: return "SpatialForceVector_mtimes";
-  case 490: return "new_Twist";
-  case 491: return "Twist_plus";
-  case 492: return "Twist_minus";
-  case 493: return "Twist_uminus";
-  case 494: return "Twist_mtimes";
-  case 495: return "delete_Twist";
-  case 496: return "new_Wrench";
-  case 497: return "Wrench_plus";
-  case 498: return "Wrench_minus";
-  case 499: return "Wrench_uminus";
-  case 500: return "delete_Wrench";
-  case 501: return "new_SpatialMomentum";
-  case 502: return "SpatialMomentum_plus";
-  case 503: return "SpatialMomentum_minus";
-  case 504: return "SpatialMomentum_uminus";
-  case 505: return "delete_SpatialMomentum";
-  case 506: return "new_SpatialAcc";
-  case 507: return "SpatialAcc_plus";
-  case 508: return "SpatialAcc_minus";
-  case 509: return "SpatialAcc_uminus";
-  case 510: return "delete_SpatialAcc";
-  case 511: return "new_ClassicalAcc";
-  case 512: return "ClassicalAcc_changeCoordFrame";
-  case 513: return "ClassicalAcc_Zero";
-  case 514: return "ClassicalAcc_fromSpatial";
-  case 515: return "ClassicalAcc_toSpatial";
-  case 516: return "delete_ClassicalAcc";
-  case 517: return "new_Direction";
-  case 518: return "Direction_Normalize";
-  case 519: return "Direction_toString";
-  case 520: return "Direction_display";
-  case 521: return "Direction_Default";
-  case 522: return "delete_Direction";
-  case 523: return "new_Axis";
-  case 524: return "Axis_getDirection";
-  case 525: return "Axis_getOrigin";
-  case 526: return "Axis_setDirection";
-  case 527: return "Axis_setOrigin";
-  case 528: return "Axis_getRotationTransform";
-  case 529: return "Axis_getRotationTransformDerivative";
-  case 530: return "Axis_getRotationTwist";
-  case 531: return "Axis_getRotationSpatialAcc";
-  case 532: return "Axis_toString";
-  case 533: return "Axis_display";
-  case 534: return "delete_Axis";
-  case 535: return "new_RotationalInertiaRaw";
-  case 536: return "RotationalInertiaRaw_Zero";
-  case 537: return "delete_RotationalInertiaRaw";
-  case 538: return "new_SpatialInertiaRaw";
-  case 539: return "SpatialInertiaRaw_fromRotationalInertiaWrtCenterOfMass";
-  case 540: return "SpatialInertiaRaw_getMass";
-  case 541: return "SpatialInertiaRaw_getCenterOfMass";
-  case 542: return "SpatialInertiaRaw_getRotationalInertiaWrtFrameOrigin";
-  case 543: return "SpatialInertiaRaw_getRotationalInertiaWrtCenterOfMass";
-  case 544: return "SpatialInertiaRaw_combine";
-  case 545: return "SpatialInertiaRaw_multiply";
-  case 546: return "SpatialInertiaRaw_zero";
-  case 547: return "delete_SpatialInertiaRaw";
-  case 548: return "new_SpatialInertia";
-  case 549: return "SpatialInertia_combine";
-  case 550: return "SpatialInertia_asMatrix";
-  case 551: return "SpatialInertia_plus";
-  case 552: return "SpatialInertia_mtimes";
-  case 553: return "SpatialInertia_biasWrench";
-  case 554: return "SpatialInertia_biasWrenchDerivative";
-  case 555: return "SpatialInertia_Zero";
-  case 556: return "SpatialInertia_asVector";
-  case 557: return "SpatialInertia_fromVector";
-  case 558: return "SpatialInertia_isPhysicallyConsistent";
-  case 559: return "SpatialInertia_momentumRegressor";
-  case 560: return "SpatialInertia_momentumDerivativeRegressor";
-  case 561: return "SpatialInertia_momentumDerivativeSlotineLiRegressor";
-  case 562: return "delete_SpatialInertia";
-  case 563: return "new_ArticulatedBodyInertia";
-  case 564: return "ArticulatedBodyInertia_getLinearLinearSubmatrix";
-  case 565: return "ArticulatedBodyInertia_getLinearAngularSubmatrix";
-  case 566: return "ArticulatedBodyInertia_getAngularAngularSubmatrix";
-  case 567: return "ArticulatedBodyInertia_combine";
-  case 568: return "ArticulatedBodyInertia_applyInverse";
-  case 569: return "ArticulatedBodyInertia_asMatrix";
-  case 570: return "ArticulatedBodyInertia_getInverse";
-  case 571: return "ArticulatedBodyInertia_plus";
-  case 572: return "ArticulatedBodyInertia_minus";
-  case 573: return "ArticulatedBodyInertia_mtimes";
-  case 574: return "ArticulatedBodyInertia_zero";
-  case 575: return "ArticulatedBodyInertia_ABADyadHelper";
-  case 576: return "ArticulatedBodyInertia_ABADyadHelperLin";
-  case 577: return "delete_ArticulatedBodyInertia";
-  case 578: return "new_RotationRaw";
-  case 579: return "RotationRaw_changeOrientFrame";
-  case 580: return "RotationRaw_changeRefOrientFrame";
-  case 581: return "RotationRaw_compose";
-  case 582: return "RotationRaw_inverse2";
-  case 583: return "RotationRaw_changeCoordFrameOf";
-  case 584: return "RotationRaw_RotX";
-  case 585: return "RotationRaw_RotY";
-  case 586: return "RotationRaw_RotZ";
-  case 587: return "RotationRaw_RPY";
-  case 588: return "RotationRaw_Identity";
-  case 589: return "RotationRaw_toString";
-  case 590: return "RotationRaw_display";
-  case 591: return "delete_RotationRaw";
-  case 592: return "new_RotationSemantics";
-  case 593: return "RotationSemantics_setToUnknown";
-  case 594: return "RotationSemantics_getOrientationFrame";
-  case 595: return "RotationSemantics_getBody";
-  case 596: return "RotationSemantics_getReferenceOrientationFrame";
-  case 597: return "RotationSemantics_getRefBody";
-  case 598: return "RotationSemantics_getCoordinateFrame";
-  case 599: return "RotationSemantics_setOrientationFrame";
-  case 600: return "RotationSemantics_setBody";
-  case 601: return "RotationSemantics_setReferenceOrientationFrame";
-  case 602: return "RotationSemantics_setRefBody";
-  case 603: return "RotationSemantics_setCoordinateFrame";
-  case 604: return "RotationSemantics_changeOrientFrame";
-  case 605: return "RotationSemantics_changeRefOrientFrame";
-  case 606: return "RotationSemantics_changeCoordFrameOf";
-  case 607: return "RotationSemantics_compose";
-  case 608: return "RotationSemantics_inverse2";
-  case 609: return "RotationSemantics_toString";
-  case 610: return "RotationSemantics_display";
-  case 611: return "delete_RotationSemantics";
-  case 612: return "new_Rotation";
-  case 613: return "Rotation_getSemantics";
-  case 614: return "Rotation_changeOrientFrame";
-  case 615: return "Rotation_changeRefOrientFrame";
-  case 616: return "Rotation_changeCoordinateFrame";
-  case 617: return "Rotation_compose";
-  case 618: return "Rotation_inverse2";
-  case 619: return "Rotation_changeCoordFrameOf";
-  case 620: return "Rotation_inverse";
-  case 621: return "Rotation_mtimes";
-  case 622: return "Rotation_log";
-  case 623: return "Rotation_fromQuaternion";
-  case 624: return "Rotation_getRPY";
-  case 625: return "Rotation_asRPY";
-  case 626: return "Rotation_getQuaternion";
-  case 627: return "Rotation_asQuaternion";
-  case 628: return "Rotation_RotX";
-  case 629: return "Rotation_RotY";
-  case 630: return "Rotation_RotZ";
-  case 631: return "Rotation_RotAxis";
-  case 632: return "Rotation_RotAxisDerivative";
-  case 633: return "Rotation_RPY";
-  case 634: return "Rotation_Identity";
-  case 635: return "Rotation_RotationFromQuaternion";
-  case 636: return "Rotation_toString";
-  case 637: return "Rotation_display";
-  case 638: return "delete_Rotation";
-  case 639: return "new_TransformSemantics";
-  case 640: return "TransformSemantics_getRotationSemantics";
-  case 641: return "TransformSemantics_getPositionSemantics";
-  case 642: return "TransformSemantics_setRotationSemantics";
-  case 643: return "TransformSemantics_setPositionSemantics";
-  case 644: return "TransformSemantics_toString";
-  case 645: return "TransformSemantics_display";
-  case 646: return "delete_TransformSemantics";
-  case 647: return "new_Transform";
-  case 648: return "Transform_getSemantics";
-  case 649: return "Transform_getRotation";
-  case 650: return "Transform_getPosition";
-  case 651: return "Transform_setRotation";
-  case 652: return "Transform_setPosition";
-  case 653: return "Transform_compose";
-  case 654: return "Transform_inverse2";
-  case 655: return "Transform_inverse";
-  case 656: return "Transform_mtimes";
-  case 657: return "Transform_Identity";
-  case 658: return "Transform_asHomogeneousTransform";
-  case 659: return "Transform_asAdjointTransform";
-  case 660: return "Transform_asAdjointTransformWrench";
-  case 661: return "Transform_log";
-  case 662: return "Transform_toString";
-  case 663: return "Transform_display";
-  case 664: return "delete_Transform";
-  case 665: return "new_TransformDerivative";
-  case 666: return "delete_TransformDerivative";
-  case 667: return "TransformDerivative_getRotationDerivative";
-  case 668: return "TransformDerivative_getPositionDerivative";
-  case 669: return "TransformDerivative_setRotationDerivative";
-  case 670: return "TransformDerivative_setPositionDerivative";
-  case 671: return "TransformDerivative_Zero";
-  case 672: return "TransformDerivative_asHomogeneousTransformDerivative";
-  case 673: return "TransformDerivative_asAdjointTransformDerivative";
-  case 674: return "TransformDerivative_asAdjointTransformWrenchDerivative";
-  case 675: return "TransformDerivative_mtimes";
-  case 676: return "TransformDerivative_derivativeOfInverse";
-  case 677: return "TransformDerivative_transform";
-  case 678: return "LINK_INVALID_INDEX_get";
-  case 679: return "LINK_INVALID_INDEX_set";
-  case 680: return "LINK_INVALID_NAME_get";
-  case 681: return "LINK_INVALID_NAME_set";
-  case 682: return "JOINT_INVALID_INDEX_get";
-  case 683: return "JOINT_INVALID_INDEX_set";
-  case 684: return "JOINT_INVALID_NAME_get";
-  case 685: return "JOINT_INVALID_NAME_set";
-  case 686: return "DOF_INVALID_INDEX_get";
-  case 687: return "DOF_INVALID_INDEX_set";
-  case 688: return "DOF_INVALID_NAME_get";
-  case 689: return "DOF_INVALID_NAME_set";
-  case 690: return "FRAME_INVALID_INDEX_get";
-  case 691: return "FRAME_INVALID_INDEX_set";
-  case 692: return "FRAME_INVALID_NAME_get";
-  case 693: return "FRAME_INVALID_NAME_set";
-  case 694: return "TRAVERSAL_INVALID_INDEX_get";
-  case 695: return "TRAVERSAL_INVALID_INDEX_set";
-  case 696: return "new_LinkPositions";
-  case 697: return "LinkPositions_resize";
-  case 698: return "LinkPositions_isConsistent";
-  case 699: return "LinkPositions_getNrOfLinks";
-  case 700: return "LinkPositions_paren";
-  case 701: return "LinkPositions_toString";
-  case 702: return "delete_LinkPositions";
-  case 703: return "new_LinkWrenches";
-  case 704: return "LinkWrenches_resize";
-  case 705: return "LinkWrenches_isConsistent";
-  case 706: return "LinkWrenches_getNrOfLinks";
-  case 707: return "LinkWrenches_paren";
-  case 708: return "LinkWrenches_toString";
-  case 709: return "delete_LinkWrenches";
-  case 710: return "new_LinkInertias";
-  case 711: return "LinkInertias_resize";
-  case 712: return "LinkInertias_isConsistent";
-  case 713: return "LinkInertias_paren";
-  case 714: return "delete_LinkInertias";
-  case 715: return "new_LinkArticulatedBodyInertias";
-  case 716: return "LinkArticulatedBodyInertias_resize";
-  case 717: return "LinkArticulatedBodyInertias_isConsistent";
-  case 718: return "LinkArticulatedBodyInertias_paren";
-  case 719: return "delete_LinkArticulatedBodyInertias";
-  case 720: return "new_LinkVelArray";
-  case 721: return "LinkVelArray_resize";
-  case 722: return "LinkVelArray_isConsistent";
-  case 723: return "LinkVelArray_getNrOfLinks";
-  case 724: return "LinkVelArray_paren";
-  case 725: return "LinkVelArray_toString";
-  case 726: return "delete_LinkVelArray";
-  case 727: return "new_LinkAccArray";
-  case 728: return "LinkAccArray_resize";
-  case 729: return "LinkAccArray_isConsistent";
-  case 730: return "LinkAccArray_paren";
-  case 731: return "LinkAccArray_getNrOfLinks";
-  case 732: return "LinkAccArray_toString";
-  case 733: return "delete_LinkAccArray";
-  case 734: return "new_Link";
-  case 735: return "Link_inertia";
-  case 736: return "Link_setInertia";
-  case 737: return "Link_getInertia";
-  case 738: return "Link_setIndex";
-  case 739: return "Link_getIndex";
-  case 740: return "delete_Link";
-  case 741: return "delete_IJoint";
-  case 742: return "IJoint_clone";
-  case 743: return "IJoint_getNrOfPosCoords";
-  case 744: return "IJoint_getNrOfDOFs";
-  case 745: return "IJoint_setAttachedLinks";
-  case 746: return "IJoint_setRestTransform";
-  case 747: return "IJoint_getFirstAttachedLink";
-  case 748: return "IJoint_getSecondAttachedLink";
-  case 749: return "IJoint_getRestTransform";
-  case 750: return "IJoint_getTransform";
-  case 751: return "IJoint_getTransformDerivative";
-  case 752: return "IJoint_getMotionSubspaceVector";
-  case 753: return "IJoint_computeChildPosVelAcc";
-  case 754: return "IJoint_computeChildVelAcc";
-  case 755: return "IJoint_computeChildVel";
-  case 756: return "IJoint_computeJointTorque";
-  case 757: return "IJoint_setIndex";
-  case 758: return "IJoint_getIndex";
-  case 759: return "IJoint_setPosCoordsOffset";
-  case 760: return "IJoint_getPosCoordsOffset";
-  case 761: return "IJoint_setDOFsOffset";
-  case 762: return "IJoint_getDOFsOffset";
-  case 763: return "IJoint_isRevoluteJoint";
-  case 764: return "IJoint_isFixedJoint";
-  case 765: return "IJoint_asRevoluteJoint";
-  case 766: return "IJoint_asFixedJoint";
-  case 767: return "new_FixedJoint";
-  case 768: return "delete_FixedJoint";
-  case 769: return "FixedJoint_clone";
-  case 770: return "FixedJoint_getNrOfPosCoords";
-  case 771: return "FixedJoint_getNrOfDOFs";
-  case 772: return "FixedJoint_setAttachedLinks";
-  case 773: return "FixedJoint_setRestTransform";
-  case 774: return "FixedJoint_getFirstAttachedLink";
-  case 775: return "FixedJoint_getSecondAttachedLink";
-  case 776: return "FixedJoint_getRestTransform";
-  case 777: return "FixedJoint_getTransform";
-  case 778: return "FixedJoint_getTransformDerivative";
-  case 779: return "FixedJoint_getMotionSubspaceVector";
-  case 780: return "FixedJoint_computeChildPosVelAcc";
-  case 781: return "FixedJoint_computeChildVelAcc";
-  case 782: return "FixedJoint_computeChildVel";
-  case 783: return "FixedJoint_computeJointTorque";
-  case 784: return "FixedJoint_setIndex";
-  case 785: return "FixedJoint_getIndex";
-  case 786: return "FixedJoint_setPosCoordsOffset";
-  case 787: return "FixedJoint_getPosCoordsOffset";
-  case 788: return "FixedJoint_setDOFsOffset";
-  case 789: return "FixedJoint_getDOFsOffset";
-  case 790: return "delete_MovableJointImpl1";
-  case 791: return "MovableJointImpl1_getNrOfPosCoords";
-  case 792: return "MovableJointImpl1_getNrOfDOFs";
-  case 793: return "MovableJointImpl1_setIndex";
-  case 794: return "MovableJointImpl1_getIndex";
-  case 795: return "MovableJointImpl1_setPosCoordsOffset";
-  case 796: return "MovableJointImpl1_getPosCoordsOffset";
-  case 797: return "MovableJointImpl1_setDOFsOffset";
-  case 798: return "MovableJointImpl1_getDOFsOffset";
-  case 799: return "delete_MovableJointImpl2";
-  case 800: return "MovableJointImpl2_getNrOfPosCoords";
-  case 801: return "MovableJointImpl2_getNrOfDOFs";
-  case 802: return "MovableJointImpl2_setIndex";
-  case 803: return "MovableJointImpl2_getIndex";
-  case 804: return "MovableJointImpl2_setPosCoordsOffset";
-  case 805: return "MovableJointImpl2_getPosCoordsOffset";
-  case 806: return "MovableJointImpl2_setDOFsOffset";
-  case 807: return "MovableJointImpl2_getDOFsOffset";
-  case 808: return "delete_MovableJointImpl3";
-  case 809: return "MovableJointImpl3_getNrOfPosCoords";
-  case 810: return "MovableJointImpl3_getNrOfDOFs";
-  case 811: return "MovableJointImpl3_setIndex";
-  case 812: return "MovableJointImpl3_getIndex";
-  case 813: return "MovableJointImpl3_setPosCoordsOffset";
-  case 814: return "MovableJointImpl3_getPosCoordsOffset";
-  case 815: return "MovableJointImpl3_setDOFsOffset";
-  case 816: return "MovableJointImpl3_getDOFsOffset";
-  case 817: return "delete_MovableJointImpl4";
-  case 818: return "MovableJointImpl4_getNrOfPosCoords";
-  case 819: return "MovableJointImpl4_getNrOfDOFs";
-  case 820: return "MovableJointImpl4_setIndex";
-  case 821: return "MovableJointImpl4_getIndex";
-  case 822: return "MovableJointImpl4_setPosCoordsOffset";
-  case 823: return "MovableJointImpl4_getPosCoordsOffset";
-  case 824: return "MovableJointImpl4_setDOFsOffset";
-  case 825: return "MovableJointImpl4_getDOFsOffset";
-  case 826: return "delete_MovableJointImpl5";
-  case 827: return "MovableJointImpl5_getNrOfPosCoords";
-  case 828: return "MovableJointImpl5_getNrOfDOFs";
-  case 829: return "MovableJointImpl5_setIndex";
-  case 830: return "MovableJointImpl5_getIndex";
-  case 831: return "MovableJointImpl5_setPosCoordsOffset";
-  case 832: return "MovableJointImpl5_getPosCoordsOffset";
-  case 833: return "MovableJointImpl5_setDOFsOffset";
-  case 834: return "MovableJointImpl5_getDOFsOffset";
-  case 835: return "delete_MovableJointImpl6";
-  case 836: return "MovableJointImpl6_getNrOfPosCoords";
-  case 837: return "MovableJointImpl6_getNrOfDOFs";
-  case 838: return "MovableJointImpl6_setIndex";
-  case 839: return "MovableJointImpl6_getIndex";
-  case 840: return "MovableJointImpl6_setPosCoordsOffset";
-  case 841: return "MovableJointImpl6_getPosCoordsOffset";
-  case 842: return "MovableJointImpl6_setDOFsOffset";
-  case 843: return "MovableJointImpl6_getDOFsOffset";
-  case 844: return "new_RevoluteJoint";
-  case 845: return "delete_RevoluteJoint";
-  case 846: return "RevoluteJoint_clone";
-  case 847: return "RevoluteJoint_setAttachedLinks";
-  case 848: return "RevoluteJoint_setRestTransform";
-  case 849: return "RevoluteJoint_setAxis";
-  case 850: return "RevoluteJoint_getFirstAttachedLink";
-  case 851: return "RevoluteJoint_getSecondAttachedLink";
-  case 852: return "RevoluteJoint_getAxis";
-  case 853: return "RevoluteJoint_getRestTransform";
-  case 854: return "RevoluteJoint_getTransform";
-  case 855: return "RevoluteJoint_getTransformDerivative";
-  case 856: return "RevoluteJoint_getMotionSubspaceVector";
-  case 857: return "RevoluteJoint_computeChildPosVelAcc";
-  case 858: return "RevoluteJoint_computeChildVel";
-  case 859: return "RevoluteJoint_computeChildVelAcc";
-  case 860: return "RevoluteJoint_computeJointTorque";
-  case 861: return "new_Traversal";
-  case 862: return "delete_Traversal";
-  case 863: return "Traversal_getNrOfVisitedLinks";
-  case 864: return "Traversal_getLink";
-  case 865: return "Traversal_getBaseLink";
-  case 866: return "Traversal_getParentLink";
-  case 867: return "Traversal_getParentJoint";
-  case 868: return "Traversal_getParentLinkFromLinkIndex";
-  case 869: return "Traversal_getParentJointFromLinkIndex";
-  case 870: return "Traversal_getTraversalIndexFromLinkIndex";
-  case 871: return "Traversal_reset";
-  case 872: return "Traversal_addTraversalBase";
-  case 873: return "Traversal_addTraversalElement";
-  case 874: return "Traversal_isParentOf";
-  case 875: return "Traversal_getChildLinkIndexFromJointIndex";
-  case 876: return "Traversal_toString";
-  case 877: return "Neighbor_neighborLink_get";
-  case 878: return "Neighbor_neighborLink_set";
-  case 879: return "Neighbor_neighborJoint_get";
-  case 880: return "Neighbor_neighborJoint_set";
-  case 881: return "new_Neighbor";
-  case 882: return "delete_Neighbor";
-  case 883: return "new_Model";
-  case 884: return "delete_Model";
-  case 885: return "Model_getNrOfLinks";
-  case 886: return "Model_getLinkName";
-  case 887: return "Model_getLinkIndex";
-  case 888: return "Model_isValidLinkIndex";
-  case 889: return "Model_getLink";
-  case 890: return "Model_addLink";
-  case 891: return "Model_getNrOfJoints";
-  case 892: return "Model_getJointName";
-  case 893: return "Model_getJointIndex";
-  case 894: return "Model_getJoint";
-  case 895: return "Model_isValidJointIndex";
-  case 896: return "Model_isLinkNameUsed";
-  case 897: return "Model_isJointNameUsed";
-  case 898: return "Model_isFrameNameUsed";
-  case 899: return "Model_addJoint";
-  case 900: return "Model_getNrOfPosCoords";
-  case 901: return "Model_getNrOfDOFs";
-  case 902: return "Model_getNrOfFrames";
-  case 903: return "Model_addAdditionalFrameToLink";
-  case 904: return "Model_getFrameName";
-  case 905: return "Model_getFrameIndex";
-  case 906: return "Model_isValidFrameIndex";
-  case 907: return "Model_getFrameTransform";
-  case 908: return "Model_getFrameLink";
-  case 909: return "Model_getNrOfNeighbors";
-  case 910: return "Model_getNeighbor";
-  case 911: return "Model_setDefaultBaseLink";
-  case 912: return "Model_getDefaultBaseLink";
-  case 913: return "Model_computeFullTreeTraversal";
-  case 914: return "Model_getInertialParameters";
-  case 915: return "Model_updateInertialParameters";
-  case 916: return "Model_toString";
-  case 917: return "new_JointPosDoubleArray";
-  case 918: return "JointPosDoubleArray_resize";
-  case 919: return "JointPosDoubleArray_isConsistent";
-  case 920: return "delete_JointPosDoubleArray";
-  case 921: return "new_JointDOFsDoubleArray";
-  case 922: return "JointDOFsDoubleArray_resize";
-  case 923: return "JointDOFsDoubleArray_isConsistent";
-  case 924: return "delete_JointDOFsDoubleArray";
-  case 925: return "new_DOFSpatialForceArray";
-  case 926: return "DOFSpatialForceArray_resize";
-  case 927: return "DOFSpatialForceArray_isConsistent";
-  case 928: return "DOFSpatialForceArray_paren";
-  case 929: return "delete_DOFSpatialForceArray";
-  case 930: return "new_DOFSpatialMotionArray";
-  case 931: return "DOFSpatialMotionArray_resize";
-  case 932: return "DOFSpatialMotionArray_isConsistent";
-  case 933: return "DOFSpatialMotionArray_paren";
-  case 934: return "delete_DOFSpatialMotionArray";
-  case 935: return "new_FreeFloatingMassMatrix";
-  case 936: return "FreeFloatingMassMatrix_resize";
-  case 937: return "delete_FreeFloatingMassMatrix";
-  case 938: return "new_FreeFloatingPos";
-  case 939: return "FreeFloatingPos_resize";
-  case 940: return "FreeFloatingPos_worldBasePos";
-  case 941: return "FreeFloatingPos_jointPos";
-  case 942: return "FreeFloatingPos_getNrOfPosCoords";
-  case 943: return "delete_FreeFloatingPos";
-  case 944: return "new_FreeFloatingGeneralizedTorques";
-  case 945: return "FreeFloatingGeneralizedTorques_resize";
-  case 946: return "FreeFloatingGeneralizedTorques_baseWrench";
-  case 947: return "FreeFloatingGeneralizedTorques_jointTorques";
-  case 948: return "FreeFloatingGeneralizedTorques_getNrOfDOFs";
-  case 949: return "delete_FreeFloatingGeneralizedTorques";
-  case 950: return "new_FreeFloatingVel";
-  case 951: return "FreeFloatingVel_resize";
-  case 952: return "FreeFloatingVel_baseVel";
-  case 953: return "FreeFloatingVel_jointVel";
-  case 954: return "FreeFloatingVel_getNrOfDOFs";
-  case 955: return "delete_FreeFloatingVel";
-  case 956: return "new_FreeFloatingAcc";
-  case 957: return "FreeFloatingAcc_resize";
-  case 958: return "FreeFloatingAcc_baseAcc";
-  case 959: return "FreeFloatingAcc_jointAcc";
-  case 960: return "FreeFloatingAcc_getNrOfDOFs";
-  case 961: return "delete_FreeFloatingAcc";
-  case 962: return "ContactWrench_contactId";
-  case 963: return "ContactWrench_contactPoint";
-  case 964: return "ContactWrench_contactWrench";
-  case 965: return "new_ContactWrench";
-  case 966: return "delete_ContactWrench";
-  case 967: return "new_LinkContactWrenches";
-  case 968: return "LinkContactWrenches_resize";
-  case 969: return "LinkContactWrenches_getNrOfContactsForLink";
-  case 970: return "LinkContactWrenches_setNrOfContactsForLink";
-  case 971: return "LinkContactWrenches_getNrOfLinks";
-  case 972: return "LinkContactWrenches_contactWrench";
-  case 973: return "LinkContactWrenches_computeNetWrenches";
-  case 974: return "LinkContactWrenches_toString";
-  case 975: return "delete_LinkContactWrenches";
-  case 976: return "_wrap_ForwardPositionKinematics";
-  case 977: return "_wrap_ForwardVelAccKinematics";
-  case 978: return "_wrap_ForwardPosVelAccKinematics";
-  case 979: return "_wrap_RNEADynamicPhase";
-  case 980: return "_wrap_CompositeRigidBodyAlgorithm";
-  case 981: return "new_ArticulatedBodyAlgorithmInternalBuffers";
-  case 982: return "ArticulatedBodyAlgorithmInternalBuffers_resize";
-  case 983: return "ArticulatedBodyAlgorithmInternalBuffers_isConsistent";
-  case 984: return "ArticulatedBodyAlgorithmInternalBuffers_S_get";
-  case 985: return "ArticulatedBodyAlgorithmInternalBuffers_S_set";
-  case 986: return "ArticulatedBodyAlgorithmInternalBuffers_U_get";
-  case 987: return "ArticulatedBodyAlgorithmInternalBuffers_U_set";
-  case 988: return "ArticulatedBodyAlgorithmInternalBuffers_D_get";
-  case 989: return "ArticulatedBodyAlgorithmInternalBuffers_D_set";
-  case 990: return "ArticulatedBodyAlgorithmInternalBuffers_u_get";
-  case 991: return "ArticulatedBodyAlgorithmInternalBuffers_u_set";
-  case 992: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_get";
-  case 993: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_set";
-  case 994: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get";
-  case 995: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set";
-  case 996: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get";
-  case 997: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set";
-  case 998: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get";
-  case 999: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set";
-  case 1000: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get";
-  case 1001: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set";
-  case 1002: return "delete_ArticulatedBodyAlgorithmInternalBuffers";
-  case 1003: return "_wrap_ArticulatedBodyAlgorithm";
-  case 1004: return "NR_OF_SENSOR_TYPES_get";
-  case 1005: return "_wrap_isLinkSensor";
-  case 1006: return "_wrap_isJointSensor";
-  case 1007: return "_wrap_getSensorTypeSize";
-  case 1008: return "delete_Sensor";
-  case 1009: return "Sensor_getName";
-  case 1010: return "Sensor_getSensorType";
-  case 1011: return "Sensor_isValid";
-  case 1012: return "Sensor_setName";
-  case 1013: return "Sensor_clone";
-  case 1014: return "Sensor_updateIndeces";
-  case 1015: return "delete_JointSensor";
-  case 1016: return "JointSensor_getParentJoint";
-  case 1017: return "JointSensor_getParentJointIndex";
-  case 1018: return "JointSensor_setParentJoint";
-  case 1019: return "JointSensor_setParentJointIndex";
-  case 1020: return "delete_LinkSensor";
-  case 1021: return "LinkSensor_getParentLink";
-  case 1022: return "LinkSensor_getParentLinkIndex";
-  case 1023: return "LinkSensor_getLinkSensorTransform";
-  case 1024: return "LinkSensor_setParentLink";
-  case 1025: return "LinkSensor_setParentLinkIndex";
-  case 1026: return "new_SensorsList";
-  case 1027: return "delete_SensorsList";
-  case 1028: return "SensorsList_addSensor";
-  case 1029: return "SensorsList_setSerialization";
-  case 1030: return "SensorsList_getSerialization";
-  case 1031: return "SensorsList_getNrOfSensors";
-  case 1032: return "SensorsList_getSensorIndex";
-  case 1033: return "SensorsList_getSizeOfAllSensorsMeasurements";
-  case 1034: return "SensorsList_getSensor";
-  case 1035: return "SensorsList_removeSensor";
-  case 1036: return "SensorsList_removeAllSensorsOfType";
-  case 1037: return "SensorsList_getSixAxisForceTorqueSensor";
-  case 1038: return "SensorsList_getAccelerometerSensor";
-  case 1039: return "SensorsList_getGyroscopeSensor";
-  case 1040: return "new_SensorsMeasurements";
-  case 1041: return "delete_SensorsMeasurements";
-  case 1042: return "SensorsMeasurements_setNrOfSensors";
-  case 1043: return "SensorsMeasurements_getNrOfSensors";
-  case 1044: return "SensorsMeasurements_resize";
-  case 1045: return "SensorsMeasurements_toVector";
-  case 1046: return "SensorsMeasurements_setMeasurement";
-  case 1047: return "SensorsMeasurements_getMeasurement";
-  case 1048: return "SensorsMeasurements_getSizeOfAllSensorsMeasurements";
-  case 1049: return "new_SixAxisForceTorqueSensor";
-  case 1050: return "delete_SixAxisForceTorqueSensor";
-  case 1051: return "SixAxisForceTorqueSensor_setName";
-  case 1052: return "SixAxisForceTorqueSensor_setFirstLinkSensorTransform";
-  case 1053: return "SixAxisForceTorqueSensor_setSecondLinkSensorTransform";
-  case 1054: return "SixAxisForceTorqueSensor_getFirstLinkIndex";
-  case 1055: return "SixAxisForceTorqueSensor_getSecondLinkIndex";
-  case 1056: return "SixAxisForceTorqueSensor_setFirstLinkName";
-  case 1057: return "SixAxisForceTorqueSensor_setSecondLinkName";
-  case 1058: return "SixAxisForceTorqueSensor_getFirstLinkName";
-  case 1059: return "SixAxisForceTorqueSensor_getSecondLinkName";
-  case 1060: return "SixAxisForceTorqueSensor_setParentJoint";
-  case 1061: return "SixAxisForceTorqueSensor_setParentJointIndex";
-  case 1062: return "SixAxisForceTorqueSensor_setAppliedWrenchLink";
-  case 1063: return "SixAxisForceTorqueSensor_getName";
-  case 1064: return "SixAxisForceTorqueSensor_getSensorType";
-  case 1065: return "SixAxisForceTorqueSensor_getParentJoint";
-  case 1066: return "SixAxisForceTorqueSensor_getParentJointIndex";
-  case 1067: return "SixAxisForceTorqueSensor_isValid";
-  case 1068: return "SixAxisForceTorqueSensor_clone";
-  case 1069: return "SixAxisForceTorqueSensor_updateIndeces";
-  case 1070: return "SixAxisForceTorqueSensor_getAppliedWrenchLink";
-  case 1071: return "SixAxisForceTorqueSensor_isLinkAttachedToSensor";
-  case 1072: return "SixAxisForceTorqueSensor_getLinkSensorTransform";
-  case 1073: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLink";
-  case 1074: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLinkMatrix";
-  case 1075: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLinkInverseMatrix";
-  case 1076: return "SixAxisForceTorqueSensor_predictMeasurement";
-  case 1077: return "SixAxisForceTorqueSensor_toString";
-  case 1078: return "new_AccelerometerSensor";
-  case 1079: return "delete_AccelerometerSensor";
-  case 1080: return "AccelerometerSensor_setName";
-  case 1081: return "AccelerometerSensor_setLinkSensorTransform";
-  case 1082: return "AccelerometerSensor_setParentLink";
-  case 1083: return "AccelerometerSensor_setParentLinkIndex";
-  case 1084: return "AccelerometerSensor_getName";
-  case 1085: return "AccelerometerSensor_getSensorType";
-  case 1086: return "AccelerometerSensor_getParentLink";
-  case 1087: return "AccelerometerSensor_getParentLinkIndex";
-  case 1088: return "AccelerometerSensor_getLinkSensorTransform";
-  case 1089: return "AccelerometerSensor_isValid";
-  case 1090: return "AccelerometerSensor_clone";
-  case 1091: return "AccelerometerSensor_updateIndeces";
-  case 1092: return "AccelerometerSensor_predictMeasurement";
-  case 1093: return "new_GyroscopeSensor";
-  case 1094: return "delete_GyroscopeSensor";
-  case 1095: return "GyroscopeSensor_setName";
-  case 1096: return "GyroscopeSensor_setLinkSensorTransform";
-  case 1097: return "GyroscopeSensor_setParentLink";
-  case 1098: return "GyroscopeSensor_setParentLinkIndex";
-  case 1099: return "GyroscopeSensor_getName";
-  case 1100: return "GyroscopeSensor_getSensorType";
-  case 1101: return "GyroscopeSensor_getParentLink";
-  case 1102: return "GyroscopeSensor_getParentLinkIndex";
-  case 1103: return "GyroscopeSensor_getLinkSensorTransform";
-  case 1104: return "GyroscopeSensor_isValid";
-  case 1105: return "GyroscopeSensor_clone";
-  case 1106: return "GyroscopeSensor_updateIndeces";
-  case 1107: return "GyroscopeSensor_predictMeasurement";
-  case 1108: return "_wrap_predictSensorsMeasurements";
-  case 1109: return "_wrap_predictSensorsMeasurementsFromRawBuffers";
-  case 1110: return "URDFParserOptions_addSensorFramesAsAdditionalFrames_get";
-  case 1111: return "URDFParserOptions_addSensorFramesAsAdditionalFrames_set";
-  case 1112: return "new_URDFParserOptions";
-  case 1113: return "delete_URDFParserOptions";
-  case 1114: return "_wrap_modelFromURDF";
-  case 1115: return "_wrap_modelFromURDFString";
-  case 1116: return "_wrap_sensorsFromURDF";
-  case 1117: return "_wrap_sensorsFromURDFString";
-  case 1118: return "new_ModelLoader";
-  case 1119: return "ModelLoader_loadModelFromString";
-  case 1120: return "ModelLoader_loadModelFromFile";
-  case 1121: return "ModelLoader_loadReducedModelFromFullModel";
-  case 1122: return "ModelLoader_loadReducedModelFromString";
-  case 1123: return "ModelLoader_loadReducedModelFromFile";
-  case 1124: return "ModelLoader_model";
-  case 1125: return "ModelLoader_sensors";
-  case 1126: return "ModelLoader_isValid";
-  case 1127: return "delete_ModelLoader";
-  case 1128: return "new_UnknownWrenchContact";
-  case 1129: return "UnknownWrenchContact_unknownType_get";
-  case 1130: return "UnknownWrenchContact_unknownType_set";
-  case 1131: return "UnknownWrenchContact_contactPoint_get";
-  case 1132: return "UnknownWrenchContact_contactPoint_set";
-  case 1133: return "UnknownWrenchContact_forceDirection_get";
-  case 1134: return "UnknownWrenchContact_forceDirection_set";
-  case 1135: return "UnknownWrenchContact_contactId_get";
-  case 1136: return "UnknownWrenchContact_contactId_set";
-  case 1137: return "delete_UnknownWrenchContact";
-  case 1138: return "new_LinkUnknownWrenchContacts";
-  case 1139: return "LinkUnknownWrenchContacts_clear";
-  case 1140: return "LinkUnknownWrenchContacts_resize";
-  case 1141: return "LinkUnknownWrenchContacts_getNrOfContactsForLink";
-  case 1142: return "LinkUnknownWrenchContacts_setNrOfContactsForLink";
-  case 1143: return "LinkUnknownWrenchContacts_addNewContactForLink";
-  case 1144: return "LinkUnknownWrenchContacts_addNewContactInFrame";
-  case 1145: return "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin";
-  case 1146: return "LinkUnknownWrenchContacts_contactWrench";
-  case 1147: return "LinkUnknownWrenchContacts_toString";
-  case 1148: return "delete_LinkUnknownWrenchContacts";
-  case 1149: return "new_LinkTraversalsCache";
-  case 1150: return "delete_LinkTraversalsCache";
-  case 1151: return "LinkTraversalsCache_resize";
-  case 1152: return "LinkTraversalsCache_getTraversalWithLinkAsBase";
-  case 1153: return "new_estimateExternalWrenchesBuffers";
-  case 1154: return "estimateExternalWrenchesBuffers_resize";
-  case 1155: return "estimateExternalWrenchesBuffers_getNrOfSubModels";
-  case 1156: return "estimateExternalWrenchesBuffers_getNrOfLinks";
-  case 1157: return "estimateExternalWrenchesBuffers_isConsistent";
-  case 1158: return "estimateExternalWrenchesBuffers_A_get";
-  case 1159: return "estimateExternalWrenchesBuffers_A_set";
-  case 1160: return "estimateExternalWrenchesBuffers_x_get";
-  case 1161: return "estimateExternalWrenchesBuffers_x_set";
-  case 1162: return "estimateExternalWrenchesBuffers_b_get";
-  case 1163: return "estimateExternalWrenchesBuffers_b_set";
-  case 1164: return "estimateExternalWrenchesBuffers_pinvA_get";
-  case 1165: return "estimateExternalWrenchesBuffers_pinvA_set";
-  case 1166: return "estimateExternalWrenchesBuffers_b_contacts_subtree_get";
-  case 1167: return "estimateExternalWrenchesBuffers_b_contacts_subtree_set";
-  case 1168: return "estimateExternalWrenchesBuffers_subModelBase_H_link_get";
-  case 1169: return "estimateExternalWrenchesBuffers_subModelBase_H_link_set";
-  case 1170: return "delete_estimateExternalWrenchesBuffers";
-  case 1171: return "_wrap_estimateExternalWrenchesWithoutInternalFT";
-  case 1172: return "_wrap_estimateExternalWrenches";
-  case 1173: return "_wrap_dynamicsEstimationForwardVelAccKinematics";
-  case 1174: return "_wrap_dynamicsEstimationForwardVelKinematics";
-  case 1175: return "_wrap_computeLinkNetWrenchesWithoutGravity";
-  case 1176: return "new_ExtWrenchesAndJointTorquesEstimator";
-  case 1177: return "delete_ExtWrenchesAndJointTorquesEstimator";
-  case 1178: return "ExtWrenchesAndJointTorquesEstimator_setModelAndSensors";
-  case 1179: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile";
-  case 1180: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs";
-  case 1181: return "ExtWrenchesAndJointTorquesEstimator_model";
-  case 1182: return "ExtWrenchesAndJointTorquesEstimator_sensors";
-  case 1183: return "ExtWrenchesAndJointTorquesEstimator_submodels";
-  case 1184: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase";
-  case 1185: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase";
-  case 1186: return "ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements";
-  case 1187: return "ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques";
-  case 1188: return "ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill";
-  case 1189: return "ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity";
-  case 1190: return "new_SimpleLeggedOdometry";
-  case 1191: return "delete_SimpleLeggedOdometry";
-  case 1192: return "SimpleLeggedOdometry_setModel";
-  case 1193: return "SimpleLeggedOdometry_loadModelFromFile";
-  case 1194: return "SimpleLeggedOdometry_loadModelFromFileWithSpecifiedDOFs";
-  case 1195: return "SimpleLeggedOdometry_model";
-  case 1196: return "SimpleLeggedOdometry_updateKinematics";
-  case 1197: return "SimpleLeggedOdometry_init";
-  case 1198: return "SimpleLeggedOdometry_changeFixedFrame";
-  case 1199: return "SimpleLeggedOdometry_getCurrentFixedLink";
-  case 1200: return "SimpleLeggedOdometry_getWorldLinkTransform";
-  case 1201: return "_wrap_isLinkBerdyDynamicVariable";
-  case 1202: return "_wrap_isJointBerdyDynamicVariable";
-  case 1203: return "_wrap_isDOFBerdyDynamicVariable";
-  case 1204: return "new_BerdyOptions";
-  case 1205: return "BerdyOptions_berdyVariant_get";
-  case 1206: return "BerdyOptions_berdyVariant_set";
-  case 1207: return "BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_get";
-  case 1208: return "BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_set";
-  case 1209: return "BerdyOptions_includeAllJointAccelerationsAsSensors_get";
-  case 1210: return "BerdyOptions_includeAllJointAccelerationsAsSensors_set";
-  case 1211: return "BerdyOptions_includeAllJointTorquesAsSensors_get";
-  case 1212: return "BerdyOptions_includeAllJointTorquesAsSensors_set";
-  case 1213: return "BerdyOptions_includeAllNetExternalWrenchesAsSensors_get";
-  case 1214: return "BerdyOptions_includeAllNetExternalWrenchesAsSensors_set";
-  case 1215: return "BerdyOptions_includeFixedBaseExternalWrench_get";
-  case 1216: return "BerdyOptions_includeFixedBaseExternalWrench_set";
-  case 1217: return "BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_get";
-  case 1218: return "BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_set";
-  case 1219: return "BerdyOptions_checkConsistency";
-  case 1220: return "delete_BerdyOptions";
-  case 1221: return "BerdySensor_type_get";
-  case 1222: return "BerdySensor_type_set";
-  case 1223: return "BerdySensor_id_get";
-  case 1224: return "BerdySensor_id_set";
-  case 1225: return "BerdySensor_range_get";
-  case 1226: return "BerdySensor_range_set";
-  case 1227: return "BerdySensor_eq";
-  case 1228: return "new_BerdySensor";
-  case 1229: return "delete_BerdySensor";
-  case 1230: return "BerdyDynamicVariable_type_get";
-  case 1231: return "BerdyDynamicVariable_type_set";
-  case 1232: return "BerdyDynamicVariable_id_get";
-  case 1233: return "BerdyDynamicVariable_id_set";
-  case 1234: return "BerdyDynamicVariable_range_get";
-  case 1235: return "BerdyDynamicVariable_range_set";
-  case 1236: return "new_BerdyDynamicVariable";
-  case 1237: return "delete_BerdyDynamicVariable";
-  case 1238: return "new_BerdyHelper";
-  case 1239: return "BerdyHelper_dynamicTraversal";
-  case 1240: return "BerdyHelper_model";
-  case 1241: return "BerdyHelper_sensors";
-  case 1242: return "BerdyHelper_init";
-  case 1243: return "BerdyHelper_getOptions";
-  case 1244: return "BerdyHelper_getNrOfDynamicVariables";
-  case 1245: return "BerdyHelper_getNrOfDynamicEquations";
-  case 1246: return "BerdyHelper_getNrOfSensorsMeasurements";
-  case 1247: return "BerdyHelper_resizeAndZeroBerdyMatrices";
-  case 1248: return "BerdyHelper_getBerdyMatrices";
-  case 1249: return "BerdyHelper_getSensorsOrdering";
-  case 1250: return "BerdyHelper_getDynamicVariablesOrdering";
-  case 1251: return "BerdyHelper_serializeDynamicVariables";
-  case 1252: return "BerdyHelper_serializeSensorVariables";
-  case 1253: return "BerdyHelper_serializeDynamicVariablesComputedFromFixedBaseRNEA";
-  case 1254: return "BerdyHelper_updateKinematicsFromFloatingBase";
-  case 1255: return "BerdyHelper_updateKinematicsFromFixedBase";
-  case 1256: return "BerdyHelper_updateKinematicsFromTraversalFixedBase";
-  case 1257: return "delete_BerdyHelper";
-  case 1258: return "DynamicsRegressorParameter_category_get";
-  case 1259: return "DynamicsRegressorParameter_category_set";
-  case 1260: return "DynamicsRegressorParameter_elemIndex_get";
-  case 1261: return "DynamicsRegressorParameter_elemIndex_set";
-  case 1262: return "DynamicsRegressorParameter_type_get";
-  case 1263: return "DynamicsRegressorParameter_type_set";
-  case 1264: return "DynamicsRegressorParameter_lt";
-  case 1265: return "DynamicsRegressorParameter_eq";
-  case 1266: return "DynamicsRegressorParameter_ne";
-  case 1267: return "new_DynamicsRegressorParameter";
-  case 1268: return "delete_DynamicsRegressorParameter";
-  case 1269: return "DynamicsRegressorParametersList_parameters_get";
-  case 1270: return "DynamicsRegressorParametersList_parameters_set";
-  case 1271: return "DynamicsRegressorParametersList_getDescriptionOfParameter";
-  case 1272: return "DynamicsRegressorParametersList_addParam";
-  case 1273: return "DynamicsRegressorParametersList_addList";
-  case 1274: return "DynamicsRegressorParametersList_findParam";
-  case 1275: return "DynamicsRegressorParametersList_getNrOfParameters";
-  case 1276: return "new_DynamicsRegressorParametersList";
-  case 1277: return "delete_DynamicsRegressorParametersList";
-  case 1278: return "new_DynamicsRegressorGenerator";
-  case 1279: return "delete_DynamicsRegressorGenerator";
-  case 1280: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile";
-  case 1281: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString";
-  case 1282: return "DynamicsRegressorGenerator_loadRegressorStructureFromFile";
-  case 1283: return "DynamicsRegressorGenerator_loadRegressorStructureFromString";
-  case 1284: return "DynamicsRegressorGenerator_isValid";
-  case 1285: return "DynamicsRegressorGenerator_getNrOfParameters";
-  case 1286: return "DynamicsRegressorGenerator_getNrOfOutputs";
-  case 1287: return "DynamicsRegressorGenerator_getNrOfDegreesOfFreedom";
-  case 1288: return "DynamicsRegressorGenerator_getDescriptionOfParameter";
-  case 1289: return "DynamicsRegressorGenerator_getDescriptionOfParameters";
-  case 1290: return "DynamicsRegressorGenerator_getDescriptionOfOutput";
-  case 1291: return "DynamicsRegressorGenerator_getDescriptionOfOutputs";
-  case 1292: return "DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom";
-  case 1293: return "DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom";
-  case 1294: return "DynamicsRegressorGenerator_getBaseLinkName";
-  case 1295: return "DynamicsRegressorGenerator_getSensorsModel";
-  case 1296: return "DynamicsRegressorGenerator_setRobotState";
-  case 1297: return "DynamicsRegressorGenerator_getSensorsMeasurements";
-  case 1298: return "DynamicsRegressorGenerator_computeRegressor";
-  case 1299: return "DynamicsRegressorGenerator_getModelParameters";
-  case 1300: return "DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace";
-  case 1301: return "DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace";
-  case 1302: return "new_KinDynComputations";
-  case 1303: return "delete_KinDynComputations";
-  case 1304: return "KinDynComputations_loadRobotModel";
-  case 1305: return "KinDynComputations_loadRobotModelFromFile";
-  case 1306: return "KinDynComputations_loadRobotModelFromString";
-  case 1307: return "KinDynComputations_isValid";
-  case 1308: return "KinDynComputations_getNrOfDegreesOfFreedom";
-  case 1309: return "KinDynComputations_getDescriptionOfDegreeOfFreedom";
-  case 1310: return "KinDynComputations_getDescriptionOfDegreesOfFreedom";
-  case 1311: return "KinDynComputations_getNrOfLinks";
-  case 1312: return "KinDynComputations_getNrOfFrames";
-  case 1313: return "KinDynComputations_getFloatingBase";
-  case 1314: return "KinDynComputations_setFloatingBase";
-  case 1315: return "KinDynComputations_getRobotModel";
-  case 1316: return "KinDynComputations_setRobotState";
-  case 1317: return "KinDynComputations_getWorldBaseTransform";
-  case 1318: return "KinDynComputations_getBaseTwist";
-  case 1319: return "KinDynComputations_getJointPos";
-  case 1320: return "KinDynComputations_getJointVel";
-  case 1321: return "KinDynComputations_getFrameIndex";
-  case 1322: return "KinDynComputations_getFrameName";
-  case 1323: return "KinDynComputations_getWorldTransform";
-  case 1324: return "KinDynComputations_getRelativeTransformExplicit";
-  case 1325: return "KinDynComputations_getRelativeTransform";
-  case 1326: return "new_DynamicsComputations";
-  case 1327: return "delete_DynamicsComputations";
-  case 1328: return "DynamicsComputations_loadRobotModelFromFile";
-  case 1329: return "DynamicsComputations_loadRobotModelFromString";
-  case 1330: return "DynamicsComputations_isValid";
-  case 1331: return "DynamicsComputations_getNrOfDegreesOfFreedom";
-  case 1332: return "DynamicsComputations_getDescriptionOfDegreeOfFreedom";
-  case 1333: return "DynamicsComputations_getDescriptionOfDegreesOfFreedom";
-  case 1334: return "DynamicsComputations_getNrOfLinks";
-  case 1335: return "DynamicsComputations_getNrOfFrames";
-  case 1336: return "DynamicsComputations_getFloatingBase";
-  case 1337: return "DynamicsComputations_setFloatingBase";
-  case 1338: return "DynamicsComputations_setRobotState";
-  case 1339: return "DynamicsComputations_getWorldBaseTransform";
-  case 1340: return "DynamicsComputations_getBaseTwist";
-  case 1341: return "DynamicsComputations_getJointPos";
-  case 1342: return "DynamicsComputations_getJointVel";
-  case 1343: return "DynamicsComputations_getFrameIndex";
-  case 1344: return "DynamicsComputations_getFrameName";
-  case 1345: return "DynamicsComputations_getWorldTransform";
-  case 1346: return "DynamicsComputations_getRelativeTransform";
-  case 1347: return "DynamicsComputations_getFrameTwist";
-  case 1348: return "DynamicsComputations_getFrameTwistInWorldOrient";
-  case 1349: return "DynamicsComputations_getFrameProperSpatialAcceleration";
-  case 1350: return "DynamicsComputations_getLinkIndex";
-  case 1351: return "DynamicsComputations_getLinkInertia";
-  case 1352: return "DynamicsComputations_getJointIndex";
-  case 1353: return "DynamicsComputations_getJointName";
-  case 1354: return "DynamicsComputations_getJointLimits";
-  case 1355: return "DynamicsComputations_inverseDynamics";
-  case 1356: return "DynamicsComputations_getFrameJacobian";
-  case 1357: return "DynamicsComputations_getDynamicsRegressor";
-  case 1358: return "DynamicsComputations_getModelDynamicsParameters";
-  case 1359: return "DynamicsComputations_getCenterOfMass";
-  case 1360: return "DynamicsComputations_getCenterOfMassJacobian";
+  case 97: return "MatrixDynSize_fromMatlab";
+  case 98: return "new_VectorDynSize";
+  case 99: return "delete_VectorDynSize";
+  case 100: return "VectorDynSize_paren";
+  case 101: return "VectorDynSize_getVal";
+  case 102: return "VectorDynSize_setVal";
+  case 103: return "VectorDynSize_size";
+  case 104: return "VectorDynSize_data";
+  case 105: return "VectorDynSize_zero";
+  case 106: return "VectorDynSize_reserve";
+  case 107: return "VectorDynSize_resize";
+  case 108: return "VectorDynSize_shrink_to_fit";
+  case 109: return "VectorDynSize_capacity";
+  case 110: return "VectorDynSize_fillBuffer";
+  case 111: return "VectorDynSize_toString";
+  case 112: return "VectorDynSize_display";
+  case 113: return "VectorDynSize_toMatlab";
+  case 114: return "VectorDynSize_fromMatlab";
+  case 115: return "new_Matrix3x3";
+  case 116: return "Matrix3x3_paren";
+  case 117: return "Matrix3x3_getVal";
+  case 118: return "Matrix3x3_setVal";
+  case 119: return "Matrix3x3_rows";
+  case 120: return "Matrix3x3_cols";
+  case 121: return "Matrix3x3_data";
+  case 122: return "Matrix3x3_zero";
+  case 123: return "Matrix3x3_fillRowMajorBuffer";
+  case 124: return "Matrix3x3_fillColMajorBuffer";
+  case 125: return "Matrix3x3_toString";
+  case 126: return "Matrix3x3_display";
+  case 127: return "Matrix3x3_toMatlab";
+  case 128: return "Matrix3x3_fromMatlab";
+  case 129: return "delete_Matrix3x3";
+  case 130: return "new_Matrix4x4";
+  case 131: return "Matrix4x4_paren";
+  case 132: return "Matrix4x4_getVal";
+  case 133: return "Matrix4x4_setVal";
+  case 134: return "Matrix4x4_rows";
+  case 135: return "Matrix4x4_cols";
+  case 136: return "Matrix4x4_data";
+  case 137: return "Matrix4x4_zero";
+  case 138: return "Matrix4x4_fillRowMajorBuffer";
+  case 139: return "Matrix4x4_fillColMajorBuffer";
+  case 140: return "Matrix4x4_toString";
+  case 141: return "Matrix4x4_display";
+  case 142: return "Matrix4x4_toMatlab";
+  case 143: return "Matrix4x4_fromMatlab";
+  case 144: return "delete_Matrix4x4";
+  case 145: return "new_Matrix6x6";
+  case 146: return "Matrix6x6_paren";
+  case 147: return "Matrix6x6_getVal";
+  case 148: return "Matrix6x6_setVal";
+  case 149: return "Matrix6x6_rows";
+  case 150: return "Matrix6x6_cols";
+  case 151: return "Matrix6x6_data";
+  case 152: return "Matrix6x6_zero";
+  case 153: return "Matrix6x6_fillRowMajorBuffer";
+  case 154: return "Matrix6x6_fillColMajorBuffer";
+  case 155: return "Matrix6x6_toString";
+  case 156: return "Matrix6x6_display";
+  case 157: return "Matrix6x6_toMatlab";
+  case 158: return "Matrix6x6_fromMatlab";
+  case 159: return "delete_Matrix6x6";
+  case 160: return "new_Matrix6x10";
+  case 161: return "Matrix6x10_paren";
+  case 162: return "Matrix6x10_getVal";
+  case 163: return "Matrix6x10_setVal";
+  case 164: return "Matrix6x10_rows";
+  case 165: return "Matrix6x10_cols";
+  case 166: return "Matrix6x10_data";
+  case 167: return "Matrix6x10_zero";
+  case 168: return "Matrix6x10_fillRowMajorBuffer";
+  case 169: return "Matrix6x10_fillColMajorBuffer";
+  case 170: return "Matrix6x10_toString";
+  case 171: return "Matrix6x10_display";
+  case 172: return "Matrix6x10_toMatlab";
+  case 173: return "Matrix6x10_fromMatlab";
+  case 174: return "delete_Matrix6x10";
+  case 175: return "new_Matrix10x16";
+  case 176: return "Matrix10x16_paren";
+  case 177: return "Matrix10x16_getVal";
+  case 178: return "Matrix10x16_setVal";
+  case 179: return "Matrix10x16_rows";
+  case 180: return "Matrix10x16_cols";
+  case 181: return "Matrix10x16_data";
+  case 182: return "Matrix10x16_zero";
+  case 183: return "Matrix10x16_fillRowMajorBuffer";
+  case 184: return "Matrix10x16_fillColMajorBuffer";
+  case 185: return "Matrix10x16_toString";
+  case 186: return "Matrix10x16_display";
+  case 187: return "Matrix10x16_toMatlab";
+  case 188: return "Matrix10x16_fromMatlab";
+  case 189: return "delete_Matrix10x16";
+  case 190: return "new_Vector3";
+  case 191: return "Vector3_paren";
+  case 192: return "Vector3_getVal";
+  case 193: return "Vector3_setVal";
+  case 194: return "Vector3_size";
+  case 195: return "Vector3_data";
+  case 196: return "Vector3_zero";
+  case 197: return "Vector3_fillBuffer";
+  case 198: return "Vector3_toString";
+  case 199: return "Vector3_display";
+  case 200: return "Vector3_toMatlab";
+  case 201: return "Vector3_fromMatlab";
+  case 202: return "delete_Vector3";
+  case 203: return "new_Vector6";
+  case 204: return "Vector6_paren";
+  case 205: return "Vector6_getVal";
+  case 206: return "Vector6_setVal";
+  case 207: return "Vector6_size";
+  case 208: return "Vector6_data";
+  case 209: return "Vector6_zero";
+  case 210: return "Vector6_fillBuffer";
+  case 211: return "Vector6_toString";
+  case 212: return "Vector6_display";
+  case 213: return "Vector6_toMatlab";
+  case 214: return "Vector6_fromMatlab";
+  case 215: return "delete_Vector6";
+  case 216: return "new_Vector10";
+  case 217: return "Vector10_paren";
+  case 218: return "Vector10_getVal";
+  case 219: return "Vector10_setVal";
+  case 220: return "Vector10_size";
+  case 221: return "Vector10_data";
+  case 222: return "Vector10_zero";
+  case 223: return "Vector10_fillBuffer";
+  case 224: return "Vector10_toString";
+  case 225: return "Vector10_display";
+  case 226: return "Vector10_toMatlab";
+  case 227: return "Vector10_fromMatlab";
+  case 228: return "delete_Vector10";
+  case 229: return "new_Vector16";
+  case 230: return "Vector16_paren";
+  case 231: return "Vector16_getVal";
+  case 232: return "Vector16_setVal";
+  case 233: return "Vector16_size";
+  case 234: return "Vector16_data";
+  case 235: return "Vector16_zero";
+  case 236: return "Vector16_fillBuffer";
+  case 237: return "Vector16_toString";
+  case 238: return "Vector16_display";
+  case 239: return "Vector16_toMatlab";
+  case 240: return "Vector16_fromMatlab";
+  case 241: return "delete_Vector16";
+  case 242: return "new_PositionRaw";
+  case 243: return "PositionRaw_changePoint";
+  case 244: return "PositionRaw_changeRefPoint";
+  case 245: return "PositionRaw_compose";
+  case 246: return "PositionRaw_inverse";
+  case 247: return "PositionRaw_changePointOf";
+  case 248: return "PositionRaw_toString";
+  case 249: return "PositionRaw_display";
+  case 250: return "delete_PositionRaw";
+  case 251: return "new_PositionSemantics";
+  case 252: return "PositionSemantics_setToUnknown";
+  case 253: return "PositionSemantics_getPoint";
+  case 254: return "PositionSemantics_getBody";
+  case 255: return "PositionSemantics_getReferencePoint";
+  case 256: return "PositionSemantics_getRefBody";
+  case 257: return "PositionSemantics_getCoordinateFrame";
+  case 258: return "PositionSemantics_setPoint";
+  case 259: return "PositionSemantics_setBody";
+  case 260: return "PositionSemantics_setReferencePoint";
+  case 261: return "PositionSemantics_setRefBody";
+  case 262: return "PositionSemantics_setCoordinateFrame";
+  case 263: return "PositionSemantics_changePoint";
+  case 264: return "PositionSemantics_changeRefPoint";
+  case 265: return "PositionSemantics_compose";
+  case 266: return "PositionSemantics_inverse";
+  case 267: return "PositionSemantics_toString";
+  case 268: return "PositionSemantics_display";
+  case 269: return "delete_PositionSemantics";
+  case 270: return "new_Position";
+  case 271: return "Position_getSemantics";
+  case 272: return "Position_changePoint";
+  case 273: return "Position_changeRefPoint";
+  case 274: return "Position_changeCoordinateFrame";
+  case 275: return "Position_compose";
+  case 276: return "Position_inverse";
+  case 277: return "Position_changePointOf";
+  case 278: return "Position_plus";
+  case 279: return "Position_minus";
+  case 280: return "Position_uminus";
+  case 281: return "Position_mtimes";
+  case 282: return "Position_toString";
+  case 283: return "Position_display";
+  case 284: return "Position_Zero";
+  case 285: return "delete_Position";
+  case 286: return "new_GeomVector3Semantics__LinearMotionVector3Semantics";
+  case 287: return "GeomVector3Semantics__LinearMotionVector3Semantics_setToUnknown";
+  case 288: return "GeomVector3Semantics__LinearMotionVector3Semantics_getBody";
+  case 289: return "GeomVector3Semantics__LinearMotionVector3Semantics_getRefBody";
+  case 290: return "GeomVector3Semantics__LinearMotionVector3Semantics_getCoordinateFrame";
+  case 291: return "GeomVector3Semantics__LinearMotionVector3Semantics_isUnknown";
+  case 292: return "GeomVector3Semantics__LinearMotionVector3Semantics_changeCoordFrame";
+  case 293: return "GeomVector3Semantics__LinearMotionVector3Semantics_compose";
+  case 294: return "GeomVector3Semantics__LinearMotionVector3Semantics_inverse";
+  case 295: return "GeomVector3Semantics__LinearMotionVector3Semantics_dot";
+  case 296: return "delete_GeomVector3Semantics__LinearMotionVector3Semantics";
+  case 297: return "new_GeomVector3Semantics__AngularMotionVector3Semantics";
+  case 298: return "GeomVector3Semantics__AngularMotionVector3Semantics_setToUnknown";
+  case 299: return "GeomVector3Semantics__AngularMotionVector3Semantics_getBody";
+  case 300: return "GeomVector3Semantics__AngularMotionVector3Semantics_getRefBody";
+  case 301: return "GeomVector3Semantics__AngularMotionVector3Semantics_getCoordinateFrame";
+  case 302: return "GeomVector3Semantics__AngularMotionVector3Semantics_isUnknown";
+  case 303: return "GeomVector3Semantics__AngularMotionVector3Semantics_changeCoordFrame";
+  case 304: return "GeomVector3Semantics__AngularMotionVector3Semantics_compose";
+  case 305: return "GeomVector3Semantics__AngularMotionVector3Semantics_inverse";
+  case 306: return "GeomVector3Semantics__AngularMotionVector3Semantics_dot";
+  case 307: return "delete_GeomVector3Semantics__AngularMotionVector3Semantics";
+  case 308: return "new_GeomVector3Semantics__LinearForceVector3Semantics";
+  case 309: return "GeomVector3Semantics__LinearForceVector3Semantics_setToUnknown";
+  case 310: return "GeomVector3Semantics__LinearForceVector3Semantics_getBody";
+  case 311: return "GeomVector3Semantics__LinearForceVector3Semantics_getRefBody";
+  case 312: return "GeomVector3Semantics__LinearForceVector3Semantics_getCoordinateFrame";
+  case 313: return "GeomVector3Semantics__LinearForceVector3Semantics_isUnknown";
+  case 314: return "GeomVector3Semantics__LinearForceVector3Semantics_changeCoordFrame";
+  case 315: return "GeomVector3Semantics__LinearForceVector3Semantics_compose";
+  case 316: return "GeomVector3Semantics__LinearForceVector3Semantics_inverse";
+  case 317: return "GeomVector3Semantics__LinearForceVector3Semantics_dot";
+  case 318: return "delete_GeomVector3Semantics__LinearForceVector3Semantics";
+  case 319: return "new_GeomVector3Semantics__AngularForceVector3Semantics";
+  case 320: return "GeomVector3Semantics__AngularForceVector3Semantics_setToUnknown";
+  case 321: return "GeomVector3Semantics__AngularForceVector3Semantics_getBody";
+  case 322: return "GeomVector3Semantics__AngularForceVector3Semantics_getRefBody";
+  case 323: return "GeomVector3Semantics__AngularForceVector3Semantics_getCoordinateFrame";
+  case 324: return "GeomVector3Semantics__AngularForceVector3Semantics_isUnknown";
+  case 325: return "GeomVector3Semantics__AngularForceVector3Semantics_changeCoordFrame";
+  case 326: return "GeomVector3Semantics__AngularForceVector3Semantics_compose";
+  case 327: return "GeomVector3Semantics__AngularForceVector3Semantics_inverse";
+  case 328: return "GeomVector3Semantics__AngularForceVector3Semantics_dot";
+  case 329: return "delete_GeomVector3Semantics__AngularForceVector3Semantics";
+  case 330: return "GeomVector3__LinearMotionVector3_semantics_get";
+  case 331: return "GeomVector3__LinearMotionVector3_semantics_set";
+  case 332: return "new_GeomVector3__LinearMotionVector3";
+  case 333: return "GeomVector3__LinearMotionVector3_setSemantics";
+  case 334: return "GeomVector3__LinearMotionVector3_changeCoordFrame";
+  case 335: return "GeomVector3__LinearMotionVector3_compose";
+  case 336: return "GeomVector3__LinearMotionVector3_inverse";
+  case 337: return "GeomVector3__LinearMotionVector3_dot";
+  case 338: return "GeomVector3__LinearMotionVector3_plus";
+  case 339: return "GeomVector3__LinearMotionVector3_minus";
+  case 340: return "GeomVector3__LinearMotionVector3_uminus";
+  case 341: return "delete_GeomVector3__LinearMotionVector3";
+  case 342: return "GeomVector3__AngularMotionVector3_semantics_get";
+  case 343: return "GeomVector3__AngularMotionVector3_semantics_set";
+  case 344: return "new_GeomVector3__AngularMotionVector3";
+  case 345: return "GeomVector3__AngularMotionVector3_setSemantics";
+  case 346: return "GeomVector3__AngularMotionVector3_changeCoordFrame";
+  case 347: return "GeomVector3__AngularMotionVector3_compose";
+  case 348: return "GeomVector3__AngularMotionVector3_inverse";
+  case 349: return "GeomVector3__AngularMotionVector3_dot";
+  case 350: return "GeomVector3__AngularMotionVector3_plus";
+  case 351: return "GeomVector3__AngularMotionVector3_minus";
+  case 352: return "GeomVector3__AngularMotionVector3_uminus";
+  case 353: return "delete_GeomVector3__AngularMotionVector3";
+  case 354: return "GeomVector3__LinearForceVector3_semantics_get";
+  case 355: return "GeomVector3__LinearForceVector3_semantics_set";
+  case 356: return "new_GeomVector3__LinearForceVector3";
+  case 357: return "GeomVector3__LinearForceVector3_setSemantics";
+  case 358: return "GeomVector3__LinearForceVector3_changeCoordFrame";
+  case 359: return "GeomVector3__LinearForceVector3_compose";
+  case 360: return "GeomVector3__LinearForceVector3_inverse";
+  case 361: return "GeomVector3__LinearForceVector3_dot";
+  case 362: return "GeomVector3__LinearForceVector3_plus";
+  case 363: return "GeomVector3__LinearForceVector3_minus";
+  case 364: return "GeomVector3__LinearForceVector3_uminus";
+  case 365: return "delete_GeomVector3__LinearForceVector3";
+  case 366: return "GeomVector3__AngularForceVector3_semantics_get";
+  case 367: return "GeomVector3__AngularForceVector3_semantics_set";
+  case 368: return "new_GeomVector3__AngularForceVector3";
+  case 369: return "GeomVector3__AngularForceVector3_setSemantics";
+  case 370: return "GeomVector3__AngularForceVector3_changeCoordFrame";
+  case 371: return "GeomVector3__AngularForceVector3_compose";
+  case 372: return "GeomVector3__AngularForceVector3_inverse";
+  case 373: return "GeomVector3__AngularForceVector3_dot";
+  case 374: return "GeomVector3__AngularForceVector3_plus";
+  case 375: return "GeomVector3__AngularForceVector3_minus";
+  case 376: return "GeomVector3__AngularForceVector3_uminus";
+  case 377: return "delete_GeomVector3__AngularForceVector3";
+  case 378: return "new_ForceVector3Semantics__LinearForceVector3Semantics";
+  case 379: return "ForceVector3Semantics__LinearForceVector3Semantics_compose";
+  case 380: return "ForceVector3Semantics__LinearForceVector3Semantics_inverse";
+  case 381: return "delete_ForceVector3Semantics__LinearForceVector3Semantics";
+  case 382: return "new_ForceVector3Semantics__AngularForceVector3Semantics";
+  case 383: return "ForceVector3Semantics__AngularForceVector3Semantics_compose";
+  case 384: return "ForceVector3Semantics__AngularForceVector3Semantics_inverse";
+  case 385: return "delete_ForceVector3Semantics__AngularForceVector3Semantics";
+  case 386: return "new_MotionVector3__LinearMotionVector3";
+  case 387: return "MotionVector3__LinearMotionVector3_cross";
+  case 388: return "delete_MotionVector3__LinearMotionVector3";
+  case 389: return "new_MotionVector3__AngularMotionVector3";
+  case 390: return "MotionVector3__AngularMotionVector3_cross";
+  case 391: return "delete_MotionVector3__AngularMotionVector3";
+  case 392: return "new_ForceVector3__LinearForceVector3";
+  case 393: return "delete_ForceVector3__LinearForceVector3";
+  case 394: return "new_ForceVector3__AngularForceVector3";
+  case 395: return "delete_ForceVector3__AngularForceVector3";
+  case 396: return "new_LinearMotionVector3Semantics";
+  case 397: return "LinearMotionVector3Semantics_changePoint";
+  case 398: return "LinearMotionVector3Semantics_compose";
+  case 399: return "delete_LinearMotionVector3Semantics";
+  case 400: return "new_LinearMotionVector3";
+  case 401: return "LinearMotionVector3_changePoint";
+  case 402: return "delete_LinearMotionVector3";
+  case 403: return "new_AngularMotionVector3Semantics";
+  case 404: return "delete_AngularMotionVector3Semantics";
+  case 405: return "new_AngularMotionVector3";
+  case 406: return "AngularMotionVector3_exp";
+  case 407: return "delete_AngularMotionVector3";
+  case 408: return "new_LinearForceVector3Semantics";
+  case 409: return "delete_LinearForceVector3Semantics";
+  case 410: return "new_LinearForceVector3";
+  case 411: return "delete_LinearForceVector3";
+  case 412: return "new_AngularForceVector3Semantics";
+  case 413: return "AngularForceVector3Semantics_changePoint";
+  case 414: return "AngularForceVector3Semantics_compose";
+  case 415: return "delete_AngularForceVector3Semantics";
+  case 416: return "new_AngularForceVector3";
+  case 417: return "AngularForceVector3_changePoint";
+  case 418: return "delete_AngularForceVector3";
+  case 419: return "new_SpatialMotionVectorSemanticsBase";
+  case 420: return "SpatialMotionVectorSemanticsBase_check_linear2angularConsistency";
+  case 421: return "SpatialMotionVectorSemanticsBase_toString";
+  case 422: return "SpatialMotionVectorSemanticsBase_display";
+  case 423: return "delete_SpatialMotionVectorSemanticsBase";
+  case 424: return "new_SpatialForceVectorSemanticsBase";
+  case 425: return "SpatialForceVectorSemanticsBase_check_linear2angularConsistency";
+  case 426: return "SpatialForceVectorSemanticsBase_toString";
+  case 427: return "SpatialForceVectorSemanticsBase_display";
+  case 428: return "delete_SpatialForceVectorSemanticsBase";
+  case 429: return "new_SpatialMotionVectorBase";
+  case 430: return "SpatialMotionVectorBase_getLinearVec3";
+  case 431: return "SpatialMotionVectorBase_getAngularVec3";
+  case 432: return "SpatialMotionVectorBase_setLinearVec3";
+  case 433: return "SpatialMotionVectorBase_setAngularVec3";
+  case 434: return "SpatialMotionVectorBase_paren";
+  case 435: return "SpatialMotionVectorBase_getVal";
+  case 436: return "SpatialMotionVectorBase_setVal";
+  case 437: return "SpatialMotionVectorBase_size";
+  case 438: return "SpatialMotionVectorBase_zero";
+  case 439: return "SpatialMotionVectorBase_changePoint";
+  case 440: return "SpatialMotionVectorBase_changeCoordFrame";
+  case 441: return "SpatialMotionVectorBase_compose";
+  case 442: return "SpatialMotionVectorBase_inverse";
+  case 443: return "SpatialMotionVectorBase_dot";
+  case 444: return "SpatialMotionVectorBase_plus";
+  case 445: return "SpatialMotionVectorBase_minus";
+  case 446: return "SpatialMotionVectorBase_uminus";
+  case 447: return "SpatialMotionVectorBase_Zero";
+  case 448: return "SpatialMotionVectorBase_asVector";
+  case 449: return "SpatialMotionVectorBase_toString";
+  case 450: return "SpatialMotionVectorBase_display";
+  case 451: return "SpatialMotionVectorBase_toMatlab";
+  case 452: return "SpatialMotionVectorBase_fromMatlab";
+  case 453: return "delete_SpatialMotionVectorBase";
+  case 454: return "new_SpatialForceVectorBase";
+  case 455: return "SpatialForceVectorBase_getLinearVec3";
+  case 456: return "SpatialForceVectorBase_getAngularVec3";
+  case 457: return "SpatialForceVectorBase_setLinearVec3";
+  case 458: return "SpatialForceVectorBase_setAngularVec3";
+  case 459: return "SpatialForceVectorBase_paren";
+  case 460: return "SpatialForceVectorBase_getVal";
+  case 461: return "SpatialForceVectorBase_setVal";
+  case 462: return "SpatialForceVectorBase_size";
+  case 463: return "SpatialForceVectorBase_zero";
+  case 464: return "SpatialForceVectorBase_changePoint";
+  case 465: return "SpatialForceVectorBase_changeCoordFrame";
+  case 466: return "SpatialForceVectorBase_compose";
+  case 467: return "SpatialForceVectorBase_inverse";
+  case 468: return "SpatialForceVectorBase_dot";
+  case 469: return "SpatialForceVectorBase_plus";
+  case 470: return "SpatialForceVectorBase_minus";
+  case 471: return "SpatialForceVectorBase_uminus";
+  case 472: return "SpatialForceVectorBase_Zero";
+  case 473: return "SpatialForceVectorBase_asVector";
+  case 474: return "SpatialForceVectorBase_toString";
+  case 475: return "SpatialForceVectorBase_display";
+  case 476: return "SpatialForceVectorBase_toMatlab";
+  case 477: return "SpatialForceVectorBase_fromMatlab";
+  case 478: return "delete_SpatialForceVectorBase";
+  case 479: return "new_Dummy";
+  case 480: return "delete_Dummy";
+  case 481: return "new_SpatialMotionVector";
+  case 482: return "SpatialMotionVector_mtimes";
+  case 483: return "SpatialMotionVector_cross";
+  case 484: return "SpatialMotionVector_asCrossProductMatrix";
+  case 485: return "SpatialMotionVector_asCrossProductMatrixWrench";
+  case 486: return "SpatialMotionVector_exp";
+  case 487: return "delete_SpatialMotionVector";
+  case 488: return "new_SpatialForceVector";
+  case 489: return "delete_SpatialForceVector";
+  case 490: return "SpatialForceVector_mtimes";
+  case 491: return "new_Twist";
+  case 492: return "Twist_plus";
+  case 493: return "Twist_minus";
+  case 494: return "Twist_uminus";
+  case 495: return "Twist_mtimes";
+  case 496: return "delete_Twist";
+  case 497: return "new_Wrench";
+  case 498: return "Wrench_plus";
+  case 499: return "Wrench_minus";
+  case 500: return "Wrench_uminus";
+  case 501: return "delete_Wrench";
+  case 502: return "new_SpatialMomentum";
+  case 503: return "SpatialMomentum_plus";
+  case 504: return "SpatialMomentum_minus";
+  case 505: return "SpatialMomentum_uminus";
+  case 506: return "delete_SpatialMomentum";
+  case 507: return "new_SpatialAcc";
+  case 508: return "SpatialAcc_plus";
+  case 509: return "SpatialAcc_minus";
+  case 510: return "SpatialAcc_uminus";
+  case 511: return "delete_SpatialAcc";
+  case 512: return "new_ClassicalAcc";
+  case 513: return "ClassicalAcc_changeCoordFrame";
+  case 514: return "ClassicalAcc_Zero";
+  case 515: return "ClassicalAcc_fromSpatial";
+  case 516: return "ClassicalAcc_toSpatial";
+  case 517: return "delete_ClassicalAcc";
+  case 518: return "new_Direction";
+  case 519: return "Direction_Normalize";
+  case 520: return "Direction_toString";
+  case 521: return "Direction_display";
+  case 522: return "Direction_Default";
+  case 523: return "delete_Direction";
+  case 524: return "new_Axis";
+  case 525: return "Axis_getDirection";
+  case 526: return "Axis_getOrigin";
+  case 527: return "Axis_setDirection";
+  case 528: return "Axis_setOrigin";
+  case 529: return "Axis_getRotationTransform";
+  case 530: return "Axis_getRotationTransformDerivative";
+  case 531: return "Axis_getRotationTwist";
+  case 532: return "Axis_getRotationSpatialAcc";
+  case 533: return "Axis_toString";
+  case 534: return "Axis_display";
+  case 535: return "delete_Axis";
+  case 536: return "new_RotationalInertiaRaw";
+  case 537: return "RotationalInertiaRaw_Zero";
+  case 538: return "delete_RotationalInertiaRaw";
+  case 539: return "new_SpatialInertiaRaw";
+  case 540: return "SpatialInertiaRaw_fromRotationalInertiaWrtCenterOfMass";
+  case 541: return "SpatialInertiaRaw_getMass";
+  case 542: return "SpatialInertiaRaw_getCenterOfMass";
+  case 543: return "SpatialInertiaRaw_getRotationalInertiaWrtFrameOrigin";
+  case 544: return "SpatialInertiaRaw_getRotationalInertiaWrtCenterOfMass";
+  case 545: return "SpatialInertiaRaw_combine";
+  case 546: return "SpatialInertiaRaw_multiply";
+  case 547: return "SpatialInertiaRaw_zero";
+  case 548: return "delete_SpatialInertiaRaw";
+  case 549: return "new_SpatialInertia";
+  case 550: return "SpatialInertia_combine";
+  case 551: return "SpatialInertia_asMatrix";
+  case 552: return "SpatialInertia_plus";
+  case 553: return "SpatialInertia_mtimes";
+  case 554: return "SpatialInertia_biasWrench";
+  case 555: return "SpatialInertia_biasWrenchDerivative";
+  case 556: return "SpatialInertia_Zero";
+  case 557: return "SpatialInertia_asVector";
+  case 558: return "SpatialInertia_fromVector";
+  case 559: return "SpatialInertia_isPhysicallyConsistent";
+  case 560: return "SpatialInertia_momentumRegressor";
+  case 561: return "SpatialInertia_momentumDerivativeRegressor";
+  case 562: return "SpatialInertia_momentumDerivativeSlotineLiRegressor";
+  case 563: return "delete_SpatialInertia";
+  case 564: return "new_ArticulatedBodyInertia";
+  case 565: return "ArticulatedBodyInertia_getLinearLinearSubmatrix";
+  case 566: return "ArticulatedBodyInertia_getLinearAngularSubmatrix";
+  case 567: return "ArticulatedBodyInertia_getAngularAngularSubmatrix";
+  case 568: return "ArticulatedBodyInertia_combine";
+  case 569: return "ArticulatedBodyInertia_applyInverse";
+  case 570: return "ArticulatedBodyInertia_asMatrix";
+  case 571: return "ArticulatedBodyInertia_getInverse";
+  case 572: return "ArticulatedBodyInertia_plus";
+  case 573: return "ArticulatedBodyInertia_minus";
+  case 574: return "ArticulatedBodyInertia_mtimes";
+  case 575: return "ArticulatedBodyInertia_zero";
+  case 576: return "ArticulatedBodyInertia_ABADyadHelper";
+  case 577: return "ArticulatedBodyInertia_ABADyadHelperLin";
+  case 578: return "delete_ArticulatedBodyInertia";
+  case 579: return "new_RotationRaw";
+  case 580: return "RotationRaw_changeOrientFrame";
+  case 581: return "RotationRaw_changeRefOrientFrame";
+  case 582: return "RotationRaw_compose";
+  case 583: return "RotationRaw_inverse2";
+  case 584: return "RotationRaw_changeCoordFrameOf";
+  case 585: return "RotationRaw_RotX";
+  case 586: return "RotationRaw_RotY";
+  case 587: return "RotationRaw_RotZ";
+  case 588: return "RotationRaw_RPY";
+  case 589: return "RotationRaw_Identity";
+  case 590: return "RotationRaw_toString";
+  case 591: return "RotationRaw_display";
+  case 592: return "delete_RotationRaw";
+  case 593: return "new_RotationSemantics";
+  case 594: return "RotationSemantics_setToUnknown";
+  case 595: return "RotationSemantics_getOrientationFrame";
+  case 596: return "RotationSemantics_getBody";
+  case 597: return "RotationSemantics_getReferenceOrientationFrame";
+  case 598: return "RotationSemantics_getRefBody";
+  case 599: return "RotationSemantics_getCoordinateFrame";
+  case 600: return "RotationSemantics_setOrientationFrame";
+  case 601: return "RotationSemantics_setBody";
+  case 602: return "RotationSemantics_setReferenceOrientationFrame";
+  case 603: return "RotationSemantics_setRefBody";
+  case 604: return "RotationSemantics_setCoordinateFrame";
+  case 605: return "RotationSemantics_changeOrientFrame";
+  case 606: return "RotationSemantics_changeRefOrientFrame";
+  case 607: return "RotationSemantics_changeCoordFrameOf";
+  case 608: return "RotationSemantics_compose";
+  case 609: return "RotationSemantics_inverse2";
+  case 610: return "RotationSemantics_toString";
+  case 611: return "RotationSemantics_display";
+  case 612: return "delete_RotationSemantics";
+  case 613: return "new_Rotation";
+  case 614: return "Rotation_getSemantics";
+  case 615: return "Rotation_changeOrientFrame";
+  case 616: return "Rotation_changeRefOrientFrame";
+  case 617: return "Rotation_changeCoordinateFrame";
+  case 618: return "Rotation_compose";
+  case 619: return "Rotation_inverse2";
+  case 620: return "Rotation_changeCoordFrameOf";
+  case 621: return "Rotation_inverse";
+  case 622: return "Rotation_mtimes";
+  case 623: return "Rotation_log";
+  case 624: return "Rotation_fromQuaternion";
+  case 625: return "Rotation_getRPY";
+  case 626: return "Rotation_asRPY";
+  case 627: return "Rotation_getQuaternion";
+  case 628: return "Rotation_asQuaternion";
+  case 629: return "Rotation_RotX";
+  case 630: return "Rotation_RotY";
+  case 631: return "Rotation_RotZ";
+  case 632: return "Rotation_RotAxis";
+  case 633: return "Rotation_RotAxisDerivative";
+  case 634: return "Rotation_RPY";
+  case 635: return "Rotation_Identity";
+  case 636: return "Rotation_RotationFromQuaternion";
+  case 637: return "Rotation_toString";
+  case 638: return "Rotation_display";
+  case 639: return "delete_Rotation";
+  case 640: return "new_TransformSemantics";
+  case 641: return "TransformSemantics_getRotationSemantics";
+  case 642: return "TransformSemantics_getPositionSemantics";
+  case 643: return "TransformSemantics_setRotationSemantics";
+  case 644: return "TransformSemantics_setPositionSemantics";
+  case 645: return "TransformSemantics_toString";
+  case 646: return "TransformSemantics_display";
+  case 647: return "delete_TransformSemantics";
+  case 648: return "new_Transform";
+  case 649: return "Transform_getSemantics";
+  case 650: return "Transform_getRotation";
+  case 651: return "Transform_getPosition";
+  case 652: return "Transform_setRotation";
+  case 653: return "Transform_setPosition";
+  case 654: return "Transform_compose";
+  case 655: return "Transform_inverse2";
+  case 656: return "Transform_inverse";
+  case 657: return "Transform_mtimes";
+  case 658: return "Transform_Identity";
+  case 659: return "Transform_asHomogeneousTransform";
+  case 660: return "Transform_asAdjointTransform";
+  case 661: return "Transform_asAdjointTransformWrench";
+  case 662: return "Transform_log";
+  case 663: return "Transform_toString";
+  case 664: return "Transform_display";
+  case 665: return "delete_Transform";
+  case 666: return "new_TransformDerivative";
+  case 667: return "delete_TransformDerivative";
+  case 668: return "TransformDerivative_getRotationDerivative";
+  case 669: return "TransformDerivative_getPositionDerivative";
+  case 670: return "TransformDerivative_setRotationDerivative";
+  case 671: return "TransformDerivative_setPositionDerivative";
+  case 672: return "TransformDerivative_Zero";
+  case 673: return "TransformDerivative_asHomogeneousTransformDerivative";
+  case 674: return "TransformDerivative_asAdjointTransformDerivative";
+  case 675: return "TransformDerivative_asAdjointTransformWrenchDerivative";
+  case 676: return "TransformDerivative_mtimes";
+  case 677: return "TransformDerivative_derivativeOfInverse";
+  case 678: return "TransformDerivative_transform";
+  case 679: return "LINK_INVALID_INDEX_get";
+  case 680: return "LINK_INVALID_INDEX_set";
+  case 681: return "LINK_INVALID_NAME_get";
+  case 682: return "LINK_INVALID_NAME_set";
+  case 683: return "JOINT_INVALID_INDEX_get";
+  case 684: return "JOINT_INVALID_INDEX_set";
+  case 685: return "JOINT_INVALID_NAME_get";
+  case 686: return "JOINT_INVALID_NAME_set";
+  case 687: return "DOF_INVALID_INDEX_get";
+  case 688: return "DOF_INVALID_INDEX_set";
+  case 689: return "DOF_INVALID_NAME_get";
+  case 690: return "DOF_INVALID_NAME_set";
+  case 691: return "FRAME_INVALID_INDEX_get";
+  case 692: return "FRAME_INVALID_INDEX_set";
+  case 693: return "FRAME_INVALID_NAME_get";
+  case 694: return "FRAME_INVALID_NAME_set";
+  case 695: return "TRAVERSAL_INVALID_INDEX_get";
+  case 696: return "TRAVERSAL_INVALID_INDEX_set";
+  case 697: return "new_LinkPositions";
+  case 698: return "LinkPositions_resize";
+  case 699: return "LinkPositions_isConsistent";
+  case 700: return "LinkPositions_getNrOfLinks";
+  case 701: return "LinkPositions_paren";
+  case 702: return "LinkPositions_toString";
+  case 703: return "delete_LinkPositions";
+  case 704: return "new_LinkWrenches";
+  case 705: return "LinkWrenches_resize";
+  case 706: return "LinkWrenches_isConsistent";
+  case 707: return "LinkWrenches_getNrOfLinks";
+  case 708: return "LinkWrenches_paren";
+  case 709: return "LinkWrenches_toString";
+  case 710: return "delete_LinkWrenches";
+  case 711: return "new_LinkInertias";
+  case 712: return "LinkInertias_resize";
+  case 713: return "LinkInertias_isConsistent";
+  case 714: return "LinkInertias_paren";
+  case 715: return "delete_LinkInertias";
+  case 716: return "new_LinkArticulatedBodyInertias";
+  case 717: return "LinkArticulatedBodyInertias_resize";
+  case 718: return "LinkArticulatedBodyInertias_isConsistent";
+  case 719: return "LinkArticulatedBodyInertias_paren";
+  case 720: return "delete_LinkArticulatedBodyInertias";
+  case 721: return "new_LinkVelArray";
+  case 722: return "LinkVelArray_resize";
+  case 723: return "LinkVelArray_isConsistent";
+  case 724: return "LinkVelArray_getNrOfLinks";
+  case 725: return "LinkVelArray_paren";
+  case 726: return "LinkVelArray_toString";
+  case 727: return "delete_LinkVelArray";
+  case 728: return "new_LinkAccArray";
+  case 729: return "LinkAccArray_resize";
+  case 730: return "LinkAccArray_isConsistent";
+  case 731: return "LinkAccArray_paren";
+  case 732: return "LinkAccArray_getNrOfLinks";
+  case 733: return "LinkAccArray_toString";
+  case 734: return "delete_LinkAccArray";
+  case 735: return "new_Link";
+  case 736: return "Link_inertia";
+  case 737: return "Link_setInertia";
+  case 738: return "Link_getInertia";
+  case 739: return "Link_setIndex";
+  case 740: return "Link_getIndex";
+  case 741: return "delete_Link";
+  case 742: return "delete_IJoint";
+  case 743: return "IJoint_clone";
+  case 744: return "IJoint_getNrOfPosCoords";
+  case 745: return "IJoint_getNrOfDOFs";
+  case 746: return "IJoint_setAttachedLinks";
+  case 747: return "IJoint_setRestTransform";
+  case 748: return "IJoint_getFirstAttachedLink";
+  case 749: return "IJoint_getSecondAttachedLink";
+  case 750: return "IJoint_getRestTransform";
+  case 751: return "IJoint_getTransform";
+  case 752: return "IJoint_getTransformDerivative";
+  case 753: return "IJoint_getMotionSubspaceVector";
+  case 754: return "IJoint_computeChildPosVelAcc";
+  case 755: return "IJoint_computeChildVelAcc";
+  case 756: return "IJoint_computeChildVel";
+  case 757: return "IJoint_computeJointTorque";
+  case 758: return "IJoint_setIndex";
+  case 759: return "IJoint_getIndex";
+  case 760: return "IJoint_setPosCoordsOffset";
+  case 761: return "IJoint_getPosCoordsOffset";
+  case 762: return "IJoint_setDOFsOffset";
+  case 763: return "IJoint_getDOFsOffset";
+  case 764: return "IJoint_isRevoluteJoint";
+  case 765: return "IJoint_isFixedJoint";
+  case 766: return "IJoint_asRevoluteJoint";
+  case 767: return "IJoint_asFixedJoint";
+  case 768: return "new_FixedJoint";
+  case 769: return "delete_FixedJoint";
+  case 770: return "FixedJoint_clone";
+  case 771: return "FixedJoint_getNrOfPosCoords";
+  case 772: return "FixedJoint_getNrOfDOFs";
+  case 773: return "FixedJoint_setAttachedLinks";
+  case 774: return "FixedJoint_setRestTransform";
+  case 775: return "FixedJoint_getFirstAttachedLink";
+  case 776: return "FixedJoint_getSecondAttachedLink";
+  case 777: return "FixedJoint_getRestTransform";
+  case 778: return "FixedJoint_getTransform";
+  case 779: return "FixedJoint_getTransformDerivative";
+  case 780: return "FixedJoint_getMotionSubspaceVector";
+  case 781: return "FixedJoint_computeChildPosVelAcc";
+  case 782: return "FixedJoint_computeChildVelAcc";
+  case 783: return "FixedJoint_computeChildVel";
+  case 784: return "FixedJoint_computeJointTorque";
+  case 785: return "FixedJoint_setIndex";
+  case 786: return "FixedJoint_getIndex";
+  case 787: return "FixedJoint_setPosCoordsOffset";
+  case 788: return "FixedJoint_getPosCoordsOffset";
+  case 789: return "FixedJoint_setDOFsOffset";
+  case 790: return "FixedJoint_getDOFsOffset";
+  case 791: return "delete_MovableJointImpl1";
+  case 792: return "MovableJointImpl1_getNrOfPosCoords";
+  case 793: return "MovableJointImpl1_getNrOfDOFs";
+  case 794: return "MovableJointImpl1_setIndex";
+  case 795: return "MovableJointImpl1_getIndex";
+  case 796: return "MovableJointImpl1_setPosCoordsOffset";
+  case 797: return "MovableJointImpl1_getPosCoordsOffset";
+  case 798: return "MovableJointImpl1_setDOFsOffset";
+  case 799: return "MovableJointImpl1_getDOFsOffset";
+  case 800: return "delete_MovableJointImpl2";
+  case 801: return "MovableJointImpl2_getNrOfPosCoords";
+  case 802: return "MovableJointImpl2_getNrOfDOFs";
+  case 803: return "MovableJointImpl2_setIndex";
+  case 804: return "MovableJointImpl2_getIndex";
+  case 805: return "MovableJointImpl2_setPosCoordsOffset";
+  case 806: return "MovableJointImpl2_getPosCoordsOffset";
+  case 807: return "MovableJointImpl2_setDOFsOffset";
+  case 808: return "MovableJointImpl2_getDOFsOffset";
+  case 809: return "delete_MovableJointImpl3";
+  case 810: return "MovableJointImpl3_getNrOfPosCoords";
+  case 811: return "MovableJointImpl3_getNrOfDOFs";
+  case 812: return "MovableJointImpl3_setIndex";
+  case 813: return "MovableJointImpl3_getIndex";
+  case 814: return "MovableJointImpl3_setPosCoordsOffset";
+  case 815: return "MovableJointImpl3_getPosCoordsOffset";
+  case 816: return "MovableJointImpl3_setDOFsOffset";
+  case 817: return "MovableJointImpl3_getDOFsOffset";
+  case 818: return "delete_MovableJointImpl4";
+  case 819: return "MovableJointImpl4_getNrOfPosCoords";
+  case 820: return "MovableJointImpl4_getNrOfDOFs";
+  case 821: return "MovableJointImpl4_setIndex";
+  case 822: return "MovableJointImpl4_getIndex";
+  case 823: return "MovableJointImpl4_setPosCoordsOffset";
+  case 824: return "MovableJointImpl4_getPosCoordsOffset";
+  case 825: return "MovableJointImpl4_setDOFsOffset";
+  case 826: return "MovableJointImpl4_getDOFsOffset";
+  case 827: return "delete_MovableJointImpl5";
+  case 828: return "MovableJointImpl5_getNrOfPosCoords";
+  case 829: return "MovableJointImpl5_getNrOfDOFs";
+  case 830: return "MovableJointImpl5_setIndex";
+  case 831: return "MovableJointImpl5_getIndex";
+  case 832: return "MovableJointImpl5_setPosCoordsOffset";
+  case 833: return "MovableJointImpl5_getPosCoordsOffset";
+  case 834: return "MovableJointImpl5_setDOFsOffset";
+  case 835: return "MovableJointImpl5_getDOFsOffset";
+  case 836: return "delete_MovableJointImpl6";
+  case 837: return "MovableJointImpl6_getNrOfPosCoords";
+  case 838: return "MovableJointImpl6_getNrOfDOFs";
+  case 839: return "MovableJointImpl6_setIndex";
+  case 840: return "MovableJointImpl6_getIndex";
+  case 841: return "MovableJointImpl6_setPosCoordsOffset";
+  case 842: return "MovableJointImpl6_getPosCoordsOffset";
+  case 843: return "MovableJointImpl6_setDOFsOffset";
+  case 844: return "MovableJointImpl6_getDOFsOffset";
+  case 845: return "new_RevoluteJoint";
+  case 846: return "delete_RevoluteJoint";
+  case 847: return "RevoluteJoint_clone";
+  case 848: return "RevoluteJoint_setAttachedLinks";
+  case 849: return "RevoluteJoint_setRestTransform";
+  case 850: return "RevoluteJoint_setAxis";
+  case 851: return "RevoluteJoint_getFirstAttachedLink";
+  case 852: return "RevoluteJoint_getSecondAttachedLink";
+  case 853: return "RevoluteJoint_getAxis";
+  case 854: return "RevoluteJoint_getRestTransform";
+  case 855: return "RevoluteJoint_getTransform";
+  case 856: return "RevoluteJoint_getTransformDerivative";
+  case 857: return "RevoluteJoint_getMotionSubspaceVector";
+  case 858: return "RevoluteJoint_computeChildPosVelAcc";
+  case 859: return "RevoluteJoint_computeChildVel";
+  case 860: return "RevoluteJoint_computeChildVelAcc";
+  case 861: return "RevoluteJoint_computeJointTorque";
+  case 862: return "new_Traversal";
+  case 863: return "delete_Traversal";
+  case 864: return "Traversal_getNrOfVisitedLinks";
+  case 865: return "Traversal_getLink";
+  case 866: return "Traversal_getBaseLink";
+  case 867: return "Traversal_getParentLink";
+  case 868: return "Traversal_getParentJoint";
+  case 869: return "Traversal_getParentLinkFromLinkIndex";
+  case 870: return "Traversal_getParentJointFromLinkIndex";
+  case 871: return "Traversal_getTraversalIndexFromLinkIndex";
+  case 872: return "Traversal_reset";
+  case 873: return "Traversal_addTraversalBase";
+  case 874: return "Traversal_addTraversalElement";
+  case 875: return "Traversal_isParentOf";
+  case 876: return "Traversal_getChildLinkIndexFromJointIndex";
+  case 877: return "Traversal_toString";
+  case 878: return "Neighbor_neighborLink_get";
+  case 879: return "Neighbor_neighborLink_set";
+  case 880: return "Neighbor_neighborJoint_get";
+  case 881: return "Neighbor_neighborJoint_set";
+  case 882: return "new_Neighbor";
+  case 883: return "delete_Neighbor";
+  case 884: return "new_Model";
+  case 885: return "delete_Model";
+  case 886: return "Model_getNrOfLinks";
+  case 887: return "Model_getLinkName";
+  case 888: return "Model_getLinkIndex";
+  case 889: return "Model_isValidLinkIndex";
+  case 890: return "Model_getLink";
+  case 891: return "Model_addLink";
+  case 892: return "Model_getNrOfJoints";
+  case 893: return "Model_getJointName";
+  case 894: return "Model_getJointIndex";
+  case 895: return "Model_getJoint";
+  case 896: return "Model_isValidJointIndex";
+  case 897: return "Model_isLinkNameUsed";
+  case 898: return "Model_isJointNameUsed";
+  case 899: return "Model_isFrameNameUsed";
+  case 900: return "Model_addJoint";
+  case 901: return "Model_getNrOfPosCoords";
+  case 902: return "Model_getNrOfDOFs";
+  case 903: return "Model_getNrOfFrames";
+  case 904: return "Model_addAdditionalFrameToLink";
+  case 905: return "Model_getFrameName";
+  case 906: return "Model_getFrameIndex";
+  case 907: return "Model_isValidFrameIndex";
+  case 908: return "Model_getFrameTransform";
+  case 909: return "Model_getFrameLink";
+  case 910: return "Model_getNrOfNeighbors";
+  case 911: return "Model_getNeighbor";
+  case 912: return "Model_setDefaultBaseLink";
+  case 913: return "Model_getDefaultBaseLink";
+  case 914: return "Model_computeFullTreeTraversal";
+  case 915: return "Model_getInertialParameters";
+  case 916: return "Model_updateInertialParameters";
+  case 917: return "Model_toString";
+  case 918: return "new_JointPosDoubleArray";
+  case 919: return "JointPosDoubleArray_resize";
+  case 920: return "JointPosDoubleArray_isConsistent";
+  case 921: return "delete_JointPosDoubleArray";
+  case 922: return "new_JointDOFsDoubleArray";
+  case 923: return "JointDOFsDoubleArray_resize";
+  case 924: return "JointDOFsDoubleArray_isConsistent";
+  case 925: return "delete_JointDOFsDoubleArray";
+  case 926: return "new_DOFSpatialForceArray";
+  case 927: return "DOFSpatialForceArray_resize";
+  case 928: return "DOFSpatialForceArray_isConsistent";
+  case 929: return "DOFSpatialForceArray_paren";
+  case 930: return "delete_DOFSpatialForceArray";
+  case 931: return "new_DOFSpatialMotionArray";
+  case 932: return "DOFSpatialMotionArray_resize";
+  case 933: return "DOFSpatialMotionArray_isConsistent";
+  case 934: return "DOFSpatialMotionArray_paren";
+  case 935: return "delete_DOFSpatialMotionArray";
+  case 936: return "new_FreeFloatingMassMatrix";
+  case 937: return "FreeFloatingMassMatrix_resize";
+  case 938: return "delete_FreeFloatingMassMatrix";
+  case 939: return "new_FreeFloatingPos";
+  case 940: return "FreeFloatingPos_resize";
+  case 941: return "FreeFloatingPos_worldBasePos";
+  case 942: return "FreeFloatingPos_jointPos";
+  case 943: return "FreeFloatingPos_getNrOfPosCoords";
+  case 944: return "delete_FreeFloatingPos";
+  case 945: return "new_FreeFloatingGeneralizedTorques";
+  case 946: return "FreeFloatingGeneralizedTorques_resize";
+  case 947: return "FreeFloatingGeneralizedTorques_baseWrench";
+  case 948: return "FreeFloatingGeneralizedTorques_jointTorques";
+  case 949: return "FreeFloatingGeneralizedTorques_getNrOfDOFs";
+  case 950: return "delete_FreeFloatingGeneralizedTorques";
+  case 951: return "new_FreeFloatingVel";
+  case 952: return "FreeFloatingVel_resize";
+  case 953: return "FreeFloatingVel_baseVel";
+  case 954: return "FreeFloatingVel_jointVel";
+  case 955: return "FreeFloatingVel_getNrOfDOFs";
+  case 956: return "delete_FreeFloatingVel";
+  case 957: return "new_FreeFloatingAcc";
+  case 958: return "FreeFloatingAcc_resize";
+  case 959: return "FreeFloatingAcc_baseAcc";
+  case 960: return "FreeFloatingAcc_jointAcc";
+  case 961: return "FreeFloatingAcc_getNrOfDOFs";
+  case 962: return "delete_FreeFloatingAcc";
+  case 963: return "ContactWrench_contactId";
+  case 964: return "ContactWrench_contactPoint";
+  case 965: return "ContactWrench_contactWrench";
+  case 966: return "new_ContactWrench";
+  case 967: return "delete_ContactWrench";
+  case 968: return "new_LinkContactWrenches";
+  case 969: return "LinkContactWrenches_resize";
+  case 970: return "LinkContactWrenches_getNrOfContactsForLink";
+  case 971: return "LinkContactWrenches_setNrOfContactsForLink";
+  case 972: return "LinkContactWrenches_getNrOfLinks";
+  case 973: return "LinkContactWrenches_contactWrench";
+  case 974: return "LinkContactWrenches_computeNetWrenches";
+  case 975: return "LinkContactWrenches_toString";
+  case 976: return "delete_LinkContactWrenches";
+  case 977: return "_wrap_ForwardPositionKinematics";
+  case 978: return "_wrap_ForwardVelAccKinematics";
+  case 979: return "_wrap_ForwardPosVelAccKinematics";
+  case 980: return "_wrap_RNEADynamicPhase";
+  case 981: return "_wrap_CompositeRigidBodyAlgorithm";
+  case 982: return "new_ArticulatedBodyAlgorithmInternalBuffers";
+  case 983: return "ArticulatedBodyAlgorithmInternalBuffers_resize";
+  case 984: return "ArticulatedBodyAlgorithmInternalBuffers_isConsistent";
+  case 985: return "ArticulatedBodyAlgorithmInternalBuffers_S_get";
+  case 986: return "ArticulatedBodyAlgorithmInternalBuffers_S_set";
+  case 987: return "ArticulatedBodyAlgorithmInternalBuffers_U_get";
+  case 988: return "ArticulatedBodyAlgorithmInternalBuffers_U_set";
+  case 989: return "ArticulatedBodyAlgorithmInternalBuffers_D_get";
+  case 990: return "ArticulatedBodyAlgorithmInternalBuffers_D_set";
+  case 991: return "ArticulatedBodyAlgorithmInternalBuffers_u_get";
+  case 992: return "ArticulatedBodyAlgorithmInternalBuffers_u_set";
+  case 993: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_get";
+  case 994: return "ArticulatedBodyAlgorithmInternalBuffers_linksVel_set";
+  case 995: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get";
+  case 996: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set";
+  case 997: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get";
+  case 998: return "ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set";
+  case 999: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get";
+  case 1000: return "ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set";
+  case 1001: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get";
+  case 1002: return "ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set";
+  case 1003: return "delete_ArticulatedBodyAlgorithmInternalBuffers";
+  case 1004: return "_wrap_ArticulatedBodyAlgorithm";
+  case 1005: return "NR_OF_SENSOR_TYPES_get";
+  case 1006: return "_wrap_isLinkSensor";
+  case 1007: return "_wrap_isJointSensor";
+  case 1008: return "_wrap_getSensorTypeSize";
+  case 1009: return "delete_Sensor";
+  case 1010: return "Sensor_getName";
+  case 1011: return "Sensor_getSensorType";
+  case 1012: return "Sensor_isValid";
+  case 1013: return "Sensor_setName";
+  case 1014: return "Sensor_clone";
+  case 1015: return "Sensor_updateIndeces";
+  case 1016: return "delete_JointSensor";
+  case 1017: return "JointSensor_getParentJoint";
+  case 1018: return "JointSensor_getParentJointIndex";
+  case 1019: return "JointSensor_setParentJoint";
+  case 1020: return "JointSensor_setParentJointIndex";
+  case 1021: return "delete_LinkSensor";
+  case 1022: return "LinkSensor_getParentLink";
+  case 1023: return "LinkSensor_getParentLinkIndex";
+  case 1024: return "LinkSensor_getLinkSensorTransform";
+  case 1025: return "LinkSensor_setParentLink";
+  case 1026: return "LinkSensor_setParentLinkIndex";
+  case 1027: return "new_SensorsList";
+  case 1028: return "delete_SensorsList";
+  case 1029: return "SensorsList_addSensor";
+  case 1030: return "SensorsList_setSerialization";
+  case 1031: return "SensorsList_getSerialization";
+  case 1032: return "SensorsList_getNrOfSensors";
+  case 1033: return "SensorsList_getSensorIndex";
+  case 1034: return "SensorsList_getSizeOfAllSensorsMeasurements";
+  case 1035: return "SensorsList_getSensor";
+  case 1036: return "SensorsList_removeSensor";
+  case 1037: return "SensorsList_removeAllSensorsOfType";
+  case 1038: return "SensorsList_getSixAxisForceTorqueSensor";
+  case 1039: return "SensorsList_getAccelerometerSensor";
+  case 1040: return "SensorsList_getGyroscopeSensor";
+  case 1041: return "new_SensorsMeasurements";
+  case 1042: return "delete_SensorsMeasurements";
+  case 1043: return "SensorsMeasurements_setNrOfSensors";
+  case 1044: return "SensorsMeasurements_getNrOfSensors";
+  case 1045: return "SensorsMeasurements_resize";
+  case 1046: return "SensorsMeasurements_toVector";
+  case 1047: return "SensorsMeasurements_setMeasurement";
+  case 1048: return "SensorsMeasurements_getMeasurement";
+  case 1049: return "SensorsMeasurements_getSizeOfAllSensorsMeasurements";
+  case 1050: return "new_SixAxisForceTorqueSensor";
+  case 1051: return "delete_SixAxisForceTorqueSensor";
+  case 1052: return "SixAxisForceTorqueSensor_setName";
+  case 1053: return "SixAxisForceTorqueSensor_setFirstLinkSensorTransform";
+  case 1054: return "SixAxisForceTorqueSensor_setSecondLinkSensorTransform";
+  case 1055: return "SixAxisForceTorqueSensor_getFirstLinkIndex";
+  case 1056: return "SixAxisForceTorqueSensor_getSecondLinkIndex";
+  case 1057: return "SixAxisForceTorqueSensor_setFirstLinkName";
+  case 1058: return "SixAxisForceTorqueSensor_setSecondLinkName";
+  case 1059: return "SixAxisForceTorqueSensor_getFirstLinkName";
+  case 1060: return "SixAxisForceTorqueSensor_getSecondLinkName";
+  case 1061: return "SixAxisForceTorqueSensor_setParentJoint";
+  case 1062: return "SixAxisForceTorqueSensor_setParentJointIndex";
+  case 1063: return "SixAxisForceTorqueSensor_setAppliedWrenchLink";
+  case 1064: return "SixAxisForceTorqueSensor_getName";
+  case 1065: return "SixAxisForceTorqueSensor_getSensorType";
+  case 1066: return "SixAxisForceTorqueSensor_getParentJoint";
+  case 1067: return "SixAxisForceTorqueSensor_getParentJointIndex";
+  case 1068: return "SixAxisForceTorqueSensor_isValid";
+  case 1069: return "SixAxisForceTorqueSensor_clone";
+  case 1070: return "SixAxisForceTorqueSensor_updateIndeces";
+  case 1071: return "SixAxisForceTorqueSensor_getAppliedWrenchLink";
+  case 1072: return "SixAxisForceTorqueSensor_isLinkAttachedToSensor";
+  case 1073: return "SixAxisForceTorqueSensor_getLinkSensorTransform";
+  case 1074: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLink";
+  case 1075: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLinkMatrix";
+  case 1076: return "SixAxisForceTorqueSensor_getWrenchAppliedOnLinkInverseMatrix";
+  case 1077: return "SixAxisForceTorqueSensor_predictMeasurement";
+  case 1078: return "SixAxisForceTorqueSensor_toString";
+  case 1079: return "new_AccelerometerSensor";
+  case 1080: return "delete_AccelerometerSensor";
+  case 1081: return "AccelerometerSensor_setName";
+  case 1082: return "AccelerometerSensor_setLinkSensorTransform";
+  case 1083: return "AccelerometerSensor_setParentLink";
+  case 1084: return "AccelerometerSensor_setParentLinkIndex";
+  case 1085: return "AccelerometerSensor_getName";
+  case 1086: return "AccelerometerSensor_getSensorType";
+  case 1087: return "AccelerometerSensor_getParentLink";
+  case 1088: return "AccelerometerSensor_getParentLinkIndex";
+  case 1089: return "AccelerometerSensor_getLinkSensorTransform";
+  case 1090: return "AccelerometerSensor_isValid";
+  case 1091: return "AccelerometerSensor_clone";
+  case 1092: return "AccelerometerSensor_updateIndeces";
+  case 1093: return "AccelerometerSensor_predictMeasurement";
+  case 1094: return "new_GyroscopeSensor";
+  case 1095: return "delete_GyroscopeSensor";
+  case 1096: return "GyroscopeSensor_setName";
+  case 1097: return "GyroscopeSensor_setLinkSensorTransform";
+  case 1098: return "GyroscopeSensor_setParentLink";
+  case 1099: return "GyroscopeSensor_setParentLinkIndex";
+  case 1100: return "GyroscopeSensor_getName";
+  case 1101: return "GyroscopeSensor_getSensorType";
+  case 1102: return "GyroscopeSensor_getParentLink";
+  case 1103: return "GyroscopeSensor_getParentLinkIndex";
+  case 1104: return "GyroscopeSensor_getLinkSensorTransform";
+  case 1105: return "GyroscopeSensor_isValid";
+  case 1106: return "GyroscopeSensor_clone";
+  case 1107: return "GyroscopeSensor_updateIndeces";
+  case 1108: return "GyroscopeSensor_predictMeasurement";
+  case 1109: return "_wrap_predictSensorsMeasurements";
+  case 1110: return "_wrap_predictSensorsMeasurementsFromRawBuffers";
+  case 1111: return "URDFParserOptions_addSensorFramesAsAdditionalFrames_get";
+  case 1112: return "URDFParserOptions_addSensorFramesAsAdditionalFrames_set";
+  case 1113: return "new_URDFParserOptions";
+  case 1114: return "delete_URDFParserOptions";
+  case 1115: return "_wrap_modelFromURDF";
+  case 1116: return "_wrap_modelFromURDFString";
+  case 1117: return "_wrap_sensorsFromURDF";
+  case 1118: return "_wrap_sensorsFromURDFString";
+  case 1119: return "new_ModelLoader";
+  case 1120: return "ModelLoader_loadModelFromString";
+  case 1121: return "ModelLoader_loadModelFromFile";
+  case 1122: return "ModelLoader_loadReducedModelFromFullModel";
+  case 1123: return "ModelLoader_loadReducedModelFromString";
+  case 1124: return "ModelLoader_loadReducedModelFromFile";
+  case 1125: return "ModelLoader_model";
+  case 1126: return "ModelLoader_sensors";
+  case 1127: return "ModelLoader_isValid";
+  case 1128: return "delete_ModelLoader";
+  case 1129: return "new_UnknownWrenchContact";
+  case 1130: return "UnknownWrenchContact_unknownType_get";
+  case 1131: return "UnknownWrenchContact_unknownType_set";
+  case 1132: return "UnknownWrenchContact_contactPoint_get";
+  case 1133: return "UnknownWrenchContact_contactPoint_set";
+  case 1134: return "UnknownWrenchContact_forceDirection_get";
+  case 1135: return "UnknownWrenchContact_forceDirection_set";
+  case 1136: return "UnknownWrenchContact_contactId_get";
+  case 1137: return "UnknownWrenchContact_contactId_set";
+  case 1138: return "delete_UnknownWrenchContact";
+  case 1139: return "new_LinkUnknownWrenchContacts";
+  case 1140: return "LinkUnknownWrenchContacts_clear";
+  case 1141: return "LinkUnknownWrenchContacts_resize";
+  case 1142: return "LinkUnknownWrenchContacts_getNrOfContactsForLink";
+  case 1143: return "LinkUnknownWrenchContacts_setNrOfContactsForLink";
+  case 1144: return "LinkUnknownWrenchContacts_addNewContactForLink";
+  case 1145: return "LinkUnknownWrenchContacts_addNewContactInFrame";
+  case 1146: return "LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin";
+  case 1147: return "LinkUnknownWrenchContacts_contactWrench";
+  case 1148: return "LinkUnknownWrenchContacts_toString";
+  case 1149: return "delete_LinkUnknownWrenchContacts";
+  case 1150: return "new_LinkTraversalsCache";
+  case 1151: return "delete_LinkTraversalsCache";
+  case 1152: return "LinkTraversalsCache_resize";
+  case 1153: return "LinkTraversalsCache_getTraversalWithLinkAsBase";
+  case 1154: return "new_estimateExternalWrenchesBuffers";
+  case 1155: return "estimateExternalWrenchesBuffers_resize";
+  case 1156: return "estimateExternalWrenchesBuffers_getNrOfSubModels";
+  case 1157: return "estimateExternalWrenchesBuffers_getNrOfLinks";
+  case 1158: return "estimateExternalWrenchesBuffers_isConsistent";
+  case 1159: return "estimateExternalWrenchesBuffers_A_get";
+  case 1160: return "estimateExternalWrenchesBuffers_A_set";
+  case 1161: return "estimateExternalWrenchesBuffers_x_get";
+  case 1162: return "estimateExternalWrenchesBuffers_x_set";
+  case 1163: return "estimateExternalWrenchesBuffers_b_get";
+  case 1164: return "estimateExternalWrenchesBuffers_b_set";
+  case 1165: return "estimateExternalWrenchesBuffers_pinvA_get";
+  case 1166: return "estimateExternalWrenchesBuffers_pinvA_set";
+  case 1167: return "estimateExternalWrenchesBuffers_b_contacts_subtree_get";
+  case 1168: return "estimateExternalWrenchesBuffers_b_contacts_subtree_set";
+  case 1169: return "estimateExternalWrenchesBuffers_subModelBase_H_link_get";
+  case 1170: return "estimateExternalWrenchesBuffers_subModelBase_H_link_set";
+  case 1171: return "delete_estimateExternalWrenchesBuffers";
+  case 1172: return "_wrap_estimateExternalWrenchesWithoutInternalFT";
+  case 1173: return "_wrap_estimateExternalWrenches";
+  case 1174: return "_wrap_dynamicsEstimationForwardVelAccKinematics";
+  case 1175: return "_wrap_dynamicsEstimationForwardVelKinematics";
+  case 1176: return "_wrap_computeLinkNetWrenchesWithoutGravity";
+  case 1177: return "new_ExtWrenchesAndJointTorquesEstimator";
+  case 1178: return "delete_ExtWrenchesAndJointTorquesEstimator";
+  case 1179: return "ExtWrenchesAndJointTorquesEstimator_setModelAndSensors";
+  case 1180: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile";
+  case 1181: return "ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs";
+  case 1182: return "ExtWrenchesAndJointTorquesEstimator_model";
+  case 1183: return "ExtWrenchesAndJointTorquesEstimator_sensors";
+  case 1184: return "ExtWrenchesAndJointTorquesEstimator_submodels";
+  case 1185: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase";
+  case 1186: return "ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase";
+  case 1187: return "ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements";
+  case 1188: return "ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques";
+  case 1189: return "ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill";
+  case 1190: return "ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity";
+  case 1191: return "new_SimpleLeggedOdometry";
+  case 1192: return "delete_SimpleLeggedOdometry";
+  case 1193: return "SimpleLeggedOdometry_setModel";
+  case 1194: return "SimpleLeggedOdometry_loadModelFromFile";
+  case 1195: return "SimpleLeggedOdometry_loadModelFromFileWithSpecifiedDOFs";
+  case 1196: return "SimpleLeggedOdometry_model";
+  case 1197: return "SimpleLeggedOdometry_updateKinematics";
+  case 1198: return "SimpleLeggedOdometry_init";
+  case 1199: return "SimpleLeggedOdometry_changeFixedFrame";
+  case 1200: return "SimpleLeggedOdometry_getCurrentFixedLink";
+  case 1201: return "SimpleLeggedOdometry_getWorldLinkTransform";
+  case 1202: return "_wrap_isLinkBerdyDynamicVariable";
+  case 1203: return "_wrap_isJointBerdyDynamicVariable";
+  case 1204: return "_wrap_isDOFBerdyDynamicVariable";
+  case 1205: return "new_BerdyOptions";
+  case 1206: return "BerdyOptions_berdyVariant_get";
+  case 1207: return "BerdyOptions_berdyVariant_set";
+  case 1208: return "BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_get";
+  case 1209: return "BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_set";
+  case 1210: return "BerdyOptions_includeAllJointAccelerationsAsSensors_get";
+  case 1211: return "BerdyOptions_includeAllJointAccelerationsAsSensors_set";
+  case 1212: return "BerdyOptions_includeAllJointTorquesAsSensors_get";
+  case 1213: return "BerdyOptions_includeAllJointTorquesAsSensors_set";
+  case 1214: return "BerdyOptions_includeAllNetExternalWrenchesAsSensors_get";
+  case 1215: return "BerdyOptions_includeAllNetExternalWrenchesAsSensors_set";
+  case 1216: return "BerdyOptions_includeFixedBaseExternalWrench_get";
+  case 1217: return "BerdyOptions_includeFixedBaseExternalWrench_set";
+  case 1218: return "BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_get";
+  case 1219: return "BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_set";
+  case 1220: return "BerdyOptions_checkConsistency";
+  case 1221: return "delete_BerdyOptions";
+  case 1222: return "BerdySensor_type_get";
+  case 1223: return "BerdySensor_type_set";
+  case 1224: return "BerdySensor_id_get";
+  case 1225: return "BerdySensor_id_set";
+  case 1226: return "BerdySensor_range_get";
+  case 1227: return "BerdySensor_range_set";
+  case 1228: return "BerdySensor_eq";
+  case 1229: return "new_BerdySensor";
+  case 1230: return "delete_BerdySensor";
+  case 1231: return "BerdyDynamicVariable_type_get";
+  case 1232: return "BerdyDynamicVariable_type_set";
+  case 1233: return "BerdyDynamicVariable_id_get";
+  case 1234: return "BerdyDynamicVariable_id_set";
+  case 1235: return "BerdyDynamicVariable_range_get";
+  case 1236: return "BerdyDynamicVariable_range_set";
+  case 1237: return "new_BerdyDynamicVariable";
+  case 1238: return "delete_BerdyDynamicVariable";
+  case 1239: return "new_BerdyHelper";
+  case 1240: return "BerdyHelper_dynamicTraversal";
+  case 1241: return "BerdyHelper_model";
+  case 1242: return "BerdyHelper_sensors";
+  case 1243: return "BerdyHelper_init";
+  case 1244: return "BerdyHelper_getOptions";
+  case 1245: return "BerdyHelper_getNrOfDynamicVariables";
+  case 1246: return "BerdyHelper_getNrOfDynamicEquations";
+  case 1247: return "BerdyHelper_getNrOfSensorsMeasurements";
+  case 1248: return "BerdyHelper_resizeAndZeroBerdyMatrices";
+  case 1249: return "BerdyHelper_getBerdyMatrices";
+  case 1250: return "BerdyHelper_getSensorsOrdering";
+  case 1251: return "BerdyHelper_getDynamicVariablesOrdering";
+  case 1252: return "BerdyHelper_serializeDynamicVariables";
+  case 1253: return "BerdyHelper_serializeSensorVariables";
+  case 1254: return "BerdyHelper_serializeDynamicVariablesComputedFromFixedBaseRNEA";
+  case 1255: return "BerdyHelper_updateKinematicsFromFloatingBase";
+  case 1256: return "BerdyHelper_updateKinematicsFromFixedBase";
+  case 1257: return "BerdyHelper_updateKinematicsFromTraversalFixedBase";
+  case 1258: return "delete_BerdyHelper";
+  case 1259: return "DynamicsRegressorParameter_category_get";
+  case 1260: return "DynamicsRegressorParameter_category_set";
+  case 1261: return "DynamicsRegressorParameter_elemIndex_get";
+  case 1262: return "DynamicsRegressorParameter_elemIndex_set";
+  case 1263: return "DynamicsRegressorParameter_type_get";
+  case 1264: return "DynamicsRegressorParameter_type_set";
+  case 1265: return "DynamicsRegressorParameter_lt";
+  case 1266: return "DynamicsRegressorParameter_eq";
+  case 1267: return "DynamicsRegressorParameter_ne";
+  case 1268: return "new_DynamicsRegressorParameter";
+  case 1269: return "delete_DynamicsRegressorParameter";
+  case 1270: return "DynamicsRegressorParametersList_parameters_get";
+  case 1271: return "DynamicsRegressorParametersList_parameters_set";
+  case 1272: return "DynamicsRegressorParametersList_getDescriptionOfParameter";
+  case 1273: return "DynamicsRegressorParametersList_addParam";
+  case 1274: return "DynamicsRegressorParametersList_addList";
+  case 1275: return "DynamicsRegressorParametersList_findParam";
+  case 1276: return "DynamicsRegressorParametersList_getNrOfParameters";
+  case 1277: return "new_DynamicsRegressorParametersList";
+  case 1278: return "delete_DynamicsRegressorParametersList";
+  case 1279: return "new_DynamicsRegressorGenerator";
+  case 1280: return "delete_DynamicsRegressorGenerator";
+  case 1281: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile";
+  case 1282: return "DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString";
+  case 1283: return "DynamicsRegressorGenerator_loadRegressorStructureFromFile";
+  case 1284: return "DynamicsRegressorGenerator_loadRegressorStructureFromString";
+  case 1285: return "DynamicsRegressorGenerator_isValid";
+  case 1286: return "DynamicsRegressorGenerator_getNrOfParameters";
+  case 1287: return "DynamicsRegressorGenerator_getNrOfOutputs";
+  case 1288: return "DynamicsRegressorGenerator_getNrOfDegreesOfFreedom";
+  case 1289: return "DynamicsRegressorGenerator_getDescriptionOfParameter";
+  case 1290: return "DynamicsRegressorGenerator_getDescriptionOfParameters";
+  case 1291: return "DynamicsRegressorGenerator_getDescriptionOfOutput";
+  case 1292: return "DynamicsRegressorGenerator_getDescriptionOfOutputs";
+  case 1293: return "DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom";
+  case 1294: return "DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom";
+  case 1295: return "DynamicsRegressorGenerator_getBaseLinkName";
+  case 1296: return "DynamicsRegressorGenerator_getSensorsModel";
+  case 1297: return "DynamicsRegressorGenerator_setRobotState";
+  case 1298: return "DynamicsRegressorGenerator_getSensorsMeasurements";
+  case 1299: return "DynamicsRegressorGenerator_computeRegressor";
+  case 1300: return "DynamicsRegressorGenerator_getModelParameters";
+  case 1301: return "DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace";
+  case 1302: return "DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace";
+  case 1303: return "new_KinDynComputations";
+  case 1304: return "delete_KinDynComputations";
+  case 1305: return "KinDynComputations_loadRobotModel";
+  case 1306: return "KinDynComputations_loadRobotModelFromFile";
+  case 1307: return "KinDynComputations_loadRobotModelFromString";
+  case 1308: return "KinDynComputations_isValid";
+  case 1309: return "KinDynComputations_getNrOfDegreesOfFreedom";
+  case 1310: return "KinDynComputations_getDescriptionOfDegreeOfFreedom";
+  case 1311: return "KinDynComputations_getDescriptionOfDegreesOfFreedom";
+  case 1312: return "KinDynComputations_getNrOfLinks";
+  case 1313: return "KinDynComputations_getNrOfFrames";
+  case 1314: return "KinDynComputations_getFloatingBase";
+  case 1315: return "KinDynComputations_setFloatingBase";
+  case 1316: return "KinDynComputations_getRobotModel";
+  case 1317: return "KinDynComputations_setRobotState";
+  case 1318: return "KinDynComputations_getWorldBaseTransform";
+  case 1319: return "KinDynComputations_getBaseTwist";
+  case 1320: return "KinDynComputations_getJointPos";
+  case 1321: return "KinDynComputations_getJointVel";
+  case 1322: return "KinDynComputations_getFrameIndex";
+  case 1323: return "KinDynComputations_getFrameName";
+  case 1324: return "KinDynComputations_getWorldTransform";
+  case 1325: return "KinDynComputations_getRelativeTransformExplicit";
+  case 1326: return "KinDynComputations_getRelativeTransform";
+  case 1327: return "new_DynamicsComputations";
+  case 1328: return "delete_DynamicsComputations";
+  case 1329: return "DynamicsComputations_loadRobotModelFromFile";
+  case 1330: return "DynamicsComputations_loadRobotModelFromString";
+  case 1331: return "DynamicsComputations_isValid";
+  case 1332: return "DynamicsComputations_getNrOfDegreesOfFreedom";
+  case 1333: return "DynamicsComputations_getDescriptionOfDegreeOfFreedom";
+  case 1334: return "DynamicsComputations_getDescriptionOfDegreesOfFreedom";
+  case 1335: return "DynamicsComputations_getNrOfLinks";
+  case 1336: return "DynamicsComputations_getNrOfFrames";
+  case 1337: return "DynamicsComputations_getFloatingBase";
+  case 1338: return "DynamicsComputations_setFloatingBase";
+  case 1339: return "DynamicsComputations_setRobotState";
+  case 1340: return "DynamicsComputations_getWorldBaseTransform";
+  case 1341: return "DynamicsComputations_getBaseTwist";
+  case 1342: return "DynamicsComputations_getJointPos";
+  case 1343: return "DynamicsComputations_getJointVel";
+  case 1344: return "DynamicsComputations_getFrameIndex";
+  case 1345: return "DynamicsComputations_getFrameName";
+  case 1346: return "DynamicsComputations_getWorldTransform";
+  case 1347: return "DynamicsComputations_getRelativeTransform";
+  case 1348: return "DynamicsComputations_getFrameTwist";
+  case 1349: return "DynamicsComputations_getFrameTwistInWorldOrient";
+  case 1350: return "DynamicsComputations_getFrameProperSpatialAcceleration";
+  case 1351: return "DynamicsComputations_getLinkIndex";
+  case 1352: return "DynamicsComputations_getLinkInertia";
+  case 1353: return "DynamicsComputations_getJointIndex";
+  case 1354: return "DynamicsComputations_getJointName";
+  case 1355: return "DynamicsComputations_getJointLimits";
+  case 1356: return "DynamicsComputations_inverseDynamics";
+  case 1357: return "DynamicsComputations_getFrameJacobian";
+  case 1358: return "DynamicsComputations_getDynamicsRegressor";
+  case 1359: return "DynamicsComputations_getModelDynamicsParameters";
+  case 1360: return "DynamicsComputations_getCenterOfMass";
+  case 1361: return "DynamicsComputations_getCenterOfMassJacobian";
   default: return 0;
   }
 }
@@ -69375,1270 +69690,1271 @@ void mexFunction(int resc, mxArray *resv[], int argc, const mxArray *argv[]) {
   case 94: flag=_wrap_MatrixDynSize_toString(resc,resv,argc,(mxArray**)(argv)); break;
   case 95: flag=_wrap_MatrixDynSize_display(resc,resv,argc,(mxArray**)(argv)); break;
   case 96: flag=_wrap_MatrixDynSize_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 97: flag=_wrap_new_VectorDynSize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 98: flag=_wrap_delete_VectorDynSize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 99: flag=_wrap_VectorDynSize_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 100: flag=_wrap_VectorDynSize_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 101: flag=_wrap_VectorDynSize_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 102: flag=_wrap_VectorDynSize_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 103: flag=_wrap_VectorDynSize_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 104: flag=_wrap_VectorDynSize_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 105: flag=_wrap_VectorDynSize_reserve(resc,resv,argc,(mxArray**)(argv)); break;
-  case 106: flag=_wrap_VectorDynSize_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 107: flag=_wrap_VectorDynSize_shrink_to_fit(resc,resv,argc,(mxArray**)(argv)); break;
-  case 108: flag=_wrap_VectorDynSize_capacity(resc,resv,argc,(mxArray**)(argv)); break;
-  case 109: flag=_wrap_VectorDynSize_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 110: flag=_wrap_VectorDynSize_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 111: flag=_wrap_VectorDynSize_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 112: flag=_wrap_VectorDynSize_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 113: flag=_wrap_VectorDynSize_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 114: flag=_wrap_new_Matrix3x3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 115: flag=_wrap_Matrix3x3_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 116: flag=_wrap_Matrix3x3_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 117: flag=_wrap_Matrix3x3_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 118: flag=_wrap_Matrix3x3_rows(resc,resv,argc,(mxArray**)(argv)); break;
-  case 119: flag=_wrap_Matrix3x3_cols(resc,resv,argc,(mxArray**)(argv)); break;
-  case 120: flag=_wrap_Matrix3x3_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 121: flag=_wrap_Matrix3x3_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 122: flag=_wrap_Matrix3x3_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 123: flag=_wrap_Matrix3x3_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 124: flag=_wrap_Matrix3x3_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 125: flag=_wrap_Matrix3x3_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 126: flag=_wrap_Matrix3x3_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 127: flag=_wrap_Matrix3x3_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 128: flag=_wrap_delete_Matrix3x3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 129: flag=_wrap_new_Matrix4x4(resc,resv,argc,(mxArray**)(argv)); break;
-  case 130: flag=_wrap_Matrix4x4_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 131: flag=_wrap_Matrix4x4_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 132: flag=_wrap_Matrix4x4_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 133: flag=_wrap_Matrix4x4_rows(resc,resv,argc,(mxArray**)(argv)); break;
-  case 134: flag=_wrap_Matrix4x4_cols(resc,resv,argc,(mxArray**)(argv)); break;
-  case 135: flag=_wrap_Matrix4x4_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 136: flag=_wrap_Matrix4x4_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 137: flag=_wrap_Matrix4x4_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 138: flag=_wrap_Matrix4x4_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 139: flag=_wrap_Matrix4x4_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 140: flag=_wrap_Matrix4x4_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 141: flag=_wrap_Matrix4x4_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 142: flag=_wrap_Matrix4x4_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 143: flag=_wrap_delete_Matrix4x4(resc,resv,argc,(mxArray**)(argv)); break;
-  case 144: flag=_wrap_new_Matrix6x6(resc,resv,argc,(mxArray**)(argv)); break;
-  case 145: flag=_wrap_Matrix6x6_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 146: flag=_wrap_Matrix6x6_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 147: flag=_wrap_Matrix6x6_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 148: flag=_wrap_Matrix6x6_rows(resc,resv,argc,(mxArray**)(argv)); break;
-  case 149: flag=_wrap_Matrix6x6_cols(resc,resv,argc,(mxArray**)(argv)); break;
-  case 150: flag=_wrap_Matrix6x6_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 151: flag=_wrap_Matrix6x6_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 152: flag=_wrap_Matrix6x6_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 153: flag=_wrap_Matrix6x6_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 154: flag=_wrap_Matrix6x6_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 155: flag=_wrap_Matrix6x6_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 156: flag=_wrap_Matrix6x6_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 157: flag=_wrap_Matrix6x6_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 158: flag=_wrap_delete_Matrix6x6(resc,resv,argc,(mxArray**)(argv)); break;
-  case 159: flag=_wrap_new_Matrix6x10(resc,resv,argc,(mxArray**)(argv)); break;
-  case 160: flag=_wrap_Matrix6x10_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 161: flag=_wrap_Matrix6x10_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 162: flag=_wrap_Matrix6x10_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 163: flag=_wrap_Matrix6x10_rows(resc,resv,argc,(mxArray**)(argv)); break;
-  case 164: flag=_wrap_Matrix6x10_cols(resc,resv,argc,(mxArray**)(argv)); break;
-  case 165: flag=_wrap_Matrix6x10_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 166: flag=_wrap_Matrix6x10_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 167: flag=_wrap_Matrix6x10_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 168: flag=_wrap_Matrix6x10_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 169: flag=_wrap_Matrix6x10_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 170: flag=_wrap_Matrix6x10_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 171: flag=_wrap_Matrix6x10_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 172: flag=_wrap_Matrix6x10_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 173: flag=_wrap_delete_Matrix6x10(resc,resv,argc,(mxArray**)(argv)); break;
-  case 174: flag=_wrap_new_Matrix10x16(resc,resv,argc,(mxArray**)(argv)); break;
-  case 175: flag=_wrap_Matrix10x16_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 176: flag=_wrap_Matrix10x16_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 177: flag=_wrap_Matrix10x16_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 178: flag=_wrap_Matrix10x16_rows(resc,resv,argc,(mxArray**)(argv)); break;
-  case 179: flag=_wrap_Matrix10x16_cols(resc,resv,argc,(mxArray**)(argv)); break;
-  case 180: flag=_wrap_Matrix10x16_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 181: flag=_wrap_Matrix10x16_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 182: flag=_wrap_Matrix10x16_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 183: flag=_wrap_Matrix10x16_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 184: flag=_wrap_Matrix10x16_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 185: flag=_wrap_Matrix10x16_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 186: flag=_wrap_Matrix10x16_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 187: flag=_wrap_Matrix10x16_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 188: flag=_wrap_delete_Matrix10x16(resc,resv,argc,(mxArray**)(argv)); break;
-  case 189: flag=_wrap_new_Vector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 190: flag=_wrap_Vector3_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 191: flag=_wrap_Vector3_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 192: flag=_wrap_Vector3_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 193: flag=_wrap_Vector3_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 194: flag=_wrap_Vector3_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 195: flag=_wrap_Vector3_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 196: flag=_wrap_Vector3_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 197: flag=_wrap_Vector3_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 198: flag=_wrap_Vector3_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 199: flag=_wrap_Vector3_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 200: flag=_wrap_Vector3_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 201: flag=_wrap_delete_Vector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 202: flag=_wrap_new_Vector6(resc,resv,argc,(mxArray**)(argv)); break;
-  case 203: flag=_wrap_Vector6_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 204: flag=_wrap_Vector6_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 205: flag=_wrap_Vector6_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 206: flag=_wrap_Vector6_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 207: flag=_wrap_Vector6_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 208: flag=_wrap_Vector6_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 209: flag=_wrap_Vector6_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 210: flag=_wrap_Vector6_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 211: flag=_wrap_Vector6_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 212: flag=_wrap_Vector6_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 213: flag=_wrap_Vector6_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 214: flag=_wrap_delete_Vector6(resc,resv,argc,(mxArray**)(argv)); break;
-  case 215: flag=_wrap_new_Vector10(resc,resv,argc,(mxArray**)(argv)); break;
-  case 216: flag=_wrap_Vector10_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 217: flag=_wrap_Vector10_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 218: flag=_wrap_Vector10_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 219: flag=_wrap_Vector10_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 220: flag=_wrap_Vector10_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 221: flag=_wrap_Vector10_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 222: flag=_wrap_Vector10_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 223: flag=_wrap_Vector10_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 224: flag=_wrap_Vector10_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 225: flag=_wrap_Vector10_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 226: flag=_wrap_Vector10_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 227: flag=_wrap_delete_Vector10(resc,resv,argc,(mxArray**)(argv)); break;
-  case 228: flag=_wrap_new_Vector16(resc,resv,argc,(mxArray**)(argv)); break;
-  case 229: flag=_wrap_Vector16_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 230: flag=_wrap_Vector16_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 231: flag=_wrap_Vector16_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 232: flag=_wrap_Vector16_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 233: flag=_wrap_Vector16_data(resc,resv,argc,(mxArray**)(argv)); break;
-  case 234: flag=_wrap_Vector16_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 235: flag=_wrap_Vector16_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
-  case 236: flag=_wrap_Vector16_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 237: flag=_wrap_Vector16_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 238: flag=_wrap_Vector16_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 239: flag=_wrap_Vector16_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 240: flag=_wrap_delete_Vector16(resc,resv,argc,(mxArray**)(argv)); break;
-  case 241: flag=_wrap_new_PositionRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 242: flag=_wrap_PositionRaw_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 243: flag=_wrap_PositionRaw_changeRefPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 244: flag=_wrap_PositionRaw_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 245: flag=_wrap_PositionRaw_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 246: flag=_wrap_PositionRaw_changePointOf(resc,resv,argc,(mxArray**)(argv)); break;
-  case 247: flag=_wrap_PositionRaw_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 248: flag=_wrap_PositionRaw_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 249: flag=_wrap_delete_PositionRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 250: flag=_wrap_new_PositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 251: flag=_wrap_PositionSemantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 252: flag=_wrap_PositionSemantics_getPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 253: flag=_wrap_PositionSemantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 254: flag=_wrap_PositionSemantics_getReferencePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 255: flag=_wrap_PositionSemantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 256: flag=_wrap_PositionSemantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 257: flag=_wrap_PositionSemantics_setPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 258: flag=_wrap_PositionSemantics_setBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 259: flag=_wrap_PositionSemantics_setReferencePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 260: flag=_wrap_PositionSemantics_setRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 261: flag=_wrap_PositionSemantics_setCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 262: flag=_wrap_PositionSemantics_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 263: flag=_wrap_PositionSemantics_changeRefPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 264: flag=_wrap_PositionSemantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 265: flag=_wrap_PositionSemantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 266: flag=_wrap_PositionSemantics_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 267: flag=_wrap_PositionSemantics_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 268: flag=_wrap_delete_PositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 269: flag=_wrap_new_Position(resc,resv,argc,(mxArray**)(argv)); break;
-  case 270: flag=_wrap_Position_getSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 271: flag=_wrap_Position_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 272: flag=_wrap_Position_changeRefPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 273: flag=_wrap_Position_changeCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 274: flag=_wrap_Position_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 275: flag=_wrap_Position_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 276: flag=_wrap_Position_changePointOf(resc,resv,argc,(mxArray**)(argv)); break;
-  case 277: flag=_wrap_Position_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 278: flag=_wrap_Position_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 279: flag=_wrap_Position_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 280: flag=_wrap_Position_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 281: flag=_wrap_Position_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 282: flag=_wrap_Position_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 283: flag=_wrap_Position_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 284: flag=_wrap_delete_Position(resc,resv,argc,(mxArray**)(argv)); break;
-  case 285: flag=_wrap_new_GeomVector3Semantics__LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 286: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 287: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 288: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 289: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 290: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 291: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 292: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 293: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 294: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 295: flag=_wrap_delete_GeomVector3Semantics__LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 296: flag=_wrap_new_GeomVector3Semantics__AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 297: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 298: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 299: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 300: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 301: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 302: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 303: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 304: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 305: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 306: flag=_wrap_delete_GeomVector3Semantics__AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 307: flag=_wrap_new_GeomVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 308: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 309: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 310: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 311: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 312: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 313: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 314: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 315: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 316: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 317: flag=_wrap_delete_GeomVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 318: flag=_wrap_new_GeomVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 319: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 320: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 321: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 322: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 323: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 324: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 325: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 326: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 327: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 328: flag=_wrap_delete_GeomVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 329: flag=_wrap_GeomVector3__LinearMotionVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 330: flag=_wrap_GeomVector3__LinearMotionVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 331: flag=_wrap_new_GeomVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 332: flag=_wrap_GeomVector3__LinearMotionVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 333: flag=_wrap_GeomVector3__LinearMotionVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 334: flag=_wrap_GeomVector3__LinearMotionVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 335: flag=_wrap_GeomVector3__LinearMotionVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 336: flag=_wrap_GeomVector3__LinearMotionVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 337: flag=_wrap_GeomVector3__LinearMotionVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 338: flag=_wrap_GeomVector3__LinearMotionVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 339: flag=_wrap_GeomVector3__LinearMotionVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 340: flag=_wrap_delete_GeomVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 341: flag=_wrap_GeomVector3__AngularMotionVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 342: flag=_wrap_GeomVector3__AngularMotionVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 343: flag=_wrap_new_GeomVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 344: flag=_wrap_GeomVector3__AngularMotionVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 345: flag=_wrap_GeomVector3__AngularMotionVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 346: flag=_wrap_GeomVector3__AngularMotionVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 347: flag=_wrap_GeomVector3__AngularMotionVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 348: flag=_wrap_GeomVector3__AngularMotionVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 349: flag=_wrap_GeomVector3__AngularMotionVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 350: flag=_wrap_GeomVector3__AngularMotionVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 351: flag=_wrap_GeomVector3__AngularMotionVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 352: flag=_wrap_delete_GeomVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 353: flag=_wrap_GeomVector3__LinearForceVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 354: flag=_wrap_GeomVector3__LinearForceVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 355: flag=_wrap_new_GeomVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 356: flag=_wrap_GeomVector3__LinearForceVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 357: flag=_wrap_GeomVector3__LinearForceVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 358: flag=_wrap_GeomVector3__LinearForceVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 359: flag=_wrap_GeomVector3__LinearForceVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 360: flag=_wrap_GeomVector3__LinearForceVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 361: flag=_wrap_GeomVector3__LinearForceVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 362: flag=_wrap_GeomVector3__LinearForceVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 363: flag=_wrap_GeomVector3__LinearForceVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 364: flag=_wrap_delete_GeomVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 365: flag=_wrap_GeomVector3__AngularForceVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 366: flag=_wrap_GeomVector3__AngularForceVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 367: flag=_wrap_new_GeomVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 368: flag=_wrap_GeomVector3__AngularForceVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 369: flag=_wrap_GeomVector3__AngularForceVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 370: flag=_wrap_GeomVector3__AngularForceVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 371: flag=_wrap_GeomVector3__AngularForceVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 372: flag=_wrap_GeomVector3__AngularForceVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 373: flag=_wrap_GeomVector3__AngularForceVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 374: flag=_wrap_GeomVector3__AngularForceVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 375: flag=_wrap_GeomVector3__AngularForceVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 376: flag=_wrap_delete_GeomVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 377: flag=_wrap_new_ForceVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 378: flag=_wrap_ForceVector3Semantics__LinearForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 379: flag=_wrap_ForceVector3Semantics__LinearForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 380: flag=_wrap_delete_ForceVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 381: flag=_wrap_new_ForceVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 382: flag=_wrap_ForceVector3Semantics__AngularForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 383: flag=_wrap_ForceVector3Semantics__AngularForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 384: flag=_wrap_delete_ForceVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 385: flag=_wrap_new_MotionVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 386: flag=_wrap_MotionVector3__LinearMotionVector3_cross(resc,resv,argc,(mxArray**)(argv)); break;
-  case 387: flag=_wrap_delete_MotionVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 388: flag=_wrap_new_MotionVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 389: flag=_wrap_MotionVector3__AngularMotionVector3_cross(resc,resv,argc,(mxArray**)(argv)); break;
-  case 390: flag=_wrap_delete_MotionVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 391: flag=_wrap_new_ForceVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 392: flag=_wrap_delete_ForceVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 393: flag=_wrap_new_ForceVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 394: flag=_wrap_delete_ForceVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 395: flag=_wrap_new_LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 396: flag=_wrap_LinearMotionVector3Semantics_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 397: flag=_wrap_LinearMotionVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 398: flag=_wrap_delete_LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 399: flag=_wrap_new_LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 400: flag=_wrap_LinearMotionVector3_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 401: flag=_wrap_delete_LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 402: flag=_wrap_new_AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 403: flag=_wrap_delete_AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 404: flag=_wrap_new_AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 405: flag=_wrap_AngularMotionVector3_exp(resc,resv,argc,(mxArray**)(argv)); break;
-  case 406: flag=_wrap_delete_AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 407: flag=_wrap_new_LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 408: flag=_wrap_delete_LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 409: flag=_wrap_new_LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 410: flag=_wrap_delete_LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 411: flag=_wrap_new_AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 412: flag=_wrap_AngularForceVector3Semantics_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 413: flag=_wrap_AngularForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 414: flag=_wrap_delete_AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 415: flag=_wrap_new_AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 416: flag=_wrap_AngularForceVector3_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 417: flag=_wrap_delete_AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 418: flag=_wrap_new_SpatialMotionVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 419: flag=_wrap_SpatialMotionVectorSemanticsBase_check_linear2angularConsistency(resc,resv,argc,(mxArray**)(argv)); break;
-  case 420: flag=_wrap_SpatialMotionVectorSemanticsBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 421: flag=_wrap_SpatialMotionVectorSemanticsBase_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 422: flag=_wrap_delete_SpatialMotionVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 423: flag=_wrap_new_SpatialForceVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 424: flag=_wrap_SpatialForceVectorSemanticsBase_check_linear2angularConsistency(resc,resv,argc,(mxArray**)(argv)); break;
-  case 425: flag=_wrap_SpatialForceVectorSemanticsBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 426: flag=_wrap_SpatialForceVectorSemanticsBase_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 427: flag=_wrap_delete_SpatialForceVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 428: flag=_wrap_new_SpatialMotionVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 429: flag=_wrap_SpatialMotionVectorBase_getLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 430: flag=_wrap_SpatialMotionVectorBase_getAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 431: flag=_wrap_SpatialMotionVectorBase_setLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 432: flag=_wrap_SpatialMotionVectorBase_setAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 433: flag=_wrap_SpatialMotionVectorBase_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 434: flag=_wrap_SpatialMotionVectorBase_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 435: flag=_wrap_SpatialMotionVectorBase_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 436: flag=_wrap_SpatialMotionVectorBase_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 437: flag=_wrap_SpatialMotionVectorBase_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 438: flag=_wrap_SpatialMotionVectorBase_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 439: flag=_wrap_SpatialMotionVectorBase_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 440: flag=_wrap_SpatialMotionVectorBase_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 441: flag=_wrap_SpatialMotionVectorBase_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 442: flag=_wrap_SpatialMotionVectorBase_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 443: flag=_wrap_SpatialMotionVectorBase_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 444: flag=_wrap_SpatialMotionVectorBase_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 445: flag=_wrap_SpatialMotionVectorBase_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 446: flag=_wrap_SpatialMotionVectorBase_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 447: flag=_wrap_SpatialMotionVectorBase_asVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 448: flag=_wrap_SpatialMotionVectorBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 449: flag=_wrap_SpatialMotionVectorBase_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 450: flag=_wrap_SpatialMotionVectorBase_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 451: flag=_wrap_SpatialMotionVectorBase_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 452: flag=_wrap_delete_SpatialMotionVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 453: flag=_wrap_new_SpatialForceVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 454: flag=_wrap_SpatialForceVectorBase_getLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 455: flag=_wrap_SpatialForceVectorBase_getAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 456: flag=_wrap_SpatialForceVectorBase_setLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 457: flag=_wrap_SpatialForceVectorBase_setAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 458: flag=_wrap_SpatialForceVectorBase_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 459: flag=_wrap_SpatialForceVectorBase_getVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 460: flag=_wrap_SpatialForceVectorBase_setVal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 461: flag=_wrap_SpatialForceVectorBase_size(resc,resv,argc,(mxArray**)(argv)); break;
-  case 462: flag=_wrap_SpatialForceVectorBase_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 463: flag=_wrap_SpatialForceVectorBase_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 464: flag=_wrap_SpatialForceVectorBase_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 465: flag=_wrap_SpatialForceVectorBase_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 466: flag=_wrap_SpatialForceVectorBase_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 467: flag=_wrap_SpatialForceVectorBase_dot(resc,resv,argc,(mxArray**)(argv)); break;
-  case 468: flag=_wrap_SpatialForceVectorBase_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 469: flag=_wrap_SpatialForceVectorBase_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 470: flag=_wrap_SpatialForceVectorBase_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 471: flag=_wrap_SpatialForceVectorBase_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 472: flag=_wrap_SpatialForceVectorBase_asVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 473: flag=_wrap_SpatialForceVectorBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 474: flag=_wrap_SpatialForceVectorBase_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 475: flag=_wrap_SpatialForceVectorBase_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 476: flag=_wrap_SpatialForceVectorBase_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
-  case 477: flag=_wrap_delete_SpatialForceVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 478: flag=_wrap_new_Dummy(resc,resv,argc,(mxArray**)(argv)); break;
-  case 479: flag=_wrap_delete_Dummy(resc,resv,argc,(mxArray**)(argv)); break;
-  case 480: flag=_wrap_new_SpatialMotionVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 481: flag=_wrap_SpatialMotionVector_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 482: flag=_wrap_SpatialMotionVector_cross(resc,resv,argc,(mxArray**)(argv)); break;
-  case 483: flag=_wrap_SpatialMotionVector_asCrossProductMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 484: flag=_wrap_SpatialMotionVector_asCrossProductMatrixWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 485: flag=_wrap_SpatialMotionVector_exp(resc,resv,argc,(mxArray**)(argv)); break;
-  case 486: flag=_wrap_delete_SpatialMotionVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 487: flag=_wrap_new_SpatialForceVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 488: flag=_wrap_delete_SpatialForceVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 489: flag=_wrap_SpatialForceVector_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 490: flag=_wrap_new_Twist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 491: flag=_wrap_Twist_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 492: flag=_wrap_Twist_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 493: flag=_wrap_Twist_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 494: flag=_wrap_Twist_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 495: flag=_wrap_delete_Twist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 496: flag=_wrap_new_Wrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 497: flag=_wrap_Wrench_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 498: flag=_wrap_Wrench_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 499: flag=_wrap_Wrench_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 500: flag=_wrap_delete_Wrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 501: flag=_wrap_new_SpatialMomentum(resc,resv,argc,(mxArray**)(argv)); break;
-  case 502: flag=_wrap_SpatialMomentum_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 503: flag=_wrap_SpatialMomentum_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 504: flag=_wrap_SpatialMomentum_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 505: flag=_wrap_delete_SpatialMomentum(resc,resv,argc,(mxArray**)(argv)); break;
-  case 506: flag=_wrap_new_SpatialAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 507: flag=_wrap_SpatialAcc_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 508: flag=_wrap_SpatialAcc_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 509: flag=_wrap_SpatialAcc_uminus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 510: flag=_wrap_delete_SpatialAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 511: flag=_wrap_new_ClassicalAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 512: flag=_wrap_ClassicalAcc_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 513: flag=_wrap_ClassicalAcc_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 514: flag=_wrap_ClassicalAcc_fromSpatial(resc,resv,argc,(mxArray**)(argv)); break;
-  case 515: flag=_wrap_ClassicalAcc_toSpatial(resc,resv,argc,(mxArray**)(argv)); break;
-  case 516: flag=_wrap_delete_ClassicalAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 517: flag=_wrap_new_Direction(resc,resv,argc,(mxArray**)(argv)); break;
-  case 518: flag=_wrap_Direction_Normalize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 519: flag=_wrap_Direction_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 520: flag=_wrap_Direction_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 521: flag=_wrap_Direction_Default(resc,resv,argc,(mxArray**)(argv)); break;
-  case 522: flag=_wrap_delete_Direction(resc,resv,argc,(mxArray**)(argv)); break;
-  case 523: flag=_wrap_new_Axis(resc,resv,argc,(mxArray**)(argv)); break;
-  case 524: flag=_wrap_Axis_getDirection(resc,resv,argc,(mxArray**)(argv)); break;
-  case 525: flag=_wrap_Axis_getOrigin(resc,resv,argc,(mxArray**)(argv)); break;
-  case 526: flag=_wrap_Axis_setDirection(resc,resv,argc,(mxArray**)(argv)); break;
-  case 527: flag=_wrap_Axis_setOrigin(resc,resv,argc,(mxArray**)(argv)); break;
-  case 528: flag=_wrap_Axis_getRotationTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 529: flag=_wrap_Axis_getRotationTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 530: flag=_wrap_Axis_getRotationTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 531: flag=_wrap_Axis_getRotationSpatialAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 532: flag=_wrap_Axis_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 533: flag=_wrap_Axis_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 534: flag=_wrap_delete_Axis(resc,resv,argc,(mxArray**)(argv)); break;
-  case 535: flag=_wrap_new_RotationalInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 536: flag=_wrap_RotationalInertiaRaw_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 537: flag=_wrap_delete_RotationalInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 538: flag=_wrap_new_SpatialInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 539: flag=_wrap_SpatialInertiaRaw_fromRotationalInertiaWrtCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
-  case 540: flag=_wrap_SpatialInertiaRaw_getMass(resc,resv,argc,(mxArray**)(argv)); break;
-  case 541: flag=_wrap_SpatialInertiaRaw_getCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
-  case 542: flag=_wrap_SpatialInertiaRaw_getRotationalInertiaWrtFrameOrigin(resc,resv,argc,(mxArray**)(argv)); break;
-  case 543: flag=_wrap_SpatialInertiaRaw_getRotationalInertiaWrtCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
-  case 544: flag=_wrap_SpatialInertiaRaw_combine(resc,resv,argc,(mxArray**)(argv)); break;
-  case 545: flag=_wrap_SpatialInertiaRaw_multiply(resc,resv,argc,(mxArray**)(argv)); break;
-  case 546: flag=_wrap_SpatialInertiaRaw_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 547: flag=_wrap_delete_SpatialInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 548: flag=_wrap_new_SpatialInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 549: flag=_wrap_SpatialInertia_combine(resc,resv,argc,(mxArray**)(argv)); break;
-  case 550: flag=_wrap_SpatialInertia_asMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 551: flag=_wrap_SpatialInertia_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 552: flag=_wrap_SpatialInertia_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 553: flag=_wrap_SpatialInertia_biasWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 554: flag=_wrap_SpatialInertia_biasWrenchDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 555: flag=_wrap_SpatialInertia_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 556: flag=_wrap_SpatialInertia_asVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 557: flag=_wrap_SpatialInertia_fromVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 558: flag=_wrap_SpatialInertia_isPhysicallyConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 559: flag=_wrap_SpatialInertia_momentumRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 560: flag=_wrap_SpatialInertia_momentumDerivativeRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 561: flag=_wrap_SpatialInertia_momentumDerivativeSlotineLiRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 562: flag=_wrap_delete_SpatialInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 563: flag=_wrap_new_ArticulatedBodyInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 564: flag=_wrap_ArticulatedBodyInertia_getLinearLinearSubmatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 565: flag=_wrap_ArticulatedBodyInertia_getLinearAngularSubmatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 566: flag=_wrap_ArticulatedBodyInertia_getAngularAngularSubmatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 567: flag=_wrap_ArticulatedBodyInertia_combine(resc,resv,argc,(mxArray**)(argv)); break;
-  case 568: flag=_wrap_ArticulatedBodyInertia_applyInverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 569: flag=_wrap_ArticulatedBodyInertia_asMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 570: flag=_wrap_ArticulatedBodyInertia_getInverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 571: flag=_wrap_ArticulatedBodyInertia_plus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 572: flag=_wrap_ArticulatedBodyInertia_minus(resc,resv,argc,(mxArray**)(argv)); break;
-  case 573: flag=_wrap_ArticulatedBodyInertia_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 574: flag=_wrap_ArticulatedBodyInertia_zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 575: flag=_wrap_ArticulatedBodyInertia_ABADyadHelper(resc,resv,argc,(mxArray**)(argv)); break;
-  case 576: flag=_wrap_ArticulatedBodyInertia_ABADyadHelperLin(resc,resv,argc,(mxArray**)(argv)); break;
-  case 577: flag=_wrap_delete_ArticulatedBodyInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 578: flag=_wrap_new_RotationRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 579: flag=_wrap_RotationRaw_changeOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 580: flag=_wrap_RotationRaw_changeRefOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 581: flag=_wrap_RotationRaw_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 582: flag=_wrap_RotationRaw_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
-  case 583: flag=_wrap_RotationRaw_changeCoordFrameOf(resc,resv,argc,(mxArray**)(argv)); break;
-  case 584: flag=_wrap_RotationRaw_RotX(resc,resv,argc,(mxArray**)(argv)); break;
-  case 585: flag=_wrap_RotationRaw_RotY(resc,resv,argc,(mxArray**)(argv)); break;
-  case 586: flag=_wrap_RotationRaw_RotZ(resc,resv,argc,(mxArray**)(argv)); break;
-  case 587: flag=_wrap_RotationRaw_RPY(resc,resv,argc,(mxArray**)(argv)); break;
-  case 588: flag=_wrap_RotationRaw_Identity(resc,resv,argc,(mxArray**)(argv)); break;
-  case 589: flag=_wrap_RotationRaw_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 590: flag=_wrap_RotationRaw_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 591: flag=_wrap_delete_RotationRaw(resc,resv,argc,(mxArray**)(argv)); break;
-  case 592: flag=_wrap_new_RotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 593: flag=_wrap_RotationSemantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
-  case 594: flag=_wrap_RotationSemantics_getOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 595: flag=_wrap_RotationSemantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 596: flag=_wrap_RotationSemantics_getReferenceOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 597: flag=_wrap_RotationSemantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 598: flag=_wrap_RotationSemantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 599: flag=_wrap_RotationSemantics_setOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 600: flag=_wrap_RotationSemantics_setBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 601: flag=_wrap_RotationSemantics_setReferenceOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 602: flag=_wrap_RotationSemantics_setRefBody(resc,resv,argc,(mxArray**)(argv)); break;
-  case 603: flag=_wrap_RotationSemantics_setCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 604: flag=_wrap_RotationSemantics_changeOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 605: flag=_wrap_RotationSemantics_changeRefOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 606: flag=_wrap_RotationSemantics_changeCoordFrameOf(resc,resv,argc,(mxArray**)(argv)); break;
-  case 607: flag=_wrap_RotationSemantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 608: flag=_wrap_RotationSemantics_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
-  case 609: flag=_wrap_RotationSemantics_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 610: flag=_wrap_RotationSemantics_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 611: flag=_wrap_delete_RotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 612: flag=_wrap_new_Rotation(resc,resv,argc,(mxArray**)(argv)); break;
-  case 613: flag=_wrap_Rotation_getSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 614: flag=_wrap_Rotation_changeOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 615: flag=_wrap_Rotation_changeRefOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 616: flag=_wrap_Rotation_changeCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 617: flag=_wrap_Rotation_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 618: flag=_wrap_Rotation_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
-  case 619: flag=_wrap_Rotation_changeCoordFrameOf(resc,resv,argc,(mxArray**)(argv)); break;
-  case 620: flag=_wrap_Rotation_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 621: flag=_wrap_Rotation_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 622: flag=_wrap_Rotation_log(resc,resv,argc,(mxArray**)(argv)); break;
-  case 623: flag=_wrap_Rotation_fromQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
-  case 624: flag=_wrap_Rotation_getRPY(resc,resv,argc,(mxArray**)(argv)); break;
-  case 625: flag=_wrap_Rotation_asRPY(resc,resv,argc,(mxArray**)(argv)); break;
-  case 626: flag=_wrap_Rotation_getQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
-  case 627: flag=_wrap_Rotation_asQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
-  case 628: flag=_wrap_Rotation_RotX(resc,resv,argc,(mxArray**)(argv)); break;
-  case 629: flag=_wrap_Rotation_RotY(resc,resv,argc,(mxArray**)(argv)); break;
-  case 630: flag=_wrap_Rotation_RotZ(resc,resv,argc,(mxArray**)(argv)); break;
-  case 631: flag=_wrap_Rotation_RotAxis(resc,resv,argc,(mxArray**)(argv)); break;
-  case 632: flag=_wrap_Rotation_RotAxisDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 633: flag=_wrap_Rotation_RPY(resc,resv,argc,(mxArray**)(argv)); break;
-  case 634: flag=_wrap_Rotation_Identity(resc,resv,argc,(mxArray**)(argv)); break;
-  case 635: flag=_wrap_Rotation_RotationFromQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
-  case 636: flag=_wrap_Rotation_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 637: flag=_wrap_Rotation_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 638: flag=_wrap_delete_Rotation(resc,resv,argc,(mxArray**)(argv)); break;
-  case 639: flag=_wrap_new_TransformSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 640: flag=_wrap_TransformSemantics_getRotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 641: flag=_wrap_TransformSemantics_getPositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 642: flag=_wrap_TransformSemantics_setRotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 643: flag=_wrap_TransformSemantics_setPositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 644: flag=_wrap_TransformSemantics_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 645: flag=_wrap_TransformSemantics_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 646: flag=_wrap_delete_TransformSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 647: flag=_wrap_new_Transform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 648: flag=_wrap_Transform_getSemantics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 649: flag=_wrap_Transform_getRotation(resc,resv,argc,(mxArray**)(argv)); break;
-  case 650: flag=_wrap_Transform_getPosition(resc,resv,argc,(mxArray**)(argv)); break;
-  case 651: flag=_wrap_Transform_setRotation(resc,resv,argc,(mxArray**)(argv)); break;
-  case 652: flag=_wrap_Transform_setPosition(resc,resv,argc,(mxArray**)(argv)); break;
-  case 653: flag=_wrap_Transform_compose(resc,resv,argc,(mxArray**)(argv)); break;
-  case 654: flag=_wrap_Transform_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
-  case 655: flag=_wrap_Transform_inverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 656: flag=_wrap_Transform_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 657: flag=_wrap_Transform_Identity(resc,resv,argc,(mxArray**)(argv)); break;
-  case 658: flag=_wrap_Transform_asHomogeneousTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 659: flag=_wrap_Transform_asAdjointTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 660: flag=_wrap_Transform_asAdjointTransformWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 661: flag=_wrap_Transform_log(resc,resv,argc,(mxArray**)(argv)); break;
-  case 662: flag=_wrap_Transform_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 663: flag=_wrap_Transform_display(resc,resv,argc,(mxArray**)(argv)); break;
-  case 664: flag=_wrap_delete_Transform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 665: flag=_wrap_new_TransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 666: flag=_wrap_delete_TransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 667: flag=_wrap_TransformDerivative_getRotationDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 668: flag=_wrap_TransformDerivative_getPositionDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 669: flag=_wrap_TransformDerivative_setRotationDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 670: flag=_wrap_TransformDerivative_setPositionDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 671: flag=_wrap_TransformDerivative_Zero(resc,resv,argc,(mxArray**)(argv)); break;
-  case 672: flag=_wrap_TransformDerivative_asHomogeneousTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 673: flag=_wrap_TransformDerivative_asAdjointTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 674: flag=_wrap_TransformDerivative_asAdjointTransformWrenchDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 675: flag=_wrap_TransformDerivative_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
-  case 676: flag=_wrap_TransformDerivative_derivativeOfInverse(resc,resv,argc,(mxArray**)(argv)); break;
-  case 677: flag=_wrap_TransformDerivative_transform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 678: flag=_wrap_LINK_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 679: flag=_wrap_LINK_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 680: flag=_wrap_LINK_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 681: flag=_wrap_LINK_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 682: flag=_wrap_JOINT_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 683: flag=_wrap_JOINT_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 684: flag=_wrap_JOINT_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 685: flag=_wrap_JOINT_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 686: flag=_wrap_DOF_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 687: flag=_wrap_DOF_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 688: flag=_wrap_DOF_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 689: flag=_wrap_DOF_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 690: flag=_wrap_FRAME_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 691: flag=_wrap_FRAME_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 692: flag=_wrap_FRAME_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 693: flag=_wrap_FRAME_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 694: flag=_wrap_TRAVERSAL_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 695: flag=_wrap_TRAVERSAL_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 696: flag=_wrap_new_LinkPositions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 697: flag=_wrap_LinkPositions_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 698: flag=_wrap_LinkPositions_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 699: flag=_wrap_LinkPositions_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 700: flag=_wrap_LinkPositions_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 701: flag=_wrap_LinkPositions_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 702: flag=_wrap_delete_LinkPositions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 703: flag=_wrap_new_LinkWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 704: flag=_wrap_LinkWrenches_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 705: flag=_wrap_LinkWrenches_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 706: flag=_wrap_LinkWrenches_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 707: flag=_wrap_LinkWrenches_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 708: flag=_wrap_LinkWrenches_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 709: flag=_wrap_delete_LinkWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 710: flag=_wrap_new_LinkInertias(resc,resv,argc,(mxArray**)(argv)); break;
-  case 711: flag=_wrap_LinkInertias_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 712: flag=_wrap_LinkInertias_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 713: flag=_wrap_LinkInertias_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 714: flag=_wrap_delete_LinkInertias(resc,resv,argc,(mxArray**)(argv)); break;
-  case 715: flag=_wrap_new_LinkArticulatedBodyInertias(resc,resv,argc,(mxArray**)(argv)); break;
-  case 716: flag=_wrap_LinkArticulatedBodyInertias_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 717: flag=_wrap_LinkArticulatedBodyInertias_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 718: flag=_wrap_LinkArticulatedBodyInertias_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 719: flag=_wrap_delete_LinkArticulatedBodyInertias(resc,resv,argc,(mxArray**)(argv)); break;
-  case 720: flag=_wrap_new_LinkVelArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 721: flag=_wrap_LinkVelArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 722: flag=_wrap_LinkVelArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 723: flag=_wrap_LinkVelArray_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 724: flag=_wrap_LinkVelArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 725: flag=_wrap_LinkVelArray_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 726: flag=_wrap_delete_LinkVelArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 727: flag=_wrap_new_LinkAccArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 728: flag=_wrap_LinkAccArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 729: flag=_wrap_LinkAccArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 730: flag=_wrap_LinkAccArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 731: flag=_wrap_LinkAccArray_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 732: flag=_wrap_LinkAccArray_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 733: flag=_wrap_delete_LinkAccArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 734: flag=_wrap_new_Link(resc,resv,argc,(mxArray**)(argv)); break;
-  case 735: flag=_wrap_Link_inertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 736: flag=_wrap_Link_setInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 737: flag=_wrap_Link_getInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 738: flag=_wrap_Link_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 739: flag=_wrap_Link_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 740: flag=_wrap_delete_Link(resc,resv,argc,(mxArray**)(argv)); break;
-  case 741: flag=_wrap_delete_IJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 742: flag=_wrap_IJoint_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 743: flag=_wrap_IJoint_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 744: flag=_wrap_IJoint_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 745: flag=_wrap_IJoint_setAttachedLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 746: flag=_wrap_IJoint_setRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 747: flag=_wrap_IJoint_getFirstAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 748: flag=_wrap_IJoint_getSecondAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 749: flag=_wrap_IJoint_getRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 750: flag=_wrap_IJoint_getTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 751: flag=_wrap_IJoint_getTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 752: flag=_wrap_IJoint_getMotionSubspaceVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 753: flag=_wrap_IJoint_computeChildPosVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 754: flag=_wrap_IJoint_computeChildVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 755: flag=_wrap_IJoint_computeChildVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 756: flag=_wrap_IJoint_computeJointTorque(resc,resv,argc,(mxArray**)(argv)); break;
-  case 757: flag=_wrap_IJoint_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 758: flag=_wrap_IJoint_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 759: flag=_wrap_IJoint_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 760: flag=_wrap_IJoint_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 761: flag=_wrap_IJoint_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 762: flag=_wrap_IJoint_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 763: flag=_wrap_IJoint_isRevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 764: flag=_wrap_IJoint_isFixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 765: flag=_wrap_IJoint_asRevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 766: flag=_wrap_IJoint_asFixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 767: flag=_wrap_new_FixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 768: flag=_wrap_delete_FixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 769: flag=_wrap_FixedJoint_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 770: flag=_wrap_FixedJoint_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 771: flag=_wrap_FixedJoint_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 772: flag=_wrap_FixedJoint_setAttachedLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 773: flag=_wrap_FixedJoint_setRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 774: flag=_wrap_FixedJoint_getFirstAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 775: flag=_wrap_FixedJoint_getSecondAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 776: flag=_wrap_FixedJoint_getRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 777: flag=_wrap_FixedJoint_getTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 778: flag=_wrap_FixedJoint_getTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 779: flag=_wrap_FixedJoint_getMotionSubspaceVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 780: flag=_wrap_FixedJoint_computeChildPosVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 781: flag=_wrap_FixedJoint_computeChildVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 782: flag=_wrap_FixedJoint_computeChildVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 783: flag=_wrap_FixedJoint_computeJointTorque(resc,resv,argc,(mxArray**)(argv)); break;
-  case 784: flag=_wrap_FixedJoint_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 785: flag=_wrap_FixedJoint_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 786: flag=_wrap_FixedJoint_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 787: flag=_wrap_FixedJoint_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 788: flag=_wrap_FixedJoint_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 789: flag=_wrap_FixedJoint_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 790: flag=_wrap_delete_MovableJointImpl1(resc,resv,argc,(mxArray**)(argv)); break;
-  case 791: flag=_wrap_MovableJointImpl1_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 792: flag=_wrap_MovableJointImpl1_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 793: flag=_wrap_MovableJointImpl1_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 794: flag=_wrap_MovableJointImpl1_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 795: flag=_wrap_MovableJointImpl1_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 796: flag=_wrap_MovableJointImpl1_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 797: flag=_wrap_MovableJointImpl1_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 798: flag=_wrap_MovableJointImpl1_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 799: flag=_wrap_delete_MovableJointImpl2(resc,resv,argc,(mxArray**)(argv)); break;
-  case 800: flag=_wrap_MovableJointImpl2_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 801: flag=_wrap_MovableJointImpl2_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 802: flag=_wrap_MovableJointImpl2_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 803: flag=_wrap_MovableJointImpl2_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 804: flag=_wrap_MovableJointImpl2_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 805: flag=_wrap_MovableJointImpl2_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 806: flag=_wrap_MovableJointImpl2_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 807: flag=_wrap_MovableJointImpl2_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 808: flag=_wrap_delete_MovableJointImpl3(resc,resv,argc,(mxArray**)(argv)); break;
-  case 809: flag=_wrap_MovableJointImpl3_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 810: flag=_wrap_MovableJointImpl3_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 811: flag=_wrap_MovableJointImpl3_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 812: flag=_wrap_MovableJointImpl3_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 813: flag=_wrap_MovableJointImpl3_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 814: flag=_wrap_MovableJointImpl3_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 815: flag=_wrap_MovableJointImpl3_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 816: flag=_wrap_MovableJointImpl3_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 817: flag=_wrap_delete_MovableJointImpl4(resc,resv,argc,(mxArray**)(argv)); break;
-  case 818: flag=_wrap_MovableJointImpl4_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 819: flag=_wrap_MovableJointImpl4_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 820: flag=_wrap_MovableJointImpl4_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 821: flag=_wrap_MovableJointImpl4_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 822: flag=_wrap_MovableJointImpl4_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 823: flag=_wrap_MovableJointImpl4_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 824: flag=_wrap_MovableJointImpl4_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 825: flag=_wrap_MovableJointImpl4_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 826: flag=_wrap_delete_MovableJointImpl5(resc,resv,argc,(mxArray**)(argv)); break;
-  case 827: flag=_wrap_MovableJointImpl5_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 828: flag=_wrap_MovableJointImpl5_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 829: flag=_wrap_MovableJointImpl5_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 830: flag=_wrap_MovableJointImpl5_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 831: flag=_wrap_MovableJointImpl5_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 832: flag=_wrap_MovableJointImpl5_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 833: flag=_wrap_MovableJointImpl5_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 834: flag=_wrap_MovableJointImpl5_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 835: flag=_wrap_delete_MovableJointImpl6(resc,resv,argc,(mxArray**)(argv)); break;
-  case 836: flag=_wrap_MovableJointImpl6_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 837: flag=_wrap_MovableJointImpl6_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 838: flag=_wrap_MovableJointImpl6_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 839: flag=_wrap_MovableJointImpl6_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 840: flag=_wrap_MovableJointImpl6_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 841: flag=_wrap_MovableJointImpl6_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 842: flag=_wrap_MovableJointImpl6_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 843: flag=_wrap_MovableJointImpl6_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 844: flag=_wrap_new_RevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 845: flag=_wrap_delete_RevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 846: flag=_wrap_RevoluteJoint_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 847: flag=_wrap_RevoluteJoint_setAttachedLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 848: flag=_wrap_RevoluteJoint_setRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 849: flag=_wrap_RevoluteJoint_setAxis(resc,resv,argc,(mxArray**)(argv)); break;
-  case 850: flag=_wrap_RevoluteJoint_getFirstAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 851: flag=_wrap_RevoluteJoint_getSecondAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 852: flag=_wrap_RevoluteJoint_getAxis(resc,resv,argc,(mxArray**)(argv)); break;
-  case 853: flag=_wrap_RevoluteJoint_getRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 854: flag=_wrap_RevoluteJoint_getTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 855: flag=_wrap_RevoluteJoint_getTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
-  case 856: flag=_wrap_RevoluteJoint_getMotionSubspaceVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 857: flag=_wrap_RevoluteJoint_computeChildPosVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 858: flag=_wrap_RevoluteJoint_computeChildVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 859: flag=_wrap_RevoluteJoint_computeChildVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 860: flag=_wrap_RevoluteJoint_computeJointTorque(resc,resv,argc,(mxArray**)(argv)); break;
-  case 861: flag=_wrap_new_Traversal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 862: flag=_wrap_delete_Traversal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 863: flag=_wrap_Traversal_getNrOfVisitedLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 864: flag=_wrap_Traversal_getLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 865: flag=_wrap_Traversal_getBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 866: flag=_wrap_Traversal_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 867: flag=_wrap_Traversal_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 868: flag=_wrap_Traversal_getParentLinkFromLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 869: flag=_wrap_Traversal_getParentJointFromLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 870: flag=_wrap_Traversal_getTraversalIndexFromLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 871: flag=_wrap_Traversal_reset(resc,resv,argc,(mxArray**)(argv)); break;
-  case 872: flag=_wrap_Traversal_addTraversalBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 873: flag=_wrap_Traversal_addTraversalElement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 874: flag=_wrap_Traversal_isParentOf(resc,resv,argc,(mxArray**)(argv)); break;
-  case 875: flag=_wrap_Traversal_getChildLinkIndexFromJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 876: flag=_wrap_Traversal_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 877: flag=_wrap_Neighbor_neighborLink_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 878: flag=_wrap_Neighbor_neighborLink_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 879: flag=_wrap_Neighbor_neighborJoint_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 880: flag=_wrap_Neighbor_neighborJoint_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 881: flag=_wrap_new_Neighbor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 882: flag=_wrap_delete_Neighbor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 883: flag=_wrap_new_Model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 884: flag=_wrap_delete_Model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 885: flag=_wrap_Model_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 886: flag=_wrap_Model_getLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 887: flag=_wrap_Model_getLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 888: flag=_wrap_Model_isValidLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 889: flag=_wrap_Model_getLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 890: flag=_wrap_Model_addLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 891: flag=_wrap_Model_getNrOfJoints(resc,resv,argc,(mxArray**)(argv)); break;
-  case 892: flag=_wrap_Model_getJointName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 893: flag=_wrap_Model_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 894: flag=_wrap_Model_getJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 895: flag=_wrap_Model_isValidJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 896: flag=_wrap_Model_isLinkNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
-  case 897: flag=_wrap_Model_isJointNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
-  case 898: flag=_wrap_Model_isFrameNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
-  case 899: flag=_wrap_Model_addJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 900: flag=_wrap_Model_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 901: flag=_wrap_Model_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 902: flag=_wrap_Model_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
-  case 903: flag=_wrap_Model_addAdditionalFrameToLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 904: flag=_wrap_Model_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 905: flag=_wrap_Model_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 906: flag=_wrap_Model_isValidFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 907: flag=_wrap_Model_getFrameTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 908: flag=_wrap_Model_getFrameLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 909: flag=_wrap_Model_getNrOfNeighbors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 910: flag=_wrap_Model_getNeighbor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 911: flag=_wrap_Model_setDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 912: flag=_wrap_Model_getDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 913: flag=_wrap_Model_computeFullTreeTraversal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 914: flag=_wrap_Model_getInertialParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 915: flag=_wrap_Model_updateInertialParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 916: flag=_wrap_Model_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 917: flag=_wrap_new_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 918: flag=_wrap_JointPosDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 919: flag=_wrap_JointPosDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 920: flag=_wrap_delete_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 921: flag=_wrap_new_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 922: flag=_wrap_JointDOFsDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 923: flag=_wrap_JointDOFsDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 924: flag=_wrap_delete_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 925: flag=_wrap_new_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 926: flag=_wrap_DOFSpatialForceArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 927: flag=_wrap_DOFSpatialForceArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 928: flag=_wrap_DOFSpatialForceArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 929: flag=_wrap_delete_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 930: flag=_wrap_new_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 931: flag=_wrap_DOFSpatialMotionArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 932: flag=_wrap_DOFSpatialMotionArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 933: flag=_wrap_DOFSpatialMotionArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
-  case 934: flag=_wrap_delete_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
-  case 935: flag=_wrap_new_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 936: flag=_wrap_FreeFloatingMassMatrix_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 937: flag=_wrap_delete_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 938: flag=_wrap_new_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 939: flag=_wrap_FreeFloatingPos_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 940: flag=_wrap_FreeFloatingPos_worldBasePos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 941: flag=_wrap_FreeFloatingPos_jointPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 942: flag=_wrap_FreeFloatingPos_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
-  case 943: flag=_wrap_delete_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 944: flag=_wrap_new_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 945: flag=_wrap_FreeFloatingGeneralizedTorques_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 946: flag=_wrap_FreeFloatingGeneralizedTorques_baseWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 947: flag=_wrap_FreeFloatingGeneralizedTorques_jointTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 948: flag=_wrap_FreeFloatingGeneralizedTorques_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 949: flag=_wrap_delete_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 950: flag=_wrap_new_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 951: flag=_wrap_FreeFloatingVel_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 952: flag=_wrap_FreeFloatingVel_baseVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 953: flag=_wrap_FreeFloatingVel_jointVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 954: flag=_wrap_FreeFloatingVel_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 955: flag=_wrap_delete_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 956: flag=_wrap_new_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 957: flag=_wrap_FreeFloatingAcc_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 958: flag=_wrap_FreeFloatingAcc_baseAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 959: flag=_wrap_FreeFloatingAcc_jointAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 960: flag=_wrap_FreeFloatingAcc_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 961: flag=_wrap_delete_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
-  case 962: flag=_wrap_ContactWrench_contactId(resc,resv,argc,(mxArray**)(argv)); break;
-  case 963: flag=_wrap_ContactWrench_contactPoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 964: flag=_wrap_ContactWrench_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 965: flag=_wrap_new_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 966: flag=_wrap_delete_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 967: flag=_wrap_new_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 968: flag=_wrap_LinkContactWrenches_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 969: flag=_wrap_LinkContactWrenches_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 970: flag=_wrap_LinkContactWrenches_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 971: flag=_wrap_LinkContactWrenches_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 972: flag=_wrap_LinkContactWrenches_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 973: flag=_wrap_LinkContactWrenches_computeNetWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 974: flag=_wrap_LinkContactWrenches_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 975: flag=_wrap_delete_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 976: flag=_wrap_ForwardPositionKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 977: flag=_wrap_ForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 978: flag=_wrap_ForwardPosVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 979: flag=_wrap_RNEADynamicPhase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 980: flag=_wrap_CompositeRigidBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
-  case 981: flag=_wrap_new_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 982: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 983: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 984: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 985: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 986: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 987: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 988: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 989: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 990: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 991: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 992: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 993: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 994: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 995: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 996: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 997: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 998: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 999: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1000: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1001: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1002: flag=_wrap_delete_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1003: flag=_wrap_ArticulatedBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1004: flag=_wrap_NR_OF_SENSOR_TYPES_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1005: flag=_wrap_isLinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1006: flag=_wrap_isJointSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1007: flag=_wrap_getSensorTypeSize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1008: flag=_wrap_delete_Sensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1009: flag=_wrap_Sensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1010: flag=_wrap_Sensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1011: flag=_wrap_Sensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1012: flag=_wrap_Sensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1013: flag=_wrap_Sensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1014: flag=_wrap_Sensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1015: flag=_wrap_delete_JointSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1016: flag=_wrap_JointSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1017: flag=_wrap_JointSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1018: flag=_wrap_JointSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1019: flag=_wrap_JointSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1020: flag=_wrap_delete_LinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1021: flag=_wrap_LinkSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1022: flag=_wrap_LinkSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1023: flag=_wrap_LinkSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1024: flag=_wrap_LinkSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1025: flag=_wrap_LinkSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1026: flag=_wrap_new_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1027: flag=_wrap_delete_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1028: flag=_wrap_SensorsList_addSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1029: flag=_wrap_SensorsList_setSerialization(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1030: flag=_wrap_SensorsList_getSerialization(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1031: flag=_wrap_SensorsList_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1032: flag=_wrap_SensorsList_getSensorIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1033: flag=_wrap_SensorsList_getSizeOfAllSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1034: flag=_wrap_SensorsList_getSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1035: flag=_wrap_SensorsList_removeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1036: flag=_wrap_SensorsList_removeAllSensorsOfType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1037: flag=_wrap_SensorsList_getSixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1038: flag=_wrap_SensorsList_getAccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1039: flag=_wrap_SensorsList_getGyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1040: flag=_wrap_new_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1041: flag=_wrap_delete_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1042: flag=_wrap_SensorsMeasurements_setNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1043: flag=_wrap_SensorsMeasurements_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1044: flag=_wrap_SensorsMeasurements_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1045: flag=_wrap_SensorsMeasurements_toVector(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1046: flag=_wrap_SensorsMeasurements_setMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1047: flag=_wrap_SensorsMeasurements_getMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1048: flag=_wrap_SensorsMeasurements_getSizeOfAllSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1049: flag=_wrap_new_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1050: flag=_wrap_delete_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1051: flag=_wrap_SixAxisForceTorqueSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1052: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1053: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1054: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1055: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1056: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1057: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1058: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1059: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1060: flag=_wrap_SixAxisForceTorqueSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1061: flag=_wrap_SixAxisForceTorqueSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1062: flag=_wrap_SixAxisForceTorqueSensor_setAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1063: flag=_wrap_SixAxisForceTorqueSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1064: flag=_wrap_SixAxisForceTorqueSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1065: flag=_wrap_SixAxisForceTorqueSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1066: flag=_wrap_SixAxisForceTorqueSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1067: flag=_wrap_SixAxisForceTorqueSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1068: flag=_wrap_SixAxisForceTorqueSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1069: flag=_wrap_SixAxisForceTorqueSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1070: flag=_wrap_SixAxisForceTorqueSensor_getAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1071: flag=_wrap_SixAxisForceTorqueSensor_isLinkAttachedToSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1072: flag=_wrap_SixAxisForceTorqueSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1073: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1074: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLinkMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1075: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLinkInverseMatrix(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1076: flag=_wrap_SixAxisForceTorqueSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1077: flag=_wrap_SixAxisForceTorqueSensor_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1078: flag=_wrap_new_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1079: flag=_wrap_delete_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1080: flag=_wrap_AccelerometerSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1081: flag=_wrap_AccelerometerSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1082: flag=_wrap_AccelerometerSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1083: flag=_wrap_AccelerometerSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1084: flag=_wrap_AccelerometerSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1085: flag=_wrap_AccelerometerSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1086: flag=_wrap_AccelerometerSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1087: flag=_wrap_AccelerometerSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1088: flag=_wrap_AccelerometerSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1089: flag=_wrap_AccelerometerSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1090: flag=_wrap_AccelerometerSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1091: flag=_wrap_AccelerometerSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1092: flag=_wrap_AccelerometerSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1093: flag=_wrap_new_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1094: flag=_wrap_delete_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1095: flag=_wrap_GyroscopeSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1096: flag=_wrap_GyroscopeSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1097: flag=_wrap_GyroscopeSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1098: flag=_wrap_GyroscopeSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1099: flag=_wrap_GyroscopeSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1100: flag=_wrap_GyroscopeSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1101: flag=_wrap_GyroscopeSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1102: flag=_wrap_GyroscopeSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1103: flag=_wrap_GyroscopeSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1104: flag=_wrap_GyroscopeSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1105: flag=_wrap_GyroscopeSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1106: flag=_wrap_GyroscopeSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1107: flag=_wrap_GyroscopeSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1108: flag=_wrap_predictSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1109: flag=_wrap_predictSensorsMeasurementsFromRawBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1110: flag=_wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1111: flag=_wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1112: flag=_wrap_new_URDFParserOptions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1113: flag=_wrap_delete_URDFParserOptions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1114: flag=_wrap_modelFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1115: flag=_wrap_modelFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1116: flag=_wrap_sensorsFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1117: flag=_wrap_sensorsFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1118: flag=_wrap_new_ModelLoader(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1119: flag=_wrap_ModelLoader_loadModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1120: flag=_wrap_ModelLoader_loadModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1121: flag=_wrap_ModelLoader_loadReducedModelFromFullModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1122: flag=_wrap_ModelLoader_loadReducedModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1123: flag=_wrap_ModelLoader_loadReducedModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1124: flag=_wrap_ModelLoader_model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1125: flag=_wrap_ModelLoader_sensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1126: flag=_wrap_ModelLoader_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1127: flag=_wrap_delete_ModelLoader(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1128: flag=_wrap_new_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1129: flag=_wrap_UnknownWrenchContact_unknownType_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1130: flag=_wrap_UnknownWrenchContact_unknownType_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1131: flag=_wrap_UnknownWrenchContact_contactPoint_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1132: flag=_wrap_UnknownWrenchContact_contactPoint_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1133: flag=_wrap_UnknownWrenchContact_forceDirection_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1134: flag=_wrap_UnknownWrenchContact_forceDirection_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1135: flag=_wrap_UnknownWrenchContact_contactId_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1136: flag=_wrap_UnknownWrenchContact_contactId_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1137: flag=_wrap_delete_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1138: flag=_wrap_new_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1139: flag=_wrap_LinkUnknownWrenchContacts_clear(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1140: flag=_wrap_LinkUnknownWrenchContacts_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1141: flag=_wrap_LinkUnknownWrenchContacts_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1142: flag=_wrap_LinkUnknownWrenchContacts_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1143: flag=_wrap_LinkUnknownWrenchContacts_addNewContactForLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1144: flag=_wrap_LinkUnknownWrenchContacts_addNewContactInFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1145: flag=_wrap_LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1146: flag=_wrap_LinkUnknownWrenchContacts_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1147: flag=_wrap_LinkUnknownWrenchContacts_toString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1148: flag=_wrap_delete_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1149: flag=_wrap_new_LinkTraversalsCache(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1150: flag=_wrap_delete_LinkTraversalsCache(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1151: flag=_wrap_LinkTraversalsCache_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1152: flag=_wrap_LinkTraversalsCache_getTraversalWithLinkAsBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1153: flag=_wrap_new_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1154: flag=_wrap_estimateExternalWrenchesBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1155: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfSubModels(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1156: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1157: flag=_wrap_estimateExternalWrenchesBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1158: flag=_wrap_estimateExternalWrenchesBuffers_A_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1159: flag=_wrap_estimateExternalWrenchesBuffers_A_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1160: flag=_wrap_estimateExternalWrenchesBuffers_x_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1161: flag=_wrap_estimateExternalWrenchesBuffers_x_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1162: flag=_wrap_estimateExternalWrenchesBuffers_b_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1163: flag=_wrap_estimateExternalWrenchesBuffers_b_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1164: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1165: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1166: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1167: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1168: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1169: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1170: flag=_wrap_delete_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1171: flag=_wrap_estimateExternalWrenchesWithoutInternalFT(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1172: flag=_wrap_estimateExternalWrenches(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1173: flag=_wrap_dynamicsEstimationForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1174: flag=_wrap_dynamicsEstimationForwardVelKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1175: flag=_wrap_computeLinkNetWrenchesWithoutGravity(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1176: flag=_wrap_new_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1177: flag=_wrap_delete_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1178: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_setModelAndSensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1179: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1180: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1181: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1182: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_sensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1183: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_submodels(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1184: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1185: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1186: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1187: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1188: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1189: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1190: flag=_wrap_new_SimpleLeggedOdometry(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1191: flag=_wrap_delete_SimpleLeggedOdometry(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1192: flag=_wrap_SimpleLeggedOdometry_setModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1193: flag=_wrap_SimpleLeggedOdometry_loadModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1194: flag=_wrap_SimpleLeggedOdometry_loadModelFromFileWithSpecifiedDOFs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1195: flag=_wrap_SimpleLeggedOdometry_model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1196: flag=_wrap_SimpleLeggedOdometry_updateKinematics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1197: flag=_wrap_SimpleLeggedOdometry_init(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1198: flag=_wrap_SimpleLeggedOdometry_changeFixedFrame(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1199: flag=_wrap_SimpleLeggedOdometry_getCurrentFixedLink(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1200: flag=_wrap_SimpleLeggedOdometry_getWorldLinkTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1201: flag=_wrap_isLinkBerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1202: flag=_wrap_isJointBerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1203: flag=_wrap_isDOFBerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1204: flag=_wrap_new_BerdyOptions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1205: flag=_wrap_BerdyOptions_berdyVariant_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1206: flag=_wrap_BerdyOptions_berdyVariant_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1207: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1208: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1209: flag=_wrap_BerdyOptions_includeAllJointAccelerationsAsSensors_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1210: flag=_wrap_BerdyOptions_includeAllJointAccelerationsAsSensors_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1211: flag=_wrap_BerdyOptions_includeAllJointTorquesAsSensors_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1212: flag=_wrap_BerdyOptions_includeAllJointTorquesAsSensors_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1213: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsSensors_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1214: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsSensors_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1215: flag=_wrap_BerdyOptions_includeFixedBaseExternalWrench_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1216: flag=_wrap_BerdyOptions_includeFixedBaseExternalWrench_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1217: flag=_wrap_BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1218: flag=_wrap_BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1219: flag=_wrap_BerdyOptions_checkConsistency(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1220: flag=_wrap_delete_BerdyOptions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1221: flag=_wrap_BerdySensor_type_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1222: flag=_wrap_BerdySensor_type_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1223: flag=_wrap_BerdySensor_id_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1224: flag=_wrap_BerdySensor_id_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1225: flag=_wrap_BerdySensor_range_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1226: flag=_wrap_BerdySensor_range_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1227: flag=_wrap_BerdySensor_eq(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1228: flag=_wrap_new_BerdySensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1229: flag=_wrap_delete_BerdySensor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1230: flag=_wrap_BerdyDynamicVariable_type_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1231: flag=_wrap_BerdyDynamicVariable_type_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1232: flag=_wrap_BerdyDynamicVariable_id_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1233: flag=_wrap_BerdyDynamicVariable_id_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1234: flag=_wrap_BerdyDynamicVariable_range_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1235: flag=_wrap_BerdyDynamicVariable_range_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1236: flag=_wrap_new_BerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1237: flag=_wrap_delete_BerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1238: flag=_wrap_new_BerdyHelper(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1239: flag=_wrap_BerdyHelper_dynamicTraversal(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1240: flag=_wrap_BerdyHelper_model(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1241: flag=_wrap_BerdyHelper_sensors(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1242: flag=_wrap_BerdyHelper_init(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1243: flag=_wrap_BerdyHelper_getOptions(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1244: flag=_wrap_BerdyHelper_getNrOfDynamicVariables(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1245: flag=_wrap_BerdyHelper_getNrOfDynamicEquations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1246: flag=_wrap_BerdyHelper_getNrOfSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1247: flag=_wrap_BerdyHelper_resizeAndZeroBerdyMatrices(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1248: flag=_wrap_BerdyHelper_getBerdyMatrices(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1249: flag=_wrap_BerdyHelper_getSensorsOrdering(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1250: flag=_wrap_BerdyHelper_getDynamicVariablesOrdering(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1251: flag=_wrap_BerdyHelper_serializeDynamicVariables(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1252: flag=_wrap_BerdyHelper_serializeSensorVariables(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1253: flag=_wrap_BerdyHelper_serializeDynamicVariablesComputedFromFixedBaseRNEA(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1254: flag=_wrap_BerdyHelper_updateKinematicsFromFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1255: flag=_wrap_BerdyHelper_updateKinematicsFromFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1256: flag=_wrap_BerdyHelper_updateKinematicsFromTraversalFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1257: flag=_wrap_delete_BerdyHelper(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1258: flag=_wrap_DynamicsRegressorParameter_category_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1259: flag=_wrap_DynamicsRegressorParameter_category_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1260: flag=_wrap_DynamicsRegressorParameter_elemIndex_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1261: flag=_wrap_DynamicsRegressorParameter_elemIndex_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1262: flag=_wrap_DynamicsRegressorParameter_type_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1263: flag=_wrap_DynamicsRegressorParameter_type_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1264: flag=_wrap_DynamicsRegressorParameter_lt(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1265: flag=_wrap_DynamicsRegressorParameter_eq(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1266: flag=_wrap_DynamicsRegressorParameter_ne(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1267: flag=_wrap_new_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1268: flag=_wrap_delete_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1269: flag=_wrap_DynamicsRegressorParametersList_parameters_get(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1270: flag=_wrap_DynamicsRegressorParametersList_parameters_set(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1271: flag=_wrap_DynamicsRegressorParametersList_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1272: flag=_wrap_DynamicsRegressorParametersList_addParam(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1273: flag=_wrap_DynamicsRegressorParametersList_addList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1274: flag=_wrap_DynamicsRegressorParametersList_findParam(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1275: flag=_wrap_DynamicsRegressorParametersList_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1276: flag=_wrap_new_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1277: flag=_wrap_delete_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1278: flag=_wrap_new_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1279: flag=_wrap_delete_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1280: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1281: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1282: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1283: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1284: flag=_wrap_DynamicsRegressorGenerator_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1285: flag=_wrap_DynamicsRegressorGenerator_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1286: flag=_wrap_DynamicsRegressorGenerator_getNrOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1287: flag=_wrap_DynamicsRegressorGenerator_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1288: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1289: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1290: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutput(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1291: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1292: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1293: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1294: flag=_wrap_DynamicsRegressorGenerator_getBaseLinkName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1295: flag=_wrap_DynamicsRegressorGenerator_getSensorsModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1296: flag=_wrap_DynamicsRegressorGenerator_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1297: flag=_wrap_DynamicsRegressorGenerator_getSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1298: flag=_wrap_DynamicsRegressorGenerator_computeRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1299: flag=_wrap_DynamicsRegressorGenerator_getModelParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1300: flag=_wrap_DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1301: flag=_wrap_DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1302: flag=_wrap_new_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1303: flag=_wrap_delete_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1304: flag=_wrap_KinDynComputations_loadRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1305: flag=_wrap_KinDynComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1306: flag=_wrap_KinDynComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1307: flag=_wrap_KinDynComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1308: flag=_wrap_KinDynComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1309: flag=_wrap_KinDynComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1310: flag=_wrap_KinDynComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1311: flag=_wrap_KinDynComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1312: flag=_wrap_KinDynComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1313: flag=_wrap_KinDynComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1314: flag=_wrap_KinDynComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1315: flag=_wrap_KinDynComputations_getRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1316: flag=_wrap_KinDynComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1317: flag=_wrap_KinDynComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1318: flag=_wrap_KinDynComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1319: flag=_wrap_KinDynComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1320: flag=_wrap_KinDynComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1321: flag=_wrap_KinDynComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1322: flag=_wrap_KinDynComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1323: flag=_wrap_KinDynComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1324: flag=_wrap_KinDynComputations_getRelativeTransformExplicit(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1325: flag=_wrap_KinDynComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1326: flag=_wrap_new_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1327: flag=_wrap_delete_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1328: flag=_wrap_DynamicsComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1329: flag=_wrap_DynamicsComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1330: flag=_wrap_DynamicsComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1331: flag=_wrap_DynamicsComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1332: flag=_wrap_DynamicsComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1333: flag=_wrap_DynamicsComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1334: flag=_wrap_DynamicsComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1335: flag=_wrap_DynamicsComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1336: flag=_wrap_DynamicsComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1337: flag=_wrap_DynamicsComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1338: flag=_wrap_DynamicsComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1339: flag=_wrap_DynamicsComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1340: flag=_wrap_DynamicsComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1341: flag=_wrap_DynamicsComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1342: flag=_wrap_DynamicsComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1343: flag=_wrap_DynamicsComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1344: flag=_wrap_DynamicsComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1345: flag=_wrap_DynamicsComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1346: flag=_wrap_DynamicsComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1347: flag=_wrap_DynamicsComputations_getFrameTwist(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1348: flag=_wrap_DynamicsComputations_getFrameTwistInWorldOrient(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1349: flag=_wrap_DynamicsComputations_getFrameProperSpatialAcceleration(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1350: flag=_wrap_DynamicsComputations_getLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1351: flag=_wrap_DynamicsComputations_getLinkInertia(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1352: flag=_wrap_DynamicsComputations_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1353: flag=_wrap_DynamicsComputations_getJointName(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1354: flag=_wrap_DynamicsComputations_getJointLimits(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1355: flag=_wrap_DynamicsComputations_inverseDynamics(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1356: flag=_wrap_DynamicsComputations_getFrameJacobian(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1357: flag=_wrap_DynamicsComputations_getDynamicsRegressor(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1358: flag=_wrap_DynamicsComputations_getModelDynamicsParameters(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1359: flag=_wrap_DynamicsComputations_getCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
-  case 1360: flag=_wrap_DynamicsComputations_getCenterOfMassJacobian(resc,resv,argc,(mxArray**)(argv)); break;
+  case 97: flag=_wrap_MatrixDynSize_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 98: flag=_wrap_new_VectorDynSize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 99: flag=_wrap_delete_VectorDynSize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 100: flag=_wrap_VectorDynSize_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 101: flag=_wrap_VectorDynSize_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 102: flag=_wrap_VectorDynSize_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 103: flag=_wrap_VectorDynSize_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 104: flag=_wrap_VectorDynSize_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 105: flag=_wrap_VectorDynSize_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 106: flag=_wrap_VectorDynSize_reserve(resc,resv,argc,(mxArray**)(argv)); break;
+  case 107: flag=_wrap_VectorDynSize_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 108: flag=_wrap_VectorDynSize_shrink_to_fit(resc,resv,argc,(mxArray**)(argv)); break;
+  case 109: flag=_wrap_VectorDynSize_capacity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 110: flag=_wrap_VectorDynSize_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 111: flag=_wrap_VectorDynSize_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 112: flag=_wrap_VectorDynSize_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 113: flag=_wrap_VectorDynSize_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 114: flag=_wrap_VectorDynSize_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 115: flag=_wrap_new_Matrix3x3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 116: flag=_wrap_Matrix3x3_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 117: flag=_wrap_Matrix3x3_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 118: flag=_wrap_Matrix3x3_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 119: flag=_wrap_Matrix3x3_rows(resc,resv,argc,(mxArray**)(argv)); break;
+  case 120: flag=_wrap_Matrix3x3_cols(resc,resv,argc,(mxArray**)(argv)); break;
+  case 121: flag=_wrap_Matrix3x3_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 122: flag=_wrap_Matrix3x3_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 123: flag=_wrap_Matrix3x3_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 124: flag=_wrap_Matrix3x3_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 125: flag=_wrap_Matrix3x3_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 126: flag=_wrap_Matrix3x3_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 127: flag=_wrap_Matrix3x3_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 128: flag=_wrap_Matrix3x3_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 129: flag=_wrap_delete_Matrix3x3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 130: flag=_wrap_new_Matrix4x4(resc,resv,argc,(mxArray**)(argv)); break;
+  case 131: flag=_wrap_Matrix4x4_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 132: flag=_wrap_Matrix4x4_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 133: flag=_wrap_Matrix4x4_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 134: flag=_wrap_Matrix4x4_rows(resc,resv,argc,(mxArray**)(argv)); break;
+  case 135: flag=_wrap_Matrix4x4_cols(resc,resv,argc,(mxArray**)(argv)); break;
+  case 136: flag=_wrap_Matrix4x4_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 137: flag=_wrap_Matrix4x4_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 138: flag=_wrap_Matrix4x4_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 139: flag=_wrap_Matrix4x4_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 140: flag=_wrap_Matrix4x4_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 141: flag=_wrap_Matrix4x4_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 142: flag=_wrap_Matrix4x4_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 143: flag=_wrap_Matrix4x4_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 144: flag=_wrap_delete_Matrix4x4(resc,resv,argc,(mxArray**)(argv)); break;
+  case 145: flag=_wrap_new_Matrix6x6(resc,resv,argc,(mxArray**)(argv)); break;
+  case 146: flag=_wrap_Matrix6x6_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 147: flag=_wrap_Matrix6x6_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 148: flag=_wrap_Matrix6x6_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 149: flag=_wrap_Matrix6x6_rows(resc,resv,argc,(mxArray**)(argv)); break;
+  case 150: flag=_wrap_Matrix6x6_cols(resc,resv,argc,(mxArray**)(argv)); break;
+  case 151: flag=_wrap_Matrix6x6_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 152: flag=_wrap_Matrix6x6_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 153: flag=_wrap_Matrix6x6_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 154: flag=_wrap_Matrix6x6_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 155: flag=_wrap_Matrix6x6_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 156: flag=_wrap_Matrix6x6_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 157: flag=_wrap_Matrix6x6_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 158: flag=_wrap_Matrix6x6_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 159: flag=_wrap_delete_Matrix6x6(resc,resv,argc,(mxArray**)(argv)); break;
+  case 160: flag=_wrap_new_Matrix6x10(resc,resv,argc,(mxArray**)(argv)); break;
+  case 161: flag=_wrap_Matrix6x10_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 162: flag=_wrap_Matrix6x10_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 163: flag=_wrap_Matrix6x10_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 164: flag=_wrap_Matrix6x10_rows(resc,resv,argc,(mxArray**)(argv)); break;
+  case 165: flag=_wrap_Matrix6x10_cols(resc,resv,argc,(mxArray**)(argv)); break;
+  case 166: flag=_wrap_Matrix6x10_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 167: flag=_wrap_Matrix6x10_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 168: flag=_wrap_Matrix6x10_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 169: flag=_wrap_Matrix6x10_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 170: flag=_wrap_Matrix6x10_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 171: flag=_wrap_Matrix6x10_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 172: flag=_wrap_Matrix6x10_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 173: flag=_wrap_Matrix6x10_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 174: flag=_wrap_delete_Matrix6x10(resc,resv,argc,(mxArray**)(argv)); break;
+  case 175: flag=_wrap_new_Matrix10x16(resc,resv,argc,(mxArray**)(argv)); break;
+  case 176: flag=_wrap_Matrix10x16_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 177: flag=_wrap_Matrix10x16_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 178: flag=_wrap_Matrix10x16_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 179: flag=_wrap_Matrix10x16_rows(resc,resv,argc,(mxArray**)(argv)); break;
+  case 180: flag=_wrap_Matrix10x16_cols(resc,resv,argc,(mxArray**)(argv)); break;
+  case 181: flag=_wrap_Matrix10x16_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 182: flag=_wrap_Matrix10x16_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 183: flag=_wrap_Matrix10x16_fillRowMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 184: flag=_wrap_Matrix10x16_fillColMajorBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 185: flag=_wrap_Matrix10x16_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 186: flag=_wrap_Matrix10x16_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 187: flag=_wrap_Matrix10x16_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 188: flag=_wrap_Matrix10x16_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 189: flag=_wrap_delete_Matrix10x16(resc,resv,argc,(mxArray**)(argv)); break;
+  case 190: flag=_wrap_new_Vector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 191: flag=_wrap_Vector3_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 192: flag=_wrap_Vector3_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 193: flag=_wrap_Vector3_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 194: flag=_wrap_Vector3_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 195: flag=_wrap_Vector3_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 196: flag=_wrap_Vector3_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 197: flag=_wrap_Vector3_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 198: flag=_wrap_Vector3_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 199: flag=_wrap_Vector3_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 200: flag=_wrap_Vector3_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 201: flag=_wrap_Vector3_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 202: flag=_wrap_delete_Vector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 203: flag=_wrap_new_Vector6(resc,resv,argc,(mxArray**)(argv)); break;
+  case 204: flag=_wrap_Vector6_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 205: flag=_wrap_Vector6_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 206: flag=_wrap_Vector6_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 207: flag=_wrap_Vector6_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 208: flag=_wrap_Vector6_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 209: flag=_wrap_Vector6_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 210: flag=_wrap_Vector6_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 211: flag=_wrap_Vector6_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 212: flag=_wrap_Vector6_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 213: flag=_wrap_Vector6_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 214: flag=_wrap_Vector6_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 215: flag=_wrap_delete_Vector6(resc,resv,argc,(mxArray**)(argv)); break;
+  case 216: flag=_wrap_new_Vector10(resc,resv,argc,(mxArray**)(argv)); break;
+  case 217: flag=_wrap_Vector10_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 218: flag=_wrap_Vector10_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 219: flag=_wrap_Vector10_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 220: flag=_wrap_Vector10_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 221: flag=_wrap_Vector10_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 222: flag=_wrap_Vector10_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 223: flag=_wrap_Vector10_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 224: flag=_wrap_Vector10_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 225: flag=_wrap_Vector10_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 226: flag=_wrap_Vector10_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 227: flag=_wrap_Vector10_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 228: flag=_wrap_delete_Vector10(resc,resv,argc,(mxArray**)(argv)); break;
+  case 229: flag=_wrap_new_Vector16(resc,resv,argc,(mxArray**)(argv)); break;
+  case 230: flag=_wrap_Vector16_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 231: flag=_wrap_Vector16_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 232: flag=_wrap_Vector16_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 233: flag=_wrap_Vector16_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 234: flag=_wrap_Vector16_data(resc,resv,argc,(mxArray**)(argv)); break;
+  case 235: flag=_wrap_Vector16_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 236: flag=_wrap_Vector16_fillBuffer(resc,resv,argc,(mxArray**)(argv)); break;
+  case 237: flag=_wrap_Vector16_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 238: flag=_wrap_Vector16_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 239: flag=_wrap_Vector16_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 240: flag=_wrap_Vector16_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 241: flag=_wrap_delete_Vector16(resc,resv,argc,(mxArray**)(argv)); break;
+  case 242: flag=_wrap_new_PositionRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 243: flag=_wrap_PositionRaw_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 244: flag=_wrap_PositionRaw_changeRefPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 245: flag=_wrap_PositionRaw_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 246: flag=_wrap_PositionRaw_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 247: flag=_wrap_PositionRaw_changePointOf(resc,resv,argc,(mxArray**)(argv)); break;
+  case 248: flag=_wrap_PositionRaw_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 249: flag=_wrap_PositionRaw_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 250: flag=_wrap_delete_PositionRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 251: flag=_wrap_new_PositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 252: flag=_wrap_PositionSemantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 253: flag=_wrap_PositionSemantics_getPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 254: flag=_wrap_PositionSemantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 255: flag=_wrap_PositionSemantics_getReferencePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 256: flag=_wrap_PositionSemantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 257: flag=_wrap_PositionSemantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 258: flag=_wrap_PositionSemantics_setPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 259: flag=_wrap_PositionSemantics_setBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 260: flag=_wrap_PositionSemantics_setReferencePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 261: flag=_wrap_PositionSemantics_setRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 262: flag=_wrap_PositionSemantics_setCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 263: flag=_wrap_PositionSemantics_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 264: flag=_wrap_PositionSemantics_changeRefPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 265: flag=_wrap_PositionSemantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 266: flag=_wrap_PositionSemantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 267: flag=_wrap_PositionSemantics_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 268: flag=_wrap_PositionSemantics_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 269: flag=_wrap_delete_PositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 270: flag=_wrap_new_Position(resc,resv,argc,(mxArray**)(argv)); break;
+  case 271: flag=_wrap_Position_getSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 272: flag=_wrap_Position_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 273: flag=_wrap_Position_changeRefPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 274: flag=_wrap_Position_changeCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 275: flag=_wrap_Position_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 276: flag=_wrap_Position_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 277: flag=_wrap_Position_changePointOf(resc,resv,argc,(mxArray**)(argv)); break;
+  case 278: flag=_wrap_Position_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 279: flag=_wrap_Position_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 280: flag=_wrap_Position_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 281: flag=_wrap_Position_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 282: flag=_wrap_Position_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 283: flag=_wrap_Position_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 284: flag=_wrap_Position_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 285: flag=_wrap_delete_Position(resc,resv,argc,(mxArray**)(argv)); break;
+  case 286: flag=_wrap_new_GeomVector3Semantics__LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 287: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 288: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 289: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 290: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 291: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 292: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 293: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 294: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 295: flag=_wrap_GeomVector3Semantics__LinearMotionVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 296: flag=_wrap_delete_GeomVector3Semantics__LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 297: flag=_wrap_new_GeomVector3Semantics__AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 298: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 299: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 300: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 301: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 302: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 303: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 304: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 305: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 306: flag=_wrap_GeomVector3Semantics__AngularMotionVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 307: flag=_wrap_delete_GeomVector3Semantics__AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 308: flag=_wrap_new_GeomVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 309: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 310: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 311: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 312: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 313: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 314: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 315: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 316: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 317: flag=_wrap_GeomVector3Semantics__LinearForceVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 318: flag=_wrap_delete_GeomVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 319: flag=_wrap_new_GeomVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 320: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 321: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 322: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 323: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 324: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_isUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 325: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 326: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 327: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 328: flag=_wrap_GeomVector3Semantics__AngularForceVector3Semantics_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 329: flag=_wrap_delete_GeomVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 330: flag=_wrap_GeomVector3__LinearMotionVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 331: flag=_wrap_GeomVector3__LinearMotionVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 332: flag=_wrap_new_GeomVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 333: flag=_wrap_GeomVector3__LinearMotionVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 334: flag=_wrap_GeomVector3__LinearMotionVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 335: flag=_wrap_GeomVector3__LinearMotionVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 336: flag=_wrap_GeomVector3__LinearMotionVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 337: flag=_wrap_GeomVector3__LinearMotionVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 338: flag=_wrap_GeomVector3__LinearMotionVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 339: flag=_wrap_GeomVector3__LinearMotionVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 340: flag=_wrap_GeomVector3__LinearMotionVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 341: flag=_wrap_delete_GeomVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 342: flag=_wrap_GeomVector3__AngularMotionVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 343: flag=_wrap_GeomVector3__AngularMotionVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 344: flag=_wrap_new_GeomVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 345: flag=_wrap_GeomVector3__AngularMotionVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 346: flag=_wrap_GeomVector3__AngularMotionVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 347: flag=_wrap_GeomVector3__AngularMotionVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 348: flag=_wrap_GeomVector3__AngularMotionVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 349: flag=_wrap_GeomVector3__AngularMotionVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 350: flag=_wrap_GeomVector3__AngularMotionVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 351: flag=_wrap_GeomVector3__AngularMotionVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 352: flag=_wrap_GeomVector3__AngularMotionVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 353: flag=_wrap_delete_GeomVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 354: flag=_wrap_GeomVector3__LinearForceVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 355: flag=_wrap_GeomVector3__LinearForceVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 356: flag=_wrap_new_GeomVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 357: flag=_wrap_GeomVector3__LinearForceVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 358: flag=_wrap_GeomVector3__LinearForceVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 359: flag=_wrap_GeomVector3__LinearForceVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 360: flag=_wrap_GeomVector3__LinearForceVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 361: flag=_wrap_GeomVector3__LinearForceVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 362: flag=_wrap_GeomVector3__LinearForceVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 363: flag=_wrap_GeomVector3__LinearForceVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 364: flag=_wrap_GeomVector3__LinearForceVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 365: flag=_wrap_delete_GeomVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 366: flag=_wrap_GeomVector3__AngularForceVector3_semantics_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 367: flag=_wrap_GeomVector3__AngularForceVector3_semantics_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 368: flag=_wrap_new_GeomVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 369: flag=_wrap_GeomVector3__AngularForceVector3_setSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 370: flag=_wrap_GeomVector3__AngularForceVector3_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 371: flag=_wrap_GeomVector3__AngularForceVector3_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 372: flag=_wrap_GeomVector3__AngularForceVector3_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 373: flag=_wrap_GeomVector3__AngularForceVector3_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 374: flag=_wrap_GeomVector3__AngularForceVector3_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 375: flag=_wrap_GeomVector3__AngularForceVector3_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 376: flag=_wrap_GeomVector3__AngularForceVector3_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 377: flag=_wrap_delete_GeomVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 378: flag=_wrap_new_ForceVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 379: flag=_wrap_ForceVector3Semantics__LinearForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 380: flag=_wrap_ForceVector3Semantics__LinearForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 381: flag=_wrap_delete_ForceVector3Semantics__LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 382: flag=_wrap_new_ForceVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 383: flag=_wrap_ForceVector3Semantics__AngularForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 384: flag=_wrap_ForceVector3Semantics__AngularForceVector3Semantics_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 385: flag=_wrap_delete_ForceVector3Semantics__AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 386: flag=_wrap_new_MotionVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 387: flag=_wrap_MotionVector3__LinearMotionVector3_cross(resc,resv,argc,(mxArray**)(argv)); break;
+  case 388: flag=_wrap_delete_MotionVector3__LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 389: flag=_wrap_new_MotionVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 390: flag=_wrap_MotionVector3__AngularMotionVector3_cross(resc,resv,argc,(mxArray**)(argv)); break;
+  case 391: flag=_wrap_delete_MotionVector3__AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 392: flag=_wrap_new_ForceVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 393: flag=_wrap_delete_ForceVector3__LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 394: flag=_wrap_new_ForceVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 395: flag=_wrap_delete_ForceVector3__AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 396: flag=_wrap_new_LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 397: flag=_wrap_LinearMotionVector3Semantics_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 398: flag=_wrap_LinearMotionVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 399: flag=_wrap_delete_LinearMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 400: flag=_wrap_new_LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 401: flag=_wrap_LinearMotionVector3_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 402: flag=_wrap_delete_LinearMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 403: flag=_wrap_new_AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 404: flag=_wrap_delete_AngularMotionVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 405: flag=_wrap_new_AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 406: flag=_wrap_AngularMotionVector3_exp(resc,resv,argc,(mxArray**)(argv)); break;
+  case 407: flag=_wrap_delete_AngularMotionVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 408: flag=_wrap_new_LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 409: flag=_wrap_delete_LinearForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 410: flag=_wrap_new_LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 411: flag=_wrap_delete_LinearForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 412: flag=_wrap_new_AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 413: flag=_wrap_AngularForceVector3Semantics_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 414: flag=_wrap_AngularForceVector3Semantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 415: flag=_wrap_delete_AngularForceVector3Semantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 416: flag=_wrap_new_AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 417: flag=_wrap_AngularForceVector3_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 418: flag=_wrap_delete_AngularForceVector3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 419: flag=_wrap_new_SpatialMotionVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 420: flag=_wrap_SpatialMotionVectorSemanticsBase_check_linear2angularConsistency(resc,resv,argc,(mxArray**)(argv)); break;
+  case 421: flag=_wrap_SpatialMotionVectorSemanticsBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 422: flag=_wrap_SpatialMotionVectorSemanticsBase_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 423: flag=_wrap_delete_SpatialMotionVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 424: flag=_wrap_new_SpatialForceVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 425: flag=_wrap_SpatialForceVectorSemanticsBase_check_linear2angularConsistency(resc,resv,argc,(mxArray**)(argv)); break;
+  case 426: flag=_wrap_SpatialForceVectorSemanticsBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 427: flag=_wrap_SpatialForceVectorSemanticsBase_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 428: flag=_wrap_delete_SpatialForceVectorSemanticsBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 429: flag=_wrap_new_SpatialMotionVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 430: flag=_wrap_SpatialMotionVectorBase_getLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 431: flag=_wrap_SpatialMotionVectorBase_getAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 432: flag=_wrap_SpatialMotionVectorBase_setLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 433: flag=_wrap_SpatialMotionVectorBase_setAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 434: flag=_wrap_SpatialMotionVectorBase_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 435: flag=_wrap_SpatialMotionVectorBase_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 436: flag=_wrap_SpatialMotionVectorBase_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 437: flag=_wrap_SpatialMotionVectorBase_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 438: flag=_wrap_SpatialMotionVectorBase_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 439: flag=_wrap_SpatialMotionVectorBase_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 440: flag=_wrap_SpatialMotionVectorBase_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 441: flag=_wrap_SpatialMotionVectorBase_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 442: flag=_wrap_SpatialMotionVectorBase_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 443: flag=_wrap_SpatialMotionVectorBase_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 444: flag=_wrap_SpatialMotionVectorBase_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 445: flag=_wrap_SpatialMotionVectorBase_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 446: flag=_wrap_SpatialMotionVectorBase_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 447: flag=_wrap_SpatialMotionVectorBase_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 448: flag=_wrap_SpatialMotionVectorBase_asVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 449: flag=_wrap_SpatialMotionVectorBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 450: flag=_wrap_SpatialMotionVectorBase_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 451: flag=_wrap_SpatialMotionVectorBase_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 452: flag=_wrap_SpatialMotionVectorBase_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 453: flag=_wrap_delete_SpatialMotionVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 454: flag=_wrap_new_SpatialForceVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 455: flag=_wrap_SpatialForceVectorBase_getLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 456: flag=_wrap_SpatialForceVectorBase_getAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 457: flag=_wrap_SpatialForceVectorBase_setLinearVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 458: flag=_wrap_SpatialForceVectorBase_setAngularVec3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 459: flag=_wrap_SpatialForceVectorBase_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 460: flag=_wrap_SpatialForceVectorBase_getVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 461: flag=_wrap_SpatialForceVectorBase_setVal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 462: flag=_wrap_SpatialForceVectorBase_size(resc,resv,argc,(mxArray**)(argv)); break;
+  case 463: flag=_wrap_SpatialForceVectorBase_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 464: flag=_wrap_SpatialForceVectorBase_changePoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 465: flag=_wrap_SpatialForceVectorBase_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 466: flag=_wrap_SpatialForceVectorBase_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 467: flag=_wrap_SpatialForceVectorBase_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 468: flag=_wrap_SpatialForceVectorBase_dot(resc,resv,argc,(mxArray**)(argv)); break;
+  case 469: flag=_wrap_SpatialForceVectorBase_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 470: flag=_wrap_SpatialForceVectorBase_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 471: flag=_wrap_SpatialForceVectorBase_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 472: flag=_wrap_SpatialForceVectorBase_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 473: flag=_wrap_SpatialForceVectorBase_asVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 474: flag=_wrap_SpatialForceVectorBase_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 475: flag=_wrap_SpatialForceVectorBase_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 476: flag=_wrap_SpatialForceVectorBase_toMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 477: flag=_wrap_SpatialForceVectorBase_fromMatlab(resc,resv,argc,(mxArray**)(argv)); break;
+  case 478: flag=_wrap_delete_SpatialForceVectorBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 479: flag=_wrap_new_Dummy(resc,resv,argc,(mxArray**)(argv)); break;
+  case 480: flag=_wrap_delete_Dummy(resc,resv,argc,(mxArray**)(argv)); break;
+  case 481: flag=_wrap_new_SpatialMotionVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 482: flag=_wrap_SpatialMotionVector_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 483: flag=_wrap_SpatialMotionVector_cross(resc,resv,argc,(mxArray**)(argv)); break;
+  case 484: flag=_wrap_SpatialMotionVector_asCrossProductMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 485: flag=_wrap_SpatialMotionVector_asCrossProductMatrixWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 486: flag=_wrap_SpatialMotionVector_exp(resc,resv,argc,(mxArray**)(argv)); break;
+  case 487: flag=_wrap_delete_SpatialMotionVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 488: flag=_wrap_new_SpatialForceVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 489: flag=_wrap_delete_SpatialForceVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 490: flag=_wrap_SpatialForceVector_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 491: flag=_wrap_new_Twist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 492: flag=_wrap_Twist_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 493: flag=_wrap_Twist_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 494: flag=_wrap_Twist_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 495: flag=_wrap_Twist_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 496: flag=_wrap_delete_Twist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 497: flag=_wrap_new_Wrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 498: flag=_wrap_Wrench_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 499: flag=_wrap_Wrench_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 500: flag=_wrap_Wrench_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 501: flag=_wrap_delete_Wrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 502: flag=_wrap_new_SpatialMomentum(resc,resv,argc,(mxArray**)(argv)); break;
+  case 503: flag=_wrap_SpatialMomentum_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 504: flag=_wrap_SpatialMomentum_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 505: flag=_wrap_SpatialMomentum_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 506: flag=_wrap_delete_SpatialMomentum(resc,resv,argc,(mxArray**)(argv)); break;
+  case 507: flag=_wrap_new_SpatialAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 508: flag=_wrap_SpatialAcc_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 509: flag=_wrap_SpatialAcc_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 510: flag=_wrap_SpatialAcc_uminus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 511: flag=_wrap_delete_SpatialAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 512: flag=_wrap_new_ClassicalAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 513: flag=_wrap_ClassicalAcc_changeCoordFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 514: flag=_wrap_ClassicalAcc_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 515: flag=_wrap_ClassicalAcc_fromSpatial(resc,resv,argc,(mxArray**)(argv)); break;
+  case 516: flag=_wrap_ClassicalAcc_toSpatial(resc,resv,argc,(mxArray**)(argv)); break;
+  case 517: flag=_wrap_delete_ClassicalAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 518: flag=_wrap_new_Direction(resc,resv,argc,(mxArray**)(argv)); break;
+  case 519: flag=_wrap_Direction_Normalize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 520: flag=_wrap_Direction_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 521: flag=_wrap_Direction_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 522: flag=_wrap_Direction_Default(resc,resv,argc,(mxArray**)(argv)); break;
+  case 523: flag=_wrap_delete_Direction(resc,resv,argc,(mxArray**)(argv)); break;
+  case 524: flag=_wrap_new_Axis(resc,resv,argc,(mxArray**)(argv)); break;
+  case 525: flag=_wrap_Axis_getDirection(resc,resv,argc,(mxArray**)(argv)); break;
+  case 526: flag=_wrap_Axis_getOrigin(resc,resv,argc,(mxArray**)(argv)); break;
+  case 527: flag=_wrap_Axis_setDirection(resc,resv,argc,(mxArray**)(argv)); break;
+  case 528: flag=_wrap_Axis_setOrigin(resc,resv,argc,(mxArray**)(argv)); break;
+  case 529: flag=_wrap_Axis_getRotationTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 530: flag=_wrap_Axis_getRotationTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 531: flag=_wrap_Axis_getRotationTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 532: flag=_wrap_Axis_getRotationSpatialAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 533: flag=_wrap_Axis_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 534: flag=_wrap_Axis_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 535: flag=_wrap_delete_Axis(resc,resv,argc,(mxArray**)(argv)); break;
+  case 536: flag=_wrap_new_RotationalInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 537: flag=_wrap_RotationalInertiaRaw_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 538: flag=_wrap_delete_RotationalInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 539: flag=_wrap_new_SpatialInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 540: flag=_wrap_SpatialInertiaRaw_fromRotationalInertiaWrtCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
+  case 541: flag=_wrap_SpatialInertiaRaw_getMass(resc,resv,argc,(mxArray**)(argv)); break;
+  case 542: flag=_wrap_SpatialInertiaRaw_getCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
+  case 543: flag=_wrap_SpatialInertiaRaw_getRotationalInertiaWrtFrameOrigin(resc,resv,argc,(mxArray**)(argv)); break;
+  case 544: flag=_wrap_SpatialInertiaRaw_getRotationalInertiaWrtCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
+  case 545: flag=_wrap_SpatialInertiaRaw_combine(resc,resv,argc,(mxArray**)(argv)); break;
+  case 546: flag=_wrap_SpatialInertiaRaw_multiply(resc,resv,argc,(mxArray**)(argv)); break;
+  case 547: flag=_wrap_SpatialInertiaRaw_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 548: flag=_wrap_delete_SpatialInertiaRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 549: flag=_wrap_new_SpatialInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 550: flag=_wrap_SpatialInertia_combine(resc,resv,argc,(mxArray**)(argv)); break;
+  case 551: flag=_wrap_SpatialInertia_asMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 552: flag=_wrap_SpatialInertia_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 553: flag=_wrap_SpatialInertia_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 554: flag=_wrap_SpatialInertia_biasWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 555: flag=_wrap_SpatialInertia_biasWrenchDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 556: flag=_wrap_SpatialInertia_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 557: flag=_wrap_SpatialInertia_asVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 558: flag=_wrap_SpatialInertia_fromVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 559: flag=_wrap_SpatialInertia_isPhysicallyConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 560: flag=_wrap_SpatialInertia_momentumRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 561: flag=_wrap_SpatialInertia_momentumDerivativeRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 562: flag=_wrap_SpatialInertia_momentumDerivativeSlotineLiRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 563: flag=_wrap_delete_SpatialInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 564: flag=_wrap_new_ArticulatedBodyInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 565: flag=_wrap_ArticulatedBodyInertia_getLinearLinearSubmatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 566: flag=_wrap_ArticulatedBodyInertia_getLinearAngularSubmatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 567: flag=_wrap_ArticulatedBodyInertia_getAngularAngularSubmatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 568: flag=_wrap_ArticulatedBodyInertia_combine(resc,resv,argc,(mxArray**)(argv)); break;
+  case 569: flag=_wrap_ArticulatedBodyInertia_applyInverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 570: flag=_wrap_ArticulatedBodyInertia_asMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 571: flag=_wrap_ArticulatedBodyInertia_getInverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 572: flag=_wrap_ArticulatedBodyInertia_plus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 573: flag=_wrap_ArticulatedBodyInertia_minus(resc,resv,argc,(mxArray**)(argv)); break;
+  case 574: flag=_wrap_ArticulatedBodyInertia_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 575: flag=_wrap_ArticulatedBodyInertia_zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 576: flag=_wrap_ArticulatedBodyInertia_ABADyadHelper(resc,resv,argc,(mxArray**)(argv)); break;
+  case 577: flag=_wrap_ArticulatedBodyInertia_ABADyadHelperLin(resc,resv,argc,(mxArray**)(argv)); break;
+  case 578: flag=_wrap_delete_ArticulatedBodyInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 579: flag=_wrap_new_RotationRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 580: flag=_wrap_RotationRaw_changeOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 581: flag=_wrap_RotationRaw_changeRefOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 582: flag=_wrap_RotationRaw_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 583: flag=_wrap_RotationRaw_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
+  case 584: flag=_wrap_RotationRaw_changeCoordFrameOf(resc,resv,argc,(mxArray**)(argv)); break;
+  case 585: flag=_wrap_RotationRaw_RotX(resc,resv,argc,(mxArray**)(argv)); break;
+  case 586: flag=_wrap_RotationRaw_RotY(resc,resv,argc,(mxArray**)(argv)); break;
+  case 587: flag=_wrap_RotationRaw_RotZ(resc,resv,argc,(mxArray**)(argv)); break;
+  case 588: flag=_wrap_RotationRaw_RPY(resc,resv,argc,(mxArray**)(argv)); break;
+  case 589: flag=_wrap_RotationRaw_Identity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 590: flag=_wrap_RotationRaw_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 591: flag=_wrap_RotationRaw_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 592: flag=_wrap_delete_RotationRaw(resc,resv,argc,(mxArray**)(argv)); break;
+  case 593: flag=_wrap_new_RotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 594: flag=_wrap_RotationSemantics_setToUnknown(resc,resv,argc,(mxArray**)(argv)); break;
+  case 595: flag=_wrap_RotationSemantics_getOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 596: flag=_wrap_RotationSemantics_getBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 597: flag=_wrap_RotationSemantics_getReferenceOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 598: flag=_wrap_RotationSemantics_getRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 599: flag=_wrap_RotationSemantics_getCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 600: flag=_wrap_RotationSemantics_setOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 601: flag=_wrap_RotationSemantics_setBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 602: flag=_wrap_RotationSemantics_setReferenceOrientationFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 603: flag=_wrap_RotationSemantics_setRefBody(resc,resv,argc,(mxArray**)(argv)); break;
+  case 604: flag=_wrap_RotationSemantics_setCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 605: flag=_wrap_RotationSemantics_changeOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 606: flag=_wrap_RotationSemantics_changeRefOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 607: flag=_wrap_RotationSemantics_changeCoordFrameOf(resc,resv,argc,(mxArray**)(argv)); break;
+  case 608: flag=_wrap_RotationSemantics_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 609: flag=_wrap_RotationSemantics_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
+  case 610: flag=_wrap_RotationSemantics_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 611: flag=_wrap_RotationSemantics_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 612: flag=_wrap_delete_RotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 613: flag=_wrap_new_Rotation(resc,resv,argc,(mxArray**)(argv)); break;
+  case 614: flag=_wrap_Rotation_getSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 615: flag=_wrap_Rotation_changeOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 616: flag=_wrap_Rotation_changeRefOrientFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 617: flag=_wrap_Rotation_changeCoordinateFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 618: flag=_wrap_Rotation_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 619: flag=_wrap_Rotation_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
+  case 620: flag=_wrap_Rotation_changeCoordFrameOf(resc,resv,argc,(mxArray**)(argv)); break;
+  case 621: flag=_wrap_Rotation_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 622: flag=_wrap_Rotation_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 623: flag=_wrap_Rotation_log(resc,resv,argc,(mxArray**)(argv)); break;
+  case 624: flag=_wrap_Rotation_fromQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
+  case 625: flag=_wrap_Rotation_getRPY(resc,resv,argc,(mxArray**)(argv)); break;
+  case 626: flag=_wrap_Rotation_asRPY(resc,resv,argc,(mxArray**)(argv)); break;
+  case 627: flag=_wrap_Rotation_getQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
+  case 628: flag=_wrap_Rotation_asQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
+  case 629: flag=_wrap_Rotation_RotX(resc,resv,argc,(mxArray**)(argv)); break;
+  case 630: flag=_wrap_Rotation_RotY(resc,resv,argc,(mxArray**)(argv)); break;
+  case 631: flag=_wrap_Rotation_RotZ(resc,resv,argc,(mxArray**)(argv)); break;
+  case 632: flag=_wrap_Rotation_RotAxis(resc,resv,argc,(mxArray**)(argv)); break;
+  case 633: flag=_wrap_Rotation_RotAxisDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 634: flag=_wrap_Rotation_RPY(resc,resv,argc,(mxArray**)(argv)); break;
+  case 635: flag=_wrap_Rotation_Identity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 636: flag=_wrap_Rotation_RotationFromQuaternion(resc,resv,argc,(mxArray**)(argv)); break;
+  case 637: flag=_wrap_Rotation_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 638: flag=_wrap_Rotation_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 639: flag=_wrap_delete_Rotation(resc,resv,argc,(mxArray**)(argv)); break;
+  case 640: flag=_wrap_new_TransformSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 641: flag=_wrap_TransformSemantics_getRotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 642: flag=_wrap_TransformSemantics_getPositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 643: flag=_wrap_TransformSemantics_setRotationSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 644: flag=_wrap_TransformSemantics_setPositionSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 645: flag=_wrap_TransformSemantics_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 646: flag=_wrap_TransformSemantics_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 647: flag=_wrap_delete_TransformSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 648: flag=_wrap_new_Transform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 649: flag=_wrap_Transform_getSemantics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 650: flag=_wrap_Transform_getRotation(resc,resv,argc,(mxArray**)(argv)); break;
+  case 651: flag=_wrap_Transform_getPosition(resc,resv,argc,(mxArray**)(argv)); break;
+  case 652: flag=_wrap_Transform_setRotation(resc,resv,argc,(mxArray**)(argv)); break;
+  case 653: flag=_wrap_Transform_setPosition(resc,resv,argc,(mxArray**)(argv)); break;
+  case 654: flag=_wrap_Transform_compose(resc,resv,argc,(mxArray**)(argv)); break;
+  case 655: flag=_wrap_Transform_inverse2(resc,resv,argc,(mxArray**)(argv)); break;
+  case 656: flag=_wrap_Transform_inverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 657: flag=_wrap_Transform_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 658: flag=_wrap_Transform_Identity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 659: flag=_wrap_Transform_asHomogeneousTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 660: flag=_wrap_Transform_asAdjointTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 661: flag=_wrap_Transform_asAdjointTransformWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 662: flag=_wrap_Transform_log(resc,resv,argc,(mxArray**)(argv)); break;
+  case 663: flag=_wrap_Transform_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 664: flag=_wrap_Transform_display(resc,resv,argc,(mxArray**)(argv)); break;
+  case 665: flag=_wrap_delete_Transform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 666: flag=_wrap_new_TransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 667: flag=_wrap_delete_TransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 668: flag=_wrap_TransformDerivative_getRotationDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 669: flag=_wrap_TransformDerivative_getPositionDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 670: flag=_wrap_TransformDerivative_setRotationDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 671: flag=_wrap_TransformDerivative_setPositionDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 672: flag=_wrap_TransformDerivative_Zero(resc,resv,argc,(mxArray**)(argv)); break;
+  case 673: flag=_wrap_TransformDerivative_asHomogeneousTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 674: flag=_wrap_TransformDerivative_asAdjointTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 675: flag=_wrap_TransformDerivative_asAdjointTransformWrenchDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 676: flag=_wrap_TransformDerivative_mtimes(resc,resv,argc,(mxArray**)(argv)); break;
+  case 677: flag=_wrap_TransformDerivative_derivativeOfInverse(resc,resv,argc,(mxArray**)(argv)); break;
+  case 678: flag=_wrap_TransformDerivative_transform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 679: flag=_wrap_LINK_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 680: flag=_wrap_LINK_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 681: flag=_wrap_LINK_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 682: flag=_wrap_LINK_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 683: flag=_wrap_JOINT_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 684: flag=_wrap_JOINT_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 685: flag=_wrap_JOINT_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 686: flag=_wrap_JOINT_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 687: flag=_wrap_DOF_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 688: flag=_wrap_DOF_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 689: flag=_wrap_DOF_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 690: flag=_wrap_DOF_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 691: flag=_wrap_FRAME_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 692: flag=_wrap_FRAME_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 693: flag=_wrap_FRAME_INVALID_NAME_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 694: flag=_wrap_FRAME_INVALID_NAME_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 695: flag=_wrap_TRAVERSAL_INVALID_INDEX_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 696: flag=_wrap_TRAVERSAL_INVALID_INDEX_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 697: flag=_wrap_new_LinkPositions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 698: flag=_wrap_LinkPositions_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 699: flag=_wrap_LinkPositions_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 700: flag=_wrap_LinkPositions_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 701: flag=_wrap_LinkPositions_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 702: flag=_wrap_LinkPositions_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 703: flag=_wrap_delete_LinkPositions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 704: flag=_wrap_new_LinkWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 705: flag=_wrap_LinkWrenches_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 706: flag=_wrap_LinkWrenches_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 707: flag=_wrap_LinkWrenches_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 708: flag=_wrap_LinkWrenches_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 709: flag=_wrap_LinkWrenches_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 710: flag=_wrap_delete_LinkWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 711: flag=_wrap_new_LinkInertias(resc,resv,argc,(mxArray**)(argv)); break;
+  case 712: flag=_wrap_LinkInertias_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 713: flag=_wrap_LinkInertias_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 714: flag=_wrap_LinkInertias_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 715: flag=_wrap_delete_LinkInertias(resc,resv,argc,(mxArray**)(argv)); break;
+  case 716: flag=_wrap_new_LinkArticulatedBodyInertias(resc,resv,argc,(mxArray**)(argv)); break;
+  case 717: flag=_wrap_LinkArticulatedBodyInertias_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 718: flag=_wrap_LinkArticulatedBodyInertias_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 719: flag=_wrap_LinkArticulatedBodyInertias_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 720: flag=_wrap_delete_LinkArticulatedBodyInertias(resc,resv,argc,(mxArray**)(argv)); break;
+  case 721: flag=_wrap_new_LinkVelArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 722: flag=_wrap_LinkVelArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 723: flag=_wrap_LinkVelArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 724: flag=_wrap_LinkVelArray_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 725: flag=_wrap_LinkVelArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 726: flag=_wrap_LinkVelArray_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 727: flag=_wrap_delete_LinkVelArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 728: flag=_wrap_new_LinkAccArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 729: flag=_wrap_LinkAccArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 730: flag=_wrap_LinkAccArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 731: flag=_wrap_LinkAccArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 732: flag=_wrap_LinkAccArray_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 733: flag=_wrap_LinkAccArray_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 734: flag=_wrap_delete_LinkAccArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 735: flag=_wrap_new_Link(resc,resv,argc,(mxArray**)(argv)); break;
+  case 736: flag=_wrap_Link_inertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 737: flag=_wrap_Link_setInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 738: flag=_wrap_Link_getInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 739: flag=_wrap_Link_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 740: flag=_wrap_Link_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 741: flag=_wrap_delete_Link(resc,resv,argc,(mxArray**)(argv)); break;
+  case 742: flag=_wrap_delete_IJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 743: flag=_wrap_IJoint_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 744: flag=_wrap_IJoint_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 745: flag=_wrap_IJoint_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 746: flag=_wrap_IJoint_setAttachedLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 747: flag=_wrap_IJoint_setRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 748: flag=_wrap_IJoint_getFirstAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 749: flag=_wrap_IJoint_getSecondAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 750: flag=_wrap_IJoint_getRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 751: flag=_wrap_IJoint_getTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 752: flag=_wrap_IJoint_getTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 753: flag=_wrap_IJoint_getMotionSubspaceVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 754: flag=_wrap_IJoint_computeChildPosVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 755: flag=_wrap_IJoint_computeChildVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 756: flag=_wrap_IJoint_computeChildVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 757: flag=_wrap_IJoint_computeJointTorque(resc,resv,argc,(mxArray**)(argv)); break;
+  case 758: flag=_wrap_IJoint_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 759: flag=_wrap_IJoint_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 760: flag=_wrap_IJoint_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 761: flag=_wrap_IJoint_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 762: flag=_wrap_IJoint_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 763: flag=_wrap_IJoint_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 764: flag=_wrap_IJoint_isRevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 765: flag=_wrap_IJoint_isFixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 766: flag=_wrap_IJoint_asRevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 767: flag=_wrap_IJoint_asFixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 768: flag=_wrap_new_FixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 769: flag=_wrap_delete_FixedJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 770: flag=_wrap_FixedJoint_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 771: flag=_wrap_FixedJoint_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 772: flag=_wrap_FixedJoint_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 773: flag=_wrap_FixedJoint_setAttachedLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 774: flag=_wrap_FixedJoint_setRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 775: flag=_wrap_FixedJoint_getFirstAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 776: flag=_wrap_FixedJoint_getSecondAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 777: flag=_wrap_FixedJoint_getRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 778: flag=_wrap_FixedJoint_getTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 779: flag=_wrap_FixedJoint_getTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 780: flag=_wrap_FixedJoint_getMotionSubspaceVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 781: flag=_wrap_FixedJoint_computeChildPosVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 782: flag=_wrap_FixedJoint_computeChildVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 783: flag=_wrap_FixedJoint_computeChildVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 784: flag=_wrap_FixedJoint_computeJointTorque(resc,resv,argc,(mxArray**)(argv)); break;
+  case 785: flag=_wrap_FixedJoint_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 786: flag=_wrap_FixedJoint_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 787: flag=_wrap_FixedJoint_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 788: flag=_wrap_FixedJoint_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 789: flag=_wrap_FixedJoint_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 790: flag=_wrap_FixedJoint_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 791: flag=_wrap_delete_MovableJointImpl1(resc,resv,argc,(mxArray**)(argv)); break;
+  case 792: flag=_wrap_MovableJointImpl1_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 793: flag=_wrap_MovableJointImpl1_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 794: flag=_wrap_MovableJointImpl1_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 795: flag=_wrap_MovableJointImpl1_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 796: flag=_wrap_MovableJointImpl1_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 797: flag=_wrap_MovableJointImpl1_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 798: flag=_wrap_MovableJointImpl1_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 799: flag=_wrap_MovableJointImpl1_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 800: flag=_wrap_delete_MovableJointImpl2(resc,resv,argc,(mxArray**)(argv)); break;
+  case 801: flag=_wrap_MovableJointImpl2_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 802: flag=_wrap_MovableJointImpl2_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 803: flag=_wrap_MovableJointImpl2_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 804: flag=_wrap_MovableJointImpl2_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 805: flag=_wrap_MovableJointImpl2_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 806: flag=_wrap_MovableJointImpl2_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 807: flag=_wrap_MovableJointImpl2_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 808: flag=_wrap_MovableJointImpl2_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 809: flag=_wrap_delete_MovableJointImpl3(resc,resv,argc,(mxArray**)(argv)); break;
+  case 810: flag=_wrap_MovableJointImpl3_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 811: flag=_wrap_MovableJointImpl3_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 812: flag=_wrap_MovableJointImpl3_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 813: flag=_wrap_MovableJointImpl3_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 814: flag=_wrap_MovableJointImpl3_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 815: flag=_wrap_MovableJointImpl3_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 816: flag=_wrap_MovableJointImpl3_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 817: flag=_wrap_MovableJointImpl3_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 818: flag=_wrap_delete_MovableJointImpl4(resc,resv,argc,(mxArray**)(argv)); break;
+  case 819: flag=_wrap_MovableJointImpl4_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 820: flag=_wrap_MovableJointImpl4_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 821: flag=_wrap_MovableJointImpl4_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 822: flag=_wrap_MovableJointImpl4_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 823: flag=_wrap_MovableJointImpl4_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 824: flag=_wrap_MovableJointImpl4_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 825: flag=_wrap_MovableJointImpl4_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 826: flag=_wrap_MovableJointImpl4_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 827: flag=_wrap_delete_MovableJointImpl5(resc,resv,argc,(mxArray**)(argv)); break;
+  case 828: flag=_wrap_MovableJointImpl5_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 829: flag=_wrap_MovableJointImpl5_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 830: flag=_wrap_MovableJointImpl5_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 831: flag=_wrap_MovableJointImpl5_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 832: flag=_wrap_MovableJointImpl5_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 833: flag=_wrap_MovableJointImpl5_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 834: flag=_wrap_MovableJointImpl5_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 835: flag=_wrap_MovableJointImpl5_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 836: flag=_wrap_delete_MovableJointImpl6(resc,resv,argc,(mxArray**)(argv)); break;
+  case 837: flag=_wrap_MovableJointImpl6_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 838: flag=_wrap_MovableJointImpl6_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 839: flag=_wrap_MovableJointImpl6_setIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 840: flag=_wrap_MovableJointImpl6_getIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 841: flag=_wrap_MovableJointImpl6_setPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 842: flag=_wrap_MovableJointImpl6_getPosCoordsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 843: flag=_wrap_MovableJointImpl6_setDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 844: flag=_wrap_MovableJointImpl6_getDOFsOffset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 845: flag=_wrap_new_RevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 846: flag=_wrap_delete_RevoluteJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 847: flag=_wrap_RevoluteJoint_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 848: flag=_wrap_RevoluteJoint_setAttachedLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 849: flag=_wrap_RevoluteJoint_setRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 850: flag=_wrap_RevoluteJoint_setAxis(resc,resv,argc,(mxArray**)(argv)); break;
+  case 851: flag=_wrap_RevoluteJoint_getFirstAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 852: flag=_wrap_RevoluteJoint_getSecondAttachedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 853: flag=_wrap_RevoluteJoint_getAxis(resc,resv,argc,(mxArray**)(argv)); break;
+  case 854: flag=_wrap_RevoluteJoint_getRestTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 855: flag=_wrap_RevoluteJoint_getTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 856: flag=_wrap_RevoluteJoint_getTransformDerivative(resc,resv,argc,(mxArray**)(argv)); break;
+  case 857: flag=_wrap_RevoluteJoint_getMotionSubspaceVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 858: flag=_wrap_RevoluteJoint_computeChildPosVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 859: flag=_wrap_RevoluteJoint_computeChildVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 860: flag=_wrap_RevoluteJoint_computeChildVelAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 861: flag=_wrap_RevoluteJoint_computeJointTorque(resc,resv,argc,(mxArray**)(argv)); break;
+  case 862: flag=_wrap_new_Traversal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 863: flag=_wrap_delete_Traversal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 864: flag=_wrap_Traversal_getNrOfVisitedLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 865: flag=_wrap_Traversal_getLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 866: flag=_wrap_Traversal_getBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 867: flag=_wrap_Traversal_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 868: flag=_wrap_Traversal_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 869: flag=_wrap_Traversal_getParentLinkFromLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 870: flag=_wrap_Traversal_getParentJointFromLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 871: flag=_wrap_Traversal_getTraversalIndexFromLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 872: flag=_wrap_Traversal_reset(resc,resv,argc,(mxArray**)(argv)); break;
+  case 873: flag=_wrap_Traversal_addTraversalBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 874: flag=_wrap_Traversal_addTraversalElement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 875: flag=_wrap_Traversal_isParentOf(resc,resv,argc,(mxArray**)(argv)); break;
+  case 876: flag=_wrap_Traversal_getChildLinkIndexFromJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 877: flag=_wrap_Traversal_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 878: flag=_wrap_Neighbor_neighborLink_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 879: flag=_wrap_Neighbor_neighborLink_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 880: flag=_wrap_Neighbor_neighborJoint_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 881: flag=_wrap_Neighbor_neighborJoint_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 882: flag=_wrap_new_Neighbor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 883: flag=_wrap_delete_Neighbor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 884: flag=_wrap_new_Model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 885: flag=_wrap_delete_Model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 886: flag=_wrap_Model_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 887: flag=_wrap_Model_getLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 888: flag=_wrap_Model_getLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 889: flag=_wrap_Model_isValidLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 890: flag=_wrap_Model_getLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 891: flag=_wrap_Model_addLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 892: flag=_wrap_Model_getNrOfJoints(resc,resv,argc,(mxArray**)(argv)); break;
+  case 893: flag=_wrap_Model_getJointName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 894: flag=_wrap_Model_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 895: flag=_wrap_Model_getJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 896: flag=_wrap_Model_isValidJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 897: flag=_wrap_Model_isLinkNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
+  case 898: flag=_wrap_Model_isJointNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
+  case 899: flag=_wrap_Model_isFrameNameUsed(resc,resv,argc,(mxArray**)(argv)); break;
+  case 900: flag=_wrap_Model_addJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 901: flag=_wrap_Model_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 902: flag=_wrap_Model_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 903: flag=_wrap_Model_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
+  case 904: flag=_wrap_Model_addAdditionalFrameToLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 905: flag=_wrap_Model_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 906: flag=_wrap_Model_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 907: flag=_wrap_Model_isValidFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 908: flag=_wrap_Model_getFrameTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 909: flag=_wrap_Model_getFrameLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 910: flag=_wrap_Model_getNrOfNeighbors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 911: flag=_wrap_Model_getNeighbor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 912: flag=_wrap_Model_setDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 913: flag=_wrap_Model_getDefaultBaseLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 914: flag=_wrap_Model_computeFullTreeTraversal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 915: flag=_wrap_Model_getInertialParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 916: flag=_wrap_Model_updateInertialParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 917: flag=_wrap_Model_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 918: flag=_wrap_new_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 919: flag=_wrap_JointPosDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 920: flag=_wrap_JointPosDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 921: flag=_wrap_delete_JointPosDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 922: flag=_wrap_new_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 923: flag=_wrap_JointDOFsDoubleArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 924: flag=_wrap_JointDOFsDoubleArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 925: flag=_wrap_delete_JointDOFsDoubleArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 926: flag=_wrap_new_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 927: flag=_wrap_DOFSpatialForceArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 928: flag=_wrap_DOFSpatialForceArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 929: flag=_wrap_DOFSpatialForceArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 930: flag=_wrap_delete_DOFSpatialForceArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 931: flag=_wrap_new_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 932: flag=_wrap_DOFSpatialMotionArray_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 933: flag=_wrap_DOFSpatialMotionArray_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 934: flag=_wrap_DOFSpatialMotionArray_paren(resc,resv,argc,(mxArray**)(argv)); break;
+  case 935: flag=_wrap_delete_DOFSpatialMotionArray(resc,resv,argc,(mxArray**)(argv)); break;
+  case 936: flag=_wrap_new_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 937: flag=_wrap_FreeFloatingMassMatrix_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 938: flag=_wrap_delete_FreeFloatingMassMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 939: flag=_wrap_new_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 940: flag=_wrap_FreeFloatingPos_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 941: flag=_wrap_FreeFloatingPos_worldBasePos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 942: flag=_wrap_FreeFloatingPos_jointPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 943: flag=_wrap_FreeFloatingPos_getNrOfPosCoords(resc,resv,argc,(mxArray**)(argv)); break;
+  case 944: flag=_wrap_delete_FreeFloatingPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 945: flag=_wrap_new_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 946: flag=_wrap_FreeFloatingGeneralizedTorques_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 947: flag=_wrap_FreeFloatingGeneralizedTorques_baseWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 948: flag=_wrap_FreeFloatingGeneralizedTorques_jointTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 949: flag=_wrap_FreeFloatingGeneralizedTorques_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 950: flag=_wrap_delete_FreeFloatingGeneralizedTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 951: flag=_wrap_new_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 952: flag=_wrap_FreeFloatingVel_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 953: flag=_wrap_FreeFloatingVel_baseVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 954: flag=_wrap_FreeFloatingVel_jointVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 955: flag=_wrap_FreeFloatingVel_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 956: flag=_wrap_delete_FreeFloatingVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 957: flag=_wrap_new_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 958: flag=_wrap_FreeFloatingAcc_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 959: flag=_wrap_FreeFloatingAcc_baseAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 960: flag=_wrap_FreeFloatingAcc_jointAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 961: flag=_wrap_FreeFloatingAcc_getNrOfDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 962: flag=_wrap_delete_FreeFloatingAcc(resc,resv,argc,(mxArray**)(argv)); break;
+  case 963: flag=_wrap_ContactWrench_contactId(resc,resv,argc,(mxArray**)(argv)); break;
+  case 964: flag=_wrap_ContactWrench_contactPoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 965: flag=_wrap_ContactWrench_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 966: flag=_wrap_new_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 967: flag=_wrap_delete_ContactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 968: flag=_wrap_new_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 969: flag=_wrap_LinkContactWrenches_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 970: flag=_wrap_LinkContactWrenches_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 971: flag=_wrap_LinkContactWrenches_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 972: flag=_wrap_LinkContactWrenches_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 973: flag=_wrap_LinkContactWrenches_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 974: flag=_wrap_LinkContactWrenches_computeNetWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 975: flag=_wrap_LinkContactWrenches_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 976: flag=_wrap_delete_LinkContactWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 977: flag=_wrap_ForwardPositionKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 978: flag=_wrap_ForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 979: flag=_wrap_ForwardPosVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 980: flag=_wrap_RNEADynamicPhase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 981: flag=_wrap_CompositeRigidBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
+  case 982: flag=_wrap_new_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 983: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 984: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 985: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 986: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_S_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 987: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 988: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_U_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 989: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 990: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_D_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 991: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 992: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_u_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 993: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 994: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksVel_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 995: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 996: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasAcceleration_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 997: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 998: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksAccelerations_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 999: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1000: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linkABIs_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1001: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1002: flag=_wrap_ArticulatedBodyAlgorithmInternalBuffers_linksBiasWrench_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1003: flag=_wrap_delete_ArticulatedBodyAlgorithmInternalBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1004: flag=_wrap_ArticulatedBodyAlgorithm(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1005: flag=_wrap_NR_OF_SENSOR_TYPES_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1006: flag=_wrap_isLinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1007: flag=_wrap_isJointSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1008: flag=_wrap_getSensorTypeSize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1009: flag=_wrap_delete_Sensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1010: flag=_wrap_Sensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1011: flag=_wrap_Sensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1012: flag=_wrap_Sensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1013: flag=_wrap_Sensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1014: flag=_wrap_Sensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1015: flag=_wrap_Sensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1016: flag=_wrap_delete_JointSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1017: flag=_wrap_JointSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1018: flag=_wrap_JointSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1019: flag=_wrap_JointSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1020: flag=_wrap_JointSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1021: flag=_wrap_delete_LinkSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1022: flag=_wrap_LinkSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1023: flag=_wrap_LinkSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1024: flag=_wrap_LinkSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1025: flag=_wrap_LinkSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1026: flag=_wrap_LinkSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1027: flag=_wrap_new_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1028: flag=_wrap_delete_SensorsList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1029: flag=_wrap_SensorsList_addSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1030: flag=_wrap_SensorsList_setSerialization(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1031: flag=_wrap_SensorsList_getSerialization(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1032: flag=_wrap_SensorsList_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1033: flag=_wrap_SensorsList_getSensorIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1034: flag=_wrap_SensorsList_getSizeOfAllSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1035: flag=_wrap_SensorsList_getSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1036: flag=_wrap_SensorsList_removeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1037: flag=_wrap_SensorsList_removeAllSensorsOfType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1038: flag=_wrap_SensorsList_getSixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1039: flag=_wrap_SensorsList_getAccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1040: flag=_wrap_SensorsList_getGyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1041: flag=_wrap_new_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1042: flag=_wrap_delete_SensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1043: flag=_wrap_SensorsMeasurements_setNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1044: flag=_wrap_SensorsMeasurements_getNrOfSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1045: flag=_wrap_SensorsMeasurements_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1046: flag=_wrap_SensorsMeasurements_toVector(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1047: flag=_wrap_SensorsMeasurements_setMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1048: flag=_wrap_SensorsMeasurements_getMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1049: flag=_wrap_SensorsMeasurements_getSizeOfAllSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1050: flag=_wrap_new_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1051: flag=_wrap_delete_SixAxisForceTorqueSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1052: flag=_wrap_SixAxisForceTorqueSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1053: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1054: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1055: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1056: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1057: flag=_wrap_SixAxisForceTorqueSensor_setFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1058: flag=_wrap_SixAxisForceTorqueSensor_setSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1059: flag=_wrap_SixAxisForceTorqueSensor_getFirstLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1060: flag=_wrap_SixAxisForceTorqueSensor_getSecondLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1061: flag=_wrap_SixAxisForceTorqueSensor_setParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1062: flag=_wrap_SixAxisForceTorqueSensor_setParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1063: flag=_wrap_SixAxisForceTorqueSensor_setAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1064: flag=_wrap_SixAxisForceTorqueSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1065: flag=_wrap_SixAxisForceTorqueSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1066: flag=_wrap_SixAxisForceTorqueSensor_getParentJoint(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1067: flag=_wrap_SixAxisForceTorqueSensor_getParentJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1068: flag=_wrap_SixAxisForceTorqueSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1069: flag=_wrap_SixAxisForceTorqueSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1070: flag=_wrap_SixAxisForceTorqueSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1071: flag=_wrap_SixAxisForceTorqueSensor_getAppliedWrenchLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1072: flag=_wrap_SixAxisForceTorqueSensor_isLinkAttachedToSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1073: flag=_wrap_SixAxisForceTorqueSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1074: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1075: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLinkMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1076: flag=_wrap_SixAxisForceTorqueSensor_getWrenchAppliedOnLinkInverseMatrix(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1077: flag=_wrap_SixAxisForceTorqueSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1078: flag=_wrap_SixAxisForceTorqueSensor_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1079: flag=_wrap_new_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1080: flag=_wrap_delete_AccelerometerSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1081: flag=_wrap_AccelerometerSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1082: flag=_wrap_AccelerometerSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1083: flag=_wrap_AccelerometerSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1084: flag=_wrap_AccelerometerSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1085: flag=_wrap_AccelerometerSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1086: flag=_wrap_AccelerometerSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1087: flag=_wrap_AccelerometerSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1088: flag=_wrap_AccelerometerSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1089: flag=_wrap_AccelerometerSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1090: flag=_wrap_AccelerometerSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1091: flag=_wrap_AccelerometerSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1092: flag=_wrap_AccelerometerSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1093: flag=_wrap_AccelerometerSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1094: flag=_wrap_new_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1095: flag=_wrap_delete_GyroscopeSensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1096: flag=_wrap_GyroscopeSensor_setName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1097: flag=_wrap_GyroscopeSensor_setLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1098: flag=_wrap_GyroscopeSensor_setParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1099: flag=_wrap_GyroscopeSensor_setParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1100: flag=_wrap_GyroscopeSensor_getName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1101: flag=_wrap_GyroscopeSensor_getSensorType(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1102: flag=_wrap_GyroscopeSensor_getParentLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1103: flag=_wrap_GyroscopeSensor_getParentLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1104: flag=_wrap_GyroscopeSensor_getLinkSensorTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1105: flag=_wrap_GyroscopeSensor_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1106: flag=_wrap_GyroscopeSensor_clone(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1107: flag=_wrap_GyroscopeSensor_updateIndeces(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1108: flag=_wrap_GyroscopeSensor_predictMeasurement(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1109: flag=_wrap_predictSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1110: flag=_wrap_predictSensorsMeasurementsFromRawBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1111: flag=_wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1112: flag=_wrap_URDFParserOptions_addSensorFramesAsAdditionalFrames_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1113: flag=_wrap_new_URDFParserOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1114: flag=_wrap_delete_URDFParserOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1115: flag=_wrap_modelFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1116: flag=_wrap_modelFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1117: flag=_wrap_sensorsFromURDF(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1118: flag=_wrap_sensorsFromURDFString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1119: flag=_wrap_new_ModelLoader(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1120: flag=_wrap_ModelLoader_loadModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1121: flag=_wrap_ModelLoader_loadModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1122: flag=_wrap_ModelLoader_loadReducedModelFromFullModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1123: flag=_wrap_ModelLoader_loadReducedModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1124: flag=_wrap_ModelLoader_loadReducedModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1125: flag=_wrap_ModelLoader_model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1126: flag=_wrap_ModelLoader_sensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1127: flag=_wrap_ModelLoader_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1128: flag=_wrap_delete_ModelLoader(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1129: flag=_wrap_new_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1130: flag=_wrap_UnknownWrenchContact_unknownType_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1131: flag=_wrap_UnknownWrenchContact_unknownType_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1132: flag=_wrap_UnknownWrenchContact_contactPoint_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1133: flag=_wrap_UnknownWrenchContact_contactPoint_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1134: flag=_wrap_UnknownWrenchContact_forceDirection_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1135: flag=_wrap_UnknownWrenchContact_forceDirection_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1136: flag=_wrap_UnknownWrenchContact_contactId_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1137: flag=_wrap_UnknownWrenchContact_contactId_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1138: flag=_wrap_delete_UnknownWrenchContact(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1139: flag=_wrap_new_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1140: flag=_wrap_LinkUnknownWrenchContacts_clear(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1141: flag=_wrap_LinkUnknownWrenchContacts_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1142: flag=_wrap_LinkUnknownWrenchContacts_getNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1143: flag=_wrap_LinkUnknownWrenchContacts_setNrOfContactsForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1144: flag=_wrap_LinkUnknownWrenchContacts_addNewContactForLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1145: flag=_wrap_LinkUnknownWrenchContacts_addNewContactInFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1146: flag=_wrap_LinkUnknownWrenchContacts_addNewUnknownFullWrenchInFrameOrigin(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1147: flag=_wrap_LinkUnknownWrenchContacts_contactWrench(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1148: flag=_wrap_LinkUnknownWrenchContacts_toString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1149: flag=_wrap_delete_LinkUnknownWrenchContacts(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1150: flag=_wrap_new_LinkTraversalsCache(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1151: flag=_wrap_delete_LinkTraversalsCache(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1152: flag=_wrap_LinkTraversalsCache_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1153: flag=_wrap_LinkTraversalsCache_getTraversalWithLinkAsBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1154: flag=_wrap_new_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1155: flag=_wrap_estimateExternalWrenchesBuffers_resize(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1156: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfSubModels(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1157: flag=_wrap_estimateExternalWrenchesBuffers_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1158: flag=_wrap_estimateExternalWrenchesBuffers_isConsistent(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1159: flag=_wrap_estimateExternalWrenchesBuffers_A_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1160: flag=_wrap_estimateExternalWrenchesBuffers_A_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1161: flag=_wrap_estimateExternalWrenchesBuffers_x_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1162: flag=_wrap_estimateExternalWrenchesBuffers_x_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1163: flag=_wrap_estimateExternalWrenchesBuffers_b_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1164: flag=_wrap_estimateExternalWrenchesBuffers_b_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1165: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1166: flag=_wrap_estimateExternalWrenchesBuffers_pinvA_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1167: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1168: flag=_wrap_estimateExternalWrenchesBuffers_b_contacts_subtree_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1169: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1170: flag=_wrap_estimateExternalWrenchesBuffers_subModelBase_H_link_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1171: flag=_wrap_delete_estimateExternalWrenchesBuffers(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1172: flag=_wrap_estimateExternalWrenchesWithoutInternalFT(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1173: flag=_wrap_estimateExternalWrenches(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1174: flag=_wrap_dynamicsEstimationForwardVelAccKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1175: flag=_wrap_dynamicsEstimationForwardVelKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1176: flag=_wrap_computeLinkNetWrenchesWithoutGravity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1177: flag=_wrap_new_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1178: flag=_wrap_delete_ExtWrenchesAndJointTorquesEstimator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1179: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_setModelAndSensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1180: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1181: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_loadModelAndSensorsFromFileWithSpecifiedDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1182: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1183: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_sensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1184: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_submodels(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1185: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1186: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_updateKinematicsFromFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1187: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_computeExpectedFTSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1188: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateExtWrenchesAndJointTorques(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1189: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_checkThatTheModelIsStill(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1190: flag=_wrap_ExtWrenchesAndJointTorquesEstimator_estimateLinkNetWrenchesWithoutGravity(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1191: flag=_wrap_new_SimpleLeggedOdometry(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1192: flag=_wrap_delete_SimpleLeggedOdometry(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1193: flag=_wrap_SimpleLeggedOdometry_setModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1194: flag=_wrap_SimpleLeggedOdometry_loadModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1195: flag=_wrap_SimpleLeggedOdometry_loadModelFromFileWithSpecifiedDOFs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1196: flag=_wrap_SimpleLeggedOdometry_model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1197: flag=_wrap_SimpleLeggedOdometry_updateKinematics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1198: flag=_wrap_SimpleLeggedOdometry_init(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1199: flag=_wrap_SimpleLeggedOdometry_changeFixedFrame(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1200: flag=_wrap_SimpleLeggedOdometry_getCurrentFixedLink(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1201: flag=_wrap_SimpleLeggedOdometry_getWorldLinkTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1202: flag=_wrap_isLinkBerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1203: flag=_wrap_isJointBerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1204: flag=_wrap_isDOFBerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1205: flag=_wrap_new_BerdyOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1206: flag=_wrap_BerdyOptions_berdyVariant_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1207: flag=_wrap_BerdyOptions_berdyVariant_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1208: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1209: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsDynamicVariables_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1210: flag=_wrap_BerdyOptions_includeAllJointAccelerationsAsSensors_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1211: flag=_wrap_BerdyOptions_includeAllJointAccelerationsAsSensors_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1212: flag=_wrap_BerdyOptions_includeAllJointTorquesAsSensors_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1213: flag=_wrap_BerdyOptions_includeAllJointTorquesAsSensors_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1214: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsSensors_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1215: flag=_wrap_BerdyOptions_includeAllNetExternalWrenchesAsSensors_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1216: flag=_wrap_BerdyOptions_includeFixedBaseExternalWrench_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1217: flag=_wrap_BerdyOptions_includeFixedBaseExternalWrench_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1218: flag=_wrap_BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1219: flag=_wrap_BerdyOptions_jointOnWhichTheInternalWrenchIsMeasured_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1220: flag=_wrap_BerdyOptions_checkConsistency(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1221: flag=_wrap_delete_BerdyOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1222: flag=_wrap_BerdySensor_type_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1223: flag=_wrap_BerdySensor_type_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1224: flag=_wrap_BerdySensor_id_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1225: flag=_wrap_BerdySensor_id_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1226: flag=_wrap_BerdySensor_range_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1227: flag=_wrap_BerdySensor_range_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1228: flag=_wrap_BerdySensor_eq(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1229: flag=_wrap_new_BerdySensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1230: flag=_wrap_delete_BerdySensor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1231: flag=_wrap_BerdyDynamicVariable_type_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1232: flag=_wrap_BerdyDynamicVariable_type_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1233: flag=_wrap_BerdyDynamicVariable_id_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1234: flag=_wrap_BerdyDynamicVariable_id_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1235: flag=_wrap_BerdyDynamicVariable_range_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1236: flag=_wrap_BerdyDynamicVariable_range_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1237: flag=_wrap_new_BerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1238: flag=_wrap_delete_BerdyDynamicVariable(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1239: flag=_wrap_new_BerdyHelper(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1240: flag=_wrap_BerdyHelper_dynamicTraversal(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1241: flag=_wrap_BerdyHelper_model(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1242: flag=_wrap_BerdyHelper_sensors(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1243: flag=_wrap_BerdyHelper_init(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1244: flag=_wrap_BerdyHelper_getOptions(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1245: flag=_wrap_BerdyHelper_getNrOfDynamicVariables(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1246: flag=_wrap_BerdyHelper_getNrOfDynamicEquations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1247: flag=_wrap_BerdyHelper_getNrOfSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1248: flag=_wrap_BerdyHelper_resizeAndZeroBerdyMatrices(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1249: flag=_wrap_BerdyHelper_getBerdyMatrices(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1250: flag=_wrap_BerdyHelper_getSensorsOrdering(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1251: flag=_wrap_BerdyHelper_getDynamicVariablesOrdering(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1252: flag=_wrap_BerdyHelper_serializeDynamicVariables(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1253: flag=_wrap_BerdyHelper_serializeSensorVariables(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1254: flag=_wrap_BerdyHelper_serializeDynamicVariablesComputedFromFixedBaseRNEA(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1255: flag=_wrap_BerdyHelper_updateKinematicsFromFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1256: flag=_wrap_BerdyHelper_updateKinematicsFromFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1257: flag=_wrap_BerdyHelper_updateKinematicsFromTraversalFixedBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1258: flag=_wrap_delete_BerdyHelper(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1259: flag=_wrap_DynamicsRegressorParameter_category_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1260: flag=_wrap_DynamicsRegressorParameter_category_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1261: flag=_wrap_DynamicsRegressorParameter_elemIndex_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1262: flag=_wrap_DynamicsRegressorParameter_elemIndex_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1263: flag=_wrap_DynamicsRegressorParameter_type_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1264: flag=_wrap_DynamicsRegressorParameter_type_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1265: flag=_wrap_DynamicsRegressorParameter_lt(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1266: flag=_wrap_DynamicsRegressorParameter_eq(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1267: flag=_wrap_DynamicsRegressorParameter_ne(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1268: flag=_wrap_new_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1269: flag=_wrap_delete_DynamicsRegressorParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1270: flag=_wrap_DynamicsRegressorParametersList_parameters_get(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1271: flag=_wrap_DynamicsRegressorParametersList_parameters_set(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1272: flag=_wrap_DynamicsRegressorParametersList_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1273: flag=_wrap_DynamicsRegressorParametersList_addParam(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1274: flag=_wrap_DynamicsRegressorParametersList_addList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1275: flag=_wrap_DynamicsRegressorParametersList_findParam(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1276: flag=_wrap_DynamicsRegressorParametersList_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1277: flag=_wrap_new_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1278: flag=_wrap_delete_DynamicsRegressorParametersList(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1279: flag=_wrap_new_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1280: flag=_wrap_delete_DynamicsRegressorGenerator(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1281: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1282: flag=_wrap_DynamicsRegressorGenerator_loadRobotAndSensorsModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1283: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1284: flag=_wrap_DynamicsRegressorGenerator_loadRegressorStructureFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1285: flag=_wrap_DynamicsRegressorGenerator_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1286: flag=_wrap_DynamicsRegressorGenerator_getNrOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1287: flag=_wrap_DynamicsRegressorGenerator_getNrOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1288: flag=_wrap_DynamicsRegressorGenerator_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1289: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameter(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1290: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1291: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutput(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1292: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfOutputs(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1293: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1294: flag=_wrap_DynamicsRegressorGenerator_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1295: flag=_wrap_DynamicsRegressorGenerator_getBaseLinkName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1296: flag=_wrap_DynamicsRegressorGenerator_getSensorsModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1297: flag=_wrap_DynamicsRegressorGenerator_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1298: flag=_wrap_DynamicsRegressorGenerator_getSensorsMeasurements(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1299: flag=_wrap_DynamicsRegressorGenerator_computeRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1300: flag=_wrap_DynamicsRegressorGenerator_getModelParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1301: flag=_wrap_DynamicsRegressorGenerator_computeFloatingBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1302: flag=_wrap_DynamicsRegressorGenerator_computeFixedBaseIdentifiableSubspace(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1303: flag=_wrap_new_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1304: flag=_wrap_delete_KinDynComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1305: flag=_wrap_KinDynComputations_loadRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1306: flag=_wrap_KinDynComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1307: flag=_wrap_KinDynComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1308: flag=_wrap_KinDynComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1309: flag=_wrap_KinDynComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1310: flag=_wrap_KinDynComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1311: flag=_wrap_KinDynComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1312: flag=_wrap_KinDynComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1313: flag=_wrap_KinDynComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1314: flag=_wrap_KinDynComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1315: flag=_wrap_KinDynComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1316: flag=_wrap_KinDynComputations_getRobotModel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1317: flag=_wrap_KinDynComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1318: flag=_wrap_KinDynComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1319: flag=_wrap_KinDynComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1320: flag=_wrap_KinDynComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1321: flag=_wrap_KinDynComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1322: flag=_wrap_KinDynComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1323: flag=_wrap_KinDynComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1324: flag=_wrap_KinDynComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1325: flag=_wrap_KinDynComputations_getRelativeTransformExplicit(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1326: flag=_wrap_KinDynComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1327: flag=_wrap_new_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1328: flag=_wrap_delete_DynamicsComputations(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1329: flag=_wrap_DynamicsComputations_loadRobotModelFromFile(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1330: flag=_wrap_DynamicsComputations_loadRobotModelFromString(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1331: flag=_wrap_DynamicsComputations_isValid(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1332: flag=_wrap_DynamicsComputations_getNrOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1333: flag=_wrap_DynamicsComputations_getDescriptionOfDegreeOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1334: flag=_wrap_DynamicsComputations_getDescriptionOfDegreesOfFreedom(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1335: flag=_wrap_DynamicsComputations_getNrOfLinks(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1336: flag=_wrap_DynamicsComputations_getNrOfFrames(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1337: flag=_wrap_DynamicsComputations_getFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1338: flag=_wrap_DynamicsComputations_setFloatingBase(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1339: flag=_wrap_DynamicsComputations_setRobotState(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1340: flag=_wrap_DynamicsComputations_getWorldBaseTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1341: flag=_wrap_DynamicsComputations_getBaseTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1342: flag=_wrap_DynamicsComputations_getJointPos(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1343: flag=_wrap_DynamicsComputations_getJointVel(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1344: flag=_wrap_DynamicsComputations_getFrameIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1345: flag=_wrap_DynamicsComputations_getFrameName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1346: flag=_wrap_DynamicsComputations_getWorldTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1347: flag=_wrap_DynamicsComputations_getRelativeTransform(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1348: flag=_wrap_DynamicsComputations_getFrameTwist(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1349: flag=_wrap_DynamicsComputations_getFrameTwistInWorldOrient(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1350: flag=_wrap_DynamicsComputations_getFrameProperSpatialAcceleration(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1351: flag=_wrap_DynamicsComputations_getLinkIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1352: flag=_wrap_DynamicsComputations_getLinkInertia(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1353: flag=_wrap_DynamicsComputations_getJointIndex(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1354: flag=_wrap_DynamicsComputations_getJointName(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1355: flag=_wrap_DynamicsComputations_getJointLimits(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1356: flag=_wrap_DynamicsComputations_inverseDynamics(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1357: flag=_wrap_DynamicsComputations_getFrameJacobian(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1358: flag=_wrap_DynamicsComputations_getDynamicsRegressor(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1359: flag=_wrap_DynamicsComputations_getModelDynamicsParameters(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1360: flag=_wrap_DynamicsComputations_getCenterOfMass(resc,resv,argc,(mxArray**)(argv)); break;
+  case 1361: flag=_wrap_DynamicsComputations_getCenterOfMassJacobian(resc,resv,argc,(mxArray**)(argv)); break;
   default: flag=1, SWIG_Error(SWIG_RuntimeError, "No function id %d.", fcn_id);
   }
   if (flag) {

--- a/bindings/matlab/matlab_matvec.i
+++ b/bindings/matlab/matlab_matvec.i
@@ -3,6 +3,76 @@
 namespace iDynTree
 {
 
+%define VECTORSPARSECOPY(sparsevector, dynVector, cols)
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(sparsevector);
+    mwIndex* jc = mxGetJc(sparsevector);
+    double *data = mxGetPr(sparsevector);
+    
+    //If cols == 1 assume it is a column vector (or a 1 element vector)
+    bool isColumnVector = (cols == 1);
+
+    //zero the matrix (iDynTree vector is dense)
+    dynVector->zero();
+    for (mwIndex col = 0; col < cols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+        
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            //iDynTree has only one size.
+            dynVector->operator()(isColumnVector ? row : col) = data[currentIndex];
+        }
+    }
+%enddef
+
+%define MATRIXSPARSECOPY(sparsematrix, dynMatrix, cols)
+    //getting pointer to sparse structure
+    mwIndex* ir = mxGetIr(sparsematrix);
+    mwIndex* jc = mxGetJc(sparsematrix);
+    double *data = mxGetPr(sparsematrix);
+
+    //zero the matrix (iDynTree matrix is dense)
+    dynMatrix->zero();
+    for (mwIndex col = 0; col < cols; col++)
+    {
+        /*
+            jc[col] contains information about the nonzero values.
+            jc[col + 1] - jc[col] = number of nonzero elements in column col
+            These nonzero elements can be access with a for loop starting at 
+            jc[col] and ending at jc[col + 1] - 1.
+            
+        */
+        mwIndex startingRowIndex = jc[col];
+        mwIndex endRowIndex = jc[col + 1];
+        if (startingRowIndex == endRowIndex)
+        {
+            //no elements in this column
+            continue;
+        }
+        for (mwIndex currentIndex = startingRowIndex; currentIndex < endRowIndex; currentIndex++)
+        {
+            //access the element
+            mwIndex row = ir[currentIndex];
+            dynMatrix->operator()(row, col) = data[currentIndex];
+        }
+    }
+%enddef
+
 %extend VectorFixSize
 {
     // Convert to a dense matrix
@@ -20,16 +90,25 @@ namespace iDynTree
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValSize = $self->size();
-        if( ( dims[0] == fixValSize && dims[1] == 1) ||
-            ( dims[0] == 1 && dims[1] == fixValSize ) )
+        size_t nonSingletonDimension = (dims[0] == 1 ? dims[1] : dims[0]);
+        
+        if (nonSingletonDimension == fixValSize)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = $self->data();
-            for(size_t i=0; i < fixValSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                VECTORSPARSECOPY(in, $self, dims[1])
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = $self->data();
+                for(size_t i=0; i < fixValSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
+        } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong vector size. Matlab size: %d. iDynTree size: %d", nonSingletonDimension, fixValSize);
         }
     }
 }
@@ -45,24 +124,32 @@ namespace iDynTree
         return p;
     }
 
-    // Convert from a dense matrix
+    // Convert from a dense or sparse matrix
     void fromMatlab(mxArray * in)
     {
         // check size
         const size_t * dims = mxGetDimensions(in);
         size_t fixValRows = $self->rows();
         size_t fixValCols = $self->cols();
-        if( dims[0] == fixValRows && dims[1] == fixValCols )
+        if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            double* d = static_cast<double*>(mxGetData(in));
-            for(size_t row=0; row < fixValRows; row++ )
+            if (mxIsSparse(in)) 
             {
-                for(size_t col=0; col < fixValCols; col++ )
+                MATRIXSPARSECOPY(in, $self, fixValCols)
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                for (size_t row = 0; row < fixValRows; row++)
                 {
-                    $self->operator()(row,col) = d[col*fixValRows + row];
+                    for (size_t col = 0; col < fixValCols; col++)
+                    {
+                        $self->operator()(row,col) = d[col*fixValRows + row];
+                    }
                 }
+                return;
             }
-            return;
+            } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+              "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
 }
@@ -85,7 +172,7 @@ namespace iDynTree
         // check size
         const size_t * dims = mxGetDimensions(in);
         $self->size();
-        if( ( dims[0] == 1 || dims[1] == 1) )
+        if (( dims[0] == 1 || dims[1] == 1))
         {
             // Get the size of the input vector
             size_t inSize;
@@ -104,13 +191,19 @@ namespace iDynTree
             if( $self->size() != inSize )
             {
                 $self->resize(inSize);
+                mexWarnMsgIdAndTxt("iDynTree:Core:perfomance", "Resizing iDynTree vector to %d", inSize);
             }
 
-            double* d = static_cast<double*>(mxGetData(in));
-            double* selfData = $self->data();
-            for(size_t i=0; i < inSize; i++ )
+            if (mxIsSparse(in))
             {
-                selfData[i] = d[i];
+                VECTORSPARSECOPY(in, $self, dims[1])
+            } else {
+                double* d = static_cast<double*>(mxGetData(in));
+                double* selfData = $self->data();
+                for(size_t i=0; i < inSize; i++ )
+                {
+                    selfData[i] = d[i];
+                }
             }
             return;
         }
@@ -126,6 +219,35 @@ namespace iDynTree
         double* d = static_cast<double*>(mxGetData(p));
         $self->fillColMajorBuffer(d); // Column-major
         return p;
+    }
+    
+    // Convert from a dense or sparse matrix
+    void fromMatlab(mxArray * in)
+    {
+        // check size
+        const size_t * dims = mxGetDimensions(in);
+        size_t rows = $self->rows();
+        size_t cols = $self->cols();
+        if (dims[0] != rows || dims[1] == cols)
+        {
+            $self->resize(rows, cols);
+            mexWarnMsgIdAndTxt("iDynTree:Core:perfomance", "Resizing iDynTree vector to (%d,%d)", rows, cols);
+        }
+
+        if (mxIsSparse(in)) 
+        {
+            MATRIXSPARSECOPY(in, $self, cols)
+        } else {
+            double* d = static_cast<double*>(mxGetData(in));
+            for (size_t row = 0; row < rows; row++)
+            {
+                for (size_t col = 0; col < cols; col++)
+                {
+                    $self->operator()(row,col) = d[col*rows + row];
+                }
+            }
+            return;
+        }
     }
 }
 

--- a/bindings/matlab/matlab_matvec.i
+++ b/bindings/matlab/matlab_matvec.i
@@ -8,7 +8,7 @@ namespace iDynTree
     mwIndex* ir = mxGetIr(sparsevector);
     mwIndex* jc = mxGetJc(sparsevector);
     double *data = mxGetPr(sparsevector);
-    
+
     //If cols == 1 assume it is a column vector (or a 1 element vector)
     bool isColumnVector = (cols == 1);
 
@@ -19,9 +19,9 @@ namespace iDynTree
         /*
             jc[col] contains information about the nonzero values.
             jc[col + 1] - jc[col] = number of nonzero elements in column col
-            These nonzero elements can be access with a for loop starting at 
+            These nonzero elements can be access with a for loop starting at
             jc[col] and ending at jc[col + 1] - 1.
-        
+
         */
         mwIndex startingRowIndex = jc[col];
         mwIndex endRowIndex = jc[col + 1];
@@ -53,9 +53,9 @@ namespace iDynTree
         /*
             jc[col] contains information about the nonzero values.
             jc[col + 1] - jc[col] = number of nonzero elements in column col
-            These nonzero elements can be access with a for loop starting at 
+            These nonzero elements can be access with a for loop starting at
             jc[col] and ending at jc[col + 1] - 1.
-            
+
         */
         mwIndex startingRowIndex = jc[col];
         mwIndex endRowIndex = jc[col + 1];
@@ -91,7 +91,7 @@ namespace iDynTree
         const size_t * dims = mxGetDimensions(in);
         size_t fixValSize = $self->size();
         size_t nonSingletonDimension = (dims[0] == 1 ? dims[1] : dims[0]);
-        
+
         if (nonSingletonDimension == fixValSize)
         {
             if (mxIsSparse(in))
@@ -107,7 +107,7 @@ namespace iDynTree
             }
             return;
         } else {
-            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension",
               "Wrong vector size. Matlab size: %d. iDynTree size: %d", nonSingletonDimension, fixValSize);
         }
     }
@@ -133,7 +133,7 @@ namespace iDynTree
         size_t fixValCols = $self->cols();
         if (dims[0] == fixValRows && dims[1] == fixValCols)
         {
-            if (mxIsSparse(in)) 
+            if (mxIsSparse(in))
             {
                 MATRIXSPARSECOPY(in, $self, fixValCols)
             } else {
@@ -147,8 +147,8 @@ namespace iDynTree
                 }
                 return;
             }
-            } else {
-            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension", 
+         } else {
+            mexErrMsgIdAndTxt("iDynTree:Core:wrongDimension",
               "Wrong matrix size. Matlab size: (%d,%d). iDynTree size: (%d,%d)", dims[0], dims[1], fixValRows, fixValCols);
         }
     }
@@ -220,7 +220,7 @@ namespace iDynTree
         $self->fillColMajorBuffer(d); // Column-major
         return p;
     }
-    
+
     // Convert from a dense or sparse matrix
     void fromMatlab(mxArray * in)
     {
@@ -230,11 +230,11 @@ namespace iDynTree
         size_t cols = $self->cols();
         if (dims[0] != rows || dims[1] == cols)
         {
-            $self->resize(rows, cols);
+            $self->resize(dims[0], dims[1]);
             mexWarnMsgIdAndTxt("iDynTree:Core:perfomance", "Resizing iDynTree vector to (%d,%d)", rows, cols);
         }
 
-        if (mxIsSparse(in)) 
+        if (mxIsSparse(in))
         {
             MATRIXSPARSECOPY(in, $self, cols)
         } else {

--- a/bindings/matlab/tests/MatrixUnitTest.m
+++ b/bindings/matlab/tests/MatrixUnitTest.m
@@ -1,0 +1,10 @@
+function test_suite=MatrixUnitTest
+    initTestSuite
+
+function test_sparse_matrices
+    iDynTreeLoad;
+    rand('state',0);
+    randSparse = sprand(10,20,0.5);
+    randSparseId = iDynTree.MatrixDynSize();
+    randSparseId.fromMatlab(randSparse);
+    assertElementsAlmostEqual(randSparseId.toMatlab(),full(randSparse))

--- a/bindings/octave/octave_matvec.i
+++ b/bindings/octave/octave_matvec.i
@@ -12,7 +12,7 @@ namespace iDynTree
         $self->fillBuffer(mat.fortran_vec()); // Column-major
         return octave_value(mat);
     }
-    
+
     // Convert from a dense matrix
     void fromMatlab(octave_value oct_val)
     {
@@ -134,6 +134,62 @@ namespace iDynTree
         Matrix mat = Matrix($self->rows(), $self->cols());
         $self->fillColMajorBuffer(mat.fortran_vec()); // Column-major
         return octave_value(mat);
+    }
+
+    // Convert from a dense matrix
+    void fromMatlab(octave_value oct_val)
+    {
+        if( !oct_val.is_matrix_type() && !oct_val.is_sparse_type() )
+        {
+            std::cerr << "VectorFixSize::fromMatlab : expected matrix or sparse matrix argument" << std::endl;
+            return;
+        }
+
+        // check size
+        size_t currRows = $self->rows();
+        size_t currCols = $self->cols();
+
+        // Copy dense matrix
+        if (oct_val.is_matrix_type())
+        {
+            Matrix mat = oct_val.matrix_value();
+
+            if (mat.rows() != currRows && mat.cols() != currCols)
+            {
+                $self->resize(mat.rows(),mat.cols());
+            }
+
+            double* d = static_cast<double*>(mat.fortran_vec());
+            for (size_t row=0; row < mat.rows(); row++)
+            {
+                for(size_t col=0; col < mat.cols(); col++ )
+                {
+                    $self->operator()(row,col) = d[col*mat.rows() + row];
+                }
+            }
+            return;
+        }
+
+        // Copy sparse matrix
+        if (oct_val.is_sparse_type())
+        {
+            SparseMatrix mat = oct_val.sparse_matrix_value();
+
+            if (mat.rows() != currRows && mat.cols() != currCols)
+            {
+                $self->resize(mat.rows(),mat.cols());
+            }
+
+
+            for (size_t row=0; row < mat.rows(); row++)
+            {
+                for (size_t col=0; col < mat.cols(); col++ )
+                {
+                    $self->operator()(row,col) = mat(row,col);
+                }
+            }
+
+        }
     }
 }
 


### PR DESCRIPTION
For now only `fromMatlab` has been implemented as `iDynTree` does not support sparse matrices yet.

This table summarises the possible cases ( ➖  means it does not apply, ✔️  means it is implemented, ✖️  means it is not implemented)

| From/to | Mat. Dense | Mat. Sparse | iDyn3 Dense | iDyn3 Sparse |
| --- | :-: | :-: | :-: | :-: |
| **iDyn3 Dense** | ✔️ | ✖️ | ➖ | ➖ |
| **iDyn3 Sparse** | ✖️ | ✖️ | ➖ | ➖ |
| **Mat. Dense** | ➖ | ➖ | ✔️ | ✖️ |
| **Mat. Sparse** | ➖ | ➖ | ✔️ | ✖️ |
