### PR TITLE
Add namePrefix option to YarpRobotStatePublisher

### DIFF
--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
     if (rf.check("help"))
     {
         cout<<"Options"<<endl;
+        cout<<"\t--name                   <name>: prefix of the yarprobotstatepublisher ports"<<endl;
         cout<<"\t--prefix                 <prefix-name>: prefix of the published TFs"<<endl;
         cout<<"\t--model                  <file-name>: file name of the model to load at startup"<<endl;
         cout<<"\t--base-frame             <frame-name>: specify the base frame of the published tf tree"<<endl;

--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -35,8 +35,8 @@ int main(int argc, char *argv[])
     if (rf.check("help"))
     {
         cout<<"Options"<<endl;
-        cout<<"\t--name                   <name>: prefix of the yarprobotstatepublisher ports"<<endl;
-        cout<<"\t--prefix                 <prefix-name>: prefix of the published TFs"<<endl;
+        cout<<"\t--namePrefix             <name-prefix>: prefix of the yarprobotstatepublisher ports"<<endl;
+        cout<<"\t--tfPrefix               <tf-prefix>: prefix of the published TFs"<<endl;
         cout<<"\t--model                  <file-name>: file name of the model to load at startup"<<endl;
         cout<<"\t--base-frame             <frame-name>: specify the base frame of the published tf tree"<<endl;
         cout<<"\t--jointstates-topic      <topic-name>: source topic that streams the joint state"<<endl;
@@ -52,4 +52,3 @@ int main(int argc, char *argv[])
     YARPRobotStatePublisherModule statepublisher;
     return statepublisher.runModule(rf);
 }
-

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -63,13 +63,21 @@ bool YARPRobotStatePublisherModule::configure(ResourceFinder &rf)
 {
     string name="yarprobotstatepublisher";
     string namePrefix = rf.check("namePrefix",Value("")).asString();
-    m_rosNode = new yarp::os::Node("/"+namePrefix+"/yarprobotstatepublisher");
+    if (!namePrefix.empty()) {
+        m_rosNode = new yarp::os::Node("/"+namePrefix+"/yarprobotstatepublisher");
+    }
+    else m_rosNode = new yarp::os::Node("/yarprobotstatepublisher");
+
     string modelFileName=rf.check("model",Value("model.urdf")).asString();
     m_period=rf.check("period",Value(0.010)).asDouble();
 
     Property pTransformclient_cfg;
     pTransformclient_cfg.put("device", "transformClient");
-    pTransformclient_cfg.put("local", "/"+namePrefix+"/"+name+"/transformClient");
+    if (!namePrefix.empty()) {
+        pTransformclient_cfg.put("local", "/"+namePrefix+"/"+name+"/transformClient");
+    }
+    else pTransformclient_cfg.put("local", "/"+name+"/transformClient");
+
     pTransformclient_cfg.put("remote", "/transformServer");
 
     m_tfPrefix = rf.check("tfPrefix",Value("")).asString();

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -62,13 +62,14 @@ YARPRobotStatePublisherModule::YARPRobotStatePublisherModule(): m_iframetrans(nu
 bool YARPRobotStatePublisherModule::configure(ResourceFinder &rf)
 {
     string name="yarprobotstatepublisher";
-    m_rosNode = new yarp::os::Node("/yarprobotstatepublisher");
+    string namePrefix = rf.check("namePrefix",Value("")).asString();
+    m_rosNode = new yarp::os::Node("/"+namePrefix+"/yarprobotstatepublisher");
     string modelFileName=rf.check("model",Value("model.urdf")).asString();
     m_period=rf.check("period",Value(0.010)).asDouble();
 
     Property pTransformclient_cfg;
     pTransformclient_cfg.put("device", "transformClient");
-    pTransformclient_cfg.put("local", "/"+name+"/transformClient");
+    pTransformclient_cfg.put("local", "/"+namePrefix+"/"+name+"/transformClient");
     pTransformclient_cfg.put("remote", "/transformServer");
 
     m_tfPrefix = rf.check("tfPrefix",Value("")).asString();


### PR DESCRIPTION
This PR adds the addition option of `namePrefix` which will allow to specify the prefix for the rosnode and transform client port

@diegoferigo @traversaro It is a very minor fix! So, I am not sure if it is ideal to open a PR. 