### PR TITLE
Fixed a locale-dependent floating point parsing in the URDF parser.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(VARS_PREFIX "iDynTree")
 
 set(${VARS_PREFIX}_MAJOR_VERSION 0)
 set(${VARS_PREFIX}_MINOR_VERSION 11)
-set(${VARS_PREFIX}_PATCH_VERSION 0)
+set(${VARS_PREFIX}_PATCH_VERSION 1)
 set(${VARS_PREFIX}_VERSION ${${VARS_PREFIX}_MAJOR_VERSION}.${${VARS_PREFIX}_MINOR_VERSION}.${${VARS_PREFIX}_PATCH_VERSION})
 
 # Pick up our CMake scripts - they are all in the cmake subdirectory.

--- a/doc/releases/v0_11_1.md
+++ b/doc/releases/v0_11_1.md
@@ -1,0 +1,12 @@
+iDynTree 0.11.1 (UNRELEASED)                                              {#v0_11_1}
+========================
+
+[TOC]
+
+iDynTree 0.11.1 Release Notes
+=========================
+
+Bug Fixes
+---------
+
+* Fixed a locale-dependent floating point parsing in the URDF parser (https://github.com/robotology/idyntree/pull/475). 

--- a/src/model_io/urdf/src/InertialElement.cpp
+++ b/src/model_io/urdf/src/InertialElement.cpp
@@ -37,13 +37,9 @@ namespace iDynTree {
             element->setAttributeCallback([this](const std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>& attributes) {
                 m_mass = 0;
                 auto mass = attributes.find("value");
-                if (mass != attributes.end()) {
-                    try {
-                        m_mass = std::stod(mass->second->value());
-                    } catch(const std::invalid_argument& ia) {
-                        std::string message = std::string("Failed to obtain floating point representation from ") + ia.what();
-                        reportWarning("InertialElement", "childElementForName::mass::f_attribute", message.c_str());
-                    }
+                if (mass != attributes.end()
+                    && !stringToDoubleWithClassicLocale(mass->second->value(), m_mass)) {
+                    reportWarning("InertiaElement", "childElementForName::mass::f_attribute", "Failed to obtain floating point representation for the mass element.");
                 }
                 return true;
             });


### PR DESCRIPTION
The mass in the <inertial> tag was parsed with a locale-dependent function.

This is my fault. I forgot the old function. I changed it back to the `iDynTree` function (so when we will migrate to the new C++ locale independent function we have only one function to change).