### PR TITLE
IK: use of a vector of regularization weights

### DIFF
--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -660,9 +660,71 @@ public:
      */
     IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit setDesiredFullJointsConfiguration or setDesiredReducedJointConfiguration instead")
     bool setDesiredJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
+
+    /*!
+     * Sets a desired final configuration for all the robot joints.
+     *
+     * The solver will try to obtain solutions as similar to the specified configuration as possible
+     *
+     * @note the desiredJointConfiguration have the same serialisation of the joints in the specified model
+     *
+     * @param[in] desiredJointConfiguration configuration for the joints
+     * @param[in] weight weight for the joint configuration cost.
+     *                   If it is not passed, the previous passed value will be mantained.
+     *                   If the value was never passed, its value is 1e-6 .
+     *
+     * @return true if successful, false otherwise.
+     */
     bool setDesiredFullJointsConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
+
+    /*!
+     * Sets a desired final configuration for all the robot joints.
+     *
+     * The solver will try to obtain solutions as similar to the specified configuration as possible
+     *
+     * @note the desiredJointConfiguration have the same serialisation of the joints in the specified model
+     *
+     * @param[in] desiredJointConfiguration configuration for the joints
+     * @param[in] weights Joint-wise weights for the joint configuration cost.
+     *                   This vector should have the same dimension of the desiredJointConfiguration.
+     *                   If one of its elements is negative, the previous value will be kept.
+     *                   If the value was never passed, its value is 1e-6, equal for all joints.
+     *
+     * @return true if successful, false otherwise.
+     */
     bool setDesiredFullJointsConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, const iDynTree::VectorDynSize& weights);
+
+    /*!
+     * Sets a desired final configuration for the set of considered joints.
+     *
+     * The solver will try to obtain solutions as similar to the specified configuration as possible
+     *
+     * @note the desiredJointConfiguration have the same order of the joints in the consideredJoints list.
+     *
+     * @param[in] desiredJointConfiguration configuration for the joints
+     * @param[in] weight weight for the joint configuration cost.
+     *                   If it is not passed, the previous passed value will be mantained.
+     *                   If the value was never passed, its value is 1e-6 .
+     *
+     * @return true if successful, false otherwise.
+     */
     bool setDesiredReducedJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
+
+    /*!
+     * Sets a desired final configuration for the set of considered joints.
+     *
+     * The solver will try to obtain solutions as similar to the specified configuration as possible
+     *
+     * @note the desiredJointConfiguration have the same order of the joints in the consideredJoints list.
+     *
+     * @param[in] desiredJointConfiguration configuration for the joints
+     * @param[in] weights Joint-wise weights for the joint configuration cost.
+     *                   This vector should have the same dimension of the desiredJointConfiguration.
+     *                   If one of its elements is negative, the previous value will be kept.
+     *                   If the value was never passed, its value is 1e-6, equal for all joints.
+     *
+     * @return true if successful, false otherwise.
+     */
     bool setDesiredReducedJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, const iDynTree::VectorDynSize& weights);
 
 

--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -661,7 +661,10 @@ public:
     IDYNTREE_DEPRECATED_WITH_MSG("Use the explicit setDesiredFullJointsConfiguration or setDesiredReducedJointConfiguration instead")
     bool setDesiredJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
     bool setDesiredFullJointsConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
+    bool setDesiredFullJointsConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, const iDynTree::VectorDynSize& weights);
     bool setDesiredReducedJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight=-1.0);
+    bool setDesiredReducedJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, const iDynTree::VectorDynSize& weights);
+
 
 
     /*!

--- a/src/inverse-kinematics/include/private/InverseKinematicsData.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsData.h
@@ -119,7 +119,7 @@ public:
     //Preferred joints configuration for the optimization
     //Size: getNrOfDOFs of the considered model
     iDynTree::VectorDynSize m_preferredJointsConfiguration;
-    double m_preferredJointsWeight;
+    iDynTree::VectorDynSize m_preferredJointsWeight;
 
     bool m_areBaseInitialConditionsSet; /*!< True if initial condition for the base pose are provided by the user */
     

--- a/src/inverse-kinematics/src/InverseKinematics.cpp
+++ b/src/inverse-kinematics/src/InverseKinematics.cpp
@@ -497,7 +497,28 @@ namespace iDynTree {
         assert(IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration.size() == desiredJointConfiguration.size());
         IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration = desiredJointConfiguration;
         if (weight >= 0.0) {
-            IK_PIMPL(m_pimpl)->m_preferredJointsWeight = weight;
+            iDynTree::toEigen(IK_PIMPL(m_pimpl)->m_preferredJointsWeight).setConstant(weight);
+        }
+        return true;
+    }
+
+    bool InverseKinematics::setDesiredFullJointsConfiguration(const VectorDynSize &desiredJointConfiguration, const VectorDynSize &weights)
+    {
+        assert(m_pimpl);
+        assert(IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration.size() == desiredJointConfiguration.size());
+
+        if (desiredJointConfiguration.size() != weights.size()){
+            reportError("InverseKinematics", "setDesiredFullJointsConfiguration", "The dimension of the desired weights is different from the desiredJointConfiguration size.");
+            return false;
+        }
+
+        IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration = desiredJointConfiguration;
+
+        assert(IK_PIMPL(m_pimpl)->m_preferredJointsWeight.size() == weights.size());
+        for (unsigned int i = 0; i < weights.size(); ++i){
+            if (weights(i) >= 0.0) {
+                IK_PIMPL(m_pimpl)->m_preferredJointsWeight(i) = weights(i);
+            }
         }
         return true;
     }
@@ -511,8 +532,28 @@ namespace iDynTree {
         }
 
         if (weight >= 0.0) {
-            IK_PIMPL(m_pimpl)->m_preferredJointsWeight = weight;
+            iDynTree::toEigen(IK_PIMPL(m_pimpl)->m_preferredJointsWeight).setConstant(weight);
         }
+        return true;
+    }
+
+    bool InverseKinematics::setDesiredReducedJointConfiguration(const VectorDynSize &desiredJointConfiguration, const VectorDynSize &weights)
+    {
+        assert(m_pimpl);
+        assert(IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints.size() == desiredJointConfiguration.size());
+
+        if (desiredJointConfiguration.size() != weights.size()){
+            reportError("InverseKinematics", "setDesiredFullJointsConfiguration", "The dimension of the desired weights is different from the desiredJointConfiguration size.");
+            return false;
+        }
+
+        for (size_t i = 0; i < desiredJointConfiguration.size(); ++i) {
+            IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration(IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]) = desiredJointConfiguration(i);
+            if (weights(i) >= 0.0) {
+                IK_PIMPL(m_pimpl)->m_preferredJointsWeight(IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]) = weights(i);
+            }
+        }
+
         return true;
     }
 

--- a/src/inverse-kinematics/src/InverseKinematicsData.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsData.cpp
@@ -139,7 +139,8 @@ namespace kinematics {
         m_jointsResults.zero();
         m_preferredJointsConfiguration.resize(m_dofs);
         m_preferredJointsConfiguration.zero();
-        m_preferredJointsWeight = 1e-6;
+        m_preferredJointsWeight.resize(m_dofs);
+       iDynTree::toEigen(m_preferredJointsWeight).setConstant(1e-6);
 
         m_state.jointsConfiguration.resize(m_dofs);
         m_state.jointsConfiguration.zero();
@@ -286,22 +287,22 @@ namespace kinematics {
         }
 
         //2) Check joint limits..
-        for (size_t i = 0; i < m_jointInitialConditions.size(); ++i) {
+        for (size_t i = 0; i < m_reducedVariablesInfo.modelJointsToOptimisedJoints.size(); ++i) {
             //check joint to be inside limit
-            double &jointValue = m_jointInitialConditions(i);
-            if (jointValue < m_jointLimits[i].first || jointValue > m_jointLimits[i].second) {
+            double &jointValue = m_jointInitialConditions(m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]);
+            if (jointValue < m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].first || jointValue > m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].second) {
                 std::cerr
-                << "[WARNING] InverseKinematics: joint " << m_dynamics.model().getJointName(i)
-                << " (index " << i << ") initial condition is outside the limits "
-                << m_jointLimits[i].first << " " << m_jointLimits[i].second
+                << "[WARNING] InverseKinematics: joint " << m_dynamics.model().getJointName(m_reducedVariablesInfo.modelJointsToOptimisedJoints[i])
+                << " (index " << m_reducedVariablesInfo.modelJointsToOptimisedJoints[i] << ") initial condition is outside the limits "
+                << m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].first << " " << m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].second
                 << ". Actual value: " << jointValue <<  std::endl;
                 //set the initial value to at the limit
-                if (jointValue < m_jointLimits[i].first) {
-                    jointValue = m_jointLimits[i].first;
+                if (jointValue < m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].first) {
+                    jointValue = m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].first;
                 }
 
-                if (jointValue > m_jointLimits[i].second) {
-                    jointValue = m_jointLimits[i].second;
+                if (jointValue > m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].second) {
+                    jointValue = m_jointLimits[m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]].second;
                 }
             }
         }


### PR DESCRIPTION
In the IK cost function, instead of using a single double, a vector of regularization weights can be used, weighting different joints separately.

Also, an annoying warning on the joint limits is modified. This check is performed only in the considered joints. In fact, the joint limits are not used for the "fixed" joints.