### PR TITLE
Make libxml2 embeddable

### DIFF
--- a/src/model_io/urdf/CMakeLists.txt
+++ b/src/model_io/urdf/CMakeLists.txt
@@ -8,7 +8,9 @@
 
 project(iDynTree_ModelIO_URDF CXX)
 
-find_package(LibXml2 REQUIRED)
+if(NOT LIBXML2_LIBRARY OR NOT LIBXML2_INCLUDE_DIR)
+    find_package(LibXml2 REQUIRED)
+endif()
 
 set(IDYNTREE_MODELIO_URDF_HEADERS include/iDynTree/ModelIO/URDFDofsImport.h
                                   include/iDynTree/ModelIO/ModelLoader.h


### PR DESCRIPTION
I see that libxml2 headers are private, so someone else can set :
```cmake
    set(LIBXML2_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external/libxml2-2.9.7/include CACHE PATH "")
    set(LIBXML2_LIBRARY xml2 CACHE STRING "")
    set(LIBXML2_FOUND TRUE CACHE BOOL "")
    set(LIBXML2_INCLUDE_DIRS ${LIBXML2_INCLUDE_DIR} CACHE PATH "")
    set(LIBXML2_LIBRARIES ${LIBXML2_LIBRARY} CACHE STRING "")
```
