### PR TITLE
ExternalWrenchesEstimation: if there are no unknowns do not do the pseudoinverse

### DIFF
--- a/doc/releases/v0_8_2.md
+++ b/doc/releases/v0_8_2.md
@@ -8,3 +8,4 @@ iDynTree 0.8.2 Release Notes
 
 Bug Fixes
 ---------
+* In the classes devoted to the external force-torque estimation, since https://github.com/robotology/idyntree/pull/343 it is possible to have external forces that are completly estimated from external sensors such as skin sensors. If in a given submodels there are no unknown due to this, the pseudoinverse should be skipped ( https://github.com/robotology/idyntree/pull/443 ) .

--- a/src/estimation/src/ExternalWrenchesEstimation.cpp
+++ b/src/estimation/src/ExternalWrenchesEstimation.cpp
@@ -603,7 +603,7 @@ bool estimateExternalWrenchesWithoutInternalFT(const Model& model,
 
    // If A has no unkowns then pseudoInverse can not be computed
    // In that case, we do not compute the x vector because it will have zero elements 
-   if (bufs.A[sm].rows() > 0 && bufs.A[sm].cols() > 0) {
+   if (bufs.A[subModelIndex].rows() > 0 && bufs.A[subModelIndex].cols() > 0) {
        // Now we compute the pseudo inverse
        pseudoInverse(toEigen(bufs.A[subModelIndex]),
                      toEigen(bufs.pinvA[subModelIndex]),

--- a/src/estimation/src/ExternalWrenchesEstimation.cpp
+++ b/src/estimation/src/ExternalWrenchesEstimation.cpp
@@ -601,13 +601,17 @@ bool estimateExternalWrenchesWithoutInternalFT(const Model& model,
    // Now we compute the A matrix
    computeMatrixOfEstimationEquationAndExtWrenchKnownTerms(model,traversal,unknownWrenches,jointPos,subModelIndex,bufs);
 
-   // Now we compute the pseudo inverse
-   pseudoInverse(toEigen(bufs.A[subModelIndex]),
-                 toEigen(bufs.pinvA[subModelIndex]),
-                 tol);
+   // If A has no unkowns then pseudoInverse can not be computed
+   // In that case, we do not compute the x vector because it will have zero elements 
+   if (bufs.A[sm].rows() > 0 && bufs.A[sm].cols() > 0) {
+       // Now we compute the pseudo inverse
+       pseudoInverse(toEigen(bufs.A[subModelIndex]),
+                     toEigen(bufs.pinvA[subModelIndex]),
+                     tol);
 
-   // Now we compute the unknowns
-   toEigen(bufs.x[subModelIndex]) = toEigen(bufs.pinvA[subModelIndex])*toEigen(bufs.b[subModelIndex]);
+       // Now we compute the unknowns
+       toEigen(bufs.x[subModelIndex]) = toEigen(bufs.pinvA[subModelIndex])*toEigen(bufs.b[subModelIndex]);
+   }
 
    // We copy the estimated unknowns in the outputContactWrenches
    // Note that the logic of conversion between input/output contacts should be
@@ -653,13 +657,17 @@ bool estimateExternalWrenches(const Model& model,
         // Now we compute the A matrix
         computeMatrixOfEstimationEquationAndExtWrenchKnownTerms(model,subModelTraversal,unknownWrenches,jointPos,sm,bufs);
 
-        // Now we compute the pseudo inverse
-        pseudoInverse(toEigen(bufs.A[sm]),
-                      toEigen(bufs.pinvA[sm]),
-                      tol);
+        // If A has no unkowns then pseudoInverse can not be computed
+        // In that case, we do not compute the x vector because it will have zero elements 
+        if (bufs.A[sm].rows() > 0 && bufs.A[sm].cols() > 0) {
+            // Now we compute the pseudo inverse
+            pseudoInverse(toEigen(bufs.A[sm]),
+                          toEigen(bufs.pinvA[sm]),
+                          tol);
 
-        // Now we compute the unknowns
-        toEigen(bufs.x[sm]) = toEigen(bufs.pinvA[sm])*toEigen(bufs.b[sm]);
+            // Now we compute the unknowns
+            toEigen(bufs.x[sm]) = toEigen(bufs.pinvA[sm])*toEigen(bufs.b[sm]);
+        }
 
         // Check if there are any nan in the estimation results
         bool someResultIsNan = false;


### PR DESCRIPTION
In the classes devoted to the external force-torque estimation, since https://github.com/robotology/idyntree/pull/343 it is possible to have external forces that are completly estimated from external sensors such as skin sensors. If in a given submodels there are no unknown due to this, the pseudoinverse should be skipped.  

See https://github.com/robotology/idyntree/commit/9517af7a232d0d3819ff24f569f1626319de0801 for the original commit.