### PR TITLE
Fix compilation with Octave >= 4.2

### DIFF
--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -133,6 +133,10 @@ if(IDYNTREE_USES_OCTAVE)
   if ("${OCTAVE_VERSION_STRING}" VERSION_LESS 4.0)
     message(FATAL_ERROR "Octave mex-based bindings required at least Octave version 4.0 or greater.")
   endif ()
+  if (NOT(OCTAVE_VERSION_STRING VERSION_LESS 4.2) )
+    # Octave >= 4.2 requires C++11 enabled, see https://github.com/robotology/idyntree/issues/344
+    idyntree_enable_cxx11()
+  endif ()
 
   # Compile MEX file
   add_library(idyntreeOctaveMex MODULE ${swig_generated_sources} ${swig_other_sources})


### PR DESCRIPTION
This should fix https://github.com/robotology/idyntree/issues/344 .