### PR TITLE
Added compatibility with SWIG 2.0

### DIFF
--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -63,6 +63,7 @@ inline Eigen::Map<const Eigen::VectorXd> toEigen(const VectorDynSize & vec)
     return Eigen::Map<const Eigen::VectorXd>(vec.data(),vec.size());
 }
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
 inline Eigen::Map<const Eigen::VectorXd> toEigen(Span<const double> vec)
 {
     return Eigen::Map<const Eigen::VectorXd>(vec.data(),vec.size());
@@ -72,6 +73,7 @@ inline Eigen::Map<Eigen::VectorXd> toEigen(iDynTree::Span<double> vec)
 {
     return Eigen::Map<Eigen::VectorXd>(vec.data(),vec.size());
 }
+#endif
 
 inline Eigen::Map<const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> > toEigen(const MatrixDynSize & mat)
 {

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -11,10 +11,11 @@
 #ifndef IDYNTREE_DYNAMIC_SIZE_VECTOR_H
 #define IDYNTREE_DYNAMIC_SIZE_VECTOR_H
 
-
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+#include <iDynTree/Core/Span.h>
+#endif
 
 #include <string>
-#include <iDynTree/Core/Span.h>
 
 namespace iDynTree
 {
@@ -97,6 +98,7 @@ namespace iDynTree
          */
         VectorDynSize & operator=(const VectorDynSize& vec);
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
         /**
          * Copy assignment operator.
          *
@@ -107,7 +109,7 @@ namespace iDynTree
          * \warning performs dynamic memory allocation operations
          */
         VectorDynSize & operator=(const Span<const double>& vec);
-
+#endif
         /**
          * @name Vector interface methods.
          * Methods exposing a vector-like interface to PositionRaw.
@@ -187,6 +189,7 @@ namespace iDynTree
          */
         void fillBuffer(double * buf) const;
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
         /** Typedefs to enable make_span.
          */
         ///@{
@@ -198,6 +201,7 @@ namespace iDynTree
 
         typedef typename std::allocator_traits<std::allocator<double>>::const_pointer const_pointer;
         ///@}
+#endif
 
         /** @name Output helpers.
          *  Output helpers.

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -12,7 +12,9 @@
 #define IDYNTREE_VECTOR_FIX_SIZE_H
 
 #include <iDynTree/Core/Utils.h>
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
 #include <iDynTree/Core/Span.h>
+#endif
 #include <string>
 #include <sstream>
 #include <cassert>
@@ -69,6 +71,7 @@ namespace iDynTree
 
         ///@}
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
         /**
          * Copy assignment operator for spans.
          *
@@ -76,6 +79,7 @@ namespace iDynTree
          *
          */
         VectorFixSize & operator=(const Span<const double>& vec);
+#endif
 
         /**
          * Raw data accessor
@@ -120,6 +124,7 @@ namespace iDynTree
         std::string reservedToString() const;
         ///@}
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
         /** Typedefs to enable make_span.
          */
         ///@{
@@ -131,6 +136,7 @@ namespace iDynTree
 
         typedef typename std::allocator_traits<std::allocator<double>>::const_pointer const_pointer;
         ///@}
+#endif
 
     };
 
@@ -185,12 +191,14 @@ namespace iDynTree
         return VecSize;
     }
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
     template<unsigned int VecSize>
     VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const Span<const double>& vec) {
         assert(VecSize == vec.size());
         std::memcpy(this->m_data, vec.data(), VecSize*sizeof(double));
         return *this;
     }
+#endif
 
     template<unsigned int VecSize>
     double VectorFixSize<VecSize>::operator()(const unsigned int index) const

--- a/src/core/src/VectorDynSize.cpp
+++ b/src/core/src/VectorDynSize.cpp
@@ -95,6 +95,7 @@ VectorDynSize& VectorDynSize::operator=(const VectorDynSize& vec)
     return *this;
 }
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
 VectorDynSize &VectorDynSize::operator=(const Span<const double> &vec)
 {
     // if the size don't match, reallocate the data
@@ -114,7 +115,7 @@ VectorDynSize &VectorDynSize::operator=(const Span<const double> &vec)
 
     return *this;
 }
-
+#endif
 
 void VectorDynSize::zero()
 {
@@ -266,9 +267,5 @@ std::string VectorDynSize::reservedToString() const
 {
     return this->toString();
 }
-
-
-
-
 
 }

--- a/src/model_io/urdf/CMakeLists.txt
+++ b/src/model_io/urdf/CMakeLists.txt
@@ -12,7 +12,9 @@ find_package(LibXml2 REQUIRED)
 
 set(IDYNTREE_MODELIO_URDF_HEADERS include/iDynTree/ModelIO/URDFDofsImport.h
                                   include/iDynTree/ModelIO/ModelLoader.h
-                                  include/deprecated/iDynTree/ModelIO/URDFModelImport.h)
+                                  include/deprecated/iDynTree/ModelIO/URDFModelImport.h
+                                  include/deprecated/iDynTree/ModelIO/URDFGenericSensorsImport.h
+                                  include/deprecated/iDynTree/ModelIO/URDFSolidShapesImport.h)
 
 set(IDYNTREE_MODELIO_URDF_PRIVATE_HEADERS include/private/URDFDocument.h
                                           include/private/InertialElement.h


### PR DESCRIPTION
Removed `Span` from the bindings if SWIG < 3.0

I marked the PR as WIP as we still have to decide what to do with some deprecated headers in `idyntree-modelio-urdf`.

@traversaro should we remove from the bindings `URDFGenericSensorsImport.h` ?