### PR TITLE
Fix getRPY documentation in Rotation.h

### DIFF
--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -164,7 +164,7 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponding to this rotation.
          *
-         * Get \f$ r \in [-π, π] , p \in [-π/2, π/2], y \in [-π, π]\f$
+         * Get \f$ r \in [-π, π] , p \in (-π/2, π/2), y \in [-π, π]\f$
          * such that
          * *this == RotZ(y)*RotY(p)*RotX(r)
          *

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -164,7 +164,7 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponding to this rotation.
          *
-         * Get \f$ (r,p,y) \in (-π, π] \times (-π/2, π/2) \times (-π, π] \bigcap  \{0\} \times \{-π/2,π/2\} \times (-π,π)\f$
+         * Get \f$ (r,p,y) \in ( (-π, π] \times (-π/2, π/2) \times (-π, π] ) \cup ( \{0\} \times \{-π/2\} \times (-π,π) ) \cup ( \{0\} \times \{π/2\} \times (-π,π) )\f$
          * such that
          * *this == RotZ(y)*RotY(p)*RotX(r)
          *

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -164,7 +164,7 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponding to this rotation.
          *
-         * Get \f$ r \in [-π, π] , p \in (-π/2, π/2), y \in [-π, π]\f$
+         * Get \f$ (r,p,y) \in (-π, π] \times (-π/2, π/2) \times (-π, π] \bigcap  \{0\} \times \{-π/2,π/2\} \times (-π,π)\f$
          * such that
          * *this == RotZ(y)*RotY(p)*RotX(r)
          *

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -164,7 +164,7 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponding to this rotation.
          *
-         * Get \f$ (r,p,y) \in ( (-π, π] \times (-π/2, π/2) \times (-π, π] ) \cup ( \{0\} \times \{-π/2\} \times (-π,π) ) \cup ( \{0\} \times \{π/2\} \times (-π,π) )\f$
+         * Get \f$ (r,p,y) \in ( (-π, π] \times (-π/2, π/2) \times (-π, π] ) \cup ( \{0\} \times \{-π/2\} \times (-π,π] ) \cup ( \{0\} \times \{π/2\} \times [-π,π) )\f$
          * such that
          * *this == RotZ(y)*RotY(p)*RotX(r)
          *


### PR DESCRIPTION
Changing limits of RPY documention:
Get `r \in [-π, π] , p \in [-π/2, π/2], y \in [-π, π]` to 
Get `r \in [-π, π] , p \in (-π/2, π/2), y \in [-π, π]`