### PR TITLE
[Estimation][AttitudeEstimator] Fix bug caused by private headers included in public headers

### DIFF
--- a/src/estimation/include/iDynTree/Estimation/AttitudeMahonyFilter.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeMahonyFilter.h
@@ -12,7 +12,6 @@
 #define ATTITUDE_MAHONY_FILTER_H
 
 #include <iDynTree/Estimation/AttitudeEstimator.h>
-#include <iDynTree/Estimation/AttitudeEstimatorUtils.h>
 #include <iDynTree/Core/Direction.h>
 
 namespace iDynTree

--- a/src/estimation/include/iDynTree/Estimation/AttitudeQuaternionEKF.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeQuaternionEKF.h
@@ -13,7 +13,6 @@
 
 #include <iDynTree/Estimation/AttitudeEstimator.h>
 #include <iDynTree/Estimation/ExtendedKalmanFilter.h>
-#include <iDynTree/Estimation/AttitudeEstimatorUtils.h>
 #include <iDynTree/Core/Direction.h>
 
 namespace iDynTree

--- a/src/estimation/src/AttitudeMahonyFilter.cpp
+++ b/src/estimation/src/AttitudeMahonyFilter.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iDynTree/Estimation/AttitudeMahonyFilter.h>
+#include <iDynTree/Estimation/AttitudeEstimatorUtils.h>
 #include <ctime>
 
 iDynTree::Matrix3x3 getMatrixFromVectorVectorMultiplication(iDynTree::Vector3 a, iDynTree::Vector3 b)

--- a/src/estimation/src/AttitudeQuaternionEKF.cpp
+++ b/src/estimation/src/AttitudeQuaternionEKF.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iDynTree/Estimation/AttitudeQuaternionEKF.h>
+#include <iDynTree/Estimation/AttitudeEstimatorUtils.h>
 
 void iDynTree::AttitudeQuaternionEKF::serializeStateVector()
 {


### PR DESCRIPTION
Fixing private headers for issue [#519](https://github.com/robotology/idyntree/issues/519)