### PR TITLE
Adding Schmitt Trigger based contact state detection for Contact Swit…

### DIFF
--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -10,7 +10,10 @@ set(IDYNTREE_ESTIMATION_HEADERS include/iDynTree/Estimation/BerdyHelper.h
                                 include/iDynTree/Estimation/ExternalWrenchesEstimation.h
                                 include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h
                                 include/iDynTree/Estimation/SimpleLeggedOdometry.h
-                                include/iDynTree/Estimation/BerdySparseMAPSolver.h)
+                                include/iDynTree/Estimation/BerdySparseMAPSolver.h
+                                include/iDynTree/Estimation/SchmittTrigger.h
+                                include/iDynTree/Estimation/ContactStateMachine.h
+                                include/iDynTree/Estimation/BipedFootContactClassifier.h)
 
 set(IDYNTREE_ESTIMATION_PRIVATE_INCLUDES )
 
@@ -18,7 +21,10 @@ set(IDYNTREE_ESTIMATION_SOURCES src/BerdyHelper.cpp
                                 src/ExternalWrenchesEstimation.cpp
                                 src/ExtWrenchesAndJointTorquesEstimator.cpp
                                 src/SimpleLeggedOdometry.cpp
-                                src/BerdySparseMAPSolver.cpp)
+                                src/BerdySparseMAPSolver.cpp
+                                src/SchmittTrigger.cpp
+                                src/ContactStateMachine.cpp
+                                src/BipedFootContactClassifier.cpp)
 
 SOURCE_GROUP("Source Files" FILES ${IDYNTREE_ESTIMATION_SOURCES})
 SOURCE_GROUP("Header Files" FILES ${IDYNTREE_ESTIMATION_HEADERS})

--- a/src/estimation/include/iDynTree/Estimation/BipedFootContactClassifier.h
+++ b/src/estimation/include/iDynTree/Estimation/BipedFootContactClassifier.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro, Prashanth Ramadoss
+ * email: silvio.traversaro@iit.it, prashanth.ramadoss@iit.it
+ *
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+ */
+#ifndef IDYNTREE_BIPED_FOOT_CONTACT_CLASSIFIER_H
+#define IDYNTREE_BIPED_FOOT_CONTACT_CLASSIFIER_H
+
+#include <memory>
+#include "ContactStateMachine.h"
+
+
+namespace iDynTree
+{
+    /**
+     * Enumeration of switching pattern
+     */
+    enum SwitchingPattern
+    {
+        /**
+         * Switching active foot between left and right at every double stance 
+         */
+        ALTERNATE_CONTACT,
+        
+        /**
+         * Setting active foot to the one that made contact most recently  
+         * @warning this pattern remains unimplemented in the current version of this class
+         *          using this pattern will always return left foot as the active foot
+         */
+        LATEST_ACTIVE_CONTACT,
+        
+        /**
+         * Fixing active foot to the default foot defined by the user  
+         * @warning this pattern remains unimplemented in the current version of this class
+         *          using this pattern will always return left foot as the active foot
+         */
+        DEFAULT_CONTACT
+    };
+
+   /* Foot Contact Classifier class for determining the primary foot in contact
+    * with the ground surface. Contains contact state machines for each foot: left and right,
+    * and implements the Schmitt Trigger thresholding on each foot to determine the primary
+    * foot which is in contact according to a switching pattern criteria. 
+    * The switching pattern is primarily used to change the frames of reference for the Legged Odometry (LO) 
+    * while one of the two foot breaks contact with the ground surface, since LO assumes that atleast one
+    * foot is in contact with ground at any instant of time. However, it is also used to assign 
+    * the primary foot in case of double stance.
+    * 
+    * In the current version of this class, switching logic is implemented only for 
+    * ALTERNATE_CONTACT patterns vastly considered during walking tasks. This class is aimed
+    * to be extended towards other switching patterns like LATEST_ACTIVE_CONTACT, DEFAULT_CONTACT
+    * for implementation along side different task based controllers. 
+    */    
+    class BipedFootContactClassifier
+    {
+    public:
+       /**
+        * Enumeration of foot in contact
+        */
+        enum contactFoot
+        {
+            LEFT_FOOT,   // 0
+            RIGHT_FOOT,  // 1
+            UNKNOWN_FOOT // 2
+        };
+        
+        /**
+         * Constructor
+         * @params leftFootSchmittParams const ref to struct containing parameters for the left foot schmitt trigger device
+         * @params rightFootSchmittParams const ref to struct containing parameters for the right foot schmitt trigger device
+         */
+        BipedFootContactClassifier(const SchmittParams& leftFootSchmittParams, const SchmittParams& rightFootSchmittParams);
+       
+        /**
+         * Updates the contact state machine for both the foot, determines the current state
+         * and detects foot transition for setting the primary foot(active foot)
+         * @param currentTime time
+         * @param leftNormalForce z-component of the force acting on the left foot 
+         * @param rightNormalForce z-component of the force acting on the right foot 
+         */
+        void updateFootContactState(double currentTime, double leftFootNormalForce, double rightFootNormalForce);
+        
+        /**
+         * Get the primary foot
+         * @return contactFoot left, right or unknown
+         */
+        contactFoot getPrimaryFoot() { return m_primaryFoot; }
+        
+        /**
+         * Get left foot contact state
+         * @return true if in contact, false otherwise
+         */
+        bool getLeftFootContactState() { return m_leftFootContactState; }
+        
+        /**
+         * Get right foot contact state
+         * @return true if in contact, false otherwise
+         */
+        bool getRightFootContactState() { return m_rightFootContactState; }
+        
+        /**
+         * set switching pattern to be considered for determining primary foot
+         * @warning no default value is considered, remember to call this method after instantiation
+         * @param pattern switching pattern
+         */
+        void setContactSwitchingPattern(SwitchingPattern pattern) { m_pattern = pattern; } 
+       
+        // unique pointer to contact state machine for left foot
+        std::unique_ptr<ContactStateMachine> m_leftFootContactClassifier;
+        
+        // unique pointer to contact state machine for right foot
+        std::unique_ptr<ContactStateMachine> m_rightFootContactClassifier;
+    
+    private:        
+        /**
+         * Determine the primary foot depending on the switching pattern
+         * compares the contact transition modes on each foot and 
+         * sets the primary foot accordingly
+         */
+        void detectFeetTransition();
+       
+        // active/primary foot
+        contactFoot m_primaryFoot;
+        
+        // left foot contact state
+        bool m_leftFootContactState;
+        
+        // right foot contact state
+        bool m_rightFootContactState;
+
+        // switching pattern
+        SwitchingPattern m_pattern;
+    };
+}
+#endif

--- a/src/estimation/include/iDynTree/Estimation/ContactStateMachine.h
+++ b/src/estimation/include/iDynTree/Estimation/ContactStateMachine.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro, Prashanth Ramadoss
+ * email: silvio.traversaro@iit.it, prashanth.ramadoss@iit.it
+ *
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+ */
+
+#ifndef IDYNTREE_CONTACTSTATEMACHINE_H
+#define IDYNTREE_CONTACTSTATEMACHINE_H
+#include <iostream>
+#include <memory>
+#include "SchmittTrigger.h"
+
+namespace iDynTree
+{
+    /**
+     * struct to hold schmitt trigger device parameters
+     */
+    struct SchmittParams
+    {
+        double stableTimeContactMake;
+        double stableTimeContactBreak;
+        double contactMakeForceThreshold;
+        double contactBreakForceThreshold;
+    };
+    
+   /**
+    * Contact State Machine class for binary contact state detection
+    * Contains a Schmitt Trigger device for updating the contact states
+    * using the contact normal force acting on the contact link and
+    * Determines contact transitions using simple binary switching logic
+    * 
+    * Can be used to determine stable contacts, contact breaking and contact making.
+    * The parameters to the Schmitt Trigger are passed as a struct and is the Schmitt 
+    * Trigger is instantiated in the class constructor. 
+    * 
+    * NOTE: There are no default parameters to the Schmitt Trigger. These parameters are set through 
+    * the constructor during instantiation.
+    * 
+    * This class does not exactly abstract the Schmitt Trigger class. Schmitt Trigger methods are still accessible through 
+    * the m_contactSchmitt object. This class uses a generic Schmitt Trigger object and augments its functionality
+    * specific to physical contacts based scenarios.
+    */
+    class ContactStateMachine
+    {
+    public:
+        /**
+         * Enumeration of contact transitions
+         */
+        enum contactTransition
+        {
+            /**
+             * previous state: off contact, current state: off contact
+             */
+            STABLE_OFFCONTACT, // 0
+            
+            /**
+             * previous state: on contact, current state: on contact
+             */
+            STABLE_ONCONTACT,  // 1
+            
+            /**
+             * previous state: on contact, current state: off contact
+             */
+            CONTACT_BREAK,     // 2
+            
+            /**
+             * previous state: off contact, current state: on contact
+             */
+            CONTACT_MAKE       // 3
+        };
+        
+        /**
+         * Constructor
+         * @param s const reference to a struct containing schmitt trigger device parameters
+         */
+        ContactStateMachine(const SchmittParams& s);
+                
+        /**
+         * Calls schmitt trigger device update 
+         * @param currentTime time
+         * @param contactNormalForce normal force acting on the contact link in consideration
+         */
+        void contactMeasurementUpdate(double currentTime, double contactNormalForce);
+        
+        /**
+         * Calls schmitt trigger device reset 
+         */
+        void resetDevice() { m_contactSchmitt.get()->resetDevice(); }
+        
+        /**
+         * Get current contact state
+         * @return true, if in contact, false otherwise
+         */
+        bool contactState() { return m_currentState; }
+        
+        /**
+         * Determines contact transitions using simple binary switching logic
+         * @return contactTransition enumerated value
+         */
+        contactTransition contactTransitionMode();
+        
+        /**
+         * Get time of last contact state update
+         * @return time
+         */
+        double lastUpdateTime();
+        
+        /**
+         * unique pointer to the schmitt trigger device
+         */
+        std::unique_ptr<SchmittTrigger> m_contactSchmitt;
+    private:
+        // previous contact state
+        bool m_previousState;
+        
+        // current contact state
+        bool m_currentState;
+        
+        // transtion mode based on previous and current contact states
+        int m_tranisitionMode;
+        
+    };
+}
+#endif

--- a/src/estimation/include/iDynTree/Estimation/SchmittTrigger.h
+++ b/src/estimation/include/iDynTree/Estimation/SchmittTrigger.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro, Prashanth Ramadoss
+ * email: silvio.traversaro@iit.it, prashanth.ramadoss@iit.it
+ *
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+ */
+
+#ifndef IDYNTREE_SCHMITT_TRIGGER_H
+#define IDYNTREE_SCHMITT_TRIGGER_H
+
+#include <iostream>
+namespace iDynTree
+{
+   /**
+    * Schmitt Trigger class for binary state detection 
+    * This device is used to obtain a binary state (ON/OFF) at 
+    * some time instant depending on a value inputted to the device.
+    * It is initialized with 4 parameters,
+    *
+    * |     Parameter    | Type |                              Description                             |
+    * |:----------------:|:----:|:--------------------------------------------------------------------:|
+    * |stableOFFTime     |double|Time to elapse to switch to OFF state, once low threshold is triggered|
+    * |stableONTime      |double|Time to elapse to switch to ON state, once high threshold is triggered|
+    * |lowValueThreshold |double|                 Threshold Value to turn state OFF                    |
+    * |highValueThreshold|double|                 Threshold Value to turn state ON                     |
+    * 
+    * The device is first configured with the user-defined parameter settings, but is not activated until 
+    * the first call of updateDevice method. The updateDevice method must be called at every iteration with 
+    * the current time and the value to be compared, for continuously updating the binary state of the device.
+    * 
+    * For instance, if the current state is OFF and there is a call to updateDevice with current time and an input 
+    * value greater than the highValueThreshold, then a timer is activated and is updated at every call to updateMethod.
+    * If there are consecutive calls to the updateMethod with input values greater than the highValueThreshold,
+    * until the timer lapses stableONTime, then the state is switched to ON, otherwise it is remains OFF.
+    * 
+    * NOTE: Time is specified relative to the process that is instantiating this device.
+    * Default state is set to ON during instantiation. This can be changed accordingly using the setInitialState method.
+    *
+    * NOTE: There are no default parameters to the Schmitt Trigger. These parameters are set through 
+    * the constructor during instantiation.
+    */
+    class SchmittTrigger
+    {
+    public:
+        /**
+         * Constructor
+         * @param stableOFFTime time to elapse to switch to OFF state
+         * @param stableONTime time to elapse to switch to ON state
+         * @param lowValueThreshold threshold value to turn state OFF
+         * @param highValueThreshold threshold value to turn state ON
+         */
+        SchmittTrigger(double stableOFFTime, 
+                       double stableONTime, 
+                       double lowValueThreshold, 
+                       double highValueThreshold);
+               
+        /**
+         * Sets the schmitt trigger settings to default values
+         */
+        void resetDevice();
+        
+        /**
+         * Update the device state with the latest time and input measurement
+         * @param currentTime current time
+         * @param rawValue input measurement
+         */
+        void updateDevice(double currentTime, double rawValue);
+        
+        /**
+         * @name Setters
+         */
+        //@{
+        
+        /**
+         * Configures the Schmitt Trigger parameters 
+         * (can be called after instantiation, to change the parameters)
+         * @param stableOFFTime time to elapse to switch to OFF state
+         * @param stableONTime time to elapse to switch to ON state
+         * @param lowValueThreshold threshold value to turn state OFF
+         * @param highValueThreshold threshold value to turn state ON
+         */
+        void configure(double stableOFFTime, 
+                       double stableONTime, 
+                       double lowValueThreshold, 
+                       double highValueThreshold);
+        
+        /**
+         * set required time to elapse to switch to OFF state
+         * @param stableOFFTime 
+         */
+        void setStableOFFTime(double stableOFFTime) { m_stableOFFTime = stableOFFTime; }
+        
+        /**
+         * set required time to elapse to switch to ON state
+         * @param stableONTime 
+         */
+        void setStableONTime(double stableONTime) { m_stableONTime = stableONTime; }
+
+        /**
+         * set low threshold value to trigger OFF state detection
+         * @param lowValueThreshold 
+         */
+        void setLowValueThreshold(double lowValueThreshold) { m_lowValueThreshold = lowValueThreshold; }
+        
+        /**
+         * set high threshold value to trigger ON state detection
+         * @param highValueThreshold 
+         */
+        void setHighValueThreshold(double highValueThreshold) { m_highValueThreshold = highValueThreshold; }
+
+        /**
+         * set initial state
+         * @param state binary state true/false
+         */
+        void setInitialState(bool state) { m_currentState = state; }
+        //@}
+    
+        /**
+         * @name Getters
+         */
+        //@{
+        
+        /**
+         * get current state
+         * @return binary state true/false
+         */
+        bool getState() { return m_currentState; }
+        
+        /**
+         * get time elapsed since the first update of the device
+         * @return time
+         */
+        double getElapsedTime() { return m_previousTime; }
+        //@}
+        
+        
+        /**
+         * @name Verbose
+         */
+        //@{
+        void setVerbose() {m_verbose = 1;}
+        void unsetVerbose() {m_verbose = 0;}
+        //@}
+    private:
+   
+        /**
+         * @name State 
+         */
+        //@{
+        bool m_currentState;
+        double m_previousTime;
+        double m_timer;
+        //@}
+        
+         /**
+         * @name Device Parameters
+         */
+        //@{
+        double m_stableOFFTime;
+        double m_stableONTime;
+        double m_highValueThreshold;
+        double m_lowValueThreshold; 
+        //@}
+        
+        /**
+         * @name Input
+         */
+        //@{   
+        double m_rawValue;
+        //@}
+        
+        
+        // Verbose flag
+        int m_verbose;
+
+    };
+}
+
+#endif

--- a/src/estimation/src/BipedFootContactClassifier.cpp
+++ b/src/estimation/src/BipedFootContactClassifier.cpp
@@ -1,0 +1,104 @@
+#include "iDynTree/Estimation/BipedFootContactClassifier.h"
+
+namespace iDynTree 
+{
+
+BipedFootContactClassifier::BipedFootContactClassifier(const SchmittParams& leftFootSchmittParams, 
+                                             const SchmittParams& rightFootSchmittParams) : m_primaryFoot(LEFT_FOOT),                                                                                          
+                                                                                            m_leftFootContactState(true),
+                                                                                            m_rightFootContactState(true),
+                                                                                            m_pattern(ALTERNATE_CONTACT)
+{
+     m_leftFootContactClassifier = std::unique_ptr<ContactStateMachine>( new ContactStateMachine(leftFootSchmittParams));
+     m_rightFootContactClassifier = std::unique_ptr<ContactStateMachine>( new ContactStateMachine(rightFootSchmittParams));
+}
+
+
+void BipedFootContactClassifier::updateFootContactState(double currentTime, double leftFootNormalForce, double rightFootNormalForce)
+{
+    m_leftFootContactClassifier.get()->contactMeasurementUpdate(currentTime, leftFootNormalForce);
+    m_rightFootContactClassifier.get()->contactMeasurementUpdate(currentTime, rightFootNormalForce);
+    m_leftFootContactState = m_leftFootContactClassifier.get()->contactState();
+    m_rightFootContactState = m_leftFootContactClassifier.get()->contactState();
+    
+    detectFeetTransition();
+}
+
+
+void BipedFootContactClassifier::detectFeetTransition()
+{
+    ContactStateMachine::contactTransition leftFootTransition = m_leftFootContactClassifier.get()->contactTransitionMode();
+    ContactStateMachine::contactTransition rightFootTransition = m_rightFootContactClassifier.get()->contactTransitionMode();
+    
+    switch (m_pattern)
+    {
+        case SwitchingPattern::ALTERNATE_CONTACT:
+            if (m_primaryFoot == LEFT_FOOT)
+            {                
+                if ((leftFootTransition == ContactStateMachine::CONTACT_BREAK && rightFootTransition == ContactStateMachine::CONTACT_MAKE) 
+                    || (leftFootTransition == ContactStateMachine::CONTACT_BREAK && rightFootTransition == ContactStateMachine::STABLE_ONCONTACT))
+                {
+                    m_primaryFoot = RIGHT_FOOT; 
+                }
+                else if (leftFootTransition == ContactStateMachine::STABLE_ONCONTACT || rightFootTransition == ContactStateMachine::STABLE_ONCONTACT)
+                {
+                    m_primaryFoot = LEFT_FOOT;
+                }
+                else if (leftFootTransition == ContactStateMachine::STABLE_OFFCONTACT)
+                {
+                    m_primaryFoot = RIGHT_FOOT;
+                    if (rightFootTransition == ContactStateMachine::STABLE_OFFCONTACT)
+                    {
+                        m_primaryFoot = UNKNOWN_FOOT;
+                    }
+                }
+            }
+            else if (m_primaryFoot == RIGHT_FOOT)
+            {                
+                if ((rightFootTransition == ContactStateMachine::CONTACT_BREAK && leftFootTransition == ContactStateMachine::CONTACT_MAKE)
+                    || (rightFootTransition == ContactStateMachine::CONTACT_BREAK && leftFootTransition == ContactStateMachine::STABLE_ONCONTACT))
+                {
+                    m_primaryFoot = LEFT_FOOT;
+                }
+                
+                else if (rightFootTransition == ContactStateMachine::STABLE_ONCONTACT || leftFootTransition == ContactStateMachine::STABLE_ONCONTACT)
+                {
+                    m_primaryFoot = RIGHT_FOOT;
+                }
+                
+                else if (rightFootTransition == ContactStateMachine::STABLE_OFFCONTACT)
+                {
+                    m_primaryFoot = LEFT_FOOT;
+                    if (leftFootTransition == ContactStateMachine::STABLE_OFFCONTACT)
+                    {
+                        m_primaryFoot = UNKNOWN_FOOT;
+                    }
+                }
+            }
+            else if (m_primaryFoot == UNKNOWN_FOOT)
+            {
+                // check if left foot has become active first, then check right foot
+                if (leftFootTransition == ContactStateMachine::CONTACT_MAKE || leftFootTransition == ContactStateMachine::STABLE_ONCONTACT)
+                {
+                    m_primaryFoot = LEFT_FOOT;
+                }
+                else if (rightFootTransition == ContactStateMachine::CONTACT_MAKE || rightFootTransition == ContactStateMachine::STABLE_ONCONTACT)
+                {
+                    m_primaryFoot = RIGHT_FOOT;
+                }
+            }
+            break;
+            
+        case SwitchingPattern::LATEST_ACTIVE_CONTACT:
+            m_primaryFoot = LEFT_FOOT;
+            break;
+            
+        case SwitchingPattern::DEFAULT_CONTACT:
+            m_primaryFoot = LEFT_FOOT;
+            break;
+    }
+}    
+
+    
+}
+

--- a/src/estimation/src/ContactStateMachine.cpp
+++ b/src/estimation/src/ContactStateMachine.cpp
@@ -1,0 +1,44 @@
+#include "iDynTree/Estimation/ContactStateMachine.h"
+namespace iDynTree
+{
+
+ContactStateMachine::ContactStateMachine(const SchmittParams& s) : m_previousState(true), 
+                                                                   m_currentState(true)                                                                   
+{
+    m_contactSchmitt = std::unique_ptr<SchmittTrigger>(new SchmittTrigger(s.stableTimeContactBreak, 
+                                                                          s.stableTimeContactMake,
+                                                                          s.contactBreakForceThreshold,
+                                                                          s.contactMakeForceThreshold));
+    m_contactSchmitt.get()->setInitialState(m_previousState);
+}
+
+
+ContactStateMachine::contactTransition ContactStateMachine::contactTransitionMode()
+{
+    if (m_previousState == 0 && m_currentState == 0)
+        return STABLE_OFFCONTACT; // 0
+    
+    if (m_previousState == 0 && m_currentState == 1)
+        return CONTACT_MAKE;      // 3
+    
+    if (m_previousState == 1 && m_currentState == 0)
+        return CONTACT_BREAK;     // 2
+    
+    if (m_previousState == 1 && m_currentState == 1)
+        return STABLE_ONCONTACT;  // 1
+}
+
+double ContactStateMachine::lastUpdateTime()
+{
+    return m_contactSchmitt.get()->getElapsedTime();
+}
+
+void ContactStateMachine::contactMeasurementUpdate(double currentTime, double contactNormalForce)
+{
+    m_contactSchmitt.get()->updateDevice(currentTime, contactNormalForce);
+    m_previousState = m_currentState;
+    m_currentState = m_contactSchmitt.get()->getState();
+}
+    
+}
+

--- a/src/estimation/src/SchmittTrigger.cpp
+++ b/src/estimation/src/SchmittTrigger.cpp
@@ -1,0 +1,104 @@
+#include "iDynTree/Estimation/SchmittTrigger.h"
+
+namespace iDynTree 
+{
+
+SchmittTrigger::SchmittTrigger(double stableOFFTime, double stableONTime, double lowValueThreshold, double highValueThreshold)
+{
+    configure(stableOFFTime, stableONTime, highValueThreshold, lowValueThreshold);
+    resetDevice();
+}
+
+
+void SchmittTrigger::resetDevice()
+{
+    m_timer = 0;
+    m_currentState = true;
+    m_rawValue = 0.;
+    m_previousTime = -1;
+    m_verbose = 0;
+}
+
+
+void SchmittTrigger::configure(double stableOFFTime, double stableONTime, double lowValueThreshold, double highValueThreshold)
+{
+    setStableOFFTime(stableOFFTime);
+    setStableONTime(stableONTime);
+    setHighValueThreshold(highValueThreshold);
+    setLowValueThreshold(lowValueThreshold);
+}
+
+void SchmittTrigger::updateDevice(double currentTime, double rawValue)
+{
+    if (m_previousTime < 0)
+    {
+        if (currentTime > 0)
+        {
+            m_previousTime = 0;
+        }
+        else
+        {
+            m_previousTime = currentTime;
+        }   
+    }
+    if (m_verbose) std::cout << "SchmittTrigger: Time:: " << currentTime << std::endl;
+    m_rawValue = rawValue;
+    
+    if (m_verbose) std::cout << "SchmittTrigger: Value:: " << m_rawValue << std::endl;
+    if (m_verbose) std::cout << "SchmittTrigger: Timer:: " << m_timer << std::endl;
+    
+    if (m_currentState == false)
+    {   
+        // Check for transition - if valid over a timeframe, then switch
+        if (m_rawValue >= m_highValueThreshold)
+        {               
+            if (m_timer > m_stableONTime)
+            {
+                // rise to high
+                m_currentState = true;
+                if (m_verbose) std::cout << "SchmittTrigger: Raising high "  << std::endl;
+            }
+            else
+            {
+                // wait for timer
+                m_timer += (currentTime - m_previousTime);
+                if (m_verbose) std::cout << "SchmittTrigger: I'm low and waiting "  << std::endl;
+            }            
+        }
+        else
+        {
+            // stable low - reset timer
+            m_timer = 0;
+            if (m_verbose) std::cout << "SchmittTrigger: Stable low "  << std::endl;
+        }
+    }
+    else
+    {
+        // check for transition - if valid over a timeframe, then switch
+        if (m_rawValue <= m_lowValueThreshold)
+        {
+            if (m_timer > m_stableOFFTime)
+            {
+                // fall to low
+                m_currentState = false;
+                if (m_verbose) std::cout << "SchmittTrigger: Falling low "  << std::endl;
+            }
+            else
+            {
+                // wait for timer
+                m_timer += (currentTime - m_previousTime);
+                if (m_verbose) std::cout << "SchmittTrigger: I'm high and waiting "  << std::endl;
+            }
+        }
+        else
+        {
+            // stable high - reset timer
+            m_timer = 0;
+            if (m_verbose) std::cout << "SchmittTrigger: Stable high "  << std::endl;
+        }
+    }
+    m_previousTime = currentTime;
+}
+
+}
+


### PR DESCRIPTION
preliminary version of contact switching

To determine the primary foot in contact with the ground, based on a alternate contact switching pattern, by performing a threshold over a contact make and contact break normal force magnitudes using a Schmitt trigger.

* Schmitt Trigger class takes 4 parameters (low threshold, high threshold, stable off time, stable on time) to determine the current binary state of the device, based on current time and an input value. 

* Contact state machine class contains an object of the Schmitt trigger specific to contact state detection and determines the contact transition modes.

* Foot contact classifier class considers contact state machines for each foot (left and right, in case of a humanoid)  and determines the contact state of each foot to set the primary foot in contact. This information can further be used by the legged odometry(LO) device to change fixed frame of reference, since the LO module assumes that atleast one foot is in contact at any instant of time. In its current implementation, the setting for primary foot is done only in the context of an alternate contact switching pattern. 