### PR TITLE
[core] bugfix in getRPY documentation in Rotation class

### DIFF
--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -164,7 +164,7 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponding to this rotation.
          *
-         * Get \f$ r \in [-180,180] , p \in [-90,90], y \in [-180,180]\f$
+         * Get \f$ r \in [-π, π] , p \in [-π/2, π/2], y \in [-π, π]\f$
          * such that
          * *this == RotZ(y)*RotY(p)*RotX(r)
          *


### PR DESCRIPTION
change it to be coherent with SI units radians