### PR TITLE
[WIP] Preliminary support for URDF export from iDynTree::Model

### DIFF
--- a/src/model_io/urdf/CMakeLists.txt
+++ b/src/model_io/urdf/CMakeLists.txt
@@ -4,12 +4,16 @@
 
 project(iDynTree_ModelIO_URDF CXX)
 
-set(IDYNTREE_MODELIO_URDF_HEADERS include/iDynTree/ModelIO/URDFModelImport.h
+idyntree_enable_cxx11()
+
+set(IDYNTREE_MODELIO_URDF_HEADERS include/iDynTree/ModelIO/URDFModelExport.h
+                                  include/iDynTree/ModelIO/URDFModelImport.h
                                   include/iDynTree/ModelIO/URDFDofsImport.h
                                   include/iDynTree/ModelIO/URDFGenericSensorsImport.h
                                   include/iDynTree/ModelIO/ModelLoader.h)
 
 set(IDYNTREE_MODELIO_URDF_SOURCES src/URDFParsingUtils.h
+                                  src/URDFModelExport.cpp
                                   src/URDFModelImport.cpp
                                   src/URDFDofsImport.cpp
                                   src/URDFGenericSensorsImport.cpp

--- a/src/model_io/urdf/include/iDynTree/ModelIO/URDFModelExport.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/URDFModelExport.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef IDYNTREE_URDF_MODEL_EXPORT_H
+#define IDYNTREE_URDF_MODEL_EXPORT_H
+
+#include <string>
+
+namespace iDynTree
+
+{
+
+class Model;
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Options for the iDynTree URDF exporter.
+ */
+struct URDFExporterOptions
+{
+    /**
+     *
+     * Specify the base link of the exported URDF.
+     *
+     * Differently from the iDynTree::Model class, the URDF file format represent the multibody structure
+     * using a directed tree representation, for which it is necessary to
+     *
+     * If this string is empty (default value), the default base link contained in the model
+     * will be used.
+     *
+     * Default value: ""
+     */
+    std::string baseLink;
+
+    /**
+     * If true, all the "additional frames"
+     * available will be added to the URDF as "fake links",
+     * because the URDF file specification does not support the concept of frames.
+     * In particular the frames with name FRAME will be added to their link via
+     * a fake fixed joint named FRAME_fixed_joint
+     *
+     * Default value: true
+     */
+    bool exportFrames;
+
+    /**
+     * Constructor, containing default values.
+     */
+    URDFExporterOptions(): baseLink(""),
+                         exportFrames(true)
+    {
+    }
+};
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Export a iDynTree::Model object to a URDF file.
+ *
+ * @see URDFExporterOptions for more details on supported options.
+ *
+ * @warning This function does not support exporting sensor or solid shapes at the moment.
+ *
+ * @param[in] options the URDFParserOptions struct of options passed to the parser
+ * @return true if all went ok, false otherwise.
+ */
+bool URDFFromModel(const iDynTree::Model & model,
+                   const std::string & urdf_filename,
+                   const URDFExporterOptions options=URDFExporterOptions());
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Export a iDynTree::Model object to a URDF string.
+ *
+ * @see URDFExporterOptions for more details on supported options.
+ *
+ * @warning This function does not support exporting sensor or solid shapes at the moment.
+ *
+ * @param[in] options the URDFParserOptions struct of options passed to the parser
+ * @return true if all went ok, false otherwise.
+ */
+bool URDFStringFromModel(const iDynTree::Model & output,
+                         std::string & urdf_string,
+                         const URDFExporterOptions options=URDFExporterOptions());
+
+
+}
+
+#endif

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include <iDynTree/ModelIO/URDFModelExport.h>
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Core/SpatialInertia.h>
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/Traversal.h>
+#include <iDynTree/Model/FixedJoint.h>
+#include <iDynTree/Model/PrismaticJoint.h>
+#include <iDynTree/Model/RevoluteJoint.h>
+
+#include "URDFParsingUtils.h"
+
+#include <tinyxml.h>
+
+#include <iomanip>
+#include <fstream>
+
+namespace iDynTree
+{
+
+bool exportTransform(const Transform &trans, TiXmlElement* xml)
+{
+    bool ok = true;
+    TiXmlElement *origin = new TiXmlElement("origin");
+    std::string pose_xyz_str;
+    ok = ok && vectorToString(trans.getPosition(), pose_xyz_str);
+    std::string pose_rpy_str;
+    Vector3 pose_rpy = trans.getRotation().asRPY();
+    ok = ok && vectorToString(pose_rpy, pose_rpy_str);
+    origin->SetAttribute("xyz", pose_xyz_str);
+    origin->SetAttribute("rpy", pose_rpy_str);
+    xml->LinkEndChild(origin);
+    return ok;
+}
+
+bool exportInertial(const SpatialInertia &i, TiXmlElement *xml)
+{
+    bool ok=true;
+    std::string bufStr;
+    TiXmlElement *inertial_xml = new TiXmlElement("inertial");
+
+    TiXmlElement *mass_xml = new TiXmlElement("mass");
+    ok = ok && doubleToStringWithClassicLocale(i.getMass(), bufStr);
+    mass_xml->SetAttribute("value", bufStr);
+    inertial_xml->LinkEndChild(mass_xml);
+
+    ok = ok && exportTransform(Transform(Rotation::Identity(), i.getCenterOfMass()), inertial_xml);
+
+    TiXmlElement *inertia_xml = new TiXmlElement("inertia");
+    RotationalInertiaRaw rotInertia = i.getRotationalInertiaWrtCenterOfMass();
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(0, 0), bufStr);
+    inertia_xml->SetAttribute("ixx", bufStr);
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(0, 1), bufStr);
+    inertia_xml->SetAttribute("ixy", bufStr);
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(0, 2), bufStr);
+    inertia_xml->SetAttribute("ixz", bufStr);
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(1, 1), bufStr);
+    inertia_xml->SetAttribute("iyy", bufStr);
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(1, 2), bufStr);
+    inertia_xml->SetAttribute("iyz", bufStr);
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(2, 2), bufStr);
+    inertia_xml->SetAttribute("izz", bufStr);
+    inertial_xml->LinkEndChild(inertia_xml);
+
+    xml->LinkEndChild(inertial_xml);
+
+    return ok;
+}
+
+bool exportLink(const Link &link, const std::string linkName, TiXmlElement* xml)
+{
+    bool ok = true;
+    TiXmlElement * link_xml = new TiXmlElement("link");
+    link_xml->SetAttribute("name", linkName.c_str());
+
+    ok = ok && exportInertial(link.getInertia(), link_xml);
+
+    /* TODO(traversaro) : support solid shapes
+    for (std::size_t i = 0 ; i < link.visual_array.size() ; ++i)
+        exportVisual(*link.visual_array[i], link_xml);
+    for (std::size_t i = 0 ; i < link.collision_array.size() ; ++i)
+        exportCollision(*link.collision_array[i], link_xml);
+    */
+
+    xml->LinkEndChild(link_xml);
+
+    return ok;
+}
+
+bool exportJoint(IJointConstPtr joint, LinkConstPtr parentLink, LinkConstPtr childLink, const Model& model, TiXmlElement* xml)
+{
+    bool ok=true;
+    TiXmlElement * joint_xml = new TiXmlElement("joint");
+    joint_xml->SetAttribute("name", model.getJointName(joint->getIndex()));
+    if (dynamic_cast<const FixedJoint*>(joint))
+    {
+        joint_xml->SetAttribute("type", "fixed");
+    }
+    else if (dynamic_cast<const RevoluteJoint*>(joint))
+    {
+        if(joint->hasPosLimits())
+        {
+            joint_xml->SetAttribute("type", "revolute");
+        }
+        else
+        {
+            joint_xml->SetAttribute("type", "continuous");
+        }
+    }
+    else if (dynamic_cast<const PrismaticJoint*>(joint))
+    {
+        joint_xml->SetAttribute("type", "revolute");
+    }
+    else
+    {
+        std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint of type "
+                  <<  typeid(joint).name() << " to a URDF joint " << std::endl;
+        return false;
+    }
+
+    // origin
+    exportTransform(joint->getRestTransform(parentLink->getIndex(), childLink->getIndex()), joint_xml);
+
+    if (joint->getNrOfDOFs() != 0)
+    {
+        Axis axis;
+
+        // Check that the axis of the joint is supported by URDF
+        if (dynamic_cast<const RevoluteJoint*>(joint))
+        {
+            const RevoluteJoint* revJoint = dynamic_cast<const RevoluteJoint*>(joint);
+            axis = revJoint->getAxis(childLink->getIndex());
+        }
+        else if (dynamic_cast<const PrismaticJoint*>(joint))
+        {
+            const PrismaticJoint* prismJoint = dynamic_cast<const PrismaticJoint*>(joint);
+            axis = prismJoint->getAxis(childLink->getIndex());
+        }
+        else
+        {
+            std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint of type "
+                      <<  typeid(joint).name() << " to a URDF joint " << std::endl;
+            return false;
+        }
+
+        // Check that the axis is URDF-compatible
+        if (toEigen(axis.getOrigin()).norm() > 1e-7)
+        {
+            std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint "
+                      <<   model.getJointName(joint->getIndex()) << " to a URDF joint without moving the link frame of link "
+                      << model.getLinkName(childLink->getIndex()) << " , because its origin is "
+                      << axis.getOrigin().toString()  << std::endl;
+            return false;
+        }
+
+        // axis
+        TiXmlElement *axis_xml = new TiXmlElement("axis");
+        std::string bufStr;
+        ok = ok && vectorToString(axis.getDirection(), bufStr);
+        axis_xml->SetAttribute("xyz", bufStr);
+        joint_xml->LinkEndChild(axis_xml);
+    }
+
+    // parent
+    TiXmlElement * parent_xml = new TiXmlElement("parent");
+    parent_xml->SetAttribute("link", model.getLinkName(parentLink->getIndex()));
+    joint_xml->LinkEndChild(parent_xml);
+
+    // child
+    TiXmlElement * child_xml = new TiXmlElement("child");
+    child_xml->SetAttribute("link", model.getLinkName(childLink->getIndex()));
+    joint_xml->LinkEndChild(child_xml);
+
+    // TODO(traversaro) : handle joint limits and friction
+
+    xml->LinkEndChild(joint_xml);
+    return ok;
+}
+
+bool URDFStringFromModel(const iDynTree::Model & model,
+                         std::string & urdf_string,
+                         const URDFExporterOptions options)
+{
+    bool ok = true;
+
+    TiXmlDocument *urdfXml = new TiXmlDocument();
+
+    TiXmlElement *robot = new TiXmlElement("robot");
+    // TODO(traversaro) properly export this
+    robot->SetAttribute("name", "iDynTreeURDFModelExportModelName");
+    urdfXml->LinkEndChild(robot);
+
+    // TODO(traversaro) : We are assuming that the model has no loops,
+    //                    we should add a check for this
+
+    // URDF assumes a directed tree of the multibody model structure, so we need to assume that a given link is
+    // the base
+    std::string baseLink = options.baseLink;
+    if (baseLink.empty())
+    {
+        baseLink = model.getLinkName(model.getDefaultBaseLink());
+    }
+
+    LinkIndex baseLinkIndex = model.getLinkIndex(baseLink);
+    if (baseLinkIndex == LINK_INVALID_INDEX)
+    {
+        std::cerr << "[ERROR] URDFStringFromModel : specified baseLink " << baseLink << " is not part of the model" << std::endl;
+        delete urdfXml;
+        return false;
+    }
+
+    // Create a Traversal
+    Traversal exportTraversal;
+    if (!model.computeFullTreeTraversal(exportTraversal, baseLinkIndex))
+    {
+        std::cerr << "[ERROR] URDFStringFromModel : error in computeFullTreeTraversal" << std::endl;
+        delete urdfXml;
+        return false;
+    }
+
+
+    // Export links and joints following the traversal
+    for (TraversalIndex trvIdx=0; trvIdx < static_cast<TraversalIndex>(exportTraversal.getNrOfVisitedLinks()); trvIdx++)
+    {
+        LinkConstPtr visitedLink = exportTraversal.getLink(trvIdx);
+        std::string visitedLinkName = model.getLinkName(visitedLink->getIndex());
+
+        // Export parent joint, if this is not the base
+        if (trvIdx != 0)
+        {
+            LinkConstPtr parentLink = exportTraversal.getParentLink(trvIdx);
+            IJointConstPtr parentJoint = exportTraversal.getParentJoint(trvIdx);
+            ok = ok && exportJoint(parentJoint, parentLink, visitedLink,  model, robot);
+        }
+
+        // Export link
+        ok = ok && exportLink(*visitedLink, visitedLinkName, robot);
+    }
+
+    // TODO(traversaro) : export additional frames
+    TiXmlPrinter printer;
+    printer.SetIndent("    ");
+    urdfXml->Accept( &printer );
+    urdf_string = printer.CStr();
+
+    delete urdfXml;
+
+    return ok;
+}
+
+
+bool URDFFromModel(const iDynTree::Model & model,
+                   const std::string & urdf_filename,
+                   const URDFExporterOptions options)
+{
+    std::ofstream ofs(urdf_filename.c_str());
+
+    if( !ofs.is_open() )
+    {
+        std::cerr << "[ERROR] iDynTree::URDFFromModel : error opening file "
+                  << urdf_filename << std::endl;
+        return false;
+    }
+
+    std::string xml_string;
+    if (!URDFStringFromModel(model, xml_string, options))
+    {
+        return false;
+    }
+
+    // Write string to file
+    ofs << xml_string;
+    ofs.close();
+
+    return true;
+}
+
+
+}

--- a/src/model_io/urdf/src/URDFParsingUtils.h
+++ b/src/model_io/urdf/src/URDFParsingUtils.h
@@ -45,6 +45,16 @@ bool inline stringToUnsignedIntWithClassicLocale(const std::string & inStr, unsi
     return !(ss.fail());
 }
 
+bool inline doubleToStringWithClassicLocale(const double & inDouble, std::string& outStr)
+{
+    std::ostringstream ss;
+    ss.imbue(std::locale::classic());
+    ss << inDouble;
+    outStr = ss.str();
+    return !(ss.fail());
+}
+
+
 std::string inline intToString(const int inInt)
 {
     std::stringstream ss;
@@ -112,6 +122,27 @@ bool inline vector3FromString(const std::string & vector_str, Vector3 & out)
     out(2) = xyz[2];
 
     return true;
+}
+
+template<typename iDynTreeVectorType>
+bool inline vectorToString(const iDynTreeVectorType & in, std::string & out_str)
+{
+    std::stringstream ss;
+    bool ok = true;
+    for (unsigned int i = 0; i < in.size(); ++i)
+    {
+        std::string bufStr;
+        ok = ok && doubleToStringWithClassicLocale(in(i), bufStr);
+        if (i != 0)
+        {
+            ss << " ";
+        }
+        ss << bufStr;
+    }
+
+    out_str = ss.str();
+
+    return ok;
 }
 
 

--- a/src/model_io/urdf/tests/CMakeLists.txt
+++ b/src/model_io/urdf/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ macro(add_modelio_urdf_unit_test classname)
 endmacro()
 
 add_modelio_urdf_unit_test(URDFModelImport)
+add_modelio_urdf_unit_test(URDFModelExport)
 add_modelio_urdf_unit_test(URDFGenericSensorImport)
 add_modelio_urdf_unit_test(PredictSensorsMeasurement)
 add_modelio_urdf_unit_test(icubSensorURDF)

--- a/src/model_io/urdf/tests/URDFModelExportUnitTest.cpp
+++ b/src/model_io/urdf/tests/URDFModelExportUnitTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include "testModels.h"
+
+#include <iDynTree/Core/TestUtils.h>
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/ModelIO/URDFModelImport.h>
+#include <iDynTree/ModelIO/URDFModelExport.h>
+#include <iDynTree/ModelIO/URDFDofsImport.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <algorithm>
+
+using namespace iDynTree;
+
+
+void checkImportExportURDF(std::string fileName)
+{
+    // Import, export and re-import a URDF file, and check that the key properties of the model are mantained
+    Model model;
+    bool ok = modelFromURDF(fileName,model);
+    ASSERT_IS_TRUE(ok);
+
+    std::cerr << "Model loaded from " << fileName << std::endl;
+    std::cerr << model.toString() << std::endl;
+
+    std::string urdfString;
+    ok = URDFStringFromModel(model, urdfString);
+    ASSERT_IS_TRUE(ok);
+
+    std::cerr << "Model serialized back to xml " << std::endl << urdfString << std::endl;
+    Model modelReloaded;
+
+    ok = modelFromURDFString(urdfString, modelReloaded);
+    ASSERT_IS_TRUE(ok);
+
+    std::cerr << "Model re-loaded " << std::endl;
+    std::cerr << modelReloaded.toString() << std::endl;
+
+    ASSERT_EQUAL_DOUBLE(model.getNrOfLinks(), modelReloaded.getNrOfLinks());
+    ASSERT_EQUAL_DOUBLE(model.getNrOfJoints(), modelReloaded.getNrOfJoints());
+    ASSERT_EQUAL_DOUBLE(model.getNrOfDOFs(), modelReloaded.getNrOfDOFs());
+
+    // TODO(traversaro) : uncomment the following line when frames are correctly handled by the exporter
+    // ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(), modelReloaded.getNrOfLinks());
+}
+
+
+int main()
+{
+    for(unsigned int mdl = 0; mdl < IDYNTREE_TESTS_URDFS_NR; mdl++ )
+    {
+        if (std::string(IDYNTREE_TESTS_URDFS[mdl]) == "bigman.urdf")
+        {
+            // walkman model fails this test due to https://github.com/robotology/idyntree/issues/247
+            continue;
+        }
+
+        std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
+        std::cout << "Checking URDF import/export test on " << urdfFileName << std::endl;
+        checkImportExportURDF(urdfFileName);
+    }
+
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Missing features: 
* [ ] Handle geometries 
* [ ] Handle sensors 
* [ ] Handle joint axis do not pass through the origin of the child link frame
* [ ] Handle https://github.com/robotology/idyntree/issues/247
* [ ] Expose in bindings 
* [ ] Have a nice class with a nice interface that in the future can support more options, like we have `iDynTree::ModelLoader` for loading models

However it is working fine, feel free to do a preliminary review if you want @francesco-romano @fiorisi @diegoferigo 