### PR TITLE
Fix bug in cacheSensorOrdering() function

### DIFF
--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1615,7 +1615,7 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
                 // system. Anyhow, we can still write the base wrench as a function
                 // of sum of the joint wrenches of all the joints attached to the base (tipically just one)
                 if (m_dynamicsTraversal.getBaseLink()->getIndex() == idx &&
-                    (m_options.berdyVariant != ORIGINAL_BERDY_FIXED_BASE ||
+                    (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE &&
                      !m_options.includeFixedBaseExternalWrench))
                 {
                     continue;


### PR DESCRIPTION
This solves issue #432.

Now, external sensors are NOT placed on the fix base link of the BerdyModel only in case of both BERDY_ORIGINAL_FIXED_BASE == true and includeFixedBaseExternalWrench == false.