### PR TITLE
yarprobotstatepublisher

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -59,3 +59,7 @@ if (IDYNTREE_USES_YARP AND IDYNTREE_USES_QT5 AND IDYNTREE_USES_ICUB_MAIN)
     endif()
     add_subdirectory(plotter)
 endif()
+
+if (IDYNTREE_USES_YARP)
+    add_subdirectory(yarprobotstatepublisher)
+endif ()

--- a/src/tools/yarprobotstatepublisher/CMakeLists.txt
+++ b/src/tools/yarprobotstatepublisher/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia (IIT)  
+# All Rights Reserved.
+# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
+
+idyntree_enable_cxx11()
+
+project(yarprobotstatepublisher)
+
+set(ROS_IDL_FILES JointState.msg)
+yarp_add_idl(IDL_GEN_FILES ${ROS_IDL_FILES})
+message("IDL_GEN_FILES : " ${IDL_GEN_FILES})
+add_executable(${PROJECT_NAME} include/robotstatepublisher.h src/main.cpp src/robotstatepublisher.cpp ${IDL_GEN_FILES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/include
+                                                     ${YARP_INCLUDE_DIRS})
+# Workaround for yarp_add_idl problems
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} idyntree-high-level idyntree-yarp)
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/src/tools/yarprobotstatepublisher/JointState.msg
+++ b/src/tools/yarprobotstatepublisher/JointState.msg
@@ -1,0 +1,6 @@
+Header header
+
+string[] name
+float64[] position
+float64[] velocity
+float64[] effort

--- a/src/tools/yarprobotstatepublisher/include/robotstatepublisher.h
+++ b/src/tools/yarprobotstatepublisher/include/robotstatepublisher.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @file robotstatepublisher.h
+ * @authors: Silvio Traversaro <silvio.traversaro@iit.it>
+ */
+
+#ifndef YARP_ROBOT_STATE_PUBLISHER_H
+#define YARP_ROBOT_STATE_PUBLISHER_H
+
+#include <vector>
+
+#include <yarp/os/all.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IFrameTransform.h>
+
+#include <iDynTree/Core/VectorDynSize.h>
+#include <iDynTree/KinDynComputations.h>
+
+#include <JointState.h>
+
+class YARPRobotStatePublisherModule;
+
+/****************************************************************/
+class JointStateSuscriber: public yarp::os::Subscriber<JointState>
+{
+private:
+    YARPRobotStatePublisherModule* m_module;
+
+public:
+    JointStateSuscriber();
+    void attach(YARPRobotStatePublisherModule* module);
+    using yarp::os::Subscriber<JointState>::onRead;
+    virtual void        onRead(JointState &v);
+};
+
+
+/****************************************************************/
+class YARPRobotStatePublisherModule : public yarp::os::RFModule
+{
+    double m_period;
+    yarp::dev::PolyDriver       m_ddtransformclient;
+    yarp::dev::IFrameTransform       *m_iframetrans;
+
+    // Clock-related workaround
+    bool m_usingNetworkClock;
+    yarp::os::NetworkClock m_netClock;
+
+    // Class for computing forward kinematics
+   iDynTree::KinDynComputations m_kinDynComp;
+   iDynTree::VectorDynSize m_jointPos;
+   std::string m_baseFrameName;
+   iDynTree::FrameIndex m_baseFrameIndex;
+   yarp::sig::Matrix m_buf4x4;
+
+   // Mutex protecting the method across the different threads
+   yarp::os::Mutex m_mutex;
+
+   // /JointState topic scruscriber
+   yarp::os::Node*      m_rosNode;
+   JointStateSuscriber* m_jointStateSubscriber;
+
+public:
+    YARPRobotStatePublisherModule();
+    bool configure(yarp::os::ResourceFinder &rf);
+    bool close();
+    double getPeriod();
+    bool updateModule();
+    virtual void        onRead(JointState &v);
+};
+
+#endif
+

--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -1,0 +1,53 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @file main.cpp
+ * @authors: Silvio Traversaro <silvio.traversaro@iit.it>
+ */
+
+#include <cstdlib>
+#include <yarp/os/all.h>
+
+#include "robotstatepublisher.h"
+
+using namespace std;
+
+
+/****************************************************************/
+int main(int argc, char *argv[])
+{
+    // initialize yarp network:
+    // the very first thing to do
+    yarp::os::Network yarp;
+
+    // load command-line options
+    yarp::os::ResourceFinder rf;
+    rf.configure(argc,argv);
+
+    // print available command-line options
+    // upon specifying --help; refer to xml
+    // descriptor for the relative documentation
+    if (rf.check("help"))
+    {
+        cout<<"Options"<<endl;
+        cout<<"\t--robot                <robot-name>: robot name"<<endl;
+        cout<<"\t--model                  <file-name>: file name of the model to load at startup"<<endl;
+        cout<<"\t--base-frame             <frame-name>: specify the base frame of the published tf tree"<<endl;
+        return EXIT_SUCCESS;
+    }
+
+    if (!yarp.checkNetwork(10.0))
+    {
+        yError()<<"YARP network is not available";
+        return EXIT_FAILURE;
+    }
+
+    YARPRobotStatePublisherModule statepublisher;
+    return statepublisher.runModule(rf);
+}
+

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -213,10 +213,7 @@ void YARPRobotStatePublisherModule::onRead(JointState &v)
     {
         iDynTree::JointIndex jntIndex = model.getJointIndex(v.name[i]);
         if (jntIndex == iDynTree::JOINT_INVALID_INDEX)
-        {
-            yError() << "Impossible to find joint " << v.name[i] << " in the model.";
             continue;
-        }
 
         m_jointPos(model.getJoint(jntIndex)->getDOFsOffset()) = v.position[i];
     }

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -162,7 +162,9 @@ bool YARPRobotStatePublisherModule::close()
 
     m_baseFrameIndex = iDynTree::FRAME_INVALID_INDEX;
 
-    delete m_rosNode;
+    if(m_rosNode)
+        delete m_rosNode;
+    m_rosNode = nullptr;
 
     return true;
 }

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -1,0 +1,236 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @file coordinator.cpp
+ * @authors: Silvio Traversaro <silvio.traversaro@iit.it>
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <cstdarg>
+#include <algorithm>
+#include <iostream>
+#include <iomanip>
+
+#include <yarp/math/Math.h>
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/yarp/YARPConversions.h>
+
+#include "robotstatepublisher.h"
+
+using namespace std;
+using namespace yarp::os;
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace yarp::math;
+
+/************************************************************/
+JointStateSuscriber::JointStateSuscriber(): m_module(nullptr)
+{
+}
+
+/************************************************************/
+void JointStateSuscriber::attach(YARPRobotStatePublisherModule* module)
+{
+    m_module = module;
+}
+
+/************************************************************/
+void JointStateSuscriber::onRead(JointState& v)
+{
+    m_module->onRead(v);
+}
+
+/************************************************************/
+YARPRobotStatePublisherModule::YARPRobotStatePublisherModule(): m_iframetrans(nullptr),
+                                                                m_usingNetworkClock(false),
+                                                                m_baseFrameName(""),
+                                                                m_baseFrameIndex(iDynTree::FRAME_INVALID_INDEX),
+                                                                m_buf4x4(4,4)
+{
+}
+
+
+/************************************************************/
+bool YARPRobotStatePublisherModule::configure(ResourceFinder &rf)
+{
+    string name="yarprobotstatepublisher";
+    m_rosNode = new yarp::os::Node("/yarprobotstatepublisher");
+    string robot=rf.check("robot",Value("isaacSim")).asString();
+    string modelFileName=rf.check("model",Value("model.urdf")).asString();
+    m_period=rf.check("period",Value(0.010)).asDouble();
+
+    Property pTransformclient_cfg;
+    pTransformclient_cfg.put("device", "transformClient");
+    pTransformclient_cfg.put("local", "/"+name+"/transformClient");
+    pTransformclient_cfg.put("remote", "/transformServer");
+
+    bool ok_client = m_ddtransformclient.open(pTransformclient_cfg);
+    if (!ok_client)
+    {
+        yError()<<"Problem in opening the transformClient device";
+        close();
+        return false;
+    }
+
+    if (!m_ddtransformclient.view(m_iframetrans))
+    {
+        yError()<<"IFrameTransform I/F is not implemented";
+        close();
+        return false;
+    }
+
+    // If YARP is using a network clock, writing on a ROS topic is not working
+    // Workaround: explicitly instantiate a network clock to read the time from gazebo
+    if( yarp::os::NetworkBase::exists("/clock") )
+    {
+        m_usingNetworkClock = true;
+        m_netClock.open("/clock");
+    }
+
+    // Open the model
+    string pathToModel=rf.findFileByName(modelFileName);
+    bool ok = m_kinDynComp.loadRobotModelFromFile(pathToModel);
+    if (!ok || !m_kinDynComp.isValid())
+    {
+        yError()<<"Impossible to load file " << pathToModel;
+        close();
+        return false;
+    }
+
+    // Resize the joint pos buffer
+    m_jointPos.resize(m_kinDynComp.model().getNrOfPosCoords());
+
+    // Get the base frame information
+    if (rf.check("base-frame"))
+    {
+        m_baseFrameName = rf.find("base-frame").asString();
+    }
+    else
+    {
+        // If base-frame is not passed, use the default base-frame of the model
+        const iDynTree::Model& model = m_kinDynComp.model();
+        m_baseFrameName = model.getLinkName(model.getDefaultBaseLink());
+    }
+
+    const iDynTree::Model& model = m_kinDynComp.model();
+    m_baseFrameIndex = model.getFrameIndex(m_baseFrameName);
+
+    if (m_baseFrameIndex == iDynTree::FRAME_INVALID_INDEX)
+    {
+        yError()<<"Impossible to find frame " << m_baseFrameName << " in the model";
+        close();
+        return false;
+    }
+
+    // Setup the topic and configureisValid the onRead callback
+    m_jointStateSubscriber = new JointStateSuscriber();
+    m_jointStateSubscriber->attach(this);
+    m_jointStateSubscriber->topic("/joint_states");
+    m_jointStateSubscriber->useCallback();
+
+    return true;
+}
+
+
+/************************************************************/
+bool YARPRobotStatePublisherModule::close()
+{
+    yarp::os::LockGuard guard(m_mutex);
+
+    // Disconnect the topic subscriber
+    if (m_jointStateSubscriber)
+    {
+        m_jointStateSubscriber->interrupt();
+        m_jointStateSubscriber->close();
+        delete m_jointStateSubscriber;
+    }
+
+    if (m_ddtransformclient.isValid())
+    {
+        yInfo()<<"Closing the tf device";
+        m_ddtransformclient.close();
+        m_iframetrans = nullptr;
+    }
+
+    m_baseFrameIndex = iDynTree::FRAME_INVALID_INDEX;
+
+    delete m_rosNode;
+
+    return true;
+}
+
+
+/************************************************************/
+double YARPRobotStatePublisherModule::getPeriod()
+{
+    return m_period;
+}
+
+
+
+/************************************************************/
+bool YARPRobotStatePublisherModule::updateModule()
+{
+    // All the actual processing is performed in the onRead callback
+    return true;
+}
+
+/************************************************************/
+void YARPRobotStatePublisherModule::onRead(JointState &v)
+{
+    yarp::os::LockGuard guard(m_mutex);
+
+    // If configure was successful, parse the data
+    if (m_baseFrameIndex == iDynTree::FRAME_INVALID_INDEX)
+    {
+        return;
+    }
+
+    // Check size
+    if (v.name.size() != m_jointPos.size())
+    {
+        yError() << "Size mismatch. Model has " << m_jointPos.size()
+                 << " joints, while the received JointState message has " << v.name.size() << " joints.";
+        return;
+    }
+
+    // TODO: this part can be drastically speed up.
+    //      Possible improvements:
+    //        * Add a map string --> indeces
+    // Fill the buffer of joints positions
+    const iDynTree::Model& model = m_kinDynComp.model();
+    for (size_t i=0; i < v.name.size(); i++)
+    {
+        iDynTree::JointIndex jntIndex = model.getJointIndex(v.name[i]);
+        if (jntIndex == iDynTree::JOINT_INVALID_INDEX)
+        {
+            yError() << "Impossible to find joint " << v.name[i] << " in the model.";
+            return;
+        }
+
+        m_jointPos(model.getJoint(jntIndex)->getDOFsOffset()) = v.position[i];
+    }
+
+    // Set the updated joint positions
+    m_kinDynComp.setJointPos(m_jointPos);
+
+    // Publish the frames on TF
+    for (size_t frameIdx=0; frameIdx < model.getNrOfFrames(); frameIdx++)
+    {
+        iDynTree::Transform base_H_frame = m_kinDynComp.getRelativeTransform(m_baseFrameIndex, frameIdx);
+        iDynTree::toYarp(base_H_frame.asHomogeneousTransform(), m_buf4x4);
+        m_iframetrans->setTransform(model.getFrameName(frameIdx),
+                                    model.getFrameName(m_baseFrameIndex),
+                                    m_buf4x4);
+    }
+
+    return;
+}

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -227,6 +227,9 @@ void YARPRobotStatePublisherModule::onRead(JointState &v)
     // Publish the frames on TF
     for (size_t frameIdx=0; frameIdx < model.getNrOfFrames(); frameIdx++)
     {
+        if(m_baseFrameIndex == frameIdx)    // skip self-tranform
+            continue;
+
         iDynTree::Transform base_H_frame = m_kinDynComp.getRelativeTransform(m_baseFrameIndex, frameIdx);
         iDynTree::toYarp(base_H_frame.asHomogeneousTransform(), m_buf4x4);
         m_iframetrans->setTransform(model.getFrameName(frameIdx),

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -215,7 +215,7 @@ void YARPRobotStatePublisherModule::onRead(JointState &v)
         if (jntIndex == iDynTree::JOINT_INVALID_INDEX)
         {
             yError() << "Impossible to find joint " << v.name[i] << " in the model.";
-            return;
+            continue;
         }
 
         m_jointPos(model.getJoint(jntIndex)->getDOFsOffset()) = v.position[i];


### PR DESCRIPTION
YARP and iDynTree powered version of ros `robot_state_publisher` . 

Main advantages over ROS's `robot_state_publisher` : 
* You can specify the desired root of the tree over all the frames of the robot 
* Also the sensor frames are broadcasted (thanks to the [`addSensorFramesAsAdditionalFrames`](http://wiki.icub.org/codyco/dox/html/idyntree/html/structiDynTree_1_1URDFParserOptions.html#a0b4a5be086b3511d0e582c91c60697f4) option of iDynTree's URDF parser ). 
* Uses YARP's `tfClient` device to publish the tf transforms, and uses YARP-ROS compatibility to read the joint states from the `/joint_states` topic, so it can run easily on Windows even without ROS. 

cc @randaz81 @aerydna 