### PR TITLE
Fix location of IDYNTREE_DEPRECATED_MGS macro

### DIFF
--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -177,9 +177,9 @@ public:
      *
      * @return true if successful, false otherwise.
      */
-    bool IDYNTREE_DEPRECATED_WITH_MSG("Use setCurrentRobotConfiguration instead")
-    setRobotConfiguration(const iDynTree::Transform& baseConfiguration,
-                          const iDynTree::VectorDynSize& jointConfiguration);
+    IDYNTREE_DEPRECATED_WITH_MSG("Use setCurrentRobotConfiguration instead")
+    bool setRobotConfiguration(const iDynTree::Transform& baseConfiguration,
+                               const iDynTree::VectorDynSize& jointConfiguration);
 
     /*!
      * Sets the robot current configuration
@@ -658,8 +658,8 @@ public:
      *
      * @return true if successful, false otherwise.
      */
-    bool IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit setDesiredFullJointsConfiguration or setDesiredReducedJointConfiguration instead")
-    setDesiredJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
+    IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit setDesiredFullJointsConfiguration or setDesiredReducedJointConfiguration instead")
+    bool setDesiredJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
     bool setDesiredFullJointsConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
     bool setDesiredReducedJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
 
@@ -672,8 +672,8 @@ public:
      * @param initialCondition  initial joints configuration
      * @return
      */
-    bool IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit setFullJointsInitialCondition or setReducedInitialCondition instead")
-    setInitialCondition(const iDynTree::Transform* baseTransform,
+    IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit setFullJointsInitialCondition or setReducedInitialCondition instead")
+    bool setInitialCondition(const iDynTree::Transform* baseTransform,
                         const iDynTree::VectorDynSize* initialCondition);
 
     bool setFullJointsInitialCondition(const iDynTree::Transform* baseTransform,
@@ -693,9 +693,9 @@ public:
      * @param[out] baseTransformSolution  solution for the base position
      * @param[out] shapeSolution       solution for the shape (the internal configurations)
      */
-    void IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit getFullJointsSolution or getReducedSolution instead")
-    getSolution(iDynTree::Transform& baseTransformSolution,
-                iDynTree::VectorDynSize& shapeSolution);
+    IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit getFullJointsSolution or getReducedSolution instead")
+    void getSolution(iDynTree::Transform& baseTransformSolution,
+                     iDynTree::VectorDynSize& shapeSolution);
 
     void getFullJointsSolution(iDynTree::Transform& baseTransformSolution,
                                iDynTree::VectorDynSize& shapeSolution);

--- a/src/sensors/include/iDynTree/Sensors/AccelerometerSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/AccelerometerSensor.h
@@ -125,7 +125,8 @@ namespace iDynTree {
         bool updateIndices(const Model & model);
 
         // Deprecated
-        bool IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead") updateIndeces(const Model & model);
+        IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead")
+        bool updateIndeces(const Model & model);
 
       /**
         * Following method is to be implemented after defining the interface

--- a/src/sensors/include/iDynTree/Sensors/GyroscopeSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/GyroscopeSensor.h
@@ -123,7 +123,8 @@ namespace iDynTree {
         bool updateIndices(const Model & model);
 
         // Deprecated
-        bool IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead") updateIndeces(const Model & model);
+        IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead")
+        bool updateIndeces(const Model & model);
 
         /**
          * Predict sensor measurement when given the parent link spatial velocity, expressed

--- a/src/sensors/include/iDynTree/Sensors/Sensors.h
+++ b/src/sensors/include/iDynTree/Sensors/Sensors.h
@@ -144,7 +144,8 @@ namespace iDynTree {
         virtual bool updateIndices(const Model & model) = 0;
 
         // Deprecated
-        virtual bool IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead") updateIndeces(const Model & model)
+        IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead")
+        virtual bool updateIndeces(const Model & model)
         {
             return updateIndices(model);
         }

--- a/src/sensors/include/iDynTree/Sensors/SixAxisFTSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/SixAxisFTSensor.h
@@ -162,7 +162,8 @@ namespace iDynTree {
         bool updateIndices(const Model & model);
 
         // Deprecated
-        bool IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead") updateIndeces(const Model & model);
+        IDYNTREE_DEPRECATED_WITH_MSG("Use updateIndices() instead")
+        bool updateIndeces(const Model & model);
 
         /**
          * The Six Axis Force Torque sensor measure the Force Torque (wrench)


### PR DESCRIPTION
See https://github.com/robotology/yarp/issues/1614