### PR TITLE
Fix bug in parsing URDF file with sphere geometry

### DIFF
--- a/src/high-level-kdl/tests/DynamicsComputationsUnitTest.cpp
+++ b/src/high-level-kdl/tests/DynamicsComputationsUnitTest.cpp
@@ -170,9 +170,13 @@ int main()
 {
     for(unsigned int mdl = 0; mdl < IDYNTREE_TESTS_URDFS_NR; mdl++ )
     {
-        std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
-        std::cout << "Testing file " << std::string(IDYNTREE_TESTS_URDFS[mdl]) <<  std::endl;
-        testModelConsistency(urdfFileName);
+        // This test fails with frame.urdf, see https://github.com/robotology/idyntree/issues/298
+        if (std::string(IDYNTREE_TESTS_URDFS[mdl]) != "frame.urdf")
+        {
+            std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
+            std::cout << "Testing file " << std::string(IDYNTREE_TESTS_URDFS[mdl]) <<  std::endl;
+            testModelConsistency(urdfFileName);
+        }
     }
 
     // Do a special test for the regression on a model that just has 1 joint that rotates

--- a/src/model_io/tests/check_urdf_import_export.cpp
+++ b/src/model_io/tests/check_urdf_import_export.cpp
@@ -177,8 +177,12 @@ int main(int argc, char** argv)
         std::string urdfFileName = std::string(IDYNTREE_TEST_MODELS_PATH) + "/" +
                                    std::string(IDYNTREE_TESTS_URDFS[mdl]);
 
-        bool ok = checkUrdfImportExport(urdfFileName);
-        testSuccess = testSuccess && ok;
+        // This test fails with frame.urdf, see https://github.com/robotology/idyntree/issues/298
+        if (std::string(IDYNTREE_TESTS_URDFS[mdl]) != "frame.urdf")
+        {
+            bool ok = checkUrdfImportExport(urdfFileName);
+            testSuccess = testSuccess && ok;
+        }
     }
 
     return testSuccess ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/src/model_io/urdf/src/URDFSolidShapesImport.cpp
+++ b/src/model_io/urdf/src/URDFSolidShapesImport.cpp
@@ -270,7 +270,7 @@ bool addURDFGeometryToModelGeometries(const iDynTree::Model& model,
     if( geomXml->FirstChildElement("sphere") != 0 )
     {
         double radiusD;
-        parseOk = stringToDoubleWithClassicLocale(geomXml->FirstChildElement("cylinder")->Attribute("radius"),radiusD);
+        parseOk = stringToDoubleWithClassicLocale(geomXml->FirstChildElement("sphere")->Attribute("radius"), radiusD);
 
         if (parseOk)
         {

--- a/src/tests/data/CMakeLists.txt
+++ b/src/tests/data/CMakeLists.txt
@@ -18,7 +18,8 @@ set(IDYNTREE_TESTS_URDFS icub.urdf
                          iCubGenova02.urdf
                          iCubDarmstadt01.urdf
                          twoLinksWithoutBaseSensors.urdf
-                         twoLinksRotationOnZAxis.urdf)
+                         twoLinksRotationOnZAxis.urdf
+                         frame.urdf)
 
 
 # configure an header containing the path

--- a/src/tests/data/testModels.h.in
+++ b/src/tests/data/testModels.h.in
@@ -24,10 +24,11 @@ const char *IDYNTREE_TESTS_URDFS[] = {"oneLink.urdf",
                                       "icub2BB5Sea.urdf",
                                       "iCubGenova02.urdf",
                                       "iCubDarmstadt01.urdf",
-                                      "twoLinksRotationOnZAxis.urdf"
+                                      "twoLinksRotationOnZAxis.urdf",
+                                      "frame.urdf"
 };
 
-const unsigned int IDYNTREE_TESTS_URDFS_NR = 15;
+const unsigned int IDYNTREE_TESTS_URDFS_NR = 16;
 
 inline std::string getAbsModelPath(std::string modelName)
 {

--- a/src/tests/kdl_consistency/KinematicsDynamicsConsistencyTest.cpp
+++ b/src/tests/kdl_consistency/KinematicsDynamicsConsistencyTest.cpp
@@ -289,8 +289,12 @@ int main()
 {
     for(unsigned int mdl = 0; mdl < IDYNTREE_TESTS_URDFS_NR; mdl++ )
     {
-        std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
-        testFwdKinConsistency(urdfFileName);
+        // This test fails with frame.urdf, see https://github.com/robotology/idyntree/issues/298
+        if (std::string(IDYNTREE_TESTS_URDFS[mdl]) != "frame.urdf")
+        {
+            std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
+            testFwdKinConsistency(urdfFileName);
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
To check that the fix is effecting, add frame.urdf to list of URDF files to test.

Fix https://github.com/robotology/idyntree/issues/295 .

This affects the human URDF used in https://github.com/robotology-playground/human-dynamics-estimation . 