### PR TITLE
Fixed sensors in reducedModel

### DIFF
--- a/src/sensors/src/AccelerometerSensor.cpp
+++ b/src/sensors/src/AccelerometerSensor.cpp
@@ -140,7 +140,7 @@ bool AccelerometerSensor::updateIndeces(const Model& model)
         return false;
     }
 
-    this->pimpl->parent_link_name = linkNewIndex;
+    this->pimpl->parent_link_index = linkNewIndex;
 
     return true;
 }

--- a/src/sensors/src/GyroscopeSensor.cpp
+++ b/src/sensors/src/GyroscopeSensor.cpp
@@ -125,7 +125,7 @@ bool GyroscopeSensor::updateIndeces(const Model& model)
         return false;
     }
 
-    this->pimpl->parent_link_name = linkNewIndex;
+    this->pimpl->parent_link_index = linkNewIndex;
 
     return true;
 }

--- a/src/sensors/src/ModelSensorsTransformers.cpp
+++ b/src/sensors/src/ModelSensorsTransformers.cpp
@@ -90,7 +90,14 @@ bool createReducedModelAndSensors(const Model& fullModel,
             // If the link to wicht the sensors is attached (parentLink) is also in the reduced model, we can just copy the sensor to the reduced sensors models
             if( reducedModel.isLinkNameUsed(sensorLinkInFullModel) )
             {
-                reducedSensors.addSensor(*s);
+                // update the link index of the reduced model
+                LinkSensor *sensorInReducedModel = static_cast<LinkSensor*>(linkSens->clone());
+                if (!sensorInReducedModel || !sensorInReducedModel->updateIndeces(reducedModel)) {
+                    reportError("","createReducedModelAndSensors", "Failed to duplicate LinkSensor and update indeces");
+                    return false;
+                }
+                reducedSensors.addSensor(*sensorInReducedModel);
+                delete sensorInReducedModel;
             }
             else
             {


### PR DESCRIPTION
- Duplicate and update index of sensors when added in the reduced model
- Fixed UpdateIndeces of accelerometers and gyroscopes: they were assigning the parent link index to the link name