### PR TITLE
 Add inertial parameters regressor method to KinDynComputations

### DIFF
--- a/doc/dcTutorialCpp.md
+++ b/doc/dcTutorialCpp.md
@@ -1,29 +1,36 @@
 
-# DynamicsComputations tutorial
+# KinDynComputations tutorial
 
-To use the DynamicsComputations class, you have to include its header.
+To use the KinDynComputations class, you have to include its header.
 For this tutorial we also use the appropriate `using` definitions to 
-avoid having to type the namespace of the class. 
+avoid having to type the `iDynTree` namespace.
 
 ~~~cpp
 #include <iostream>
 
-#include <iDynTree/HighLevel/DynamicsComputations.h>
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
 
 using namespace iDynTree;
-using namespace iDynTree::HighLevel;
 ~~~
 
 The first thing that we have to do 
 is to initialize the class by providing a model of the robot. Currently 
 iDynTree supports only URDF models to specify the model. 
+All the logic for loading models, including loading reduced models,
+is contained in the iDynTree::ModelLoader class.
 ~~~cpp
 int main()
 {
-    DynamicsComputations dynComp;
-    dynComp.loadRobotModelFromFile("model.urdf");
-    std::cout << "The loaded model has " << dynComp.getNrOfDegreesOfFreedom() 
-          << "internal degrees of freedom and " << dynComp.getNrOfLinks() 
+    ModelLoader mdlLoader;
+    bool ok = mdlLoader.loadModelFromFile(urdf_filename);
+
+    // Check that ok is actually true
+
+    KinDynComputations kinDynComp;
+    kinDynComp.loadRobotModel(mdlLoader.model());
+    std::cout << "The loaded model has " << kinDynComp.model().getNrOfDOFs()
+          << "internal degrees of freedom and " << kinDynComp.model().getNrOfLinks()
           << "links." << std::endl;
 ~~~
 
@@ -34,37 +41,37 @@ to specify the joint position, velocity and accelerations and the gravity in the
 base frame. 
 
 ~~~cpp
-    unsigned int dofs = dynComp.getNrOfDegreesOfFreedom();
-    VectorDynSize q(dofs), dq(dofs), ddq(dofs);
+    unsigned int dofs = kinDynComp.model();
+    VectorDynSize s(dofs), ds(dofs), dds(dofs);
     for(unsigned int dof = 0; dof < dofs; dof++ )
     {
         // For the sake of the example, we fill the joints
         // vector with gibberish data (remember in any case
         // that all quantities are expressed in radians-based 
         // units 
-        q(dof) = 1.0;
-        dq(dof) = 0.4;
-        ddq(dof) = 0.3;
+        s(dof) = 1.0;
+        ds(dof) = 0.4;
+        dds(dof) = 0.3;
     }
     
-    // The spatial acceleration is a 6d acceleration vector. 
+    // The gravity acceleration is a 3d vector.
+    //
     // For all 6d quantities, we use the linear-angular serialization
     // (the first three value are for the linear quantity, the 
     //  the last  three values are for the angular quantity)
-    SpatialAcc gravity;
-    gravity(3) = -9.81;
-    dynComp.setRobotState(q,dq,ddq,gravity);
+    Vector3 gravity;
+    gravity.zero();
+    gravity(2) = -9.81;
+    kinDynComp.setRobotState(s,ds,gravity);
 ~~~
 
 Once you set the state, you can access the computed dynamical quantities. 
 For example you can get the jacobian for a given frame with name "frameName".
 Note that "frameName" should be the name of a link in the URDF model. 
-Note that the jacobian is the floating base jacobian as described in 
-http://wiki.icub.org/codyco/dox/html/dynamics_notation.html . 
 
 ~~~cpp
     MatrixDynSize jac(6,6+dofs);
-    bool ok = dynComp.getFrameJacobian("frameName",jac);
+    bool ok = kinDynComp.getFrameFreeFloatingJacobian("frameName", jac);
     
     if( !ok )
     {
@@ -79,8 +86,7 @@ http://wiki.icub.org/codyco/dox/html/dynamics_notation.html .
 
 You can also get the dynamics regressor. 
 The dynamics regressor is a (6+dofs) \* (10 \* nrOfLinks) Y matrix such that:
-Y pi = M(q) d(v)/dt + C(q,v)v + g(q) 
-with M(q), C(q,v) and g(q) defined in http://wiki.icub.org/codyco/dox/html/dynamics_notation.html .
+Y pi = M(q) d(v)/dt + C(q,v)v + g(q) .
 The pi vector is a 10 \* nrOfLinks inertial parameters vector, such that the elements of the vector
 from the ((i-1) \* 10)-th to the (i \* 10-1)-th belong to the i-th link. For more details on the inertial
 parameters vector, please check https://hal.archives-ouvertes.fr/hal-01137215/document . 
@@ -88,7 +94,9 @@ parameters vector, please check https://hal.archives-ouvertes.fr/hal-01137215/do
 ~~~cpp
     unsigned int links = dynComp.getNrOfLinks();
     MatrixDynSize regr(6+dofs,10*links);
-    ok = dynComp.getDynamicsRegressor(regr);
+    Vector6 baseAcc;
+    baseAcc.zero();
+    ok = kinDynComp.inverseDynamicsInertialParametersRegressor(baseAcc, dds, regr);
     
     if( !ok )
     {

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -83,6 +83,13 @@
  */
 
 
+ /**
+ * \defgroup iDynTreeDeprecated Deprecated functions and classes
+ *
+ * \warning The functions and classes in this component should not be used for new code.
+ *
+ */
+
 
 
 
@@ -120,6 +127,12 @@ some parts of it are activly developed and their interface can abroutly change b
 Until this components are ready to be integrated in a proper part of iDynTree, we keep them in the "experimental" part of iDynTree :
 
 \li  \ref iDynTreeExperimental "Experimental" : Experimental data structures and algorithms, whose interface is not guaranteed to be stable.
+
+iDynTree started as a tiny wrapper of code between [YARP](http://yarp.it/) and [KDL](https://github.com/orocos/orocos_kinematics_dynamics).
+For this reason, in the repository there is still some legacy code, that should not be used by users, as it is going to be removed from iDynTree.
+
+\li  \ref iDynTreeDeprecated "Deprecated" : Deprecated data structures and algorithms, that are going to be removed from iDynTree.
+
 
  *
  */

--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -13,6 +13,10 @@ Summary
 Important Changes
 -----------------
 
+#### `high-level`
+* Added method to compute the inverse dynamics inertial parameters regressor in KinDynComputations ( https://github.com/robotology/idyntree/pull/480 ).
+KinDynComputations finally reached feature parity with respect to DynamicsComputations, that will finally be removed in one of the future iDynTree feature releases.
+
 #### `inverse-kinematics`
 * Added method to return the convex hull of the constraint on the projection of the center of mass (https://github.com/robotology/idyntree/pull/478).
 

--- a/examples/python/dynamicsComputationTutorial.py
+++ b/examples/python/dynamicsComputationTutorial.py
@@ -6,46 +6,52 @@ Created on Tue Jun 23 11:35:46 2015
 """
 
 import iDynTree
-from iDynTree import DynamicsComputations
+from iDynTree import KinDynComputations
+from iDynTree import ModelLoader
+
 
 URDF_FILE = '/home/username/path/robot.urdf';
 
-dynComp = DynamicsComputations();
-dynComp.loadRobotModelFromFile(URDF_FILE);
-print "The loaded model has", dynComp.getNrOfDegreesOfFreedom(), \
-    "internal degrees of freedom and",dynComp.getNrOfLinks(),"links."
+dynComp = KinDynComputations();
+mdlLoader = ModelLoader();
+mdlLoader.loadModelFromFile(URDF_FILE);
 
-dofs = dynComp.getNrOfDegreesOfFreedom();
-q = iDynTree.VectorDynSize(dofs);
-dq = iDynTree.VectorDynSize(dofs);
-ddq = iDynTree.VectorDynSize(dofs);
+dynComp.loadRobotModel(mdlLoader.model());
+
+print "The loaded model has", dynComp.model().getNrOfDOFs(), \
+    "internal degrees of freedom and",dynComp.model().getNrOfLinks(),"links."
+
+dofs = dynComp.model().getNrOfDOFs();
+s = iDynTree.VectorDynSize(dofs);
+ds = iDynTree.VectorDynSize(dofs);
+dds = iDynTree.VectorDynSize(dofs);
 for dof in range(dofs):
     # For the sake of the example, we fill the joints vector with gibberish data (remember in any case
     # that all quantities are expressed in radians-based units 
-    q.setVal(dof, 1.0);
-    dq.setVal(dof, 0.4);
-    ddq.setVal(dof, 0.3);
+    s.setVal(dof, 1.0);
+    ds.setVal(dof, 0.4);
+    dds.setVal(dof, 0.3);
 
 
-# The spatial acceleration is a 6d acceleration vector. 
-# For all 6d quantities, we use the linear-angular serialization
-# (the first three value are for the linear quantity, the 
-#  the last  three values are for the angular quantity)
-gravity = iDynTree.SpatialAcc();
+# The gravity acceleration is a 3d acceleration vector.
+gravity = iDynTree.Vector3();
 gravity.zero();
 gravity.setVal(2, -9.81);
-dynComp.setRobotState(q,dq,ddq,gravity);
+dynComp.setRobotState(s,ds,gravity);
 
 jac = iDynTree.MatrixDynSize(6,6+dofs);
-ok = dynComp.getFrameJacobian("lf_foot", jac);
+ok = dynComp.getFreeFloatingJacobian("lf_foot", jac);
 if( not ok ):
     print "Error in computing jacobian of frame " + "lf_foot";
 else: 
     print "Jacobian of lf_foot is\n" + jac.toString();
-    
-links = dynComp.getNrOfLinks();
+
+
+baseAcc = iDynTree.Vector6();
+baseAcc.zero();
+links = dynComp.model().getNrOfLinks();
 regr = iDynTree.MatrixDynSize(6+dofs,10*links);
-ok = dynComp.getDynamicsRegressor(regr);
+ok = dynComp.inverseDynamicsInertialParametersRegressor(baseAcc, dds, regr);
 if( not ok ):
     print "Error in computing the dynamics regressor";
 else :

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -697,6 +697,39 @@ public:
      */
     bool generalizedGravityForces(FreeFloatingGeneralizedTorques & generalizedGravityForces);
 
+    /**
+     * Compute the getNrOfDOFS()+6 vector of generalized external forces.
+     *
+     * The semantics of baseAcc, the base part of baseForceAndJointTorques
+     * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
+     *
+     * The state is the one given set by the setRobotState method.
+     *
+     * @param[out] generalizedExternalForces the output external generalized forces
+     * @return true if all went well, false otherwise
+     */
+    bool generalizedExternalForces(const LinkNetExternalWrenches & linkExtForces,
+                                         FreeFloatingGeneralizedTorques & generalizedExternalForces);
+
+    /**
+     * @brief Compute the free floating inverse dynamics as a linear function of inertial parameters.
+     *
+     * The semantics of baseAcc, the base part (first six rows) of baseForceAndJointTorques
+     * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
+     *
+     * The state is the one given set by the setRobotState method.
+     *
+     * @see iDynTree::InverseDynamicsInertialParametersRegressor for more info on the underlying algorithm.
+     *
+     * @param[in] baseAcc the acceleration of the base link
+     * @param[in] s_ddot the accelerations of the joints
+     * @param[out] baseForceAndJointTorquesRegressor The (6+model.getNrOfDOFs() X 10*model.getNrOfLinks()) inverse dynamics regressor.
+     * @return true if all went well, false otherwise
+     */
+    bool inverseDynamicsInertialParametersRegressor(const Vector6& baseAcc,
+                                                    const VectorDynSize& s_ddot,
+                                                          MatrixDynSize& baseForceAndJointTorquesRegressor);
+
     //@}
 
 

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -108,6 +108,7 @@ public:
     /**
      * @name Model loading and definition methods
      * This methods are used to load the structure of your model.
+     *
      */
     //@{
 
@@ -148,11 +149,14 @@ public:
 
     /**
      * Set the used FrameVelocityRepresentation.
+     *
+     * @see FrameVelocityRepresentation
      */
     bool setFrameVelocityRepresentation(const FrameVelocityRepresentation frameVelRepr) const;
 
     /**
-     * Get the used FrameVelocityRepresentation.
+     * @brief Get the used FrameVelocityRepresentation.
+     * @see setFrameVelocityRepresentation
      */
     FrameVelocityRepresentation getFrameVelocityRepresentation() const;
     //@}
@@ -189,20 +193,6 @@ public:
     unsigned int getNrOfLinks() const;
 
     /**
-     * Get a human readable description of a given link in the model.
-     *
-     * @return a human readable description of a given link in the model.
-     */
-    //std::string getDescriptionOfLink(int link_index);
-
-    /**
-     * Get a human readable description of all links considered in the model.
-     *
-     * @return a std::string containing the description of all the links.
-     */
-    //std::string getDescriptionOfLinks();
-
-    /**
      * Get the number of frames contained in the model.
      *
      * \note The number of frames is always greater than or equal to
@@ -211,20 +201,6 @@ public:
      *       can associated to a given link.
      */
     unsigned int getNrOfFrames() const;
-
-    /**
-     * Get a human readable description of a given frame considered in the model.
-     *
-     * @return a human readable description of a given frame considered in the model.
-     */
-    //std::string getDescriptionOfFrame(int frame_index);
-
-    /**
-     * Get a human readable description of all frames considered in the model.
-     *
-     * @return a std::string containing the description of all the frame considered in the model.
-     */
-    //std::string getDescriptionOfLinks();
 
     /**
      * Get the name of the link considered as the floating base.
@@ -368,8 +344,7 @@ public:
     //@}
 
     /**
-      * @name Methods to get transform information between frames in the model,
-      *       given the current state.
+      * @name Methods to get transform information between frames in the model, given the current state.
       */
     //@{
 
@@ -623,12 +598,54 @@ public:
 
 
     /**
-      * @name Methods to get quantities related to dynamics matrices.
+      * @name Methods to get quantities related to unconstrained free floating equation of motions.
+      *
+      * This methods permits to compute several quantities related to free floating equation of methods.
+      * Note that this equations needs to be coupled with a description of the interaction between the model
+      * and the enviroment (such as a contant model, a bilateral constraint on some links or by considering
+      * some external forces as inputs) to actually obtain a dynamical system description of the mechanical model evolution.
+      *
+      * The equations of motion of a free floating mechanical system under the effect of a uniform gravitational field are:
+      * \f[
+      * M(q) \dot{\nu} +
+      * C(q, \nu) \nu +
+      * G(q)
+      * =
+      * \begin{bmatrix}
+      * 0_{6\times1} \newline
+      * \tau
+      * \end{bmatrix}
+      * +
+      * \sum_{L \in \mathcal{L}}
+      * J_L^T \mathrm{f}_L^x
+      * \f]
+      *
+      * where:
+      *
+      * * \f$n_{PC}\f$ is the value returned by Model::getNrOfPosCoords,
+      * * \f$n_{DOF}\f$ is the value returned by Model::getNrOfDOFs,
+      * * \f$n_{L}\f$ is the value returned by Model::getNrOfLinks,
+      * * \f$q \in \mathbb{R}^3 \times \textrm{SO}(3) \times \mathbb{R}^{n_{PC}}\f$ is the robot position,
+      * * \f$\nu \in \mathbb{R}^{6+n_{DOF}}\f$ is the robot velocity,
+      * * \f$\dot{\nu} \in \mathbb{R}^{6+n_{DOF}}\f$ is the robot acceleration,
+      * * \f$M(q) \in \mathbb{R}^{(6+n_{DOF}) \times (6+n_{DOF})}\f$ is the free floating mass matrix,
+      * * \f$C(q, \nu)  \in \mathbb{R}^{(6+n_{DOF}) \times (6+n_{DOF})}\f$ is the coriolis matrix,
+      * * \f$G(q) \in \mathbb{R}^{6+n_{DOF}}\f$ is the vector of gravity generalized forces,
+      * * \f$\tau \in \mathbb{R}^6\f$ is the vector of torques applied on the joint of the multibody model,
+      * * \f$\mathcal{L}\f$ is the set of all the links contained in the multibody model,
+      * * \f$J_L \in \mathbb{R}^{6+n_{DOF}}\f$ is the free floating jacobian of link \f$L\f$ as obtained by KinDynComputations::getFrameFreeFloatingJacobian,
+      * * \f$\mathrm{f}_L^x\f$ is the 6D force/torque applied by the enviroment on link \f$L\f$.
+      *
+      * The precise definition of each quantity (in particular the part related to the base) actually depends on the
+      * choice of FrameVelocityRepresentation, specified with the setFrameVelocityRepresentation method.
+      *
       */
     //@{
 
     /**
-     * Get the free floating mass matrix of the system.
+     * @brief Get the free floating mass matrix of the system.
+     *
+     * This method computes \f$M(q) \in \mathbb{R}^{(6+n_{DOF}) \times (6+n_{DOF})}\f$.
      *
      * The mass matrix depends on the joint positions, specified by the setRobotState methods.
      * If the chosen FrameVelocityRepresentation is MIXED_REPRESENTATION or INERTIAL_FIXED_REPRESENTATION,
@@ -645,15 +662,11 @@ public:
      */
     bool getFreeFloatingMassMatrix(MatrixDynSize & freeFloatingMassMatrix);
 
-    //@}
 
     /**
-      * @name Methods to unconstrained free floating dynamics.
-      */
-    //@{
-
-    /**
-     * Compute the free floating inverse dynamics.
+     * @brief Compute the free floating inverse dynamics.
+     *
+     * This method computes \f$M(q) \dot{\nu} + C(q, \nu) \nu + G(q) - \sum_{L \in \mathcal{L}} J_L^T \mathrm{f}_L^x \in \mathbb{R}^{6+n_{DOF}}\f$.
      *
      * The semantics of baseAcc, the base part of baseForceAndJointTorques
      * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
@@ -672,10 +685,11 @@ public:
                                FreeFloatingGeneralizedTorques & baseForceAndJointTorques);
 
     /**
-     * Compute the getNrOfDOFS()+6 vector of generalized bias (gravity+coriolis) forces.
+     * @brief Compute the getNrOfDOFS()+6 vector of generalized bias (gravity+coriolis) forces.
      *
-     * The semantics of baseAcc, the base part of baseForceAndJointTorques
-     * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
+     * This method computes \f$C(q, \nu) \nu + G(q) \in \mathbb{R}^{6+n_{DOF}}\f$.
+     *
+     * The semantics of the base part of generalizedBiasForces depend of the chosen FrameVelocityRepresentation .
      *
      * The state is the one given set by the setRobotState method.
      *
@@ -685,10 +699,11 @@ public:
     bool generalizedBiasForces(FreeFloatingGeneralizedTorques & generalizedBiasForces);
 
     /**
-     * Compute the getNrOfDOFS()+6 vector of generalized gravity forces.
+     * @brief Compute the getNrOfDOFS()+6 vector of generalized gravity forces.
      *
-     * The semantics of baseAcc, the base part of baseForceAndJointTorques
-     * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
+     * This method computes \f$G(q) \in \mathbb{R}^{6+n_{DOF}}\f$.
+     *
+     * The semantics of the base part of generalizedGravityForces depend of the chosen FrameVelocityRepresentation .
      *
      * The state is the one given set by the setRobotState method.
      *
@@ -698,9 +713,14 @@ public:
     bool generalizedGravityForces(FreeFloatingGeneralizedTorques & generalizedGravityForces);
 
     /**
-     * Compute the getNrOfDOFS()+6 vector of generalized external forces.
+     * @brief Compute the getNrOfDOFS()+6 vector of generalized external forces.
      *
-     * The semantics of baseAcc, the base part of baseForceAndJointTorques
+     * This method computes \f$ -\sum_{L \in \mathcal{L}} J_L^T \mathrm{f}_L^x \in \mathbb{R}^{6+n_{DOF}} \f$.
+     *
+     * @warning Note that this method returns the **negated** sum of the product of jacobian and the external force,
+     *          consistently with how the generalized external forces are computed in the KinDynComputations::inverseDynamics method.
+     *
+     * The semantics of the base part of generalizedExternalForces
      * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
      *
      * The state is the one given set by the setRobotState method.
@@ -714,8 +734,15 @@ public:
     /**
      * @brief Compute the free floating inverse dynamics as a linear function of inertial parameters.
      *
-     * The semantics of baseAcc, the base part (first six rows) of baseForceAndJointTorques
-     * and of the elements of linkExtWrenches depend of the chosen FrameVelocityRepresentation .
+     * This methods computes the \f$ Y(\dot{\nu}, \nu, q) \in \mathbb{R}^{ (6+n_{DOF}) \times (10n_{L}) } \f$ matrix such that:
+     * \f[
+     *  Y(\dot{\nu}, \nu, q) \phi = M(q) \dot{\nu} + C(q, \nu) \nu + G(q)
+     * \f]
+     *
+     * where \f$\phi \in \mathbb{R}^{10n_{L}}\f$ is the vector of inertial parameters returned by the Model::getInertialParameters .
+     *
+     * The semantics of baseAcc, the base part (first six rows) of baseForceAndJointTorquesRegressor
+     * depend of the chosen FrameVelocityRepresentation .
      *
      * The state is the one given set by the setRobotState method.
      *

--- a/src/legacy/estimation-kdl/include/iDynTree/Estimation/simpleLeggedOdometryKDL.h
+++ b/src/legacy/estimation-kdl/include/iDynTree/Estimation/simpleLeggedOdometryKDL.h
@@ -15,7 +15,7 @@
 
 namespace iDynTree {
 /**
- * \ingroup iDynTreeEstimation
+ * \ingroup iDynTreeDeprecated
  *
  * A simple legged odometry for a legged robot.
  *

--- a/src/legacy/high-level-kdl/include/iDynTree/HighLevel/DynamicsComputations.h
+++ b/src/legacy/high-level-kdl/include/iDynTree/HighLevel/DynamicsComputations.h
@@ -30,7 +30,7 @@ class Wrench;
 namespace HighLevel {
 
 /**
- * \ingroup iDynTreeHighLevel
+ * \ingroup iDynTreeDeprecated
  *
  * The dynamics computations class is an high level class stateful to access
  * several algorithms related to kinematics and dynamics of free floating

--- a/src/model/include/iDynTree/Model/FreeFloatingMatrices.h
+++ b/src/model/include/iDynTree/Model/FreeFloatingMatrices.h
@@ -19,9 +19,15 @@ namespace iDynTree
 class Model;
 
 /**
- * Enum describing the possible frame velocity representation convention.
+ * @brief Possible frame velocity representation convention.
  *
- * See KinDynComputations documentation for more details.
+ * Given a link \f$L\f$ and an absolute frame \f$A\f$, the
+ * the possible frame velocity representation are the following:
+ * * `INERTIAL_FIXED_REPRESENTATION` : Velocity representation is \f${}^{A} \mathrm{v}_{A,B}\f$,
+ * * `BODY_FIXED_REPRESENTATION` : Velocity representation is \f${}^{B} \mathrm{v}_{A,B}\f$,
+ * * `MIXED_REPRESENTATION` : Velocity representation is \f${}^{B[A]} \mathrm{v}_{A,B}\f$.
+ *
+ * See iDynTree::KinDynComputations documentation for more details.
  */
 enum FrameVelocityRepresentation
 {


### PR DESCRIPTION
In particular, add the inverseDynamicsInertialParametersRegressor that
computes the (6+nrOfDofs) \times (10*nrOfLinks) matrix  that maps the inertial parameters
to the part of inverse dynamics that depends on inertial parameters,
and the generalizedExternalForces that computes the contribution of external
forces to inverse dynamics (useful because those are not included in the
torques computed by the regressor).

I would still like to add some more docs, but nevertheless the code and the tests should be complete. 