### PR TITLE
Fix compilation of example if iDynTree is compiled without YARP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,12 +74,12 @@ script:
   - cmake --build . --config ${TRAVIS_BUILD_TYPE}
   - sudo cmake --build . --config ${TRAVIS_BUILD_TYPE} --target install
   - ctest --output-on-failure --build-config ${TRAVIS_BUILD_TYPE}
-  # test examples 
-  - cd ../examples
-  - mkdir build 
-  - cd build
-  - cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DCODYCO_TRAVIS_CI:BOOL=ON -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} ..
-  - cmake --build . --config ${TRAVIS_BUILD_TYPE}
+  # test examples (only on macOS because on Trusty Eigen3 does not ship with an Eigen3Config.cmake
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cd ../examples ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then mkdir build ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cd build ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DCODYCO_TRAVIS_CI:BOOL=ON -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} .. ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cmake --build . --config ${TRAVIS_BUILD_TYPE} ; fi
 
 notifications:
   email:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,5 +7,5 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project("iDynTree_Examples")
 
-add_subdirectory(icubArmRegressor)
-add_subdirectory(fixedBaseGravityCompensation)
+add_subdirectory(KinDynComputationsWithEigen)
+

--- a/examples/KinDynComputationsWithEigen/CMakeLists.txt
+++ b/examples/KinDynComputationsWithEigen/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright: 2016 Fondazione Istituto Italiano di Tecnologia
+# Copyright: 2017 Fondazione Istituto Italiano di Tecnologia
 # Author: Silvio Traversaro
 # CopyPolicy: Released under the terms of the GNU LGPL v2.0+.
 #

--- a/examples/fixedBaseGravityCompensation/CMakeLists.txt
+++ b/examples/fixedBaseGravityCompensation/CMakeLists.txt
@@ -16,6 +16,7 @@ source_group("Source Files" FILES ${folder_source})
 
 add_executable(${PROJECT_NAME} ${folder_source})
 
+target_include_directories(${PROJECT_NAME} PUBLIC ${YARP_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES}
                                      ${iDynTree_LIBRARIES})
 

--- a/examples/icubArmRegressor/CMakeLists.txt
+++ b/examples/icubArmRegressor/CMakeLists.txt
@@ -16,6 +16,7 @@ source_group("Source Files" FILES ${folder_source})
 
 add_executable(${PROJECT_NAME} ${folder_source})
 
+target_include_directories(${PROJECT_NAME} PUBLIC ${YARP_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES}
                                       ${iDynTree_LIBRARIES})
 


### PR DESCRIPTION
This should fix the `FULL_DEPS=OFF` Travis build. 