### PR TITLE
Fixed not initialized memory bug in convertBodyFixedAccelerationToMixedAcceleration function

### DIFF
--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1101,7 +1101,7 @@ Vector6 convertBodyFixedAccelerationToMixedAcceleration(const SpatialAcc & bodyF
     linMixedAcc = inertial_R_body_eig*(linBodyFixedAcc + angBodyFixedTwist.cross(linBodyFixedTwist));
 
     // Angular acceleration can be copied
-    angMixedAcc = inertial_R_body_eig*angMixedAcc;
+    angMixedAcc = inertial_R_body_eig*angBodyFixedAcc;
 
     return mixedAcceleration;
 }

--- a/src/high-level/tests/CMakeLists.txt
+++ b/src/high-level/tests/CMakeLists.txt
@@ -7,6 +7,10 @@ macro(add_unit_test_hl classname)
     target_include_directories(${testbinary} PRIVATE ${EIGEN3_INCLUDE_DIR} ${IDYNTREE_TREE_INCLUDE_DIRS})
     target_link_libraries(${testbinary} idyntree-core idyntree-model idyntree-high-level idyntree-modelio-urdf)
     add_test(NAME ${testname} COMMAND ${testbinary})
+    
+    if(IDYNTREE_RUN_VALGRIND_TESTS)
+        add_test(NAME memcheck_${testname} COMMAND ${MEMCHECK_COMMAND_COMPLETE} ./${testbinary})
+    endif()
 endmacro()
 
 # todo

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -321,7 +321,7 @@ void testModelConsistency(std::string modelFilePath, const FrameVelocityRepresen
     ok = dynComp.setFrameVelocityRepresentation(frameVelRepr);
     ASSERT_IS_TRUE(ok);
 
-    for(int i=0; i < 5; i++)
+    for(int i=0; i < 1; i++)
     {
         setRandomState(dynComp);
         testRelativeTransform(dynComp);

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -333,16 +333,24 @@ void testModelConsistency(std::string modelFilePath, const FrameVelocityRepresen
 
 }
 
+void testModelConsistencyAllRepresentations(std::string modelName)
+{
+    std::string urdfFileName = getAbsModelPath(modelName);
+    std::cout << "Testing file " << urdfFileName <<  std::endl;
+    testModelConsistency(urdfFileName,iDynTree::MIXED_REPRESENTATION);
+    testModelConsistency(urdfFileName,iDynTree::BODY_FIXED_REPRESENTATION);
+    testModelConsistency(urdfFileName,iDynTree::INERTIAL_FIXED_REPRESENTATION);
+}
+
 int main()
 {
-    for(unsigned int mdl = 0; mdl < IDYNTREE_TESTS_URDFS_NR; mdl++ )
-    {
-        std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
-        std::cout << "Testing file " << std::string(IDYNTREE_TESTS_URDFS[mdl]) <<  std::endl;
-        testModelConsistency(urdfFileName,iDynTree::MIXED_REPRESENTATION);
-        testModelConsistency(urdfFileName,iDynTree::BODY_FIXED_REPRESENTATION);
-        testModelConsistency(urdfFileName,iDynTree::INERTIAL_FIXED_REPRESENTATION);
-    }
+    // Just run the tests on a handful of models to avoid
+    // a long testing time under valgrind
+    testModelConsistencyAllRepresentations("oneLink.urdf");
+    testModelConsistencyAllRepresentations("twoLinks.urdf");
+    testModelConsistencyAllRepresentations("threeLinks.urdf");
+    testModelConsistencyAllRepresentations("bigman.urdf");
+    testModelConsistencyAllRepresentations("icub_skin_frames.urdf");
 
     return EXIT_SUCCESS;
 }

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -301,6 +301,16 @@ void testRelativeJacobians(KinDynComputations & dynComp)
     dynComp.setFrameVelocityRepresentation(representation);
 }
 
+// Dummy test: for now it just prints the frameBiasAcc, to check there is no
+// usage of not initialized memory
+void testFrameBiasAcc(KinDynComputations & dynComp)
+{
+    FrameIndex frame = real_random_int(0, dynComp.getNrOfFrames());
+
+    // Compute and print frameBiasAcc
+    std::cerr << "Computed frameBiasAcc " << dynComp.getFrameBiasAcc(frame).toString() << std::endl;
+}
+
 void testModelConsistency(std::string modelFilePath, const FrameVelocityRepresentation frameVelRepr)
 {
     iDynTree::KinDynComputations dynComp;
@@ -318,6 +328,7 @@ void testModelConsistency(std::string modelFilePath, const FrameVelocityRepresen
         testAverageVelocityAndTotalMomentumJacobian(dynComp);
         testInverseDynamics(dynComp);
         testRelativeJacobians(dynComp);
+        testFrameBiasAcc(dynComp);
     }
 
 }


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/366 . 

While checking the issue raised in  https://github.com/robotology/idyntree/issues/366, I noticed that we don't have any test on `getFrameBiasAcc`, and I also noticed that there is a bug related in `getFrameBiasAcc` when the representation is `MIXED_REPRESENTATION` and the linear and angular component of the base velocity are non-zero. 

So this **does not fix** all the problems related to the getFrameBiasAcc, but it fixes the most critical one. 