### PR TITLE
Add BERDY_FLOATING_BASE variant to BerdyHelper 

### DIFF
--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -7,6 +7,7 @@
 
 #include <iDynTree/Estimation/BerdyHelper.h>
 
+#include <iDynTree/Core/ClassicalAcc.h>
 #include <iDynTree/Core/EigenHelpers.h>
 #include <iDynTree/Core/SparseMatrix.h>
 
@@ -41,6 +42,8 @@ bool isJointBerdyDynamicVariable(const BerdyDynamicVariablesTypes dynamicVariabl
             return false;
         case DOF_ACCELERATION:
             return false;
+        case LINK_BODY_PROPER_CLASSICAL_ACCELERATION:
+            return false;
         default:
             return false;
     }
@@ -62,6 +65,8 @@ bool isLinkBerdyDynamicVariable(const BerdyDynamicVariablesTypes dynamicVariable
             return true;
         case DOF_ACCELERATION:
             return false;
+        case LINK_BODY_PROPER_CLASSICAL_ACCELERATION:
+            return true;
         default:
             return false;
     }
@@ -83,6 +88,8 @@ bool isDOFBerdyDynamicVariable(const BerdyDynamicVariablesTypes dynamicVariableT
             return false;
         case DOF_ACCELERATION:
             return true;
+        case LINK_BODY_PROPER_CLASSICAL_ACCELERATION:
+            return false;
         default:
             return false;
     }
@@ -180,10 +187,12 @@ bool BerdyHelper::init(const Model& model,
     {
         case ORIGINAL_BERDY_FIXED_BASE :
             res = initOriginalBerdyFixedBase();
+            cacheDynamicVariablesOrderingFixedBase();
             break;
 
         case BERDY_FLOATING_BASE :
             res = initBerdyFloatingBase();
+            cacheDynamicVariablesOrderingFloatingBase();
             break;
 
         default:
@@ -193,7 +202,6 @@ bool BerdyHelper::init(const Model& model,
 
     if( res )
     {
-        cacheDynamicVariablesOrdering();
         m_areModelAndSensorsValid = true;
     }
     else
@@ -332,7 +340,7 @@ bool BerdyHelper::initOriginalBerdyFixedBase()
     return true;
 }
 
-IndexRange BerdyHelper::getRangeOriginalBerdyFixedBase(BerdyDynamicVariablesTypes dynamicVariableType, TraversalIndex idx)
+IndexRange BerdyHelper::getRangeOriginalBerdyFixedBase(BerdyDynamicVariablesTypes dynamicVariableType, TraversalIndex idx) const
 {
     IndexRange ret;
     size_t dynamicVariableSize, dynamicVariableOffset, nrOfVariablesForJoint;
@@ -387,16 +395,43 @@ IndexRange BerdyHelper::getRangeOriginalBerdyFixedBase(BerdyDynamicVariablesType
     return ret;
 }
 
-IndexRange BerdyHelper::getRangeLinkVariable(BerdyDynamicVariablesTypes dynamicVariableType, LinkIndex idx)
+IndexRange BerdyHelper::getRangeLinkVariable(BerdyDynamicVariablesTypes dynamicVariableType, LinkIndex idx) const
 {
-    assert(m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE);
-
     if( !isLinkBerdyDynamicVariable(dynamicVariableType) )
     {
         return IndexRange::InvalidRange();
     }
 
-    return getRangeOriginalBerdyFixedBase(dynamicVariableType,m_dynamicsTraversal.getTraversalIndexFromLinkIndex(idx));
+    if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+    {
+        return getRangeOriginalBerdyFixedBase(dynamicVariableType,
+                                              m_dynamicsTraversal.getTraversalIndexFromLinkIndex(idx));
+    }
+    else
+    {
+        IndexRange ret;
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+        assert(m_options.includeAllNetExternalWrenchesAsDynamicVariables);
+        // For BERDY_FLOATING_BASE, the only two link dynamic variable are the proper classical acceleration and the
+        // external force-torque
+        switch (dynamicVariableType)
+        {
+            case LINK_BODY_PROPER_CLASSICAL_ACCELERATION:
+                ret.offset = 12*idx;
+                ret.size = 6;
+                break;
+            case NET_EXT_WRENCH:
+                ret.offset = 12*idx + 6;
+                ret.size = 6;
+                break;
+            default:
+                assert(false);
+                ret = IndexRange::InvalidRange();
+                break;
+        }
+
+        return ret;
+    }
 }
 
 // \todo TODO remove
@@ -408,33 +443,82 @@ TraversalIndex getTraversalIndexFromJointIndex(const Model & m_model, const Trav
 }
 
 
-IndexRange BerdyHelper::getRangeJointVariable(BerdyDynamicVariablesTypes dynamicVariableType, JointIndex idx)
+IndexRange BerdyHelper::getRangeJointVariable(BerdyDynamicVariablesTypes dynamicVariableType, JointIndex idx) const
 {
-    assert(m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE);
-
     if( !isJointBerdyDynamicVariable(dynamicVariableType) )
     {
         assert(false);
         return IndexRange::InvalidRange();
     }
 
-    return getRangeOriginalBerdyFixedBase(dynamicVariableType,getTraversalIndexFromJointIndex(m_model,m_dynamicsTraversal,idx));
+    if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+    {
+        return getRangeOriginalBerdyFixedBase(dynamicVariableType,
+                                              getTraversalIndexFromJointIndex(m_model, m_dynamicsTraversal, idx));
+    }
+    else
+    {
+        IndexRange ret;
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+        assert(m_options.includeAllNetExternalWrenchesAsDynamicVariables);
+
+        int totalSizeOfLinkVariables  = 12*m_model.getNrOfLinks();
+
+        switch (dynamicVariableType)
+        {
+            case JOINT_WRENCH:
+                ret.offset = totalSizeOfLinkVariables + 6*idx;
+                ret.size = 6;
+                break;
+            default:
+                assert(false);
+                ret = IndexRange::InvalidRange();
+                break;
+        }
+
+        return ret;
+    }
 }
 
-IndexRange BerdyHelper::getRangeDOFVariable(BerdyDynamicVariablesTypes dynamicVariableType, DOFIndex idx)
+IndexRange BerdyHelper::getRangeDOFVariable(BerdyDynamicVariablesTypes dynamicVariableType, DOFIndex idx) const
 {
-    assert(m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE);
-
     if( !isDOFBerdyDynamicVariable(dynamicVariableType) )
     {
         return IndexRange::InvalidRange();
     }
 
-    // For a model with all 1-dofs, dof index and joint index matches
-    return getRangeOriginalBerdyFixedBase(dynamicVariableType,getTraversalIndexFromJointIndex(m_model,m_dynamicsTraversal,idx));
+    if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+    {
+        // For a model with all 1-dofs, dof index and joint index matches
+        return getRangeOriginalBerdyFixedBase(dynamicVariableType,
+                                              getTraversalIndexFromJointIndex(m_model, m_dynamicsTraversal, idx));
+    }
+    else
+    {
+        IndexRange ret;
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+        assert(m_options.includeAllNetExternalWrenchesAsDynamicVariables);
+
+        int totalSizeOfLinkVariables  = 12*m_model.getNrOfLinks();
+        int totalSizeOfJointVariables = 6*m_model.getNrOfJoints();
+
+        switch (dynamicVariableType)
+        {
+            case DOF_ACCELERATION:
+                ret.offset = totalSizeOfLinkVariables + totalSizeOfJointVariables + idx;
+                ret.size = 1;
+                break;
+            default:
+                assert(false);
+                ret = IndexRange::InvalidRange();
+                break;
+        }
+
+        return ret;
+    }
 }
 
-IndexRange BerdyHelper::getRangeSensorVariable(const SensorType type, const unsigned int sensorIdx)
+IndexRange BerdyHelper::getRangeSensorVariable(const SensorType type, const unsigned int sensorIdx) const
 {
     unsigned int sensorOffset = 0;
 
@@ -453,6 +537,11 @@ IndexRange BerdyHelper::getRangeSensorVariable(const SensorType type, const unsi
         sensorOffset += 3*m_sensors.getNrOfSensors(GYROSCOPE);
     }
 
+    if( type > THREE_AXIS_ANGULAR_ACCELEROMETER )
+    {
+        sensorOffset += 3*m_sensors.getNrOfSensors(THREE_AXIS_ANGULAR_ACCELEROMETER);
+    }
+
     sensorOffset += sensorIdx*getSensorTypeSize(type);
 
     IndexRange ret;
@@ -462,12 +551,12 @@ IndexRange BerdyHelper::getRangeSensorVariable(const SensorType type, const unsi
     return ret;
 }
 
-IndexRange BerdyHelper::getRangeDOFSensorVariable(const BerdySensorTypes sensorType, const DOFIndex idx)
+IndexRange BerdyHelper::getRangeDOFSensorVariable(const BerdySensorTypes sensorType, const DOFIndex idx) const
 {
     IndexRange ret = IndexRange::InvalidRange();
     ret.size = 1;
 
-    if( m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE )
+    if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
     {
         // For ORIGINAL_BERDY_FIXED_BASE we know  that DOFIndex is always equalt to JointIndex
         TraversalIndex trvIdx = getTraversalIndexFromJointIndex(m_model,m_dynamicsTraversal,(JointIndex)idx);
@@ -482,38 +571,49 @@ IndexRange BerdyHelper::getRangeDOFSensorVariable(const BerdySensorTypes sensorT
             ret.offset = berdySensorTypeOffsets.dofTorquesOffset + (trvIdx-1);
         }
     }
-
-    return ret;
-}
-
-IndexRange BerdyHelper::getRangeJointSensorVariable(const BerdySensorTypes sensorType, const JointIndex idx)
-{
-    IndexRange ret = IndexRange::InvalidRange();
-    ret.size = 6;
-
-    if( sensorType == JOINT_WRENCH_SENSOR )
+    else
     {
-        if( m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE )
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+
+        if( sensorType == DOF_ACCELERATION_SENSOR )
         {
-            ret.offset = berdySensorsInfo.jntIdxToOffset[idx];
+            ret.offset = berdySensorTypeOffsets.dofAccelerationOffset + idx;
+        }
+
+        if( sensorType == DOF_TORQUE_SENSOR )
+        {
+            ret.offset = berdySensorTypeOffsets.dofTorquesOffset + idx;
         }
     }
 
     return ret;
 }
 
-IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx)
+IndexRange BerdyHelper::getRangeJointSensorVariable(const BerdySensorTypes sensorType, const JointIndex idx) const
+{
+    IndexRange ret = IndexRange::InvalidRange();
+    ret.size = 6;
+
+    if( sensorType == JOINT_WRENCH_SENSOR )
+    {
+        ret.offset = berdySensorsInfo.jntIdxToOffset[idx];
+    }
+
+    return ret;
+}
+
+IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx) const
 {
     IndexRange ret = IndexRange::InvalidRange();
     ret.size = 6;
 
     if( sensorType == NET_EXT_WRENCH_SENSOR )
     {
-        if( m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE )
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
         {
             TraversalIndex trvIdx = m_dynamicsTraversal.getTraversalIndexFromLinkIndex(idx);
 
-            if( m_options.includeFixedBaseExternalWrench )
+            if (m_options.includeFixedBaseExternalWrench)
             {
                 ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*trvIdx;
             }
@@ -522,13 +622,18 @@ IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensor
                 ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*(trvIdx-1);
             }
         }
+        else
+        {
+            assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+            ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*idx;
+        }
     }
 
     assert(ret.isValid());
     return ret;
 }
 
-IndexRange BerdyHelper::getRangeLinkProperAccDynEq(const LinkIndex idx)
+IndexRange BerdyHelper::getRangeLinkProperAccDynEqFixedBase(const LinkIndex idx) const
 {
     IndexRange ret;
 
@@ -543,7 +648,7 @@ IndexRange BerdyHelper::getRangeLinkProperAccDynEq(const LinkIndex idx)
     return IndexRange::InvalidRange();
 }
 
-IndexRange BerdyHelper::getRangeLinkNetTotalwrenchDynEq(const LinkIndex idx)
+IndexRange BerdyHelper::getRangeLinkNetTotalWrenchDynEqFixedBase(const LinkIndex idx) const
 {
     IndexRange ret;
 
@@ -558,7 +663,7 @@ IndexRange BerdyHelper::getRangeLinkNetTotalwrenchDynEq(const LinkIndex idx)
     return IndexRange::InvalidRange();
 }
 
-IndexRange BerdyHelper::getRangeJointWrench(const JointIndex idx)
+IndexRange BerdyHelper::getRangeJointWrenchDynEqFixedBase(const JointIndex idx) const
 {
     IndexRange ret;
 
@@ -573,7 +678,7 @@ IndexRange BerdyHelper::getRangeJointWrench(const JointIndex idx)
     return IndexRange::InvalidRange();
 }
 
-IndexRange BerdyHelper::getRangeDOFTorqueDynEq(const DOFIndex idx)
+IndexRange BerdyHelper::getRangeDOFTorqueDynEqFixedBase(const DOFIndex idx) const
 {
     IndexRange ret;
 
@@ -588,8 +693,25 @@ IndexRange BerdyHelper::getRangeDOFTorqueDynEq(const DOFIndex idx)
     return IndexRange::InvalidRange();
 }
 
+IndexRange BerdyHelper::getRangeAccelerationPropagationFloatingBase(const JointIndex idx) const
+{
+    assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+    IndexRange ret;
+    ret.offset = 6*m_model.getNrOfLinks() + 6*idx;
+    ret.size = 6;
+    return ret;
+}
 
-bool BerdyHelper::computeBerdyDynamicsMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD)
+IndexRange BerdyHelper::getRangeNewtonEulerEquationsFloatingBase(const LinkIndex idx) const
+{
+    assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+    IndexRange ret;
+    ret.offset = 6*idx;
+    ret.size = 6;
+    return ret;
+}
+
+bool BerdyHelper::computeBerdyDynamicsMatricesFixedBase(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD)
 {
     D.resize(m_nrOfDynamicEquations,m_nrOfDynamicalVariables);
     bD.resize(m_nrOfDynamicEquations);
@@ -603,42 +725,43 @@ bool BerdyHelper::computeBerdyDynamicsMatrices(SparseMatrix<iDynTree::ColumnMajo
         traversalEl++)
     {
         LinkConstPtr visitedLink = m_dynamicsTraversal.getLink(traversalEl);
-        LinkConstPtr parentLink  = m_dynamicsTraversal.getParentLink(traversalEl);
+        LinkConstPtr parentLink = m_dynamicsTraversal.getParentLink(traversalEl);
         IJointConstPtr toParentJoint = m_dynamicsTraversal.getParentJoint(traversalEl);
-        LinkIndex    visitedLinkIdx = visitedLink->getIndex();
-        LinkIndex    parentLinkIdx   = parentLink->getIndex();
+        LinkIndex visitedLinkIdx = visitedLink->getIndex();
+        LinkIndex parentLinkIdx = parentLink->getIndex();
 
         ///////////////////////////////////////////////////////////
         // Acceleration forward kinematics propagation (D part)
         ///////////////////////////////////////////////////////////
-        const Transform & visited_X_parent = toParentJoint->getTransform(m_jointPos,visitedLinkIdx,parentLinkIdx);
+        const Transform &visited_X_parent = toParentJoint->getTransform(m_jointPos, visitedLinkIdx, parentLinkIdx);
 
         // Proper acc propagation equations
-        matrixDElements.addDiagonalMatrix(getRangeLinkProperAccDynEq(visitedLinkIdx),
-                                          getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,visitedLinkIdx),
+        matrixDElements.addDiagonalMatrix(getRangeLinkProperAccDynEqFixedBase(visitedLinkIdx),
+                                          getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION, visitedLinkIdx),
                                           -1);
 
         // This should not be added if the variant is ORIGINAL_BERDY_FIXED_BASE and the parentLink is the base
         // because in that case the acceleration of the base is not a dynamic variable
-        if( !(m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE && parentLinkIdx == m_dynamicsTraversal.getBaseLink()->getIndex()) )
+        if (!(m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE &&
+              parentLinkIdx == m_dynamicsTraversal.getBaseLink()->getIndex()))
         {
-            matrixDElements.addSubMatrix(getRangeLinkProperAccDynEq(visitedLinkIdx).offset,
-                                         getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,parentLinkIdx).offset,
+            matrixDElements.addSubMatrix(getRangeLinkProperAccDynEqFixedBase(visitedLinkIdx).offset,
+                                         getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION, parentLinkIdx).offset,
                                          visited_X_parent.asAdjointTransform());
         }
 
         size_t jointDOFs = toParentJoint->getNrOfDOFs();
         size_t dofOffset = toParentJoint->getDOFsOffset();
 
-        for(size_t localDof = 0; localDof < jointDOFs; localDof++)
+        for (size_t localDof = 0; localDof < jointDOFs; localDof++)
         {
-            SpatialMotionVector S = toParentJoint->getMotionSubspaceVector(localDof,visitedLinkIdx,parentLinkIdx);
+            SpatialMotionVector S = toParentJoint->getMotionSubspaceVector(localDof, visitedLinkIdx, parentLinkIdx);
             Matrix6x1 SdynTree;
             toEigen(SdynTree) = toEigen(S);
 
             //From S to iDynTreeMatrix
-            matrixDElements.addSubMatrix(getRangeLinkProperAccDynEq(visitedLinkIdx).offset,
-                                         getRangeDOFVariable(DOF_ACCELERATION,dofOffset+localDof).offset,
+            matrixDElements.addSubMatrix(getRangeLinkProperAccDynEqFixedBase(visitedLinkIdx).offset,
+                                         getRangeDOFVariable(DOF_ACCELERATION, dofOffset + localDof).offset,
                                          SdynTree);
         }
 
@@ -648,42 +771,45 @@ bool BerdyHelper::computeBerdyDynamicsMatrices(SparseMatrix<iDynTree::ColumnMajo
         SpatialMotionVector biasAcc;
         biasAcc.zero();
 
-        for(size_t localDof = 0; localDof < jointDOFs; localDof++)
+        for (size_t localDof = 0; localDof < jointDOFs; localDof++)
         {
-            SpatialMotionVector S = toParentJoint->getMotionSubspaceVector(localDof,visitedLinkIdx,parentLinkIdx);
-            biasAcc = biasAcc + m_linkVels(visitedLinkIdx).cross(S*m_jointVel(dofOffset+localDof));
+            SpatialMotionVector S = toParentJoint->getMotionSubspaceVector(localDof, visitedLinkIdx, parentLinkIdx);
+            biasAcc = biasAcc + m_linkVels(visitedLinkIdx).cross(S * m_jointVel(dofOffset + localDof));
         }
 
-        if( m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE && parentLinkIdx == m_dynamicsTraversal.getBaseLink()->getIndex() )
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE &&
+            parentLinkIdx == m_dynamicsTraversal.getBaseLink()->getIndex())
         {
             // If the variant is ORIGINAL_BERDY_FIXED_BASE variant, we need to account explicitly for the gravity for links whose parent is the base
-            biasAcc = biasAcc - visited_X_parent*m_gravity6D;
+            biasAcc = biasAcc - visited_X_parent * m_gravity6D;
         }
 
         setSubVector(bD,
-                     getRangeLinkProperAccDynEq(visitedLinkIdx),
+                     getRangeLinkProperAccDynEqFixedBase(visitedLinkIdx),
                      toEigen(biasAcc));
 
 
-        if( m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE )
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
         {
             ///////////////////////////////////////////////////////////
             // Total net wrench without gravity (D part, only for ORIGINAL_BERDY_FIXED_BASE
             ///////////////////////////////////////////////////////////
-            matrixDElements.addDiagonalMatrix(getRangeLinkNetTotalwrenchDynEq(visitedLinkIdx),
-                                              getRangeLinkVariable(NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV,visitedLinkIdx),
+            matrixDElements.addDiagonalMatrix(getRangeLinkNetTotalWrenchDynEqFixedBase(visitedLinkIdx),
+                                              getRangeLinkVariable(NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV,
+                                                                   visitedLinkIdx),
                                               -1);
 
-            matrixDElements.addSubMatrix(getRangeLinkNetTotalwrenchDynEq(visitedLinkIdx).offset,
-                                         getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,visitedLinkIdx).offset,
+            matrixDElements.addSubMatrix(getRangeLinkNetTotalWrenchDynEqFixedBase(visitedLinkIdx).offset,
+                                         getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION, visitedLinkIdx).offset,
                                          visitedLink->getInertia().asMatrix());
 
             ///////////////////////////////////////////////////////////
             // Total net wrench without gravity (bD part, only for ORIGINAL_BERDY_FIXED_BASE
             ///////////////////////////////////////////////////////////
             setSubVector(bD,
-                         getRangeLinkNetTotalwrenchDynEq(visitedLinkIdx),
-                         toEigen(m_linkVels(visitedLinkIdx)*(visitedLink->getInertia()*m_linkVels(visitedLinkIdx))));
+                         getRangeLinkNetTotalWrenchDynEqFixedBase(visitedLinkIdx),
+                         toEigen(m_linkVels(visitedLinkIdx) *
+                                 (visitedLink->getInertia() * m_linkVels(visitedLinkIdx))));
 
         }
 
@@ -692,8 +818,8 @@ bool BerdyHelper::computeBerdyDynamicsMatrices(SparseMatrix<iDynTree::ColumnMajo
         ///////////////////////////////////////////////////////////
 
         // Joint wrench itself
-        matrixDElements.addDiagonalMatrix(getRangeJointWrench(toParentJoint->getIndex()),
-                                          getRangeJointVariable(JOINT_WRENCH,toParentJoint->getIndex()),
+        matrixDElements.addDiagonalMatrix(getRangeJointWrenchDynEqFixedBase(toParentJoint->getIndex()),
+                                          getRangeJointVariable(JOINT_WRENCH, toParentJoint->getIndex()),
                                           -1);
 
         // Wrench of child links
@@ -703,77 +829,229 @@ bool BerdyHelper::computeBerdyDynamicsMatrices(SparseMatrix<iDynTree::ColumnMajo
         // \todo TODO this point is definitly Tree-specific
         // \todo TODO this "get child" for is duplicated in the code, we
         //            should try to consolidate it
-        for(unsigned int neigh_i=0; neigh_i < m_model.getNrOfNeighbors(visitedLinkIdx); neigh_i++)
+        for (unsigned int neigh_i = 0; neigh_i < m_model.getNrOfNeighbors(visitedLinkIdx); neigh_i++)
         {
-             LinkIndex neighborIndex = m_model.getNeighbor(visitedLinkIdx,neigh_i).neighborLink;
-             if( !parentLink || neighborIndex != parentLink->getIndex() )
-             {
-                 LinkIndex childIndex = neighborIndex;
-                 IJointConstPtr neighborJoint = m_model.getJoint(m_model.getNeighbor(visitedLinkIdx,neigh_i).neighborJoint);
-                 const Transform & visitedLink_X_child = neighborJoint->getTransform(m_jointPos,visitedLinkIdx,childIndex);
+            LinkIndex neighborIndex = m_model.getNeighbor(visitedLinkIdx, neigh_i).neighborLink;
+            if (!parentLink || neighborIndex != parentLink->getIndex())
+            {
+                LinkIndex childIndex = neighborIndex;
+                IJointConstPtr neighborJoint = m_model.getJoint(
+                        m_model.getNeighbor(visitedLinkIdx, neigh_i).neighborJoint);
+                const Transform &visitedLink_X_child = neighborJoint->getTransform(m_jointPos, visitedLinkIdx,
+                                                                                   childIndex);
 
-                 matrixDElements.addSubMatrix(getRangeJointWrench(toParentJoint->getIndex()).offset,
-                                              getRangeJointVariable(JOINT_WRENCH,neighborJoint->getIndex()).offset,
-                                              visitedLink_X_child.asAdjointTransformWrench());
+                matrixDElements.addSubMatrix(getRangeJointWrenchDynEqFixedBase(toParentJoint->getIndex()).offset,
+                                             getRangeJointVariable(JOINT_WRENCH, neighborJoint->getIndex()).offset,
+                                             visitedLink_X_child.asAdjointTransformWrench());
 
-             }
+            }
         }
 
         // Net external wrench
-        if( m_options.includeAllNetExternalWrenchesAsDynamicVariables )
+        if (m_options.includeAllNetExternalWrenchesAsDynamicVariables)
         {
-            matrixDElements.addDiagonalMatrix(getRangeJointWrench(toParentJoint->getIndex()),
-                                              getRangeLinkVariable(NET_EXT_WRENCH,visitedLinkIdx),
+            matrixDElements.addDiagonalMatrix(getRangeJointWrenchDynEqFixedBase(toParentJoint->getIndex()),
+                                              getRangeLinkVariable(NET_EXT_WRENCH, visitedLinkIdx),
                                               -1);
         }
 
 
-        if( m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE )
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
         {
             // In the ORIGINAL_BERDY_FIXED_BASE, we also add to the rows of the joint wrenches
             // the depend on the total wrenches
-            matrixDElements.addDiagonalMatrix(getRangeJointWrench(toParentJoint->getIndex()),
-                                              getRangeLinkVariable(NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV,visitedLinkIdx),
+            matrixDElements.addDiagonalMatrix(getRangeJointWrenchDynEqFixedBase(toParentJoint->getIndex()),
+                                              getRangeLinkVariable(NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV,
+                                                                   visitedLinkIdx),
                                               1);
 
         }
 
-        if( m_options.berdyVariant == BERDY_FLOATING_BASE )
+        if (m_options.berdyVariant == BERDY_FLOATING_BASE)
         {
-            // In the floating base variant, we embed all the inertia related terms directly in the floaging base
-            matrixDElements.addSubMatrix(getRangeJointWrench(toParentJoint->getIndex()).offset,
-                                         getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,visitedLinkIdx).offset,
+            // In the floating base variant, we embed all the inertia related terms directly in the floating base
+            matrixDElements.addSubMatrix(getRangeJointWrenchDynEqFixedBase(toParentJoint->getIndex()).offset,
+                                         getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION, visitedLinkIdx).offset,
                                          visitedLink->getInertia().asMatrix());
         }
 
         ///////////////////////////////////////////////////////////
         // Joint wrench (bD part, only for BERDY_FLOATING_BASE)
         ///////////////////////////////////////////////////////////
-        if( m_options.berdyVariant == BERDY_FLOATING_BASE )
+        if (m_options.berdyVariant == BERDY_FLOATING_BASE)
         {
             setSubVector(bD,
-                         getRangeJointWrench(toParentJoint->getIndex()),
-                         toEigen(m_linkVels(visitedLinkIdx).cross(visitedLink->getInertia()*m_linkVels(visitedLinkIdx))));
+                         getRangeJointWrenchDynEqFixedBase(toParentJoint->getIndex()),
+                         toEigen(m_linkVels(visitedLinkIdx).cross(
+                                 visitedLink->getInertia() * m_linkVels(visitedLinkIdx))));
         }
 
         ////////////////////////////////////////////////////////////
-        /// DOF torques equations (D part, bD is always zero)
+        /// DOF torques equations (D part, bD is always zero).
+        /// Only for ORIGINAL_BERDY_FIXED_BASE, BERDY_FLOATING_BASE does not
+        // include the torques as dynamic variables
         ////////////////////////////////////////////////////////////
-        for(size_t localDof = 0; localDof < jointDOFs; localDof++)
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
         {
-            SpatialMotionVector S = toParentJoint->getMotionSubspaceVector(localDof,visitedLinkIdx,parentLinkIdx);
-            Matrix1x6 SdynTree;
-            toEigen(SdynTree) = toEigen(S).transpose();
+            for (size_t localDof = 0; localDof < jointDOFs; localDof++)
+            {
+                SpatialMotionVector S = toParentJoint->getMotionSubspaceVector(localDof, visitedLinkIdx, parentLinkIdx);
+                Matrix1x6 SdynTree;
+                toEigen(SdynTree) = toEigen(S).transpose();
 
-            matrixDElements.addSubMatrix(getRangeDOFTorqueDynEq(dofOffset+localDof).offset,
-                                         getRangeJointVariable(JOINT_WRENCH,toParentJoint->getIndex()).offset,
-                                         SdynTree);
+                matrixDElements.addSubMatrix(getRangeDOFTorqueDynEqFixedBase(dofOffset + localDof).offset,
+                                             getRangeJointVariable(JOINT_WRENCH, toParentJoint->getIndex()).offset,
+                                             SdynTree);
 
-            matrixDElements.pushTriplet(Triplet(getRangeDOFTorqueDynEq(dofOffset+localDof).offset,
-                                                getRangeDOFVariable(DOF_TORQUE,dofOffset+localDof).offset,
-                                                -1));
+                matrixDElements.pushTriplet(Triplet(getRangeDOFTorqueDynEqFixedBase(dofOffset + localDof).offset,
+                                                    getRangeDOFVariable(DOF_TORQUE, dofOffset + localDof).offset,
+                                                    -1));
 
+            }
         }
+    }
+
+    D.setFromTriplets(matrixDElements);
+    return true;
+}
+
+Matrix6x1 BerdyHelper::getBiasTermJointAccelerationPropagation(IJointConstPtr joint,
+                                                               const LinkIndex parentLinkIdx,
+                                                               const LinkIndex childLinkIdx,
+                                                               const Transform &child_X_parent)
+{
+    Matrix6x1 biasTerm;
+    biasTerm.zero();
+
+    auto biasTermEig = toEigen(biasTerm);
+
+    // Implementing equation 36 in https://www.sharelatex.com/project/59439ec80788901873a803fb
+    Vector3 parentBodyAngularVel = m_linkVels(parentLinkIdx).getAngularVec3();
+
+    Rotation  child_R_parent = child_X_parent.getRotation();
+    Transform parent_X_child = child_X_parent.inverse();
+    Position  parent_o_child = parent_X_child.getPosition();
+    Rotation  parent_R_child = parent_X_child.getRotation();
+    Transform mixed_X_leftTrivialized = Transform(parent_R_child, Position::Zero());
+
+    // Compute the mixed relative velocity of the child w.r.t to the parent
+    Twist relJointVelInMixed = Twist::Zero();
+    for (size_t localDof=0; localDof < joint->getNrOfDOFs(); localDof++)
+    {
+        SpatialMotionVector SleftTrivialzed = joint->getMotionSubspaceVector(localDof, childLinkIdx, parentLinkIdx);
+        SpatialMotionVector Smixed = mixed_X_leftTrivialized*SleftTrivialzed;
+
+        relJointVelInMixed = relJointVelInMixed + (Smixed*m_jointVel(joint->getDOFsOffset()+localDof));
+    }
+
+    // Compute the first term
+    biasTermEig.segment<3>(0) = 2*toEigen(child_R_parent)*(toEigen(parentBodyAngularVel).cross(toEigen(relJointVelInMixed.getLinearVec3())));
+    biasTermEig.segment<3>(3) = toEigen(child_R_parent)*(toEigen(parentBodyAngularVel).cross(toEigen(relJointVelInMixed.getAngularVec3())));
+
+    // Compute the second term
+    biasTermEig.segment<3>(0) += toEigen(child_R_parent)*(toEigen(parentBodyAngularVel).cross(toEigen(parentBodyAngularVel).cross(toEigen(parent_o_child))));
+
+    return biasTerm;
+}
+
+bool BerdyHelper::computeBerdyDynamicsMatricesFloatingBase(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD)
+{
+    D.resize(m_nrOfDynamicEquations,m_nrOfDynamicalVariables);
+    bD.resize(m_nrOfDynamicEquations);
+    //TODO: \todo check if this is a bottleneck
+    matrixDElements.clear();
+    bD.zero();
+
+    // Add the equation of the Newton-Euler for a link
+    for (LinkIndex lnkIdx=0; lnkIdx < static_cast<LinkIndex>(m_model.getNrOfLinks()); lnkIdx++)
+    {
+        LinkConstPtr link = m_model.getLink(lnkIdx);
+
+        // Term depending on the sensor acceleration
+        matrixDElements.addSubMatrix(getRangeNewtonEulerEquationsFloatingBase(lnkIdx).offset,
+                                     getRangeLinkVariable(LINK_BODY_PROPER_CLASSICAL_ACCELERATION, lnkIdx).offset,
+                                     link->getInertia().asMatrix());
+
+        // Term depending on external force-torque
+        matrixDElements.addDiagonalMatrix(getRangeNewtonEulerEquationsFloatingBase(lnkIdx),
+                                          getRangeLinkVariable(NET_EXT_WRENCH, lnkIdx),
+                                          -1);
+
+        // Term depending on the force exchanged with the parent link, if this link is not the base of the traversal
+        LinkIndex parentLinkIdx = LINK_INVALID_INDEX;
+        if (lnkIdx != m_dynamicsTraversal.getBaseLink()->getIndex())
+        {
+            JointIndex parentJointIdx = m_dynamicsTraversal.getParentJointFromLinkIndex(lnkIdx)->getIndex();
+            parentLinkIdx = m_dynamicsTraversal.getParentLinkFromLinkIndex(lnkIdx)->getIndex();
+            matrixDElements.addDiagonalMatrix(getRangeNewtonEulerEquationsFloatingBase(lnkIdx),
+                                              getRangeJointVariable(JOINT_WRENCH, parentJointIdx),
+                                              -1);
+        }
+
+        // Term depending on the force exchanged with the children links
+        for (unsigned int neigh_i = 0; neigh_i < m_model.getNrOfNeighbors(lnkIdx); neigh_i++)
+        {
+            LinkIndex neighborIndex = m_model.getNeighbor(lnkIdx, neigh_i).neighborLink;
+            if (neighborIndex != parentLinkIdx)
+            {
+                LinkIndex childIndex = neighborIndex;
+                IJointConstPtr neighborJoint = m_model.getJoint(
+                        m_model.getNeighbor(lnkIdx, neigh_i).neighborJoint);
+                const Transform &visitedLink_X_child = neighborJoint->getTransform(m_jointPos, lnkIdx,
+                                                                                   childIndex);
+
+                matrixDElements.addSubMatrix(getRangeNewtonEulerEquationsFloatingBase(lnkIdx).offset,
+                                             getRangeJointVariable(JOINT_WRENCH, neighborJoint->getIndex()).offset,
+                                             visitedLink_X_child.asAdjointTransformWrench());
+
+            }
+        }
+
+        // bias Term
+        Twist angularPartOfLeftTrivializedVel = Twist(LinearMotionVector3(0.0, 0.0, 0.0), m_linkVels(lnkIdx).getAngularVec3());
+        setSubVector(bD,
+                     getRangeNewtonEulerEquationsFloatingBase(lnkIdx),
+                     toEigen(angularPartOfLeftTrivializedVel.cross(
+                             link->getInertia() * angularPartOfLeftTrivializedVel)));
+    }
+
+    // Add the equation of the kinematic propagation of sensor acceleration
+    for (JointIndex jntIdx=0; jntIdx < static_cast<JointIndex>(m_model.getNrOfJoints()); jntIdx++)
+    {
+        // This equation is one of the few place in which we use the parent-child relations
+        LinkIndex childLinkIdx = m_dynamicsTraversal.getChildLinkIndexFromJointIndex(m_model, jntIdx);
+        LinkIndex parentLinkIdx = m_dynamicsTraversal.getParentLinkIndexFromJointIndex(m_model, jntIdx);
+
+        matrixDElements.addDiagonalMatrix(getRangeAccelerationPropagationFloatingBase(jntIdx),
+                                          getRangeLinkVariable(LINK_BODY_PROPER_CLASSICAL_ACCELERATION, childLinkIdx),
+                                          -1);
+
+        IJointConstPtr joint = m_model.getJoint(jntIdx);
+        const Transform &child_X_parent = joint->getTransform(m_jointPos, childLinkIdx, parentLinkIdx);
+
+        matrixDElements.addSubMatrix(getRangeAccelerationPropagationFloatingBase(jntIdx).offset,
+                                     getRangeLinkVariable(LINK_BODY_PROPER_CLASSICAL_ACCELERATION, parentLinkIdx).offset,
+                                     child_X_parent.asAdjointTransform());
+
+        // This for automatically handles joint with any number of DOFs
+        for (size_t localDof=0; localDof < joint->getNrOfDOFs(); localDof++)
+        {
+            SpatialMotionVector S = joint->getMotionSubspaceVector(localDof, childLinkIdx, parentLinkIdx);
+            Matrix6x1 SdynTree;
+            toEigen(SdynTree) = toEigen(S);
+
+            matrixDElements.addSubMatrix(getRangeAccelerationPropagationFloatingBase(jntIdx).offset,
+                                         getRangeDOFVariable(DOF_ACCELERATION, joint->getDOFsOffset() + localDof).offset,
+                                         SdynTree);
+        }
+
+        // The known term for kinematic calibration is quite complicate due to the use of sensor proper acceleration,
+        // for this reason it is implemented in a separate function
+        Matrix6x1 biasTerm = getBiasTermJointAccelerationPropagation(joint, parentLinkIdx, childLinkIdx, child_X_parent);
+        setSubVector(bD,
+                     getRangeAccelerationPropagationFloatingBase(jntIdx),
+                     toEigen(biasTerm));
+
     }
 
     D.setFromTriplets(matrixDElements);
@@ -809,7 +1087,6 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
         matrixYElements.addSubMatrix(sensorRange.offset,
                                      jointWrenchRange.offset,
                                      sensor_M_link);
-
         // bY for the F/T sensor is equal to zero
     }
 
@@ -823,20 +1100,44 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
         LinkIndex parentLinkId = accelerometer->getParentLinkIndex();
         Transform sensor_X_link = accelerometer->getLinkSensorTransform().inverse();
         IndexRange sensorRange = this->getRangeSensorVariable(ACCELEROMETER,idx);
-        IndexRange linkBodyProperAcRange = this->getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,parentLinkId);
 
-        // Y(sensorRange,linkBodyProperAcRange) for the accelerometer is the first three rows of the sensor_X_link adjoint matrix
-        MatrixFixSize<3, 6> xLinkLinear;
-        toEigen(xLinkLinear) = toEigen(sensor_X_link.asAdjointTransform()).block<3,6>(0,0);
+        // The sensor equation are different between ORIGINAL_BERDY_FIXED_BASE and BERDY_FLOATING_BASE, due to
+        // the difference in the convention used for expressing the body acceleration
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+        {
+            // Y(sensorRange,linkBodyProperAcRange) for the accelerometer is the first three rows of the sensor_X_link adjoint matrix
+            MatrixFixSize<3, 6> xLinkLinear;
+            toEigen(xLinkLinear) = toEigen(sensor_X_link.asAdjointTransform()).block<3, 6>(0, 0);
 
-        matrixYElements.addSubMatrix(sensorRange.offset,
-                                     linkBodyProperAcRange.offset,
-                                     xLinkLinear);
+            IndexRange linkBodyProperAcRange = this->getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,parentLinkId);
+            matrixYElements.addSubMatrix(sensorRange.offset,
+                                         linkBodyProperAcRange.offset,
+                                         xLinkLinear);
 
-        Twist vSensor = sensor_X_link*m_linkVels(parentLinkId);
+            Twist vSensor = sensor_X_link * m_linkVels(parentLinkId);
 
-        // bY for the accelerometer is the cross product of the angular part and the linear part of the body 6D velocity expressed in the sensor orientation and wrt to the
-        setSubVector(bY,sensorRange, toEigen(vSensor.getAngularVec3().cross(vSensor.getLinearVec3())) );
+            // bY for the accelerometer is the cross product of the angular part and the linear part of the body 6D velocity expressed in the sensor orientation and wrt to the
+            setSubVector(bY, sensorRange, toEigen(vSensor.getAngularVec3().cross(vSensor.getLinearVec3())));
+        }
+        else
+        {
+            assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+            // Y(sensorRange,linkBodyProperAcRange) for the accelerometer is the first three rows of the sensor_X_link adjoint matrix
+            MatrixFixSize<3, 6> xLinkLinear;
+            toEigen(xLinkLinear) = toEigen(sensor_X_link.asAdjointTransform()).block<3, 6>(0, 0);
+
+            IndexRange linkBodyProperAcRange = this->getRangeLinkVariable(LINK_BODY_PROPER_CLASSICAL_ACCELERATION, parentLinkId);
+            matrixYElements.addSubMatrix(sensorRange.offset,
+                                         linkBodyProperAcRange.offset,
+                                         xLinkLinear);
+
+            Position link_o_sensor = sensor_X_link.inverse().getPosition();
+            Rotation sensor_R_link = sensor_X_link.getRotation();
+
+            // bY for the accelerometer
+            Eigen::Vector3d linkAngVel = toEigen(m_linkVels(parentLinkId).getAngularVec3());
+            setSubVector(bY, sensorRange, toEigen(sensor_R_link)*(linkAngVel.cross(linkAngVel.cross(toEigen(link_o_sensor)))));
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -854,6 +1155,38 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
 
         // bY for the gyroscope is just the angular velocity of the link rotated in the sensor frame
         setSubVector(bY,sensorRange,toEigen((sensor_X_link*m_linkVels(parentLinkId)).getAngularVec3()));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    ///// THREE AXIS ANGULAR ACCELEROMETERS
+    ////////////////////////////////////////////////////////////////////////
+    unsigned int numThreeAxisAngularAccelerometer = m_sensors.getNrOfSensors(iDynTree::THREE_AXIS_ANGULAR_ACCELEROMETER);
+    for(size_t idx = 0; idx<numThreeAxisAngularAccelerometer; idx++)
+    {
+        ThreeAxisAngularAccelerometerSensor * angAccelerometer = (ThreeAxisAngularAccelerometerSensor*)m_sensors.getSensor(iDynTree::THREE_AXIS_ANGULAR_ACCELEROMETER, idx);
+        LinkIndex parentLinkId = angAccelerometer->getParentLinkIndex();
+        Transform sensor_X_link = angAccelerometer->getLinkSensorTransform().inverse();
+        IndexRange sensorRange = this->getRangeSensorVariable(THREE_AXIS_ANGULAR_ACCELEROMETER, idx);
+
+        // Y for the gyroscope is just a rotation between the link frame and the sensor frame
+        // for all the rappresentations of acceleration
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+        {
+            IndexRange linkBodyProperAcRange = this->getRangeLinkVariable(LINK_BODY_PROPER_ACCELERATION,parentLinkId);
+            matrixYElements.addSubMatrix(sensorRange.offset,
+                                         linkBodyProperAcRange.offset+3,
+                                         sensor_X_link.getRotation());
+        }
+        else
+        {
+            assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+            IndexRange linkBodyProperAcRange = this->getRangeLinkVariable(LINK_BODY_PROPER_CLASSICAL_ACCELERATION, parentLinkId);
+            matrixYElements.addSubMatrix(sensorRange.offset,
+                                         linkBodyProperAcRange.offset+3,
+                                         sensor_X_link.getRotation());
+        }
+
+        // bY for the angular accelerometer is zero
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -973,10 +1306,15 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
 
 bool BerdyHelper::initBerdyFloatingBase()
 {
-    bool res = false;
+    bool res = true;
 
-    assert(false);
-    //
+    assert(m_options.includeAllNetExternalWrenchesAsDynamicVariables);
+
+    // In the floating berdy formulation, the amount of dynamic variables is 12*nrOfLinks + 6*nrOfJoints + nrOfDofs
+    m_nrOfDynamicalVariables = 12*m_model.getNrOfLinks() + 6*m_model.getNrOfJoints() + m_model.getNrOfDOFs();
+    // The dynamics equations considered by floating berdy are the acceleration propagation for each joint and the
+    // Newton-Euler equations for each link
+    m_nrOfDynamicEquations   = 6*m_model.getNrOfLinks() + 6*m_model.getNrOfJoints();
 
     initSensorsMeasurements();
 
@@ -1003,7 +1341,7 @@ const SensorsList& BerdyHelper::sensors() const
     return this->m_sensors;
 }
 
-const Traversal& BerdyHelper::dynamicTraversal()
+const Traversal& BerdyHelper::dynamicTraversal() const
 {
     return this->m_dynamicsTraversal;
 }
@@ -1079,9 +1417,9 @@ bool BerdyHelper::updateKinematicsFromFixedBase(const JointPosDoubleArray& joint
 }
 
 bool BerdyHelper::updateKinematicsFromFloatingBase(const JointPosDoubleArray& jointPos,
-                                                    const JointDOFsDoubleArray& jointVel,
-                                                    const FrameIndex& floatingFrame,
-                                                    const Vector3& angularVel)
+                                                   const JointDOFsDoubleArray& jointVel,
+                                                   const FrameIndex& floatingFrame,
+                                                   const Vector3& angularVel)
 {
     if( !m_areModelAndSensorsValid )
     {
@@ -1139,7 +1477,15 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
     bool res = true;
 
     // Compute D matrix of dynamics equations
-    res = res && computeBerdyDynamicsMatrices(D, bD);
+    if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+    {
+        res = res && computeBerdyDynamicsMatricesFixedBase(D, bD);
+    }
+    else
+    {
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+        res = res && computeBerdyDynamicsMatricesFloatingBase(D, bD);
+    }
 
     // Compute Y matrix of sensors
     res = res && computeBerdySensorMatrices(Y, bY);
@@ -1264,16 +1610,11 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
         std::sort(m_sensorsOrdering.begin(), m_sensorsOrdering.end());
     }
 
-    void BerdyHelper::cacheDynamicVariablesOrdering()
+    void BerdyHelper::cacheDynamicVariablesOrderingFixedBase()
     {
         m_dynamicVariablesOrdering.clear();
         unsigned size = 0;
         m_dynamicVariablesOrdering.reserve(size);
-
-        //TODO: implement berdy variant
-        if (m_options.berdyVariant == BERDY_FLOATING_BASE) {
-            assert(false);
-        }
 
         /* Ordering:
          * For each Link - {Base} (and parente Joint) add:
@@ -1341,8 +1682,69 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
 
         //To avoid any problem, sort m_dynamicVariablesOrdering by range.offset
         std::sort(m_dynamicVariablesOrdering.begin(), m_dynamicVariablesOrdering.end());
+    }
 
+    void BerdyHelper::cacheDynamicVariablesOrderingFloatingBase()
+    {
+        m_dynamicVariablesOrdering.clear();
+        unsigned size = 0;
+        m_dynamicVariablesOrdering.reserve(size);
 
+        /*
+         * Ordering:
+         * The serialization we use is:
+         * * All the link variables (proper classical acc and external force-torque), ordered using the link index.
+         * * All the joint variables (joint force-torque), ordered using the joint index.
+         * * All the dof variables (dof acceleration), ordered using the dof index.
+         */
+
+        for (LinkIndex link = 0; link < static_cast<LinkIndex>(m_model.getNrOfLinks()); ++link)
+        {
+            std::string linkName = m_model.getLinkName(link);
+
+            BerdyDynamicVariable acceleration;
+            acceleration.type = LINK_BODY_PROPER_CLASSICAL_ACCELERATION;
+            acceleration.id = linkName;
+            acceleration.range = getRangeLinkVariable(acceleration.type , link);
+
+            BerdyDynamicVariable netExtWrench;
+            netExtWrench.type = NET_EXT_WRENCH;
+            netExtWrench.id = linkName;
+            netExtWrench.range = getRangeLinkVariable(netExtWrench.type , link);
+
+            m_dynamicVariablesOrdering.push_back(acceleration);
+            m_dynamicVariablesOrdering.push_back(netExtWrench);
+        }
+
+        for (JointIndex jntIdx = 0; jntIdx < static_cast<JointIndex>(m_model.getNrOfJoints()); ++jntIdx)
+        {
+            IJointPtr joint = m_model.getJoint(jntIdx);
+
+            BerdyDynamicVariable jointForceTorque;
+            jointForceTorque.type = JOINT_WRENCH;
+            jointForceTorque.id = m_model.getJointName(jntIdx);
+            jointForceTorque.range = getRangeJointVariable(jointForceTorque.type , jntIdx);
+
+            m_dynamicVariablesOrdering.push_back(jointForceTorque);
+
+            // If the joint is not fixed, we also add the descriptor of the acceleration of the relative dof
+            // The internal order of the descriptors will be fixed by the call to std::sort
+            if (joint->getNrOfDOFs() > 0)
+            {
+                // TODO(traversaro) At the time of implementing this (late 2017) the concept of dof name is not
+                // present in iDynTree . We will then just assume that the joint have at maximum one dof.
+                // This can be fixed in the future by introducing a proper dof name
+                assert(joint->getNrOfDOFs() == 1);
+
+                BerdyDynamicVariable dofAcceleration;
+                dofAcceleration.type = DOF_ACCELERATION;
+                dofAcceleration.id = m_model.getJointName(jntIdx);
+                dofAcceleration.range = getRangeDOFVariable(dofAcceleration.type, joint->getDOFsOffset());
+            }
+        }
+
+        //To avoid any problem, sort m_dynamicVariablesOrdering by range.offset
+        std::sort(m_dynamicVariablesOrdering.begin(), m_dynamicVariablesOrdering.end());
     }
 
     const std::vector<BerdySensor>& BerdyHelper::getSensorsOrdering() const
@@ -1356,12 +1758,41 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
     }
 
 bool BerdyHelper::serializeDynamicVariables(LinkProperAccArray& properAccs,
-                                             LinkNetTotalWrenchesWithoutGravity& netTotalWrenchesWithoutGrav,
-                                             LinkNetExternalWrenches& netExtWrenches,
-                                             LinkInternalWrenches& linkJointWrenches,
-                                             JointDOFsDoubleArray& jointTorques,
-                                             JointDOFsDoubleArray& jointAccs,
-                                             VectorDynSize& d)
+                                                     LinkNetTotalWrenchesWithoutGravity& netTotalWrenchesWithoutGrav,
+                                                     LinkNetExternalWrenches& netExtWrenches,
+                                                     LinkInternalWrenches& linkJointWrenches,
+                                                     JointDOFsDoubleArray& jointTorques,
+                                                     JointDOFsDoubleArray& jointAccs,
+                                                     VectorDynSize& d)
+{
+    bool res = false;
+    switch(m_options.berdyVariant)
+    {
+        case ORIGINAL_BERDY_FIXED_BASE :
+            res = serializeDynamicVariablesFixedBase(properAccs, netTotalWrenchesWithoutGrav, netExtWrenches, linkJointWrenches,
+                                                     jointTorques, jointAccs, d);
+            break;
+
+        case BERDY_FLOATING_BASE :
+            res = serializeDynamicVariablesFloatingBase(properAccs, netTotalWrenchesWithoutGrav, netExtWrenches,
+                                                        linkJointWrenches, jointTorques, jointAccs, d);
+            break;
+
+        default:
+            reportError("BerdyHelpers", "serializeDynamicVariablesFixedBase", "unknown berdy variant");
+            assert(false);
+            res = false;
+    }
+    return res;
+}
+
+bool BerdyHelper::serializeDynamicVariablesFixedBase(LinkProperAccArray& properAccs,
+                                                                  LinkNetTotalWrenchesWithoutGravity& netTotalWrenchesWithoutGrav,
+                                                                  LinkNetExternalWrenches& netExtWrenches,
+                                                                  LinkInternalWrenches& linkJointWrenches,
+                                                                  JointDOFsDoubleArray& jointTorques,
+                                                                  JointDOFsDoubleArray& jointAccs,
+                                                                  VectorDynSize& d)
 {
     assert(d.size() == this->getNrOfDynamicVariables());
     assert(this->m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE);
@@ -1396,6 +1827,55 @@ bool BerdyHelper::serializeDynamicVariables(LinkProperAccArray& properAccs,
             setSubVector(d,getRangeDOFVariable(DOF_TORQUE,jntIdx),jointTorques(jnt->getDOFsOffset()));
         }
     }
+
+    return true;
+}
+
+bool BerdyHelper::serializeDynamicVariablesFloatingBase(LinkProperAccArray& properAccs,
+                                                     LinkNetTotalWrenchesWithoutGravity& netTotalWrenchesWithoutGrav,
+                                                     LinkNetExternalWrenches& netExtWrenches,
+                                                     LinkInternalWrenches& linkJointWrenches,
+                                                     JointDOFsDoubleArray& jointTorques,
+                                                     JointDOFsDoubleArray& jointAccs,
+                                                     VectorDynSize& d)
+{
+    d.resize(this->getNrOfDynamicVariables());
+    assert(this->m_options.berdyVariant == BERDY_FLOATING_BASE);
+
+    for (LinkIndex link = 0; link < static_cast<LinkIndex>(m_model.getNrOfLinks()); ++link)
+    {
+        // Handle acceleration
+        // Convert left trivialized proper acceleration to sensor proper acceleration
+        ClassicalAcc sensorProperAcc;
+
+        sensorProperAcc.fromSpatial(properAccs(link), m_linkVels(link));
+        setSubVector(d, getRangeLinkVariable(LINK_BODY_PROPER_CLASSICAL_ACCELERATION, link), toEigen(sensorProperAcc));
+
+        // Handle external force
+        setSubVector(d, getRangeLinkVariable(NET_EXT_WRENCH, link), toEigen(netExtWrenches(link)));
+
+    }
+
+    for (JointIndex jntIdx = 0; jntIdx < static_cast<JointIndex>(m_model.getNrOfJoints()); ++jntIdx)
+    {
+        IJointPtr joint = m_model.getJoint(jntIdx);
+
+        // Handle joint wrench
+        // Warning: for legacy reason linkJointWrenches is addressed using the child link index of its joint
+        LinkIndex childLinkIndex = m_dynamicsTraversal.getChildLinkIndexFromJointIndex(m_model, jntIdx);
+        setSubVector(d, getRangeJointVariable(JOINT_WRENCH, jntIdx), toEigen(linkJointWrenches(childLinkIndex)));
+
+        // If the joint is not fixed, we also need to serialize the acceleration of the relative dof
+        if (joint->getNrOfDOFs() > 0)
+        {
+            for (unsigned int localDof = 0; localDof < joint->getNrOfDOFs(); localDof++)
+            {
+                DOFIndex dofIdx =  joint->getDOFsOffset() + localDof;
+                setSubVector(d, getRangeDOFVariable(DOF_ACCELERATION, dofIdx), jointAccs(dofIdx));
+            }
+        }
+    }
+
 
     return true;
 }
@@ -1462,7 +1942,6 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
 {
     bool ret=true;
     assert(y.size() == this->getNrOfSensorsMeasurements());
-    assert(this->m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE);
 
     bool ok = sensMeas.toVector(realSensorMeas);
     ret = ret && ok;

--- a/src/estimation/tests/CMakeLists.txt
+++ b/src/estimation/tests/CMakeLists.txt
@@ -14,10 +14,8 @@ macro(add_estimation_test classname)
     endif()
 endmacro()
 
-
 add_estimation_test(BerdyHelper)
 add_estimation_test(BerdyMAPSolver)
-
 add_estimation_test(ExternalWrenchesEstimation)
 add_estimation_test(ExtWrenchesAndJointTorquesEstimator)
 add_estimation_test(SimpleLeggedOdometry)

--- a/src/model/include/iDynTree/Model/ModelTestUtils.h
+++ b/src/model/include/iDynTree/Model/ModelTestUtils.h
@@ -199,8 +199,8 @@ inline bool getRandomInverseDynamicsInputs(FreeFloatingPos& pos,
                                            FreeFloatingAcc& acc,
                                            LinkNetExternalWrenches& extWrenches)
 {
-    pos.worldBasePos() =  getRandomTransform();
-    vel.baseVel() = getRandomTwist();
+    pos.worldBasePos() = getRandomTransform();
+    vel.baseVel() =  getRandomTwist();
     acc.baseAcc() =  getRandomTwist();
 
 

--- a/src/model/include/iDynTree/Model/Traversal.h
+++ b/src/model/include/iDynTree/Model/Traversal.h
@@ -196,7 +196,16 @@ namespace iDynTree
          * @param[in] jntIdx the index of the joint of which we want to get the child link.
          * @return the index of the child link if all went well, LINK_INVALID_INDEX otherwise .
          */
-        LinkIndex getChildLinkIndexFromJointIndex(const Model & m_model, const JointIndex jntIdx) const;
+        LinkIndex getChildLinkIndexFromJointIndex(const Model & model, const JointIndex jntIdx) const;
+
+        /**
+         * \brief Get the parent link (according to the traversal) of a Joint.
+         *
+         * @param[in] m_model the considered model.
+         * @param[in] jntIdx the index of the joint of which we want to get the parent link.
+         * @return the index of the parent link if all went well, LINK_INVALID_INDEX otherwise .
+         */
+        LinkIndex getParentLinkIndexFromJointIndex(const Model & model, const JointIndex jntIdx) const;
 
         /**
          * Return a human-readable representation of the traversal.

--- a/src/model/src/Traversal.cpp
+++ b/src/model/src/Traversal.cpp
@@ -143,10 +143,15 @@ bool Traversal::isParentOf(const LinkIndex parentCandidate,
     }
 }
 
-LinkIndex Traversal::getChildLinkIndexFromJointIndex(const Model& m_model, const JointIndex jntIdx) const
+LinkIndex Traversal::getChildLinkIndexFromJointIndex(const Model& model, const JointIndex jntIdx) const
 {
     // Get the two links connected by this joint
-    IJointConstPtr jnt = m_model.getJoint(jntIdx);
+    IJointConstPtr jnt = model.getJoint(jntIdx);
+    if (!jnt)
+    {
+        return LINK_INVALID_INDEX;
+    }
+
     LinkIndex link1 = jnt->getFirstAttachedLink();
     LinkIndex link2 = jnt->getSecondAttachedLink();
 
@@ -162,6 +167,32 @@ LinkIndex Traversal::getChildLinkIndexFromJointIndex(const Model& m_model, const
     }
 
     return childLink;
+}
+
+LinkIndex Traversal::getParentLinkIndexFromJointIndex(const Model& model, const JointIndex jntIdx) const
+{
+    // Get the two links connected by this joint
+    IJointConstPtr jnt = model.getJoint(jntIdx);
+    if (!jnt)
+    {
+        return LINK_INVALID_INDEX;
+    }
+
+    LinkIndex link1 = jnt->getFirstAttachedLink();
+    LinkIndex link2 = jnt->getSecondAttachedLink();
+
+    // Get the traversal index of the child link (according to the traversal)
+    LinkIndex parentLink;
+    if( this->isParentOf(link1,link2) )
+    {
+        parentLink = link1;
+    }
+    else
+    {
+        parentLink = link2;
+    }
+
+    return parentLink;
 }
 
 

--- a/src/model_io/urdf/src/URDFGenericSensorsImport.cpp
+++ b/src/model_io/urdf/src/URDFGenericSensorsImport.cpp
@@ -383,7 +383,7 @@ bool sensorsFromURDFString(const std::string& urdfXml,
             SixAxisForceTorqueSensor * sensor = new SixAxisForceTorqueSensor();
             sensor->setName(sensorName);
             sensor->setParentJoint(parentJoint);
-            sensor->setParentJointIndex(parentLinkIndex);
+            sensor->setParentJointIndex(parentJointIndex);
             if( measure_direction_type == PARENT_TO_CHILD )
             {
                 sensor->setAppliedWrenchLink(childLinkIndex);

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -14,6 +14,7 @@ set(IDYNTREE_SENSORS_HEADERS include/iDynTree/Sensors/Sensors.h
                              include/iDynTree/Sensors/SixAxisFTSensor.h
                              include/iDynTree/Sensors/GyroscopeSensor.h
                              include/iDynTree/Sensors/AccelerometerSensor.h
+                             include/iDynTree/Sensors/ThreeAxisAngularAccelerometerSensor.h
                              include/iDynTree/Sensors/PredictSensorsMeasurements.h
                              include/iDynTree/Sensors/ModelSensorsTransformers.h)
 
@@ -21,6 +22,7 @@ set(IDYNTREE_SENSORS_SOURCES src/Sensors.cpp
                              src/SixAxisFTSensor.cpp
                              src/AccelerometerSensor.cpp
                              src/GyroscopeSensor.cpp
+                             src/ThreeAxisAngularAccelerometerSensor.cpp
                              src/PredictSensorsMeasurements.cpp
                              src/ModelSensorsTransformers.cpp)
 

--- a/src/sensors/include/iDynTree/Sensors/AllSensorsTypes.h
+++ b/src/sensors/include/iDynTree/Sensors/AllSensorsTypes.h
@@ -11,5 +11,6 @@
 #include <iDynTree/Sensors/SixAxisFTSensor.h>
 #include <iDynTree/Sensors/AccelerometerSensor.h>
 #include <iDynTree/Sensors/GyroscopeSensor.h>
+#include <iDynTree/Sensors/ThreeAxisAngularAccelerometerSensor.h>
 
 #endif

--- a/src/sensors/include/iDynTree/Sensors/ThreeAxisAngularAccelerometerSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/ThreeAxisAngularAccelerometerSensor.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Author: Silvio Traversaro
+ * email:  silvio.traversaro@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+ */
+
+
+#ifndef THREE_AXIS_ANGULAR_ACCELEROMETER_H
+#define THREE_AXIS_ANGULAR_ACCELEROMETER_H
+
+
+namespace iDynTree
+{
+    class Transform;
+    class LinearMotionVector3;
+    typedef LinearMotionVector3 LinAcceleration;
+    class SpatialAcc;
+    class Twist;
+}
+
+#include <iDynTree/Sensors/Sensors.h>
+
+namespace iDynTree {
+
+    /**
+     * Class representing a three axis angular accelerometer, i.e. a sensor that measures
+     * the 3D angular acceleration of the sensor frame.
+     *
+     * \ingroup iDynTreeSensors
+     *
+     */
+    class ThreeAxisAngularAccelerometerSensor: public LinkSensor
+    {
+    private:
+        struct ThreeAxisAngularAccelerometerPrivateAttributes;
+        ThreeAxisAngularAccelerometerPrivateAttributes * pimpl;
+
+    public:
+        /**
+         * Constructor.
+         */
+        ThreeAxisAngularAccelerometerSensor();
+
+        /**
+         * Copy constructor
+         */
+        ThreeAxisAngularAccelerometerSensor(const ThreeAxisAngularAccelerometerSensor& other);
+
+        /**
+         * Copy operator
+         */
+        ThreeAxisAngularAccelerometerSensor& operator=(const ThreeAxisAngularAccelerometerSensor &other);
+
+        /**
+         * Destructor.
+         */
+        virtual ~ThreeAxisAngularAccelerometerSensor();
+
+        /**
+         * Set the name (id) of the sensor
+         *
+         */
+        bool setName(const std::string &_name);
+
+       /**
+         * Set the transform from the sensor to the parent link attached to the sensor.
+         *
+         * @return true if link_index is parent link attached to the accelerometer sensor, false otherwise.
+         */
+        bool setLinkSensorTransform(const iDynTree::Transform & link_H_sensor);
+
+        /*
+         * Documented in Sensor
+         */
+        bool setParentLink(const std::string &parent);
+
+        /*
+         * Documented in Sensor
+         */
+        bool setParentLinkIndex(const LinkIndex & parent_index);
+
+        /*
+         * Documented in the sensor
+         *
+         */
+        std::string getName() const;
+
+        /*
+         * Documented in Sensor
+         */
+        SensorType getSensorType() const;
+
+
+        /*
+         * Documented in Sensor
+         */
+        std::string getParentLink() const;
+
+        /*
+         * Documented in Sensor
+         */
+        LinkIndex getParentLinkIndex() const;
+
+        // Documented in LinkSensor
+        Transform getLinkSensorTransform() const;
+
+        /*
+         * Documented in Sensor
+         */
+        bool isValid() const;
+
+        /*
+         * Documented in Sensor
+         */
+        Sensor * clone() const;
+
+        /*
+         * Documented in Sensor
+         */
+        bool updateIndices(const Model & model);
+
+       /**
+        * Simulate the measurement of the Three Axis angular accelerometer
+        *
+        * @param[in] linkAcc the left trivialized acceleration of the link frame w.r.t. to an inertial frame
+        * @param[in] linkTwist the left trivialized velocity of the link frame w.r.t. to an inertial frame
+        *
+        * @return the predicted measurement as a AngAcceleration
+        */
+       Vector3 predictMeasurement(const iDynTree::SpatialAcc &linkAcc, const iDynTree::Twist &linkTwist);
+    };
+
+
+
+
+
+}
+
+
+
+#endif

--- a/src/sensors/src/Sensors.cpp
+++ b/src/sensors/src/Sensors.cpp
@@ -137,7 +137,7 @@ int SensorsList::addSensor(const Sensor& sensor)
          return -1;
     }
 
-    if( !(newSensor->getSensorType() >= 0 && newSensor->getSensorType() < NR_OF_SENSOR_TYPES) )
+    if( !(newSensor->getSensorType() >= 0) )
     {
          std::cerr << "[ERR] SensorsTree::addSensor error : sensor  " << sensor.getName()
                        << " has an unknown sensor type " << newSensor->getSensorType() << std::endl;
@@ -257,6 +257,18 @@ size_t SensorsList::getSizeOfAllSensorsMeasurements() const
         res += getSensorTypeSize(type)*getNrOfSensors(type);
     }
     return res;
+}
+
+bool SensorsList::isConsistent(const Model& model) const
+{
+    bool isConsistent = true;
+    for (SensorsList::ConstIterator it = this->allSensorsIterator();
+         it.isValid(); ++it)
+    {
+        bool isCurrentSensorConsistent = (*it)->isConsistent(model);
+        isConsistent = isConsistent && isCurrentSensorConsistent;
+    }
+    return isConsistent;
 }
 
 bool SensorsList::removeAllSensorsOfType(const iDynTree::SensorType &sensor_type)
@@ -573,6 +585,58 @@ bool SensorsList::removeAllSensorsOfType(const iDynTree::SensorType &sensor_type
     }
 
 ///////////////////////////////////////////////////////////////////////////////
+///// LinkSensor
+///////////////////////////////////////////////////////////////////////////////
+
+bool LinkSensor::isConsistent(const Model& model) const
+{
+    LinkIndex lnkIdxInModel = model.getLinkIndex(this->getParentLink());
+
+    if (lnkIdxInModel == LINK_INVALID_INDEX)
+    {
+        std::cerr << "[ERROR] Sensor " << this->getName() << " is not consistent because the link "
+                  << this->getParentLink() << " does not exist in the specified model" << std::endl;
+        return false;
+    }
+
+    if (lnkIdxInModel != this->getParentLinkIndex())
+    {
+        std::cerr << "[ERROR] Sensor " << this->getName() << " is not consistent because it is attached to link "
+                  << this->getParentLink() << " that has index " << lnkIdxInModel << " in the model, while the sensor "
+                  << " has it saved with link index " << this->getParentLinkIndex() << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+///// JointSensor
+///////////////////////////////////////////////////////////////////////////////
+
+bool JointSensor::isConsistent(const Model& model) const
+{
+    LinkIndex jntIdxInModel = model.getJointIndex(this->getParentJoint());
+
+    if (jntIdxInModel == JOINT_INVALID_INDEX)
+    {
+        std::cerr << "[ERROR] Sensor " << this->getName() << " is not consistent because the joint "
+                  << this->getParentJoint() << " does not exist in the specified model" << std::endl;
+        return false;
+    }
+
+    if (jntIdxInModel != this->getParentJointIndex())
+    {
+        std::cerr << "[ERROR] Sensor " << this->getName() << " is not consistent because it is attached to joint "
+                  << this->getParentJoint() << " that has index " << jntIdxInModel << " in the model, while the sensor "
+                  << " has it saved with link index " << this->getParentJointIndex() << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 ///// SensorMeasurements
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -581,6 +645,8 @@ struct SensorsMeasurements::SensorsMeasurementsPrivateAttributes
     std::vector< iDynTree::Wrench > SixAxisFTSensorsMeasurements;
     std::vector< iDynTree::AngVelocity > GyroscopeMeasurements;
     std::vector< iDynTree::LinAcceleration> AccelerometerMeasurements;
+    std::vector< Vector3 > ThreeAxisAngularAccelerometerMeasurements;
+
 };
 
 
@@ -592,9 +658,10 @@ struct SensorsMeasurements::SensorsMeasurementsPrivateAttributes
 SensorsMeasurements::SensorsMeasurements(const SensorsList &sensorsList)
 {
     this->pimpl = new SensorsMeasurementsPrivateAttributes;
-    this->pimpl->SixAxisFTSensorsMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE));
-    this->pimpl->AccelerometerMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::ACCELEROMETER));
-    this->pimpl->GyroscopeMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::GYROSCOPE));
+    this->pimpl->SixAxisFTSensorsMeasurements.resize(sensorsList.getNrOfSensors(SIX_AXIS_FORCE_TORQUE));
+    this->pimpl->AccelerometerMeasurements.resize(sensorsList.getNrOfSensors(ACCELEROMETER));
+    this->pimpl->GyroscopeMeasurements.resize(sensorsList.getNrOfSensors(GYROSCOPE));
+    this->pimpl->ThreeAxisAngularAccelerometerMeasurements.resize(sensorsList.getNrOfSensors(THREE_AXIS_ANGULAR_ACCELEROMETER));
 }
 SensorsMeasurements::SensorsMeasurements(const SensorsMeasurements & other):
 pimpl(new SensorsMeasurementsPrivateAttributes(*(other.pimpl)))
@@ -621,7 +688,7 @@ bool SensorsMeasurements::setNrOfSensors(const SensorType& sensor_type, unsigned
     Wrench zeroWrench;
     LinAcceleration zeroLinAcc;
     AngVelocity zeroAngVel;
-    unsigned int returnVal = 0;
+    bool ret = true;
     switch (sensor_type)
     {
         case SIX_AXIS_FORCE_TORQUE :
@@ -635,13 +702,20 @@ bool SensorsMeasurements::setNrOfSensors(const SensorType& sensor_type, unsigned
         case GYROSCOPE :
             zeroAngVel.zero();
             this->pimpl->GyroscopeMeasurements.resize(nrOfSensors,zeroAngVel);
+            break;
+        case THREE_AXIS_ANGULAR_ACCELEROMETER:
+        {
+            Vector3 zeroAngAcc;
+            zeroAngAcc.zero();
+            this->pimpl->ThreeAxisAngularAccelerometerMeasurements.resize(nrOfSensors, zeroAngAcc);
+        }
+            break;
         default :
-            returnVal = 0;
+            ret = false;
+            break;
     }
-   return(returnVal);
 
-
-    return true;
+    return ret;
 }
 
 bool SensorsMeasurements::resize(const SensorsList &sensorsList)
@@ -653,6 +727,7 @@ bool SensorsMeasurements::resize(const SensorsList &sensorsList)
     this->pimpl->SixAxisFTSensorsMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE),zeroWrench);
     this->pimpl->AccelerometerMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::ACCELEROMETER),zeroLinAcc);
     this->pimpl->GyroscopeMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::GYROSCOPE),zeroAngVel);
+    this->pimpl->ThreeAxisAngularAccelerometerMeasurements.resize(sensorsList.getNrOfSensors(iDynTree::THREE_AXIS_ANGULAR_ACCELEROMETER),zeroAngVel);
 
     return true;
 }
@@ -666,9 +741,10 @@ bool SensorsMeasurements::toVector(VectorDynSize & measurementVector) const
     unsigned int numFT = this->pimpl->SixAxisFTSensorsMeasurements.size();
     unsigned int numAcc = this->pimpl->AccelerometerMeasurements.size();
     unsigned int numGyro = this->pimpl->GyroscopeMeasurements.size();
+    unsigned int numThreeAxisAngularAcc = this->pimpl->ThreeAxisAngularAccelerometerMeasurements.size();
     bool ok = true;
 
-    measurementVector.resize(6*numFT + 3*numAcc + 3*numGyro);
+    measurementVector.resize(6*numFT + 3*numAcc + 3*numGyro + 3*numThreeAxisAngularAcc);
 
     for(itr = 0; itr<numFT; itr++)
     {
@@ -694,6 +770,14 @@ bool SensorsMeasurements::toVector(VectorDynSize & measurementVector) const
         ok && measurementVector.setVal(6*numFT + 3*numAcc + 3*itr,thisAngVel.getVal(0));
         ok && measurementVector.setVal(6*numFT + 3*numAcc + 3*itr+1,thisAngVel.getVal(1));
         ok && measurementVector.setVal(6*numFT + 3*numAcc + 3*itr+2,thisAngVel.getVal(2));
+    }
+    for(itr = 0; itr<numThreeAxisAngularAcc; itr++)
+    {
+        int offset = 6*numFT + 3*numAcc + 3*numGyro;
+        Vector3 thisAngAcc = this->pimpl->ThreeAxisAngularAccelerometerMeasurements.at(itr);
+        ok && measurementVector.setVal(offset,   thisAngAcc.getVal(0));
+        ok && measurementVector.setVal(offset+1, thisAngAcc.getVal(1));
+        ok && measurementVector.setVal(offset+2, thisAngAcc.getVal(2));
     }
 
 
@@ -748,8 +832,8 @@ bool SensorsMeasurements::setMeasurement(const SensorType& sensor_type,
 }
 
 bool SensorsMeasurements::setMeasurement(const SensorType& sensor_type,
-                                         const unsigned int& sensor_index,
-                                         const iDynTree::AngVelocity & measurement)
+                                          const unsigned int& sensor_index,
+                                          const iDynTree::AngVelocity & measurement)
 {
     if( sensor_type == GYROSCOPE )
     {
@@ -769,6 +853,62 @@ bool SensorsMeasurements::setMeasurement(const SensorType& sensor_type,
 
     return false;
 }
+
+bool SensorsMeasurements::setMeasurement(const SensorType& sensor_type,
+                                         const unsigned int& sensor_index,
+                                         const Vector3& measurement)
+{
+    if( sensor_type == ACCELEROMETER )
+    {
+        if( sensor_index < this->pimpl->AccelerometerMeasurements.size() )
+        {
+            this->pimpl->AccelerometerMeasurements[sensor_index] = measurement;
+            return true;
+        }
+        else
+        {
+            std::cerr << "[ERROR] setMeasurement failed: sensor_index " << sensor_index
+                      << "is out of bounds, because nrOfSensors is "
+                      << this->pimpl->AccelerometerMeasurements.size() << std::endl;
+            return false;
+        }
+    }
+
+    if( sensor_type == GYROSCOPE )
+    {
+        if( sensor_index < this->pimpl->GyroscopeMeasurements.size() )
+        {
+            this->pimpl->GyroscopeMeasurements[sensor_index] = measurement;
+            return true;
+        }
+        else
+        {
+            std::cerr << "[ERROR] setMeasurement failed: sensor_index " << sensor_index
+                      << "is out of bounds, because nrOfSensors is "
+                      << this->pimpl->GyroscopeMeasurements.size() << std::endl;
+            return false;
+        }
+    }
+
+    if (sensor_type == THREE_AXIS_ANGULAR_ACCELEROMETER)
+    {
+        if( sensor_index < this->pimpl->ThreeAxisAngularAccelerometerMeasurements.size() )
+        {
+            this->pimpl->ThreeAxisAngularAccelerometerMeasurements[sensor_index] = measurement;
+            return true;
+        }
+        else
+        {
+            std::cerr << "[ERROR] setMeasurement failed: sensor_index " << sensor_index
+                      << "is out of bounds, because nrOfSensors is "
+                      << this->pimpl->ThreeAxisAngularAccelerometerMeasurements.size() << std::endl;
+            return false;
+        }
+    }
+
+    return false;
+}
+
 bool SensorsMeasurements::getMeasurement(const SensorType& sensor_type,
                                          const unsigned int& sensor_index,
                                          Wrench& measurement) const
@@ -837,6 +977,60 @@ bool SensorsMeasurements::getMeasurement(const SensorType& sensor_type,
     return false;
 }
 
+bool SensorsMeasurements::getMeasurement(const SensorType &sensor_type, const unsigned int &sensor_index,
+                                         Vector3 &measurement) const
+{
+    if( sensor_type == ACCELEROMETER )
+    {
+        if( sensor_index < this->pimpl->AccelerometerMeasurements.size() )
+        {
+            measurement = this->pimpl->AccelerometerMeasurements[sensor_index];
+            return true;
+        }
+        else
+        {
+            std::cerr << "[ERROR] getMeasurement failed: sensor_index " << sensor_index
+                      << "is out of bounds, because nrOfSensors is "
+                      << this->pimpl->AccelerometerMeasurements.size() << std::endl;
+            return false;
+        }
+    }
+
+    if( sensor_type == GYROSCOPE )
+    {
+        if( sensor_index < this->pimpl->GyroscopeMeasurements.size() )
+        {
+            measurement = this->pimpl->GyroscopeMeasurements[sensor_index];
+            return true;
+        }
+        else
+        {
+            std::cerr << "[ERROR] getMeasurement failed: sensor_index " << sensor_index
+                      << "is out of bounds, because nrOfSensors is "
+                      << this->pimpl->GyroscopeMeasurements.size() << std::endl;
+            return false;
+        }
+    }
+
+    if( sensor_type == THREE_AXIS_ANGULAR_ACCELEROMETER )
+    {
+        if( sensor_index < this->pimpl->ThreeAxisAngularAccelerometerMeasurements.size() )
+        {
+            measurement = this->pimpl->ThreeAxisAngularAccelerometerMeasurements[sensor_index];
+            return true;
+        }
+        else
+        {
+            std::cerr << "[ERROR] getMeasurement failed: sensor_index " << sensor_index
+                      << "is out of bounds, because nrOfSensors is "
+                      << this->pimpl->ThreeAxisAngularAccelerometerMeasurements.size() << std::endl;
+            return false;
+        }
+    }
+
+    return false;
+}
+
 unsigned int SensorsMeasurements::getNrOfSensors(const SensorType& sensor_type) const
 {
     unsigned int returnVal = 0;
@@ -850,6 +1044,10 @@ unsigned int SensorsMeasurements::getNrOfSensors(const SensorType& sensor_type) 
             break;
         case GYROSCOPE :
             returnVal =  this->pimpl->GyroscopeMeasurements.size();
+            break;
+        case THREE_AXIS_ANGULAR_ACCELEROMETER :
+            returnVal =  this->pimpl->ThreeAxisAngularAccelerometerMeasurements.size();
+            break;
         default :
             returnVal = 0;
     }

--- a/src/sensors/src/SixAxisFTSensor.cpp
+++ b/src/sensors/src/SixAxisFTSensor.cpp
@@ -364,6 +364,7 @@ bool SixAxisForceTorqueSensor::getWrenchAppliedOnLinkInverseMatrix(const LinkInd
     }
     else
     {
+        assert(false);
         wrench_applied_on_link_inverse_matrix.zero();
         return false;
     }


### PR DESCRIPTION
Main differences of this version of Berdy:
* It does not assume that the mechanical system is fixed base.
* It does not require the knowledge of the floating base pose or linear velocity
* It uses sensor acceleration as the representation of body acceleration
* It reduces the number of dynamic variable considered

Temporary theory note available at  https://www.sharelatex.com/project/59439ec80788901873a803fb .

Require commits are also contained in this PR, check the commit message for them. 