### PR TITLE
Fix installation location of deprecated headers

### DIFF
--- a/src/icub/CMakeLists.txt
+++ b/src/icub/CMakeLists.txt
@@ -61,5 +61,5 @@ set_property(GLOBAL APPEND PROPERTY IDYNTREE_TREE_INCLUDE_DIRS ${CMAKE_CURRENT_S
 
 # Install headers in deprecated location
 install(DIRECTORY include/iDynTree/iCub
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/iDynTree/iCub")
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/iDynTree")
 


### PR DESCRIPTION
Without this fix, the headers were installed in the `iDynTree/iCub/iCub` directory.