### PR TITLE
[FindIPOPT.cmake] synch with YCM 0.4.0

### DIFF
--- a/cmake/FindIPOPT.cmake
+++ b/cmake/FindIPOPT.cmake
@@ -8,8 +8,8 @@
 # if this fails then try to locate the library in the directory pointed by
 # the IPOPT_DIR enviromental variable.
 #
-# On Windows systems,  just try to find the library using the IPOPT_DIR 
-# enviromental variable.  
+# On Windows systems,  just try to find the library using the IPOPT_DIR
+# enviromental variable.
 #
 # Create the following variables::
 #
@@ -60,7 +60,10 @@ if(NOT WIN32)
         find_library(${_LIBRARY}_PATH
                      NAMES ${_LIBRARY}
                      PATHS ${_PC_IPOPT_LIBRARY_DIRS})
-        list(APPEND IPOPT_LIBRARIES ${${_LIBRARY}_PATH})
+        # Workaround for https://github.com/robotology/icub-main/issues/418
+        if(${_LIBRARY}_PATH)
+          list(APPEND IPOPT_LIBRARIES ${${_LIBRARY}_PATH})
+        endif()
       endforeach()
     else()
       set(IPOPT_DEFINITIONS "")
@@ -142,12 +145,7 @@ else()
   # libraries embedded in the library, newer releases require them to
   # be explicitly linked.
   if(IPOPT_IPOPT_LIBRARY)
-    # FIXME Remove this check when CMake 2.8.11 or later is required
-    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-      get_filename_component(_MSVC_BINDIR "${CMAKE_LINKER}" PATH)
-    else()
-      get_filename_component(_MSVC_DIR "${CMAKE_LINKER}" DIRECTORY)
-    endif()
+    get_filename_component(_MSVC_DIR "${CMAKE_LINKER}" DIRECTORY)
 
     # Find the lib.exe executable
     find_program(LIB_EXECUTABLE
@@ -200,12 +198,7 @@ else()
     unset(_path)
 
     if(NOT "${_lib_output}" MATCHES "libifcoremd.dll")
-      # FIXME Remove this check when CMake 2.8.11 or later is required
-      if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-        get_filename_component(_IPOPT_IPOPT_LIBRARY_DIR "${_IPOPT_LIB}" PATH)
-      else()
-        get_filename_component(_IPOPT_IPOPT_LIBRARY_DIR "${_IPOPT_LIB}" DIRECTORY)
-      endif()
+      get_filename_component(_IPOPT_IPOPT_LIBRARY_DIR "${_IPOPT_LIB}" DIRECTORY)
 
       foreach(_lib ifconsol
                    libifcoremd


### PR DESCRIPTION
In particular, add the workaround for https://github.com/robotology/icub-main/issues/418 , that should solve https://github.com/robotology/idyntree/issues/329 as well.
[WIP] because I still need to test if ipopt actually runs fine without blas and lapack.