### PR TITLE
Gravity projection imu dev

### DIFF
--- a/src/inverse-kinematics/include/iDynTree/ConvexHullHelpers.h
+++ b/src/inverse-kinematics/include/iDynTree/ConvexHullHelpers.h
@@ -174,6 +174,13 @@ namespace iDynTree
         Matrix2x3 P;
 
         /**
+         * Projection matrix 'Pdirection' defined by a given direction.
+         * The projection 'x' of a 3D point 'c' along a given vector is obtained as:
+         * x = Pdirection*(c-o).
+         */
+        Matrix2x3 Pdirection;
+
+        /**
          * Matrix obtained multiplyng the matrix A for the matrix P.
          */
         MatrixDynSize AtimesP;
@@ -223,6 +230,23 @@ namespace iDynTree
          */
         double computeMargin(const Vector2& posIn2D);
 
+        /*!
+         * Set the projection matrix 'Pdirection' given a desired projection direction.
+         *
+         * \author Aiko Dinale (29/08/2017)
+         *
+         * @param direction     vector along which we want to project a point
+         */
+        void setProjectionAlongDirection(Vector3 direction);
+
+        /*!
+         * Project a point along a direction defined by the projection matrix 'Pdirection'
+         *
+         * \author Aiko Dinale (29/08/2017)
+         *
+         * @param posIn3dInAbsoluteFrame     a point we want to project
+         */
+        Vector2 projectAlongDirection(iDynTree::Position& posIn3dInAbsoluteFrame);
 
     };
 }

--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -641,7 +641,6 @@ public:
     /*! @name Solution-related methods
       */
     ///@{
-
     /*!
      * Return the last solution of the inverse kinematics problem
      *
@@ -704,6 +703,15 @@ public:
     bool isCOMTargetActive();
     
     void deactivateCOMTarget();
+
+    /*!
+     * Set the directions along which a point will be projected.
+     *
+     * \author Aiko Dinale (29/08/2017)
+     *
+     * @param direction    vector along which we want to project a point
+     */
+    void setCOMConstraintProjectionDirection(iDynTree::Vector3 direction);
 
 private:
     void* m_pimpl; /*!< private implementation */

--- a/src/inverse-kinematics/src/ConvexHullHelpers.cpp
+++ b/src/inverse-kinematics/src/ConvexHullHelpers.cpp
@@ -128,8 +128,8 @@ namespace iDynTree
                                                          const std::vector<Transform> &absoluteFrame_X_supportFrame)
     {
         o = originOfPlaneInWorld;
-        toEigen(P).block<1,3>(0,0) = toEigen(xAxisOfPlaneInWorld);
-        toEigen(P).block<1,3>(1,0) = toEigen(yAxisOfPlaneInWorld);
+        toEigen(P).block<1, 3>(0,0) = toEigen(xAxisOfPlaneInWorld);
+        toEigen(P).block<1, 3>(1,0) = toEigen(yAxisOfPlaneInWorld);
 
         // Transform the polygons in the absolute frame
         std::vector<Polygon> supportPolygonsExpressedInAbsoluteFrame;
@@ -253,7 +253,7 @@ namespace iDynTree
     Vector2 ConvexHullProjectionConstraint::project(Position& pos3dInAbsoluteFrame)
     {
         iDynTree::Vector2 projected;
-        toEigen(projected) = toEigen(P)*toEigen(pos3dInAbsoluteFrame-o);
+        toEigen(projected) = toEigen(P) * toEigen(pos3dInAbsoluteFrame - o);
         return projected;
     }
 
@@ -339,8 +339,35 @@ namespace iDynTree
         {
             margin = -distanceWithoutSign;
         }
+
         return margin;
     }
 
+    void ConvexHullProjectionConstraint::setProjectionAlongDirection(Vector3 direction)
+    {
+        Vector3 xProjection, yProjection;
+
+        // define the projection for the x-component
+        xProjection.setVal(0, 1.0);
+        xProjection.setVal(1, 0.0);
+        xProjection.setVal(2, -direction.getVal(0) / direction.getVal(2));
+
+        // define the projection for the y-component
+        yProjection.setVal(0, 0.0);
+        yProjection.setVal(1, 1.0);
+        yProjection.setVal(2, -direction.getVal(1) / direction.getVal(2));
+
+        // fill the projection matrix
+        toEigen(Pdirection).block<1, 3>(0,0) = toEigen(xProjection);
+        toEigen(Pdirection).block<1, 3>(1,0) = toEigen(yProjection);
+
+    }
+
+    Vector2 ConvexHullProjectionConstraint::projectAlongDirection(iDynTree::Position& posIn3dInAbsoluteFrame)
+    {
+        iDynTree::Vector2 projected;
+        toEigen(projected) = toEigen(Pdirection) * toEigen(posIn3dInAbsoluteFrame - o);
+        return projected;
+    }
 
 }

--- a/src/inverse-kinematics/src/InverseKinematics.cpp
+++ b/src/inverse-kinematics/src/InverseKinematics.cpp
@@ -327,7 +327,6 @@ namespace iDynTree {
         iDynTree::Position comInAbsoluteConstraintFrame =
             IK_PIMPL(m_pimpl)->m_comHullConstraint.absoluteFrame_X_supportFrame[0]*(kinDyn.getWorldTransform(IK_PIMPL(m_pimpl)->m_comHullConstraint.supportFrameIndices[0]).inverse()*kinDyn.getCenterOfMassPosition());
 
-        //iDynTree::Vector2 comProjection = IK_PIMPL(m_pimpl)->m_comHullConstraint.project(comInAbsoluteConstraintFrame);
         iDynTree::Vector2 comProjection = IK_PIMPL(m_pimpl)->m_comHullConstraint.projectAlongDirection(comInAbsoluteConstraintFrame);
         return IK_PIMPL(m_pimpl)->m_comHullConstraint.computeMargin(comProjection);
     }

--- a/src/inverse-kinematics/src/InverseKinematicsData.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsData.cpp
@@ -50,7 +50,6 @@ namespace kinematics {
         m_state.worldGravity.zero();
 
         m_state.baseTwist.zero();
-        
         m_comTarget.isActive = false;
         m_comTarget.weight = 0;
         m_comTarget.desiredPosition.zero();

--- a/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
@@ -238,8 +238,10 @@ namespace kinematics {
 
             if (m_data.m_comHullConstraint.isActive()) {
                 // Project the jacobian and the com
-                iDynTree::toEigen(comInfo.projectedCom) =
-                    iDynTree::toEigen(m_data.m_comHullConstraint.P) * iDynTree::toEigen(comInfo.com - m_data.m_comHullConstraint.o);
+                // comInfo.projectedCom = m_data.m_comHullConstraint.project(comInfo.com);
+
+                // Project the COM along the gravity vector
+                comInfo.projectedCom = m_data.m_comHullConstraint.projectAlongDirection(comInfo.com);
             }
         }
 
@@ -898,7 +900,7 @@ namespace kinematics {
                 if (m_data.m_comHullConstraint.isActive()) {
                     // Project the jacobian
                     iDynTree::toEigen(comInfo.projectedComJacobian) =
-                            iDynTree::toEigen(m_data.m_comHullConstraint.AtimesP) * iDynTree::toEigen(comInfo.comJacobianAnalytical);
+                            iDynTree::toEigen(m_data.m_comHullConstraint.A) * iDynTree::toEigen(m_data.m_comHullConstraint.Pdirection) * iDynTree::toEigen(comInfo.comJacobianAnalytical);
 
                     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*n], comInfo.projectedComJacobian.rows(), n);
                     currentConstraint = iDynTree::toEigen(comInfo.projectedComJacobian);

--- a/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
@@ -237,10 +237,7 @@ namespace kinematics {
             m_data.m_dynamics.getCenterOfMassJacobian(comInfo.comJacobian);
 
             if (m_data.m_comHullConstraint.isActive()) {
-                // Project the jacobian and the com
-                // comInfo.projectedCom = m_data.m_comHullConstraint.project(comInfo.com);
-
-                // Project the COM along the gravity vector
+                // Project the COM along the desired direction
                 comInfo.projectedCom = m_data.m_comHullConstraint.projectAlongDirection(comInfo.com);
             }
         }

--- a/src/inverse-kinematics/tests/ConvexHullHelpersUnitTest.cpp
+++ b/src/inverse-kinematics/tests/ConvexHullHelpersUnitTest.cpp
@@ -17,10 +17,10 @@ void testConvexHullProjectionConstraint()
 
     // Add a nice big square convex hull
     iDynTree::Polygon notProjectedConvexHull;
-    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position( 1.0, 1.0,5.0));
-    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position(-1.0, 1.0,10.0));
-    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position(-1.0,-1.0,-10.0));
-    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position( 1.0,-1.0,-15.0));
+    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position( 1.0, 1.0, 5.0));
+    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position(-1.0, 1.0, 10.0));
+    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position(-1.0, -1.0, -10.0));
+    notProjectedConvexHull.m_vertices.push_back(iDynTree::Position( 1.0, -1.0, -15.0));
 
     std::vector<iDynTree::Polygon> polygons;
     polygons.resize(1);
@@ -28,10 +28,10 @@ void testConvexHullProjectionConstraint()
 
     // Add a smaller polygon inside the other one
     iDynTree::Polygon notProjectedConvexHullSmall;
-    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position( 0.5, 0.5,5.0));
-    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position(-0.5, 0.5,10.0));
-    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position(-0.5,-0.5,-10.0));
-    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position( 0.5,-0.5,-15.0));
+    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position( 0.5, 0.5, 5.0));
+    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position(-0.5, 0.5, 10.0));
+    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position(-0.5, -0.5, -10.0));
+    notProjectedConvexHullSmall.m_vertices.push_back(iDynTree::Position( 0.5, -0.5, -15.0));
 
     polygons.push_back(notProjectedConvexHullSmall);
 
@@ -40,11 +40,10 @@ void testConvexHullProjectionConstraint()
     transforms.push_back(iDynTree::Transform::Identity());
 
 
-    iDynTree::Direction xAxis(1.0,0.0,0.0);
-    iDynTree::Direction yAxis(0.0,1.0,0.0);
+    iDynTree::Direction xAxis(1.0, 0.0, 0.0);
+    iDynTree::Direction yAxis(0.0, 1.0, 0.0);
 
     bool ok = projectionConstraint.buildConvexHull(xAxis,yAxis,iDynTree::Position::Zero(),polygons,transforms);
-
     ASSERT_IS_TRUE(ok);
 
     ASSERT_IS_TRUE(projectionConstraint.projectedConvexHull.getNrOfVertices() == 4);
@@ -64,12 +63,74 @@ void testConvexHullProjectionConstraint()
     // Fourth point
     ASSERT_EQUAL_DOUBLE(projectionConstraint.projectedConvexHull(3)(0),-1.0);
     ASSERT_EQUAL_DOUBLE(projectionConstraint.projectedConvexHull(3)(1), 1.0);
+}
+
+void testConvexHullProjectionWithGravity()
+{
+    // For this test, we will use a simple convex hull of side 1 meter
+    // centered in the origin of the world and laying on the XY plane
+    iDynTree::ConvexHullProjectionConstraint projectionConstraint;
+    iDynTree::Polygon convexHull;
+    convexHull.m_vertices.push_back(iDynTree::Position( 0.5, 0.5, 0.0));
+    convexHull.m_vertices.push_back(iDynTree::Position(-0.5, 0.5, 0.0));
+    convexHull.m_vertices.push_back(iDynTree::Position(-0.5, -0.5, 0.0));
+    convexHull.m_vertices.push_back(iDynTree::Position( 0.5, -0.5, 0.0));
+    std::vector<iDynTree::Polygon> polygons;
+    polygons.resize(1);
+    polygons[0] = convexHull;
+
+
+    // The convex hull is already expressed in the world
+    std::vector<iDynTree::Transform> transforms;
+    transforms.push_back(iDynTree::Transform::Identity());
+
+    iDynTree::Direction xAxis(1.0, 0.0, 0.0);
+    iDynTree::Direction yAxis(0.0, 1.0, 0.0);
+
+    bool ok = projectionConstraint.buildConvexHull(xAxis,yAxis,iDynTree::Position::Zero(),polygons,transforms);
+    ASSERT_IS_TRUE(ok);
+
+    // Use a test position that is outside the convex hull with the normal projection
+    iDynTree::Position testPoint(1.0, 0.0, 1.0);
+
+    // Projected along the normal of the plane, this point is outside the convex hull
+    // Note: positive margin means inside, negative outside
+    ASSERT_IS_TRUE(projectionConstraint.computeMargin(projectionConstraint.project(testPoint)) < 0);
+
+    //----------------------------------------------------------------------------------------------
+    // If the direction along which we are projecting is the normal of the plane, the projection
+    // should match the one done without direction
+    iDynTree::Direction planeNormal(0.0, 0.0, -1.0);
+    projectionConstraint.setProjectionAlongDirection(planeNormal);
+    ASSERT_EQUAL_VECTOR(projectionConstraint.project(testPoint), projectionConstraint.projectAlongDirection(testPoint));
+
+    //----------------------------------------------------------------------------------------------
+    // If the direction of the projection is "skewed" to the left, the point should instead be inside the convex hull
+    iDynTree::Direction skewedDirection(-1.0, 0.0, -1.0);
+
+    projectionConstraint.setProjectionAlongDirection(skewedDirection);
+    std::cerr << projectionConstraint.computeMargin(projectionConstraint.projectAlongDirection(testPoint)) << std::endl;
+
+    ASSERT_IS_TRUE(projectionConstraint.computeMargin(projectionConstraint.projectAlongDirection(testPoint)) > 0);
+
+    //----------------------------------------------------------------------------------------------
+    // The code should work even if I try to project in the opposite direction wrt 'planeNormal'
+    iDynTree::Direction upwardDirection(0.0, 0.0, 1.0);
+
+    projectionConstraint.setProjectionAlongDirection(upwardDirection);
+
+    // I should obtain the same result as the orthogonal projection
+    ASSERT_EQUAL_VECTOR(projectionConstraint.project(testPoint), projectionConstraint.projectAlongDirection(testPoint));
+    
+    // The projected point should be again outside the convex hull
+    ASSERT_IS_TRUE(projectionConstraint.computeMargin(projectionConstraint.projectAlongDirection(testPoint))< 0);
 
 }
 
 int main()
 {
     testConvexHullProjectionConstraint();
+    testConvexHullProjectionWithGravity();
 
     return EXIT_SUCCESS;
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -27,6 +27,6 @@ if(IDYNTREE_USES_ICUB_MAIN)
 
     # Add a subdirectory of all the consistency tests between the old
     # iCub-dependent external force/internal torque estimation
-    #  implementations and the new native iDynTree implementations
+    # implementations and the new native iDynTree implementations
     add_subdirectory(icub_consistency)
 endif()

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -45,7 +45,7 @@ if(IDYNTREE_USES_ICUB_MAIN)
   install(TARGETS urdf2dh DESTINATION bin)
 endif()
 
-if (IDYNTREE_USES_YARP AND IDYNTREE_USES_QT5)
+if (IDYNTREE_USES_YARP AND IDYNTREE_USES_QT5 AND IDYNTREE_USES_ICUB_MAIN)
     if (IDYNTREE_BUILD_IK)
         add_subdirectory(idyntree-sole-gui)
     endif()

--- a/src/tools/idyntree-sole-gui/plugin/CMakeLists.txt
+++ b/src/tools/idyntree-sole-gui/plugin/CMakeLists.txt
@@ -2,11 +2,11 @@
 # Author: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  
-
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 include_directories(${YARP_INCLUDE_DIRS}
-                    ${GSL_INCLUDE_DIRS})
+                    ${GSL_INCLUDE_DIRS}
+                    ${ctrlLib_INCLUDE_DIRS})
 
 set(QtiDynTreeSoleGuiPlugin_SRCS
                              qticubskinguiplugin.cpp
@@ -30,7 +30,8 @@ target_link_libraries(QtiDynTreeSoleGuiPlugin YARP::YARP_OS
                                               YARP::YARP_dev
                                               ${GSL_LIBRARIES}
                                               idyntree-high-level
-                                              idyntree-inverse-kinematics)
+                                              idyntree-inverse-kinematics
+                                              ctrlLib)
 target_link_libraries(QtiDynTreeSoleGuiPlugin Qt5::Quick)
 
 qticub_qml_plugin(QtiDynTreeSoleGuiPlugin "${QtiDynTreeSoleGuiPlugin_QMLDIR}")

--- a/src/tools/idyntree-sole-gui/plugin/include/ObserverThread.h
+++ b/src/tools/idyntree-sole-gui/plugin/include/ObserverThread.h
@@ -24,8 +24,11 @@
 
 #include <yarp/sig/Vector.h>
 
+#include <iDynTree/Core/Direction.h>
 #include <iDynTree/ConvexHullHelpers.h>
 #include <iDynTree/KinDynComputations.h>
+
+#include <iCub/ctrl/minJerkCtrl.h>
 
 using namespace yarp::dev;
 
@@ -56,6 +59,16 @@ protected:
     yarp::sig::Vector m_measuredPressureSecondarySoleInN;
 
     yarp::os::BufferedPort<yarp::os::Bottle> skin_port;
+
+    // Attributes to read gravity direction
+    bool m_skip_gravity;
+    yarp::os::BufferedPort<yarp::sig::Vector> m_imuPort;
+    std::string m_imuFrameName;
+    std::string m_remoteImuPortName;
+    std::string m_localImuPortName;
+    iDynTree::Direction m_gravityDirection;
+    iCub::ctrl::FirstOrderLowPassFilter *filtIMUGravity;    //!< filter the gravity vector received from the IMU
+
     yarp::os::Semaphore mutex;
 
     int sensorsNum;


### PR DESCRIPTION
I modified `inverse-kinematics` in order to be able to project a 3D point along a direction specified by IMU's measurements.

In particular, I added the following methods:
* `setProjectionDirection` defines the direction along which we want to project a 3D point (see `InverseKinematics.h/cpp)`,
* `setPimu` defines the projection matrix according to the IMU's measurements (see `ConvexHullHelpers.h/cpp`),
* `projectAlongGravity` projects a 3D point according to the projection matrix defined by `setPimu`  (see `ConvexHullHelpers.h/cpp`).

The method `projectAlongGravity` substitutes the method `project` in:
* `getCenterOfMassProjectionMargin` in `InverseKinematics.cpp`,
* `updateState` in `InverseKinematicsNLP.cpp`.
