### PR TITLE
Added support to Inverse kinematics warmstart

### DIFF
--- a/src/inverse-kinematics/include/private/InverseKinematicsData.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsData.h
@@ -10,15 +10,16 @@
 #ifndef IDYNTREE_INTERNAL_INVERSEKINEMATICSDATA_H
 #define IDYNTREE_INTERNAL_INVERSEKINEMATICSDATA_H
 
+#include "InverseKinematicsNLP.h"
+#include <iDynTree/ConvexHullHelpers.h>
+#include <iDynTree/InverseKinematics.h>
+
 #include <iDynTree/KinDynComputations.h>
 #include <iDynTree/Model/Model.h>
 #include <iDynTree/Core/VectorDynSize.h>
 #include <iDynTree/Core/MatrixDynSize.h>
 #include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/Twist.h>
-
-#include <iDynTree/ConvexHullHelpers.h>
-#include <iDynTree/InverseKinematics.h>
 
 #include <IpIpoptApplication.hpp>
 
@@ -122,10 +123,17 @@ public:
     //Result of optimization
     iDynTree::Transform m_baseResults;
     iDynTree::VectorDynSize m_jointsResults;
+    iDynTree::VectorDynSize m_constraintMultipliers;
+    iDynTree::VectorDynSize m_lowerBoundMultipliers;
+    iDynTree::VectorDynSize m_upperBoundMultipliers;
 
     ///@}
 
+    bool m_problemInitialized;
+    size_t m_numberOfOptimisationVariables;
+    size_t m_numberOfOptimisationConstraints;
     Ipopt::SmartPtr<Ipopt::IpoptApplication> m_solver; /*!< Instance of IPOPT solver */
+    Ipopt::SmartPtr<internal::kinematics::InverseKinematicsNLP> m_nlpProblem;
 
     /*!
      * Update internal variables given a change in the robot state
@@ -136,6 +144,11 @@ public:
      * Prepare the internal data to run an optimization
      */
     void prepareForOptimization();
+
+    /*!
+     * compute the problem size (number of optimisation variables and constraints)
+     */
+    void computeProblemSizeAndResizeBuffers();
 
     /*! @name Optimization-related parameters
      */

--- a/src/inverse-kinematics/include/private/InverseKinematicsData.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsData.h
@@ -130,6 +130,7 @@ public:
     ///@}
 
     bool m_problemInitialized;
+    bool m_warmStartEnabled;
     size_t m_numberOfOptimisationVariables;
     size_t m_numberOfOptimisationConstraints;
     Ipopt::SmartPtr<Ipopt::IpoptApplication> m_solver; /*!< Instance of IPOPT solver */

--- a/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
@@ -113,14 +113,6 @@ class internal::kinematics::InverseKinematicsNLP : public Ipopt::TNLP {
     bool updateState(const Ipopt::Number * x);
 
     /*!
-     * @brief Initialize buffers given the specified problem size
-     *
-     * @param n size of the optimization variable
-     * @param m size of the constraints
-     */
-    void initializeInternalData(Ipopt::Index n, Ipopt::Index m);
-
-    /*!
      * Specify which part of the Jacobian should be computed/updated
      */
     enum ComputeContraintJacobianOption {
@@ -182,6 +174,14 @@ public:
     InverseKinematicsNLP(InverseKinematicsData& data);
 
     virtual ~InverseKinematicsNLP();
+
+    /*!
+     * @brief Initialize buffers given the specified problem size
+     *
+     * @param n size of the optimization variable
+     * @param m size of the constraints
+     */
+    void initializeInternalData();
 
 #pragma mark - IpOpt methods
 

--- a/src/inverse-kinematics/src/InverseKinematicsData.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsData.cpp
@@ -31,7 +31,11 @@ namespace kinematics {
     , m_rotationParametrization(iDynTree::InverseKinematicsRotationParametrizationQuaternion)
     , m_areBaseInitialConditionsSet(false)
     , m_areJointsInitialConditionsSet(InverseKinematicsInitialConditionNotSet)
+    , m_problemInitialized(false)
+    , m_numberOfOptimisationVariables(0)
+    , m_numberOfOptimisationConstraints(0)
     , m_solver(NULL)
+    , m_nlpProblem(new internal::kinematics::InverseKinematicsNLP(*this))
     // The default values for the ipopt related parameters are exactly the one of IPOPT,
     // see https://www.coin-or.org/Ipopt/documentation/node41.html
     //     https://www.coin-or.org/Ipopt/documentation/node42.html
@@ -155,6 +159,8 @@ namespace kinematics {
         m_comTarget.weight = 0;
         m_comTarget.desiredPosition.zero();
         m_comTarget.constraintTolerance = 1e-8;
+
+        m_problemInitialized = false;
     }
 
     bool InverseKinematicsData::addFrameConstraint(const kinematics::TransformConstraint& frameTransformConstraint)
@@ -348,15 +354,13 @@ namespace kinematics {
             }
         }
 
+        if (!m_problemInitialized) {
+            computeProblemSizeAndResizeBuffers();
+        }
+
         prepareForOptimization();
-
-        //instantiate the IpOpt problem
-        internal::kinematics::InverseKinematicsNLP *iKin = new internal::kinematics::InverseKinematicsNLP(*this);
-        //Do something (if necessary)
-        Ipopt::SmartPtr<Ipopt::TNLP> problem(iKin);
-
         // Ask Ipopt to solve the problem
-        solverStatus = m_solver->OptimizeTNLP(problem);
+        solverStatus = m_solver->OptimizeTNLP(m_nlpProblem);
 
         if (solverStatus == Ipopt::Solve_Succeeded || solverStatus == Ipopt::Solved_To_Acceptable_Level ) {
             return true;
@@ -404,6 +408,62 @@ namespace kinematics {
         this->m_comTarget.isActive = false;
         this->m_comTarget.weight = 0;
         this->m_comTarget.desiredPosition.zero();
+    }
+
+    void InverseKinematicsData::computeProblemSizeAndResizeBuffers()
+    {
+        //Size of optimization variables is 3 + Orientation (base) + size of joints we optimize
+        m_numberOfOptimisationVariables = 3 + sizeOfRotationParametrization(m_rotationParametrization) + m_dofs;
+
+        //Start adding constraints
+        m_numberOfOptimisationConstraints = 0;
+        for (auto && constraint : m_constraints) {
+            //Frame constraint: it can have position, rotation or both elements
+            if (constraint.second.hasPositionConstraint()) {
+                m_numberOfOptimisationConstraints += 3;
+            }
+            if (constraint.second.hasRotationConstraint()) {
+                m_numberOfOptimisationConstraints += sizeOfRotationParametrization(m_rotationParametrization);
+            }
+        }
+
+        // COM Convex Hull constraint
+        if (m_comHullConstraint.isActive()) {
+            m_numberOfOptimisationConstraints += m_comHullConstraint.getNrOfConstraints();
+        }
+
+        if (isCoMTargetActive() && isCoMaConstraint()) {
+            m_numberOfOptimisationConstraints += 3;
+        }
+        //add target if considered as constraints
+        for (auto && target : m_targets) {
+            if (target.second.targetResolutionMode() & iDynTree::InverseKinematicsTreatTargetAsConstraintPositionOnly
+                && target.second.hasPositionConstraint()) {
+                m_numberOfOptimisationConstraints += 3;
+            }
+            if (target.second.targetResolutionMode() & iDynTree::InverseKinematicsTreatTargetAsConstraintRotationOnly
+                && target.second.hasRotationConstraint()) {
+
+                m_numberOfOptimisationConstraints += sizeOfRotationParametrization(m_rotationParametrization);;
+            }
+        }
+
+        if (m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
+            //If the rotation is parametrized as quaternion
+            //that the base orientation yields an additional
+            //constraint, i.e. norm of quaternion = 1
+            m_numberOfOptimisationConstraints += 1; //quaternion norm constraint
+        }
+
+        m_constraintMultipliers.resize(m_numberOfOptimisationConstraints);
+        m_constraintMultipliers.zero();
+        m_lowerBoundMultipliers.resize(m_numberOfOptimisationVariables);
+        m_lowerBoundMultipliers.zero();
+        m_upperBoundMultipliers.resize(m_numberOfOptimisationVariables);
+        m_upperBoundMultipliers.zero();
+        m_nlpProblem->initializeInternalData();
+
+        m_problemInitialized = true;
     }
 
 }

--- a/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
@@ -591,11 +591,11 @@ namespace kinematics {
                     //RPY parametrization for the base
                     iDynTree::Vector3 rpy;
                     iDynTree::toEigen(rpy) = iDynTree::toEigen(this->optimizedBaseOrientation).head<3>();
-                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0),rpy(1),rpy(2));
+                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0), rpy(1), rpy(2));
 
                     // RPY parametrization for the constraint
                     iDynTree::Vector3 rpy_target = targetsInfo[target->first].transform.getRotation().asRPY();
-                    iDynTree::Matrix3x3 omegaToRPYMap_target = iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_target(0),rpy_target(1),rpy_target(2));
+                    iDynTree::Matrix3x3 omegaToRPYMap_target = iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_target(0), rpy_target(1), rpy_target(2));
 
                     computeConstraintJacobianRPY(targetsInfo[target->first].jacobian,
                                                  omegaToRPYMap_target,
@@ -641,7 +641,7 @@ namespace kinematics {
                     //RPY parametrization for the base
                     iDynTree::Vector3 rpy;
                     iDynTree::toEigen(rpy) = iDynTree::toEigen(this->optimizedBaseOrientation).head<3>();
-                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0),rpy(1),rpy(2));
+                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0), rpy(1), rpy(2));
                     FrameInfo &targetInfo = targetsInfo[target->first];
 
                     iDynTree::Rotation rotation_target = targetInfo.transform.getRotation();
@@ -650,7 +650,7 @@ namespace kinematics {
                     iDynTree::toEigen(rotation_error) = iDynTree::toEigen(rotation_desired).transpose() * iDynTree::toEigen(rotation_target);
                     iDynTree::Vector3 rpy_error = rotation_error.asRPY();
                     iDynTree::Matrix3x3 omegaToRPYMap_target;
-                    iDynTree::toEigen(omegaToRPYMap_target) = iDynTree::toEigen(iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_error(0),rpy_error(1),rpy_error(2))) * iDynTree::toEigen(rotation_desired).transpose();
+                    iDynTree::toEigen(omegaToRPYMap_target) = iDynTree::toEigen(iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_error(0), rpy_error(1), rpy_error(2))) * iDynTree::toEigen(rotation_desired).transpose();
 
                     computeConstraintJacobianRPY(targetInfo.jacobian,
                                                 omegaToRPYMap_target,
@@ -723,8 +723,8 @@ namespace kinematics {
         // COM constraint
         if (m_data.m_comHullConstraint.isActive()) {
             constraints.segment(index, m_data.m_comHullConstraint.getNrOfConstraints()) =
-                iDynTree::toEigen(m_data.m_comHullConstraint.A)*iDynTree::toEigen(comInfo.projectedCom);
-            index = index+m_data.m_comHullConstraint.getNrOfConstraints();
+                iDynTree::toEigen(m_data.m_comHullConstraint.A) * iDynTree::toEigen(comInfo.projectedCom);
+            index += m_data.m_comHullConstraint.getNrOfConstraints();
         }
         
         if (m_data.isCoMTargetActive() && (m_data.isCoMaConstraint())){
@@ -855,11 +855,11 @@ namespace kinematics {
                     //RPY parametrization for the base
                     iDynTree::Vector3 rpy;
                     iDynTree::toEigen(rpy) = iDynTree::toEigen(this->optimizedBaseOrientation).head<3>();
-                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0),rpy(1),rpy(2));
+                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0), rpy(1), rpy(2));
 
                     // RPY parametrization for the constraint
                     iDynTree::Vector3 rpy_target = constraintInfo.transform.getRotation().asRPY();
-                    iDynTree::Matrix3x3 omegaToRPYMap_target = iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_target(0),rpy_target(1),rpy_target(2));
+                    iDynTree::Matrix3x3 omegaToRPYMap_target = iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_target(0), rpy_target(1), rpy_target(2));
 
                     computeConstraintJacobianRPY(constraintInfo.jacobian,
                                                  omegaToRPYMap_target,
@@ -874,13 +874,13 @@ namespace kinematics {
                 //We have to assign it to the correct variable
                 if (constraint->second.hasPositionConstraint()) {
                     //Position part
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*finalJacobianBuffer.cols()], 3, n);
+                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex * finalJacobianBuffer.cols()], 3, n);
                     currentConstraint = toEigen(finalJacobianBuffer).topRows<3>();
                     constraintIndex += 3;
                 }
                 if (constraint->second.hasRotationConstraint()) {
                     //Orientation part
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*finalJacobianBuffer.cols()], sizeOfRotationParametrization(m_data.m_rotationParametrization), n);
+                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex * finalJacobianBuffer.cols()], sizeOfRotationParametrization(m_data.m_rotationParametrization), n);
                     currentConstraint = toEigen(finalJacobianBuffer).bottomRows(sizeOfRotationParametrization(m_data.m_rotationParametrization));
                     constraintIndex += sizeOfRotationParametrization(m_data.m_rotationParametrization);
                 }
@@ -893,7 +893,7 @@ namespace kinematics {
                 iDynTree::Vector3 rpy;
                 iDynTree::toEigen(rpy) = iDynTree::toEigen(this->optimizedBaseOrientation).head<3>();
                 iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0), rpy(1), rpy(2));
-                computeConstraintJacobianCOMRPY(comInfo.comJacobian,RPYToOmega,comInfo.comJacobianAnalytical);
+                computeConstraintJacobianCOMRPY(comInfo.comJacobian, RPYToOmega, comInfo.comJacobianAnalytical);
                 
                 if (m_data.m_comHullConstraint.isActive()) {
                     // Project the jacobian
@@ -927,6 +927,8 @@ namespace kinematics {
                 if (target->second.targetResolutionMode() & iDynTree::InverseKinematicsTreatTargetAsConstraintRotationOnly)
                     computationOption |= ComputeContraintJacobianOptionAngularPart;
 
+                if (computationOption == 0) continue; // no need for further computations
+
                 if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
 
                     //We adapt the jacobian to handle two things
@@ -944,11 +946,11 @@ namespace kinematics {
                     //RPY parametrization for the base
                     iDynTree::Vector3 rpy;
                     iDynTree::toEigen(rpy) = iDynTree::toEigen(this->optimizedBaseOrientation).head<3>();
-                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0),rpy(1),rpy(2));
+                    iDynTree::Matrix3x3 RPYToOmega = iDynTree::Rotation::RPYRightTrivializedDerivative(rpy(0), rpy(1), rpy(2));
 
                     // RPY parametrization for the constraint
                     iDynTree::Vector3 rpy_target = targetInfo.transform.getRotation().asRPY();
-                    iDynTree::Matrix3x3 omegaToRPYMap_target = iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_target(0),rpy_target(1),rpy_target(2));
+                    iDynTree::Matrix3x3 omegaToRPYMap_target = iDynTree::Rotation::RPYRightTrivializedDerivativeInverse(rpy_target(0), rpy_target(1), rpy_target(2));
 
                     computeConstraintJacobianRPY(targetInfo.jacobian,
                                                  omegaToRPYMap_target,
@@ -961,7 +963,7 @@ namespace kinematics {
                     && target->second.hasPositionConstraint()) {
 
                     //Copy position part
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*finalJacobianBuffer.cols()], 3, n);
+                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex * finalJacobianBuffer.cols()], 3, n);
                     currentConstraint = toEigen(finalJacobianBuffer).topRows<3>();
                     constraintIndex += 3;
                 }
@@ -970,7 +972,7 @@ namespace kinematics {
                     && target->second.hasRotationConstraint()) {
                     //Orientation part
 
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*finalJacobianBuffer.cols()], sizeOfRotationParametrization(m_data.m_rotationParametrization), n);
+                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex * finalJacobianBuffer.cols()], sizeOfRotationParametrization(m_data.m_rotationParametrization), n);
                     currentConstraint = toEigen(finalJacobianBuffer).bottomRows(sizeOfRotationParametrization(m_data.m_rotationParametrization));
                     constraintIndex += sizeOfRotationParametrization(m_data.m_rotationParametrization);
                 }
@@ -1193,8 +1195,8 @@ namespace kinematics {
         map(0, 1) = std::sin(rpyAngles(2)) / detMapMatrix;
         map(1, 0) = -std::sin(rpyAngles(2));
         map(1, 1) = std::cos(rpyAngles(2));
-        map(2, 0) = -std::cos(rpyAngles(2))* std::tan(rpyAngles(1));
-        map(2, 1) = -std::sin(rpyAngles(2))* std::tan(rpyAngles(1));
+        map(2, 0) = -std::cos(rpyAngles(2)) * std::tan(rpyAngles(1));
+        map(2, 1) = -std::sin(rpyAngles(2)) * std::tan(rpyAngles(1));
         map(2, 2) = 1;
 
     }


### PR DESCRIPTION
Added support to warmstart in inverse kinematics.

At the current state we cannot achieve a huge gain as the analytical hessian is missing and thus IPOpt needs some iterations to build its approximation.
Anyway, from some tests I found a decrease up to 50% (in the number of iterations)