### PR TITLE
Fix bug in URDF parsing of six axis FT sensor

### DIFF
--- a/src/model_io/urdf/src/URDFGenericSensorsImport.cpp
+++ b/src/model_io/urdf/src/URDFGenericSensorsImport.cpp
@@ -381,7 +381,7 @@ bool sensorsFromURDFString(const std::string& urdfXml,
             SixAxisForceTorqueSensor * sensor = new SixAxisForceTorqueSensor();
             sensor->setName(sensorName);
             sensor->setParentJoint(parentJoint);
-            sensor->setParentJointIndex(parentLinkIndex);
+            sensor->setParentJointIndex(parentJointIndex);
             if( measure_direction_type == PARENT_TO_CHILD )
             {
                 sensor->setAppliedWrenchLink(childLinkIndex);


### PR DESCRIPTION
The bug went not noticed for such a long time because most of the time the couple (model, sensor) 
is extracted through the [`createReducedModelAndSensors`](https://github.com/robotology/idyntree/blob/2470a71cee49ee3a611195e36b8dc447eca9f154/src/sensors/include/iDynTree/Sensors/ModelSensorsTransformers.h#L29) function. In such function, the [`updatedIndices`](https://github.com/robotology/idyntree/blob/850c0c64d9901e0d448f2d1390a73622dcae2e7b/src/sensors/src/ModelSensorsTransformers.cpp#L70) method is called, and that correct any wrong joint index previously present in the sensor.