### PR TITLE
Add support for enabling and disabling constraints dynamically in InverseKinematics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(VARS_PREFIX "iDynTree")
 
 set(${VARS_PREFIX}_MAJOR_VERSION 0)
 set(${VARS_PREFIX}_MINOR_VERSION 9)
-set(${VARS_PREFIX}_PATCH_VERSION 0)
+set(${VARS_PREFIX}_PATCH_VERSION 1)
 set(${VARS_PREFIX}_VERSION ${${VARS_PREFIX}_MAJOR_VERSION}.${${VARS_PREFIX}_MINOR_VERSION}.${${VARS_PREFIX}_PATCH_VERSION})
 
 # Pick up our CMake scripts - they are all in the cmake subdirectory.

--- a/doc/releases/v0_10.md
+++ b/doc/releases/v0_10.md
@@ -9,3 +9,7 @@ iDynTree 0.10 Release Notes
 
 Important Changes
 -----------------
+
+#### `inverse-kinematics`
+
+* Frame Constraints can now be enabled and disabled dynamically ( https://github.com/robotology/idyntree/pull/389 ).

--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -379,9 +379,18 @@ public:
      *       returns false if the constraint was never added.
      *
      * @param frameName       the name of the frame on which to attach the constraint
-     * @return true if successful (i.e. the constraint is present , false otherwise.
+     * @return true if successful (i.e. the constraint is present) , false otherwise.
      */
     bool deactivateFrameConstraint(const std::string& frameName);
+
+    /*!
+     * Check if a given constraint is active or not.
+
+     *
+     * @param frameName       the name of the constrained frame
+     * @return true if the constraint is active, false if it is not active or it does not exist, or if the frame does not exist.
+     */
+    bool isFrameConstraintActive(const std::string& frameName) const;
 
     /*!
      * Specialization of addCenterOfMassProjectionConstraint when only two support frames are specified.

--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -356,12 +356,35 @@ public:
                                     const iDynTree::Transform& constraintValue);
 
     /*!
-     * Add a constant inequality constraint on the projection of the center of mass,
-     * assuming one support links.
+     * Activate a given constraint previously added with an addFrame**Constraint method.
      *
-     * This method assume that the position of two links is constrained by a FrameConstraint,
-     * and adds a inequality constraint to ensure that the center of mass projection lies on the
-     * convex hull of the contact polygon.
+     * \note In this version of iDynTree, it is not possible to change the nature of the constraint
+     *       (Full, Position or Rotation) when activating it again.
+     *
+     * @note This method returns true even if the frame constraint was already activate, it only
+     *       returns false if the constraint was never added.
+     * @warning This method is not meant to be called at each IK loop, and it can increase the computational
+     *          time of the next call to solve.
+     *
+     * @param frameName       the name of the frame on which to attach the constraint
+     * @param newConstraintValue the pose of the constrained frame (r) in the world frame (w), i.e. ʷHᵣ .
+     * @return true if successful, false otherwise.
+     */
+    bool activateFrameConstraint(const std::string& frameName,
+                                 const Transform& newConstraintValue);
+    /*!
+     * Deactivate a given constraint previously added with an addFrame**Constraint method.
+     *
+     * @note This method returns true even if the frame constraint was already deactivated, it only
+     *       returns false if the constraint was never added.
+     *
+     * @param frameName       the name of the frame on which to attach the constraint
+     * @return true if successful (i.e. the constraint is present , false otherwise.
+     */
+    bool deactivateFrameConstraint(const std::string& frameName);
+
+    /*!
+     * Specialization of addCenterOfMassProjectionConstraint when only two support frames are specified.
      */
     bool addCenterOfMassProjectionConstraint(const std::string& firstSupportFrame,
                                              const Polygon& firstSupportPolygon,
@@ -370,12 +393,7 @@ public:
                                              const iDynTree::Position originOfPlaneInWorld = iDynTree::Position::Zero());
 
     /*!
-     * Add a constant inequality constraint on the projection of the center of mass,
-     * assuming two support links.
-     *
-     * This method assume that the position of two links is constrained by a FrameConstraint,
-     * and adds a inequality constraint to ensure that the center of mass projection lies on the
-     * convex hull of the contact polygons.
+     * Specialization of addCenterOfMassProjectionConstraint when only two support frames are specified.
      */
     bool addCenterOfMassProjectionConstraint(const std::string& firstSupportFrame,
                                              const Polygon& firstSupportPolygon,
@@ -389,9 +407,9 @@ public:
      * Add a constant inequality constraint on the projection of the center of mass,
      * assuming an arbitrary number of support links.
      *
-     * This method assume that the position of two links is constrained by a FrameConstraint,
-     * and adds a inequality constraint to ensure that the center of mass projection lies on the
-     * convex hull of the contact polygons.
+     * If a subset of the supportFrames is contrained by a FrameConstraint (both position and constraint) and such
+     * constraint is active, this constraint adds a inequality constraint to ensure that the center of mass projection
+     * lies on the convex hull of the contact polygons.
      */
     bool addCenterOfMassProjectionConstraint(const std::vector<std::string>& supportFrames,
                                              const std::vector<Polygon>& supportPolygons,

--- a/src/inverse-kinematics/include/private/InverseKinematicsData.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsData.h
@@ -105,7 +105,15 @@ public:
 
     TransformMap m_constraints; /*!< list of hard constraints */
     TransformMap m_targets; /*!< list of targets */
+
+    // Attributes relative to the COM Projection constraint (TODO(traversaro): move most of them in a constraint-specific class)
     iDynTree::ConvexHullProjectionConstraint m_comHullConstraint; /*!< Helper to implement COM constraint */
+    iDynTree::Vector3 m_comHullConstraint_projDirection;
+    std::vector<iDynTree::FrameIndex> m_comHullConstraint_supportFramesIndeces;
+    std::vector<iDynTree::Polygon> m_comHullConstraint_supportPolygons;
+    iDynTree::Direction m_comHullConstraint_xAxisOfPlaneInWorld;
+    iDynTree::Direction m_comHullConstraint_yAxisOfPlaneInWorld;
+    iDynTree::Position m_comHullConstraint_originOfPlaneInWorld;
     
     //Preferred joints configuration for the optimization
     //Size: getNrOfDOFs of the considered model
@@ -150,6 +158,11 @@ public:
      * compute the problem size (number of optimisation variables and constraints)
      */
     void computeProblemSizeAndResizeBuffers();
+
+    /*!
+     * Configure the COM projection constraints given the current active contraints.
+     */
+    void configureCenterOfMassProjectionConstraint();
 
     /*! @name Optimization-related parameters
      */

--- a/src/inverse-kinematics/include/private/TransformConstraint.h
+++ b/src/inverse-kinematics/include/private/TransformConstraint.h
@@ -65,6 +65,7 @@ private:
     double m_posWeight; /*!< Weight for the (eventual) cost associated with the position part of the task */
     double m_rotWeight; /*!< Weight for the (eventual) cost associated with the rotation part of the task */
     enum iDynTree::InverseKinematicsTreatTargetAsConstraint m_resolutionMode; /*!< Resolution mode in case of target */
+    bool m_isActive; /*! Is the constraint active or not? */
 
 public:
 
@@ -165,7 +166,7 @@ public:
     /*!
      * Set the position component of the current constrained value of the Transform.
      */
-    void setPosition(iDynTree::Position& newPos);
+    void setPosition(const iDynTree::Position& newPos);
 
     /*!
      * Return the rotation component of the current constrained value of the Transform.
@@ -176,7 +177,7 @@ public:
     /*!
      * Set the rotation component of the current constrained value of the Transform.
      */
-    void setRotation(iDynTree::Rotation& newRot);
+    void setRotation(const iDynTree::Rotation& newRot);
 
     /*!
      * Return the current constrained value of the Transform.
@@ -224,6 +225,12 @@ public:
      * @return the current rotation parametrization
      */
     enum iDynTree::InverseKinematicsTreatTargetAsConstraint targetResolutionMode() const;
+
+    /*! Set if the task is active or not */
+    void setActive(const bool isActive);
+
+    /*! Get if the task is active or not */
+    bool isActive() const;
 
 };
 

--- a/src/inverse-kinematics/src/InverseKinematics.cpp
+++ b/src/inverse-kinematics/src/InverseKinematics.cpp
@@ -254,6 +254,24 @@ namespace iDynTree {
         return true;
     }
 
+    bool  InverseKinematics::isFrameConstraintActive(const std::string& frameName) const
+    {
+        iDynTree::LinkIndex frameIndex = IK_PIMPL(m_pimpl)->m_dynamics.getFrameIndex(frameName);
+        if (frameIndex < 0)
+        {
+            return false;
+        }
+
+        internal::kinematics::TransformMap::iterator it = IK_PIMPL(m_pimpl)->m_constraints.find(frameIndex);
+        if (it == IK_PIMPL(m_pimpl)->m_constraints.end())
+        {
+            return false;
+        }
+
+        return it->second.isActive();
+    }
+
+
     bool InverseKinematics::addCenterOfMassProjectionConstraint(const std::string &firstSupportFrame,
                                                                 const Polygon &firstSupportPolygon,
                                                                 const iDynTree::Direction xAxisOfPlaneInWorld,

--- a/src/inverse-kinematics/src/TransformConstraint.cpp
+++ b/src/inverse-kinematics/src/TransformConstraint.cpp
@@ -20,6 +20,7 @@ namespace kinematics {
     , m_posWeight(1.0)
     , m_rotWeight(1.0)
     , m_resolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraintNone)
+    , m_isActive(true)
     {}
 
     TransformConstraint TransformConstraint::positionConstraint(const std::string& frameName, const iDynTree::Position &position, const double posWeight)
@@ -77,18 +78,28 @@ namespace kinematics {
     bool TransformConstraint::hasRotationConstraint() const { return m_type == TransformConstraintTypeRotation || m_type == TransformConstraintTypeFullTransform; }
 
     const iDynTree::Position& TransformConstraint::getPosition() const { return m_transform.getPosition(); }
-    void TransformConstraint::setPosition(iDynTree::Position& newPos) { m_transform.setPosition(newPos); }
+    void TransformConstraint::setPosition(const iDynTree::Position& newPos) { m_transform.setPosition(newPos); }
     const iDynTree::Rotation& TransformConstraint::getRotation() const { return m_transform.getRotation(); }
-    void TransformConstraint::setRotation(iDynTree::Rotation& newRot) { m_transform.setRotation(newRot); }
+    void TransformConstraint::setRotation(const iDynTree::Rotation& newRot) { m_transform.setRotation(newRot); }
     const iDynTree::Transform& TransformConstraint::getTransform() const { return m_transform; }
     const std::string& TransformConstraint::getFrameName() const { return m_frameName; }
     const double TransformConstraint::getPositionWeight() const { return m_posWeight; }
     void TransformConstraint::setPositionWeight(const double newPosWeight) { if (newPosWeight >= 0.0) m_posWeight = newPosWeight; }
     const double TransformConstraint::getRotationWeight() const { return m_rotWeight; }
     void TransformConstraint::setRotationWeight(const double newRotWeight) { if (newRotWeight >= 0.0) m_posWeight = newRotWeight; }
-    
+
     void TransformConstraint::setTargetResolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraint mode){ m_resolutionMode = mode; }
     iDynTree::InverseKinematicsTreatTargetAsConstraint TransformConstraint::targetResolutionMode() const{ return m_resolutionMode; }
-    
+
+    void TransformConstraint::setActive(const bool isActive)
+    {
+        m_isActive = isActive;
+    }
+
+    bool TransformConstraint::isActive() const
+    {
+        return m_isActive;
+    }
+
 }
 }

--- a/src/inverse-kinematics/tests/InverseKinematicsUnitTest.cpp
+++ b/src/inverse-kinematics/tests/InverseKinematicsUnitTest.cpp
@@ -554,8 +554,11 @@ void COMConvexHullConstraintWithSwitchingConstraints()
     // We deactivate both constraints. The solution should be still all the joints to zero
     ok = ik.deactivateFrameConstraint("l_sole");
     ASSERT_IS_TRUE(ok);
+    ASSERT_IS_FALSE(ik.isFrameConstraintActive("l_sole"));
+
     ok = ik.deactivateFrameConstraint("r_sole");
     ASSERT_IS_TRUE(ok);
+    ASSERT_IS_FALSE(ik.isFrameConstraintActive("r_sole"));
 
     tic = clock();
     ik.setFullJointsInitialCondition(&identityTransform, &refereceJointPos);
@@ -571,8 +574,11 @@ void COMConvexHullConstraintWithSwitchingConstraints()
     // We only activate the left sole constraint, placing the "world" on the left_sole
     ok = ik.activateFrameConstraint("l_sole", Transform::Identity());
     ASSERT_IS_TRUE(ok);
+    ASSERT_IS_TRUE(ik.isFrameConstraintActive("l_sole"));
+
     ok = ik.deactivateFrameConstraint("r_sole");
     ASSERT_IS_TRUE(ok);
+    ASSERT_IS_FALSE(ik.isFrameConstraintActive("r_sole"));
 
     // We solve the problem and verify that the y-component of com projected in the l_sole frame is less than stripWidth/2
     tic = clock();
@@ -589,8 +595,11 @@ void COMConvexHullConstraintWithSwitchingConstraints()
     // We only activate the right sole constraint, placing the "world" on the left_sole
     ok = ik.activateFrameConstraint("r_sole", Transform::Identity());
     ASSERT_IS_TRUE(ok);
+    ASSERT_IS_TRUE(ik.isFrameConstraintActive("r_sole"));
+
     ok = ik.deactivateFrameConstraint("l_sole");
     ASSERT_IS_TRUE(ok);
+    ASSERT_IS_FALSE(ik.isFrameConstraintActive("l_sole"));
 
     // We solve the problem and verify that the y-component of com projected in the l_sole frame is less than stripWidth/2
     tic = clock();

--- a/src/inverse-kinematics/tests/InverseKinematicsUnitTest.cpp
+++ b/src/inverse-kinematics/tests/InverseKinematicsUnitTest.cpp
@@ -8,6 +8,7 @@
 #include <iDynTree/InverseKinematics.h>
 #include <iDynTree/KinDynComputations.h>
 
+#include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/TestUtils.h>
 #include <iDynTree/Model/JointState.h>
 #include <iDynTree/Model/ModelTestUtils.h>
@@ -19,6 +20,8 @@
 #include <cstdlib>
 
 #include <ctime>
+
+using namespace iDynTree;
 
 /**
  * Return the current time in seconds, with respect
@@ -474,6 +477,135 @@ void simpleHumanoidWholeBodyIKCoMandChestConsistency(const iDynTree::InverseKine
     return;
 }
 
+void COMConvexHullConstraintWithSwitchingConstraints()
+{
+    // Load an humanoid model
+    iDynTree::InverseKinematics ik;
+
+    ik.setMaxIterations(500);
+    ik.setVerbosity(0);
+
+    // Use the requested parametrization
+    ik.setRotationParametrization(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
+
+    //ik.setCostTolerance(1e-4);
+    //ik.setConstraintsTolerance(1e-5);
+
+    bool ok = ik.loadModelFromFile(getAbsModelPath("iCubGenova02.urdf"));
+    ASSERT_IS_TRUE(ok);
+
+    // Also create a KinDynComputation object for some forward kinematics
+    KinDynComputations kinDynRef;
+    ok = kinDynRef.loadRobotModel(ik.fullModel());
+    ASSERT_IS_TRUE(ok);
+    KinDynComputations kinDynsol;
+    ok = kinDynsol.loadRobotModel(ik.fullModel());
+    ASSERT_IS_TRUE(ok);
+
+
+    // We use the joints all set to 0 as a reference position
+    Transform identityTransform = Transform::Identity();
+    VectorDynSize refereceJointPos(ik.fullModel().getNrOfDOFs());
+    refereceJointPos.zero();
+
+    // For the elbow we set another position as 0 is outside the limits
+    const Model& model = ik.fullModel();
+    int lElbowDofIndex = model.getJoint(model.getJointIndex("l_elbow"))->getDOFsOffset();
+    refereceJointPos(lElbowDofIndex) = 0.5;
+    int rElbowDofIndex = model.getJoint(model.getJointIndex("r_elbow"))->getDOFsOffset();
+    refereceJointPos(rElbowDofIndex) = 0.5;
+
+    kinDynRef.setJointPos(refereceJointPos);
+
+    // Add a postural "task" to the IK
+    ik.setDesiredFullJointsConfiguration(refereceJointPos, 1e-2);
+
+    // Add two frames constraints on both soles (assuming initially that l_sole == world)
+    ik.addFrameConstraint("l_sole", Transform::Identity());
+    ik.addFrameConstraint("r_sole", kinDynRef.getRelativeTransform("l_sole", "r_sole"));
+
+    // Add the COM convex hull constraint, where the polygon are just a long strip of 2 centimeters at the origin of the frames
+    // The COM projection plane will always be the world XY plane, so the world plane need to be always coincident with a support sole
+    iDynTree::Direction xAxis(1.0, 0.0, 0.0);
+    iDynTree::Direction yAxis(0.0, 1.0, 0.0);
+    // The strips are long on the x direction so we don't need to care where the COM is actually in the X direction
+    double stripWidth = 0.02;
+    ik.addCenterOfMassProjectionConstraint("l_sole", iDynTree::Polygon::XYRectangleFromOffsets(1, 1, stripWidth/2, stripWidth/2),
+                                           "r_sole", iDynTree::Polygon::XYRectangleFromOffsets(1, 1, stripWidth/2, stripWidth/2),
+                                           xAxis, yAxis);
+
+    // Solve the problem in this case: as the com projection of all the joint set to 0 is in in between the soles
+    // the inverse kinematics should give the joints all to zero as the solution
+    clock_t tic = clock();
+    Transform initialCondition = kinDynRef.getRelativeTransform("l_sole", "root_link");
+    ik.setFullJointsInitialCondition(&initialCondition, &refereceJointPos);
+    //ik.setVerbosity(5);
+    ok = ik.solve();
+    ASSERT_IS_TRUE(ok);
+    std::cerr << "COMConvexHullConstraintWithSwitchingConstraints: IK with both constraints solved in " << clockDurationInSeconds(clock() - tic) << "s" << std::endl;
+
+    Transform baseSolution;
+    VectorDynSize jointPosSolution(ik.fullModel().getNrOfDOFs());
+    ik.getFullJointsSolution(baseSolution, jointPosSolution);
+
+    ASSERT_EQUAL_VECTOR_TOL(refereceJointPos,
+                            jointPosSolution, 1e-4);
+
+    // We deactivate both constraints. The solution should be still all the joints to zero
+    ok = ik.deactivateFrameConstraint("l_sole");
+    ASSERT_IS_TRUE(ok);
+    ok = ik.deactivateFrameConstraint("r_sole");
+    ASSERT_IS_TRUE(ok);
+
+    tic = clock();
+    ik.setFullJointsInitialCondition(&identityTransform, &refereceJointPos);
+    ok = ik.solve();
+    std::cerr << "COMConvexHullConstraintWithSwitchingConstraints: IK with no constraints solved in " << clockDurationInSeconds(clock() - tic) << "s" << std::endl;
+    ASSERT_IS_TRUE(ok);
+
+    ik.getFullJointsSolution(baseSolution, jointPosSolution);
+
+    ASSERT_EQUAL_VECTOR_TOL(refereceJointPos,
+                            jointPosSolution, 1e-3);
+
+    // We only activate the left sole constraint, placing the "world" on the left_sole
+    ok = ik.activateFrameConstraint("l_sole", Transform::Identity());
+    ASSERT_IS_TRUE(ok);
+    ok = ik.deactivateFrameConstraint("r_sole");
+    ASSERT_IS_TRUE(ok);
+
+    // We solve the problem and verify that the y-component of com projected in the l_sole frame is less than stripWidth/2
+    tic = clock();
+    ik.setFullJointsInitialCondition(&identityTransform, &refereceJointPos);
+    ok = ik.solve();
+    std::cerr << "COMConvexHullConstraintWithSwitchingConstraints: IK with l_sole constraint solved in " << clockDurationInSeconds(clock() - tic) << "s" << std::endl;
+    ASSERT_IS_TRUE(ok);
+
+    ik.getFullJointsSolution(baseSolution, jointPosSolution);
+    kinDynsol.setJointPos(jointPosSolution);
+    Position com_l_sole = kinDynsol.getWorldTransform("l_sole").inverse()*(kinDynsol.getCenterOfMassPosition());
+    ASSERT_IS_TRUE(std::abs(com_l_sole(1)) < stripWidth/2.0 + 1e-9);
+
+    // We only activate the right sole constraint, placing the "world" on the left_sole
+    ok = ik.activateFrameConstraint("r_sole", Transform::Identity());
+    ASSERT_IS_TRUE(ok);
+    ok = ik.deactivateFrameConstraint("l_sole");
+    ASSERT_IS_TRUE(ok);
+
+    // We solve the problem and verify that the y-component of com projected in the l_sole frame is less than stripWidth/2
+    tic = clock();
+    ik.setFullJointsInitialCondition(&identityTransform, &refereceJointPos);
+    ok = ik.solve();
+    std::cerr << "COMConvexHullConstraintWithSwitchingConstraints: IK with r_sole constraint solved in " << clockDurationInSeconds(clock() - tic) << "s" << std::endl;
+    ASSERT_IS_TRUE(ok);
+
+    ik.getFullJointsSolution(baseSolution, jointPosSolution);
+    kinDynsol.setJointPos(jointPosSolution);
+    Position com_r_sole = kinDynsol.getWorldTransform("r_sole").inverse()*(kinDynsol.getCenterOfMassPosition());
+    ASSERT_IS_TRUE(std::abs(com_r_sole(1)) < stripWidth/2.0 + 1e-9);
+
+}
+
 int main()
 {
     // Improve repetability (at least in the same platform)
@@ -483,7 +615,6 @@ int main()
 
     // This is not working at the moment, there is some problem with quaternion constraints
     //simpleChainIK(10,iDynTree::InverseKinematicsRotationParametrizationQuaternion);
-
     simpleHumanoidWholeBodyIKConsistency(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
     simpleHumanoidWholeBodyIKCoMConsistency(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw, iDynTree::InverseKinematicsTreatTargetAsConstraintNone);
     simpleHumanoidWholeBodyIKCoMConsistency(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw, iDynTree::InverseKinematicsTreatTargetAsConstraintFull);
@@ -493,6 +624,8 @@ int main()
         std::cerr << "Removing " << i << " Dofs" << std::endl;
         simpleHumanoidWholeBodyIKCoMConsistency(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw, iDynTree::InverseKinematicsTreatTargetAsConstraintFull, i);
     }
+
+    COMConvexHullConstraintWithSwitchingConstraints();
 
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Furthermore, modify the COM Convex Hull constraints to take in consideration only the constraints that are active at a given moment.

The best documentation for now on how to use this feature is the unit test COMConvexHullConstraintWithSwitchingConstraints ( https://github.com/robotology/idyntree/pull/389/files#diff-955ad995d9a7c401e7404ad8dac5e534R480 ) .

As several other functionalities added in InverseKinematics, also this one is adding technical debt, but unfortunately we need this functionality.  Tagging issue https://github.com/robotology/idyntree/issues/282 to keep track of this. 

Sorry @francesco-romano and @S-Dafarra , this PR will probably conflict with https://github.com/robotology/idyntree/pull/386 , but this functionality is required for a close demo, so I am going to merge this before and later I will take care to rebase and merge with https://github.com/robotology/idyntree/pull/386 .