### PR TITLE
Fix handling of Eigen version in CMake

### DIFF
--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -81,9 +81,9 @@ else (EIGEN3_INCLUDE_DIR)
     _eigen3_check_version()
   endif(EIGEN3_INCLUDE_DIR)
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
-
   mark_as_advanced(EIGEN3_INCLUDE_DIR)
 
 endif(EIGEN3_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)

--- a/cmake/iDynTreeDependencies.cmake
+++ b/cmake/iDynTreeDependencies.cmake
@@ -24,8 +24,8 @@ macro(idyntree_handle_dependency package)
   endif ()
 endmacro ()
 
-# Eigen is compulsory (minimum version 3.3)
-find_package(Eigen3 REQUIRED 3.3)
+# Eigen is compulsory (minimum version 3.2.92)
+find_package(Eigen3 3.2.92 REQUIRED)
 
 # For orocos_kdl we have custom logic, because we want to set it to FALSE by default
 option(IDYNTREE_USES_KDL "Build the part of iDynTree that depends on package orocos_kdl" FALSE)


### PR DESCRIPTION
The issues fixed are:
  * We need to remaing compatible with Eigen 3.2.92 as it is the version shipped in Xenial (3.3-beta2).
  * The order of the find_package version argument was wrong.
  * The FindEigen3.cmake was not givien error if the version requirement was changed after `EIGEN3_INCLUDE_DIR` was already defined.