### PR TITLE
Added support to Jacobians sparsity pattern

### DIFF
--- a/doc/releases/v0_10.md
+++ b/doc/releases/v0_10.md
@@ -24,13 +24,9 @@ Important Changes
   vector type the downstream code is using, for example if it is one of `std::vector<double>`,
   `Eigen::VectorXd` or `yarp::sig::Vector` .
 
-#### `high-level`
-* Added method to obtain relative Jacobians sparsity pattern
-* Added method to obtain free floating Jacobians sparsity pattern
-
 #### `inverse-kinematics`
+
 * Frame Constraints can now be enabled and disabled dynamically ( https://github.com/robotology/idyntree/pull/389 ).
-* Constraints Jacobian now exploit sparsity pattern
 
 #### `estimation`
 * Addition of iDynTree::SchmittTrigger, iDynTree::ContactStateMachine and iDynTree::BipedFootContactClassifier classes for performing contact state detection using Schmitt trigger based thresholding and biped foot contact classification based on an alternate contact switching pattern reasoning over contact makes used for getting primary foot in contact

--- a/doc/releases/v0_10.md
+++ b/doc/releases/v0_10.md
@@ -24,9 +24,13 @@ Important Changes
   vector type the downstream code is using, for example if it is one of `std::vector<double>`,
   `Eigen::VectorXd` or `yarp::sig::Vector` .
 
-#### `inverse-kinematics`
+#### `high-level`
+* Added method to obtain relative Jacobians sparsity pattern
+* Added method to obtain free floating Jacobians sparsity pattern
 
+#### `inverse-kinematics`
 * Frame Constraints can now be enabled and disabled dynamically ( https://github.com/robotology/idyntree/pull/389 ).
+* Constraints Jacobian now exploit sparsity pattern
 
 #### `estimation`
 * Addition of iDynTree::SchmittTrigger, iDynTree::ContactStateMachine and iDynTree::BipedFootContactClassifier classes for performing contact state detection using Schmitt trigger based thresholding and biped foot contact classification based on an alternate contact switching pattern reasoning over contact makes used for getting primary foot in contact

--- a/doc/releases/v0_11.md
+++ b/doc/releases/v0_11.md
@@ -22,3 +22,10 @@ Important Changes
 * Added `toEigen` methods for `Span` and added typedef for `Eigen` maps of vectors.
 * Added some typedefs to `VectorDynsize` and `VectorFixSize` classes to enable the use of `make_span` with these objects.
 * Added copy operator in `VectorDynSize` and `VectorFixSize` for `Span<double>`.
+
+#### `high-level`
+* Added method to obtain relative Jacobians sparsity pattern
+* Added method to obtain free floating Jacobians sparsity pattern
+
+#### `inverse-kinematics`
+* Constraints Jacobian now exploit sparsity pattern

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -256,6 +256,48 @@ public:
     //@}
 
     /**
+     * @name Methods to obtain the sparity patterns of Jacobians and Hessians
+     * @note Sparsity patterns does not depend on the particular joint configuration.
+     * The only requirement is that the model has been loaded before
+     */
+    //@{
+
+    /**
+     * Returns the sparsity pattern of the relative Jacobian for the specified frames
+     *
+     * The resulting matrix has the same size of the free floating Jacobian (6 x #DoFs)
+     * It is filled with only 0 and 1 with the following meaning:
+     * - 0: the element will always have 0 (for every robot configuration)
+     * - 1: it exists a robot configuration such that the element have a value different from zero.
+     * @param refFrameIndex refence frame for the Jacobian
+     * @param frameIndex Jacobian frame
+     * @param outJacobianPattern the Jacobian sparsity pattern
+     * @return true on success. False otherwise
+     */
+    bool getRelativeJacobianSparsityPattern(const iDynTree::FrameIndex refFrameIndex,
+                                            const iDynTree::FrameIndex frameIndex,
+                                            iDynTree::MatrixDynSize & outJacobianPattern) const;
+
+
+    /**
+     * Returns the sparsity pattern of the free floating Jacobian for the specified frame
+     *
+     * The resulting matrix has the same size of the free floating Jacobian (6 x 6 + #DoFs)
+     * It is filled with only 0 and 1 with the following meaning:
+     * - 0: the element will always have 0 (for every robot configuration)
+     * - 1: it exists a robot configuration such that the element have a value different from zero.
+     * @param frameIndex Jacobian frame
+     * @param outJacobianPattern the Jacobian sparsity pattern
+     * @return true on success. False otherwise
+     */
+    bool getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
+                                                     iDynTree::MatrixDynSize & outJacobianPattern) const;
+
+
+    //@}
+
+
+    /**
       * @name Methods to submit the input data for dynamics computations.
       */
     //@{

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -236,7 +236,6 @@ void testRelativeJacobians(KinDynComputations & dynComp)
     } else {
         //Pick two frames at random
         frame = real_random_int(0, dynComp.getNrOfFrames());
-        refFrame = -1;
         //be sure to pick two different frames
         do {
             refFrame = real_random_int(0, dynComp.getNrOfFrames());
@@ -345,6 +344,109 @@ void testModelConsistencyAllRepresentations(std::string modelName)
     testModelConsistency(urdfFileName,iDynTree::INERTIAL_FIXED_REPRESENTATION);
 }
 
+void testRelativeJacobianSparsity(KinDynComputations & dynComp)
+{
+    // take two frames
+    if (dynComp.getNrOfLinks() < 2) return;
+    FrameIndex frame = -1;
+    FrameIndex refFrame = -1;
+
+    if (dynComp.getNrOfLinks() == 2) {
+        frame = 0;
+        refFrame = 1;
+    } else {
+        //Pick two frames at random
+        frame = real_random_int(0, dynComp.getNrOfFrames());
+        //be sure to pick two different frames
+        do {
+            refFrame = real_random_int(0, dynComp.getNrOfFrames());
+        } while (refFrame == frame && frame >= 0);
+    }
+    
+    // get sparsity pattern
+    MatrixDynSize jacobianPattern(6, dynComp.getNrOfDegreesOfFreedom());
+    bool ok = dynComp.getRelativeJacobianSparsityPattern(refFrame, frame, jacobianPattern);
+    ASSERT_IS_TRUE(ok);
+
+    // Now computes the actual jacobian
+    MatrixDynSize jacobian(6, dynComp.getNrOfDegreesOfFreedom());
+    ok = dynComp.getRelativeJacobian(refFrame, frame, jacobian);
+    ASSERT_IS_TRUE(ok);
+
+    ASSERT_IS_TRUE(jacobian.rows() == jacobianPattern.rows() && jacobian.cols() == jacobian.cols());
+
+    for (size_t row = 0; row < jacobian.rows(); ++row) {
+        for (size_t col = 0; col < jacobian.cols(); ++col) {
+            // if jacobian has value != 0, pattern should have 1
+            if (std::abs(jacobian(row, col)) > iDynTree::DEFAULT_TOL) {
+                ASSERT_EQUAL_DOUBLE(jacobianPattern(row, col), 1.0);
+            }
+        }
+    }
+}
+
+void testAbsoluteJacobianSparsity(KinDynComputations & dynComp)
+{
+    // take one frames
+    if (dynComp.getNrOfLinks() < 1) return;
+    FrameIndex frame = -1;
+
+    if (dynComp.getNrOfLinks() == 1) {
+        frame = 0;
+    } else {
+        //Pick one frames at random
+        frame = real_random_int(0, dynComp.getNrOfFrames());
+    }
+
+    // get sparsity pattern
+    MatrixDynSize jacobianPattern(6, 6 + dynComp.getNrOfDegreesOfFreedom());
+    bool ok = dynComp.getFrameFreeFloatingJacobianSparsityPattern(frame, jacobianPattern);
+    ASSERT_IS_TRUE(ok);
+
+    // Now computes the actual jacobian
+    MatrixDynSize jacobian(6, 6 + dynComp.getNrOfDegreesOfFreedom());
+    ok = dynComp.getFrameFreeFloatingJacobian(frame, jacobian);
+    ASSERT_IS_TRUE(ok);
+
+    ASSERT_IS_TRUE(jacobian.rows() == jacobianPattern.rows() && jacobian.cols() == jacobian.cols());
+
+    for (size_t row = 0; row < jacobian.rows(); ++row) {
+        for (size_t col = 0; col < jacobian.cols(); ++col) {
+            // if jacobian has value != 0, pattern should have 1
+            if (std::abs(jacobian(row, col)) > iDynTree::DEFAULT_TOL) {
+                ASSERT_EQUAL_DOUBLE(jacobianPattern(row, col), 1.0);
+            }
+        }
+    }
+}
+
+void testSparsityPattern(std::string modelFilePath, const FrameVelocityRepresentation frameVelRepr)
+{
+    iDynTree::KinDynComputations dynComp;
+
+    bool ok = dynComp.loadRobotModelFromFile(modelFilePath);
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.setFrameVelocityRepresentation(frameVelRepr);
+    ASSERT_IS_TRUE(ok);
+
+    for(int i=0; i < 10; i++)
+    {
+        setRandomState(dynComp);
+        testRelativeJacobianSparsity(dynComp);
+        testAbsoluteJacobianSparsity(dynComp);
+    }
+}
+
+void testSparsityPatternAllRepresentations(std::string modelName)
+{
+    std::string urdfFileName = getAbsModelPath(modelName);
+    std::cout << "Testing file " << urdfFileName <<  std::endl;
+    testSparsityPattern(urdfFileName,iDynTree::MIXED_REPRESENTATION);
+    testSparsityPattern(urdfFileName,iDynTree::BODY_FIXED_REPRESENTATION);
+    testSparsityPattern(urdfFileName,iDynTree::INERTIAL_FIXED_REPRESENTATION);
+}
+
 int main()
 {
     // Just run the tests on a handful of models to avoid
@@ -356,6 +458,14 @@ int main()
     testModelConsistencyAllRepresentations("icub_skin_frames.urdf");
     testModelConsistencyAllRepresentations("iCubGenova02.urdf");
     testModelConsistencyAllRepresentations("icalibrate.urdf");
+
+    testSparsityPatternAllRepresentations("oneLink.urdf");
+    testSparsityPatternAllRepresentations("twoLinks.urdf");
+    testSparsityPatternAllRepresentations("threeLinks.urdf");
+    testSparsityPatternAllRepresentations("bigman.urdf");
+    testSparsityPatternAllRepresentations("icub_skin_frames.urdf");
+
+
 
     return EXIT_SUCCESS;
 }

--- a/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
@@ -28,8 +28,161 @@ namespace internal {
 namespace kinematics {
     class InverseKinematicsNLP;
     class InverseKinematicsData;
+    class TransformConstraint;
+
+    class SparsityHelper;
 }
 }
+
+/*! @brief Helper class to manage sparsity
+ */
+class internal::kinematics::SparsityHelper
+{
+    std::vector<size_t> m_numberOfNonZeros; /*!< number of non zeros for each rows */
+    std::vector<std::vector<size_t>> m_nonZeroIndices; /*!< nonzero columns for each row */
+
+    static const std::vector<size_t> s_nullVector; /*!< invalid vector */
+
+
+    /**
+     * Adds a constraint sparsity pattern from the specified matrix
+     * and constraint range
+     *
+     * @note this is the templated function that accepts fix and dynamic size matrices
+     * @param newConstraint the matrix containing the pattern (1 for nonzero, 0 otherwise)
+     * @param constraintRange contiguous subset of the newConstraint matrix to be considered
+     * @return true on success. False otherwise
+     */
+    template <typename MatrixType>
+    bool addConstraintSparsityPatternTemplated(const MatrixType& newConstraint, const iDynTree::IndexRange& constraintRange);
+
+public:
+
+
+    /**
+     * The invalid null indices vector
+     *
+     * @return The invalid null indices vector
+     */
+    static const std::vector<size_t>& NullIndicesVector();
+
+    /** Default constructor */
+    SparsityHelper();
+
+    SparsityHelper(const SparsityHelper&) = delete;
+    SparsityHelper& operator=(const SparsityHelper&) = delete;
+
+    SparsityHelper(SparsityHelper&&) = default;
+    SparsityHelper& operator=(SparsityHelper&&) = default;
+
+
+    /**
+     * Remove all constraint sparsity patterns
+     */
+    void clear();
+
+    /**
+     * Adds a constraint sparsity pattern from the specified matrix
+     *
+     * @param newConstraint the matrix containing the pattern (1 for nonzero, 0 otherwise)
+     * @return true on success. False otherwise
+     */
+    bool addConstraintSparsityPattern(const iDynTree::MatrixDynSize& newConstraint);
+
+    /**
+     * Adds a constraint sparsity pattern from the specified matrix
+     *
+     * @param newConstraint the matrix containing the pattern (1 for nonzero, 0 otherwise)
+     * @return true on success. False otherwise
+     */
+    template<unsigned int nRows, unsigned int nCols>
+    bool addConstraintSparsityPattern(const iDynTree::MatrixFixSize<nRows, nCols>& newConstraint);
+
+    /**
+     * Adds a constraint sparsity pattern from the specified matrix
+     * and constraint range
+     *
+     * @param newConstraint the matrix containing the pattern (1 for nonzero, 0 otherwise)
+     * @param constraintRange contiguous subset of the newConstraint matrix to be considered
+     * @return true on success. False otherwise
+     */
+    bool addConstraintSparsityPattern(const iDynTree::MatrixDynSize& newConstraint,
+                                      const iDynTree::IndexRange& constraintRange);
+
+    /**
+     * Adds a constraint sparsity pattern from the specified matrix
+     * and constraint range
+     *
+     * @param newConstraint the matrix containing the pattern (1 for nonzero, 0 otherwise)
+     * @param constraintRange contiguous subset of the newConstraint matrix to be considered
+     * @return true on success. False otherwise
+     */
+    template<unsigned int nRows, unsigned int nCols>
+    bool addConstraintSparsityPattern(const iDynTree::MatrixFixSize<nRows, nCols>& newConstraint,
+                                      const iDynTree::IndexRange& constraintRange);
+
+
+    /**
+     * Returns the number of nonzeros in the specified row
+     *
+     * @param rowIndex index of the row
+     * @return number of nonzeros
+     */
+    size_t numberOfNonZerosForRow(size_t rowIndex) const;
+
+
+    /**
+     * Returns the total number of nonzeros in the sparsity pattern
+     *
+     * @return the total number of nonzeros in the sparsity pattern
+     */
+    size_t numberOfNonZeros() const;
+
+
+    /**
+     * Returns the cumulative number of nonzeros in all the rows before the specified one
+     *
+     * @param rowIndex the row (excluded) to compute the cumulative number of nonzeros
+     * @return the cumulative number of nonzeros in all the rows before the specified one
+     */
+    size_t totalNumberOfNonZerosBeforeRow(size_t rowIndex) const;
+
+    
+    /**
+     * Returns a vector with the indices of the non zero columns for the specified contraint (row)
+     *
+     * @param rowIndex the specified constraint
+     * @return a vector with the indices of the non zero columns
+     */
+    const std::vector<size_t>& nonZeroIndicesForRow(size_t rowIndex) const;
+
+
+    /**
+     * Helper function to assign values to a contiguous buffer given the current sparsity pattern
+     *
+     * @param constraintRange range of the constraint that should be sparsified
+     * @param fullMatrix matrix specifying the non sparse constraint
+     * @param fullMatrixStartingRowIndex starting row index of the non sparse matrix to be considered. The
+     *                                   size is automatically inferred by the constraint size
+     * @param outputBuffer the buffer on which the sparsified values should be written
+     */
+    void assignActualMatrixValues(const iDynTree::IndexRange& constraintRange,
+                                  const iDynTree::MatrixDynSize& fullMatrix,
+                                  size_t fullMatrixStartingRowIndex,
+                                  Ipopt::Number *outputBuffer);
+
+
+    /**
+     * @brief Returns a textual description of the sparsity pattern
+     *
+     * Useful for debug
+     * @note this method perform dynamic memory allocation
+     * @return a textual description of the sparsity pattern
+     */
+    std::string toString() const;
+
+};
+
 
 /*!
  * @brief Implementation of the inverse kinematics with IPOPT
@@ -66,6 +219,8 @@ namespace kinematics {
  *   between iDynTree DoFs and optimizer DoFs which was not present before
  */
 class internal::kinematics::InverseKinematicsNLP : public Ipopt::TNLP {
+
+    SparsityHelper m_jacobianSparsityHelper;
 
     /*! @brief information about a Frame during optimization
      * All the values are computed given the current robot configuration
@@ -167,6 +322,22 @@ class internal::kinematics::InverseKinematicsNLP : public Ipopt::TNLP {
      */
     void omegaToRPYParameters(const iDynTree::Vector3& rpyAngles,
                               iDynTree::Matrix3x3& map);
+
+
+    /**
+     * Helper method to create sparity information for a specific constraint
+     *
+     * @param constraintID id of the constraint
+     * @param constraint constraint object
+     */
+    void addSparsityInformationForConstraint(int constraintID, const internal::kinematics::TransformConstraint& constraint);
+
+    /**
+     * Initialize the sparsity information
+     * @note this method should be called after all constraints have been specified.
+     * It also uses the buffers created for the constraints, so it should not be called at runtime
+     */
+    void initializeSparsityInformation();
 
 public:
     /*! Constructor

--- a/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
@@ -339,6 +339,18 @@ class internal::kinematics::InverseKinematicsNLP : public Ipopt::TNLP {
      */
     void initializeSparsityInformation();
 
+#ifndef NDEBUG
+    // IpOpt should not call the same callback twice for the same set of input parameters
+    // To be sure of this, we add some assert in the code
+    // In the case, in the future, IpOpt changes behaviour, this asserts will
+    // notify us of this change, and we can (easily, at the cost of adding more functions)
+    // circunvent this with our code.
+    static bool eval_f_called;
+    static bool eval_grad_f_called;
+    static bool eval_g_called;
+    static bool eval_jac_g_called;
+#endif
+
 public:
     /*! Constructor
      * @param data reference to the InverseKinematicsData object

--- a/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsNLP.cpp
@@ -24,9 +24,147 @@
 #include <cmath>
 
 
-
 namespace internal {
 namespace kinematics {
+
+    // Check of MatrixFixSize
+    template<typename>
+    struct is_matrixfixsize : std::false_type {};
+
+    template<unsigned row, unsigned col>
+    struct is_matrixfixsize<iDynTree::MatrixFixSize<row, col>> : std::true_type {};
+
+    //MARK: - SparsityHelper implementation
+
+    const std::vector<size_t> SparsityHelper::s_nullVector = std::vector<size_t>();
+    const std::vector<size_t>& SparsityHelper::NullIndicesVector() { return s_nullVector; }
+
+    SparsityHelper::SparsityHelper()
+    {
+        m_numberOfNonZeros.resize(1, 0);
+    }
+
+    void SparsityHelper::clear()
+    {
+        m_nonZeroIndices.clear();
+        m_numberOfNonZeros.clear();
+        m_numberOfNonZeros.resize(1, 0);
+    }
+
+    template <typename MatrixType>
+    bool SparsityHelper::addConstraintSparsityPatternTemplated(const MatrixType& newConstraint, const iDynTree::IndexRange& constraintRange)
+    {
+        static_assert(std::is_base_of<MatrixType, iDynTree::MatrixDynSize>::value
+                      || is_matrixfixsize<MatrixType>::value,
+                      "addConstraintSparsityPatternTemplated can be called only with iDynTree::MatrixFixSize and iDynTree::MatrixDynSize");
+
+        size_t constraintSize = constraintRange.size;
+        if (constraintSize == 0) return false;
+        size_t previousConstraintSize = m_nonZeroIndices.size();
+
+        // append this constraint to the current pattern
+        // Update the number of nonzeros
+        m_numberOfNonZeros.resize(1 + previousConstraintSize + constraintSize, m_numberOfNonZeros[previousConstraintSize]);
+        m_nonZeroIndices.resize(previousConstraintSize + constraintSize);
+        for (size_t row = 0; row < constraintSize; ++row) {
+            size_t numberOfNonZeros = static_cast<size_t>(iDynTree::toEigen(newConstraint).row(constraintRange.offset + row).sum());
+            m_numberOfNonZeros[1 + previousConstraintSize + row] = totalNumberOfNonZerosBeforeRow(previousConstraintSize + row) +  numberOfNonZeros;
+            assert(numberOfNonZeros == numberOfNonZerosForRow(previousConstraintSize + row));
+
+            // Update indices
+            m_nonZeroIndices[previousConstraintSize + row].reserve(numberOfNonZeros);
+            for (size_t col = 0; col < newConstraint.cols(); ++col) {
+                if (std::abs(newConstraint(constraintRange.offset + row, col) - 1) < iDynTree::DEFAULT_TOL) {
+                    m_nonZeroIndices[previousConstraintSize + row].push_back(col);
+                }
+            }
+        }
+
+        return true;
+    }
+
+
+    bool SparsityHelper::addConstraintSparsityPattern(const iDynTree::MatrixDynSize& newConstraint)
+    {
+        return addConstraintSparsityPattern(newConstraint, {0, newConstraint.rows()});
+    }
+
+    template<unsigned int nRows, unsigned int nCols>
+    bool SparsityHelper::addConstraintSparsityPattern(const iDynTree::MatrixFixSize<nRows, nCols>& newConstraint)
+    {
+        return addConstraintSparsityPattern(newConstraint, {0, newConstraint.rows()});
+    }
+
+    bool SparsityHelper::addConstraintSparsityPattern(const iDynTree::MatrixDynSize& newConstraint,
+                                                      const iDynTree::IndexRange& constraintRange)
+    {
+        return addConstraintSparsityPatternTemplated(newConstraint, constraintRange);
+    }
+
+    template<unsigned int nRows, unsigned int nCols>
+    bool SparsityHelper::addConstraintSparsityPattern(const iDynTree::MatrixFixSize<nRows, nCols>& newConstraint,
+                                                      const iDynTree::IndexRange& constraintRange)
+    {
+        return addConstraintSparsityPatternTemplated(newConstraint, constraintRange);
+    }
+
+
+
+    size_t SparsityHelper::numberOfNonZerosForRow(size_t rowIndex) const
+    {
+        if (rowIndex >= m_numberOfNonZeros.size() - 1) return 0;
+        return m_numberOfNonZeros[rowIndex + 1] - m_numberOfNonZeros[rowIndex];
+    }
+    size_t SparsityHelper::numberOfNonZeros() const { return m_numberOfNonZeros[m_numberOfNonZeros.size() - 1]; }
+    size_t SparsityHelper::totalNumberOfNonZerosBeforeRow(size_t rowIndex) const
+    {
+        if (rowIndex >= m_numberOfNonZeros.size() - 1) return 0;
+        return m_numberOfNonZeros[rowIndex];
+    }
+
+    const std::vector<size_t>& SparsityHelper::nonZeroIndicesForRow(size_t rowIndex) const
+    {
+        if (rowIndex > m_nonZeroIndices.size()) return s_nullVector;
+        return m_nonZeroIndices[rowIndex];
+    }
+
+    void SparsityHelper::assignActualMatrixValues(const iDynTree::IndexRange& constraintRange,
+                                                  const iDynTree::MatrixDynSize& fullMatrix,
+                                                  size_t fullMatrixStartingRowIndex,
+                                                  Ipopt::Number *outputBuffer)
+    {
+        for (size_t row = 0; row < constraintRange.size; ++row) {
+            // get the current row in the sparsity pattern matrix
+            const std::vector<size_t>& currentSparsityRow = nonZeroIndicesForRow(constraintRange.offset + row);
+            Ipopt::Number *startingValue = &outputBuffer[totalNumberOfNonZerosBeforeRow(constraintRange.offset + row)];
+
+            for (size_t colIndex = 0; colIndex < currentSparsityRow.size(); ++colIndex) {
+                startingValue[colIndex] = fullMatrix(fullMatrixStartingRowIndex + row, currentSparsityRow[colIndex]);
+            }
+        }
+    }
+
+    std::string SparsityHelper::toString() const
+    {
+        size_t maxCol = 0;
+        for (const auto& row : m_nonZeroIndices) {
+            if (row.empty()) continue;
+            maxCol = std::max(maxCol, 1 + *(--row.end()));
+        }
+
+        iDynTree::MatrixDynSize matrix(m_nonZeroIndices.size(), maxCol);
+        matrix.zero();
+        if (maxCol > 0) {
+            for (size_t row = 0; row < m_nonZeroIndices.size(); ++row) {
+                for (const auto& col : m_nonZeroIndices[row]) {
+                    matrix(row, col) = 1;
+                }
+            }
+        }
+        return matrix.toString();
+    }
+
+    //MARK: - InverseKinematicsNLP implementation
 
     //To understand IPOpt log:
     //http://www.coin-or.org/Ipopt/documentation/node36.html#sec:output
@@ -76,6 +214,151 @@ namespace kinematics {
         comInfo.comJacobian.resize(3, m_data.m_dofs + 6);
         comInfo.comJacobianAnalytical.resize(3, m_data.m_dofs + 3 + sizeOfRotationParametrization(m_data.m_rotationParametrization));
         comInfo.projectedComJacobian.resize(m_data.m_comHullConstraint.getNrOfConstraints(), m_data.m_dofs + 3 + sizeOfRotationParametrization(m_data.m_rotationParametrization));
+
+        initializeSparsityInformation();
+    }
+
+void InverseKinematicsNLP::addSparsityInformationForConstraint(int constraintID,
+                                                               const internal::kinematics::TransformConstraint& constraint)
+    {
+        //For each constraint compute its jacobian pattern
+        FrameInfo &constraintInfo = constraintsInfo[constraintID];
+        // iDynTree pattern
+        m_data.dynamics().getFrameFreeFloatingJacobianSparsityPattern(constraintID, constraintInfo.jacobian);
+        // Now we have to modify it depending on the orientation parametrization
+
+
+        if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
+
+            // Create sparsity of quaternion inverse and direct maps
+            // Does not have any sparsity.
+            iDynTree::MatrixFixSize<3, 4> quaternionDerivativeInverseMap;
+            iDynTree::toEigen(quaternionDerivativeInverseMap).setOnes();
+            iDynTree::MatrixFixSize<4, 3> quaternionDerivativeMap;
+            iDynTree::toEigen(quaternionDerivativeMap).setOnes();
+
+            finalJacobianBuffer.zero();
+            computeConstraintJacobian(constraintInfo.jacobian, // this has the sparsity
+                                      quaternionDerivativeMap, // this is a all 1s matrix
+                                      quaternionDerivativeInverseMap, // this is a all 1s matrix
+                                      ComputeContraintJacobianOptionLinearPart|ComputeContraintJacobianOptionAngularPart,
+                                      finalJacobianBuffer);
+
+
+        } else if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw) {
+            //RPY sparsity parametrization for the base
+            /*  -       -
+             * | x  x  0 |
+             * | x  x  0 |
+             * | x  0  x |
+             *  -       -
+             */
+            iDynTree::Matrix3x3 RPYToOmega;
+            iDynTree::toEigen(RPYToOmega).setIdentity();
+            iDynTree::toEigen(RPYToOmega).topLeftCorner<2, 2>().setOnes();
+            RPYToOmega(2, 0) = 1.0;
+
+            // RPY sparsity parametrization for the constraint
+            /*  -       -
+             * | x  x  0 |
+             * | x  x  0 |
+             * | x  x  x |
+             *  -       -
+             */
+            iDynTree::Matrix3x3 omegaToRPYMap_target;
+            iDynTree::toEigen(omegaToRPYMap_target).setZero();
+            iDynTree::toEigen(omegaToRPYMap_target).topLeftCorner<2, 2>().setOnes();
+            iDynTree::toEigen(omegaToRPYMap_target).bottomRows<1>().setOnes();
+
+
+            computeConstraintJacobianRPY(constraintInfo.jacobian,
+                                         omegaToRPYMap_target,
+                                         RPYToOmega,
+                                         ComputeContraintJacobianOptionLinearPart|ComputeContraintJacobianOptionAngularPart,
+                                         finalJacobianBuffer);
+        }
+
+        // Now "normalize" (i.e. only 0.0 and 1.0) the result
+        for (unsigned row = 0; row < finalJacobianBuffer.rows(); ++row) {
+            for (unsigned col = 0; col < finalJacobianBuffer.cols(); ++col) {
+                finalJacobianBuffer(row, col) = std::abs(finalJacobianBuffer(row, col)) < iDynTree::DEFAULT_TOL ? 0.0 : 1.0;
+            }
+        }
+
+        //Now that we computed the actual Jacobian needed by IPOPT
+        //We have to assign it to the correct variable
+        if (constraint.hasPositionConstraint()) {
+            //Position part
+            m_jacobianSparsityHelper.addConstraintSparsityPattern(finalJacobianBuffer, {0, 3});
+        }
+        if (constraint.hasRotationConstraint()) {
+            //Orientation part
+            m_jacobianSparsityHelper.addConstraintSparsityPattern(finalJacobianBuffer, {3, sizeOfRotationParametrization(m_data.m_rotationParametrization)});
+        }
+    }
+
+    void InverseKinematicsNLP::initializeSparsityInformation()
+    {
+        m_jacobianSparsityHelper.clear();
+
+        for (TransformMap::const_iterator constraint = m_data.m_constraints.begin();
+             constraint != m_data.m_constraints.end(); ++constraint) {
+            if (constraint->second.isActive()) {
+                addSparsityInformationForConstraint(constraint->first, constraint->second);
+            }
+        }
+
+        //For COM constraint
+        //RPY parametrization for the base
+        if (m_data.m_comHullConstraint.isActive() || (m_data.isCoMTargetActive() && m_data.isCoMaConstraint())) {
+            //TODO: implement quaternion part
+            assert(m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
+
+            // CoM Jacobian is always full by definition
+            iDynTree::toEigen(comInfo.comJacobianAnalytical).setOnes();
+
+            if (m_data.m_comHullConstraint.isActive()) {
+                iDynTree::toEigen(comInfo.projectedComJacobian).setOnes();
+                m_jacobianSparsityHelper.addConstraintSparsityPattern(comInfo.projectedComJacobian);
+            }
+
+            if (m_data.isCoMTargetActive()) {
+                m_jacobianSparsityHelper.addConstraintSparsityPattern(comInfo.comJacobianAnalytical);
+            }
+        }
+
+
+        //For all targets enforced as constraints
+        for (TransformMap::const_iterator target = m_data.m_targets.begin();
+             target != m_data.m_targets.end(); ++target) {
+
+            if (target->second.isActive()) {
+                //Depending if we need position and/or orientation
+                //we have to adapt different parts of the jacobian
+                int computationOption = 0;
+                if (target->second.targetResolutionMode() & iDynTree::InverseKinematicsTreatTargetAsConstraintPositionOnly)
+                    computationOption |= ComputeContraintJacobianOptionLinearPart;
+                if (target->second.targetResolutionMode() & iDynTree::InverseKinematicsTreatTargetAsConstraintRotationOnly)
+                    computationOption |= ComputeContraintJacobianOptionAngularPart;
+
+                if (computationOption == 0) continue; // no need for further computations
+
+                addSparsityInformationForConstraint(target->first, target->second);
+            }
+
+        }
+
+
+        //Finally, the norm of the base orientation quaternion parametrization
+        if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
+            iDynTree::MatrixFixSize<1, 7> baseQuaternionConstraint;
+            baseQuaternionConstraint.zero();
+            iDynTree::toEigen(baseQuaternionConstraint).rightCols<4>().setOnes();
+            m_jacobianSparsityHelper.addConstraintSparsityPattern(baseQuaternionConstraint);
+        }
+
+
+
     }
 
     bool InverseKinematicsNLP::updateState(const Ipopt::Number * x)
@@ -257,13 +540,7 @@ namespace kinematics {
         n = m_data.m_numberOfOptimisationVariables;
         m = m_data.m_numberOfOptimisationConstraints;
 
-        nnz_jac_g = m * n;
-
-        if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
-            // constraints already considers the quaternion constraints.
-            // so the Jacobian should be changed
-            nnz_jac_g = (m - 1) * n + 4;
-        }
+        nnz_jac_g = m_jacobianSparsityHelper.numberOfNonZeros();
 
         nnz_h_lag = n * n; //this is currently ignored
 
@@ -801,42 +1078,15 @@ namespace kinematics {
             //Define the sparsity pattern of the jacobian
             Ipopt::Index index = 0;
 
-            //As we do not have sparse jacobians for now
-            //the jacobian has the same number of rows as the constraints
-            Ipopt::Index jacobianRows = m;
-            //The only exception is the base expressed in quaternion which is sparse
-            //So we remove one line as we add it back after the dense part
-            if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
-                jacobianRows--;
-            }
-            //Fill sparsity structure of the jacobian
-            //For now the jacobian is dense, so I don't care of the pattern
-            for (Ipopt::Index row = 0; row < jacobianRows; row++) {
-                for (Ipopt::Index col = 0; col < n; col++) {
-                    //row-based indexing
-                    iRow[row * n + col] = row;
-                    jCol[row * n + col] = col;
-                    index++;
+            for (Ipopt::Index row = 0; row < m; row++) {
+                auto columnIndices = m_jacobianSparsityHelper.nonZeroIndicesForRow(row);
+                size_t numberOfPreviousNonzeros = m_jacobianSparsityHelper.totalNumberOfNonZerosBeforeRow(row);
+                for (size_t col = 0; col < columnIndices.size(); ++col) {
+                    iRow[numberOfPreviousNonzeros + col] = row;
+                    jCol[numberOfPreviousNonzeros + col] = columnIndices[col];
+                    ++index;
                 }
             }
-
-            //If the base orientation is parametrized in quaternion
-            //add the sparsity of the jacobian for that constraint
-            if (m_data.m_rotationParametrization == iDynTree::InverseKinematicsRotationParametrizationQuaternion) {
-                iRow[index] = m - 1;
-                jCol[index] = 3;
-                index++;
-                iRow[index] = m - 1;
-                jCol[index] = 4;
-                index++;
-                iRow[index] = m - 1;
-                jCol[index] = 5;
-                index++;
-                iRow[index] = m - 1;
-                jCol[index] = 6;
-                index++;
-            }
-
             assert(nele_jac == index);
 
         } else {
@@ -894,22 +1144,22 @@ namespace kinematics {
                                                      finalJacobianBuffer);
                     }
 
+
                     //Now that we computed the actual Jacobian needed by IPOPT
                     //We have to assign it to the correct variable
                     if (constraint->second.hasPositionConstraint()) {
                         //Position part
-                        Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(
-                                &values[constraintIndex * finalJacobianBuffer.cols()], 3, n);
-                        currentConstraint = toEigen(finalJacobianBuffer).topRows<3>();
+                        m_jacobianSparsityHelper.assignActualMatrixValues({constraintIndex, 3},
+                                                                          finalJacobianBuffer, 0,
+                                                                          values);
                         constraintIndex += 3;
                     }
                     if (constraint->second.hasRotationConstraint()) {
                         //Orientation part
-                        Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(
-                                &values[constraintIndex * finalJacobianBuffer.cols()],
-                                sizeOfRotationParametrization(m_data.m_rotationParametrization), n);
-                        currentConstraint = toEigen(finalJacobianBuffer).bottomRows(
-                                sizeOfRotationParametrization(m_data.m_rotationParametrization));
+                        m_jacobianSparsityHelper.assignActualMatrixValues({constraintIndex,
+                                                                           sizeOfRotationParametrization(m_data.m_rotationParametrization)},
+                                                                          finalJacobianBuffer, 3,
+                                                                          values);
                         constraintIndex += sizeOfRotationParametrization(m_data.m_rotationParametrization);
                     }
                 }
@@ -929,14 +1179,17 @@ namespace kinematics {
                     iDynTree::toEigen(comInfo.projectedComJacobian) =
                             iDynTree::toEigen(m_data.m_comHullConstraint.A) * iDynTree::toEigen(m_data.m_comHullConstraint.Pdirection) * iDynTree::toEigen(comInfo.comJacobianAnalytical);
 
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*n], comInfo.projectedComJacobian.rows(), n);
-                    currentConstraint = iDynTree::toEigen(comInfo.projectedComJacobian);
+                    m_jacobianSparsityHelper.assignActualMatrixValues({constraintIndex, comInfo.projectedComJacobian.rows()},
+                                                                      comInfo.projectedComJacobian, 0,
+                                                                      values);
+
                     constraintIndex += comInfo.projectedComJacobian.rows();
                 }
                 
                 if (m_data.isCoMTargetActive()) {
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex*n], comInfo.comJacobianAnalytical.rows(), n);
-                    currentConstraint = iDynTree::toEigen(comInfo.comJacobianAnalytical);
+                    m_jacobianSparsityHelper.assignActualMatrixValues({constraintIndex, comInfo.comJacobianAnalytical.rows()},
+                                                                      comInfo.comJacobianAnalytical, 0,
+                                                                      values);
                     constraintIndex += 3;
                 }
             }
@@ -992,17 +1245,19 @@ namespace kinematics {
                     && target->second.hasPositionConstraint()) {
 
                     //Copy position part
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex * finalJacobianBuffer.cols()], 3, n);
-                    currentConstraint = toEigen(finalJacobianBuffer).topRows<3>();
+                    m_jacobianSparsityHelper.assignActualMatrixValues({constraintIndex, 3},
+                                                                      finalJacobianBuffer, 0,
+                                                                      values);
                     constraintIndex += 3;
                 }
 
                 if (target->second.targetResolutionMode() & iDynTree::InverseKinematicsTreatTargetAsConstraintRotationOnly
                     && target->second.hasRotationConstraint()) {
                     //Orientation part
-
-                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > currentConstraint(&values[constraintIndex * finalJacobianBuffer.cols()], sizeOfRotationParametrization(m_data.m_rotationParametrization), n);
-                    currentConstraint = toEigen(finalJacobianBuffer).bottomRows(sizeOfRotationParametrization(m_data.m_rotationParametrization));
+                    m_jacobianSparsityHelper.assignActualMatrixValues({constraintIndex,
+                        sizeOfRotationParametrization(m_data.m_rotationParametrization)},
+                                                                      finalJacobianBuffer, 3,
+                                                                      values);
                     constraintIndex += sizeOfRotationParametrization(m_data.m_rotationParametrization);
                 }
             }

--- a/src/inverse-kinematics/tests/InverseKinematicsUnitTest.cpp
+++ b/src/inverse-kinematics/tests/InverseKinematicsUnitTest.cpp
@@ -105,6 +105,7 @@ void simpleChainIK(int minNrOfJoints, int maxNrOfJoints, const iDynTree::Inverse
 
         // Create IK
         iDynTree::InverseKinematics ik;
+        ik.setVerbosity(0);
         bool ok = ik.setModel(chain);
         ASSERT_IS_TRUE(ok);
         // Always express the target as cost


### PR DESCRIPTION
Added two methods to `KinDynComputations` to output the Jacobian sparsity pattern.
The supported Jacobians are the relative Jacobian and the free floating Jacobian.
The last available Jacobian, i.e. the CoM Jacobian, does not have a sparsity pattern as it is dense by definition.

Adapted IK to use the sparsity pattern for the Jacobians.
A small performance increase (up to 20%) can be notice in some tests.
Of course the more sparse is the Jacobian, the higher the performance benefit. 
Potentially, if the Jacobians are dense, it is possible that IK is slightly slower, given the overhead introduced.