### PR TITLE
Add the possibility to set a desired homogeneous transformation for the FixedFrame in the SimpleLeggedOdometry

### DIFF
--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -37,3 +37,5 @@ KinDynComputations finally reached feature parity with respect to DynamicsComput
 * Added `AttitudeMahonyFilter` implementation of an explicit formulation of passive complementary filter over quaternion groups
 * Added `AttitudeQuaternionEKF` implementation
 * All of the above addressed in the PR (https://github.com/robotology/idyntree/pull/516)
+* Added `getWorldFrameTransform` implementation in `SimpleLeggedOdometry` class
+* Added a new version of `changeFixedFrame` in `SimpleLeggedOdometry`class. This can be used to set a desired homogeneous transformation for the fixed frame

--- a/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
+++ b/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
@@ -269,11 +269,11 @@ public:
     iDynTree::Transform getWorldLinkTransform(const LinkIndex frame_index);
 
     /**
-     * Get the world_H_link transform for an arbitrary link.
+     * Get the world_H_frame transform for an arbitrary frame.
      *
      * \note this method works also for arbitrary frames.
      */
-    iDynTree::Transform getWorldFrameTransform(const LinkIndex frame_index);
+    iDynTree::Transform getWorldFrameTransform(const FrameIndex frame_index);
 };
 
 

--- a/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
+++ b/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
@@ -249,11 +249,16 @@ public:
      * \note this method works only for link, not for arbitrary frames.
      */
     iDynTree::Transform getWorldLinkTransform(const LinkIndex frame_index);
+
+    /**
+     * Get the world_H_link transform for an arbitrary link.
+     *
+     * \note this method works also for arbitrary frames.
+     */
+    iDynTree::Transform getWorldFrameTransform(const LinkIndex frame_index);
 };
 
 
 } // End namespace iDynTree
 
 #endif // IDYNTREE_SIMPLE_LEGGED_ODOMETRY2_
-
-

--- a/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
+++ b/src/estimation/include/iDynTree/Estimation/SimpleLeggedOdometry.h
@@ -234,6 +234,24 @@ public:
     bool changeFixedFrame(const FrameIndex newFixedFrame);
 
     /**
+     * Change the link that the odometry assumes to be fixed
+     * with respect to the inertial/world frame.
+     *
+     * \note The position of the external frame is set by the user
+     */
+    bool changeFixedFrame(const std::string & newFixedFrame,
+                          const Transform & world_H_newFixedFrame);
+
+    /**
+     * Change the link that the odometry assumes to be fixed
+     * with respect to the inertial/world frame.
+     *
+     * \note The position of the external frame is set by the user
+     */
+    bool changeFixedFrame(const FrameIndex newFixedFrame,
+                          const Transform & world_H_newFixedFrame);
+
+    /**
      * Get the link currently considered fixed with respect to the inertial frame.
      *
      * \note This can be diffent from what was set with changeFixedFrame, because

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -358,8 +358,8 @@ Transform SimpleLeggedOdometry::getWorldFrameTransform(const LinkIndex frame_ind
     }
 
     LinkIndex linkIndex = this->m_model.getFrameLink(frame_index);
-    Transform fixedLink_H_fixedFrame = m_model.getFrameTransform(frame_index);
-    return getWorldLinkTransform(linkIndex) * fixedLink_H_fixedFrame;
+    Transform link_H_frame = m_model.getFrameTransform(frame_index);
+    return getWorldLinkTransform(linkIndex) * link_H_frame;
 }
 
 }

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -339,7 +339,7 @@ Transform SimpleLeggedOdometry::getWorldLinkTransform(const LinkIndex link_index
     return m_world_H_fixedLink*base_H_fixed.inverse()*base_H_link;
 }
 
-Transform SimpleLeggedOdometry::getWorldFrameTransform(const LinkIndex frame_index)
+Transform SimpleLeggedOdometry::getWorldFrameTransform(const FrameIndex frame_index)
 {
     if( !this->m_kinematicsUpdated || !this->m_isOdometryInitialized  )
     {

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -257,6 +257,48 @@ bool SimpleLeggedOdometry::changeFixedFrame(const FrameIndex newFixedFrame)
     return true;
 }
 
+bool SimpleLeggedOdometry::changeFixedFrame(const FrameIndex newFixedFrame, const Transform & world_H_newFixedFrame)
+{
+    if( !this->m_kinematicsUpdated )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "changeFixedFrame",
+                    "changeFixedFrame was called, but the kinematics info was never setted.");
+        return false;
+    }
+
+    LinkIndex newFixedLink = this->m_model.getFrameLink(newFixedFrame);
+
+    if( newFixedLink == LINK_INVALID_INDEX )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "changeFixedFrame",
+                    "changeFixedFrame was called, but the provided new fixed frame is unknown.");
+        return false;
+    }
+
+    Transform newFixedFrame_H_newFixedLink = m_model.getFrameTransform(newFixedFrame).inverse();
+    this->m_world_H_fixedLink = world_H_newFixedFrame * newFixedFrame_H_newFixedLink;
+    this->m_fixedLinkIndex = newFixedLink;
+
+    return true;
+}
+
+bool SimpleLeggedOdometry::changeFixedFrame(const std::string& newFixedFrame, const Transform & world_H_newFixedFrame)
+{
+    iDynTree::FrameIndex newFixedFrameIndex = this->m_model.getFrameIndex(newFixedFrame);
+
+    if( newFixedFrameIndex == FRAME_INVALID_INDEX )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "changeFixedFrame",
+                    "changeFixedFrame was called, but the provided new fixed frame is unknown.");
+        return false;
+    }
+
+    return this->changeFixedFrame(newFixedFrameIndex, world_H_newFixedFrame);
+}
+
 bool SimpleLeggedOdometry::changeFixedFrame(const std::string& newFixedFrame)
 {
     iDynTree::FrameIndex newFixedFrameIndex = this->m_model.getFrameIndex(newFixedFrame);

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -297,6 +297,27 @@ Transform SimpleLeggedOdometry::getWorldLinkTransform(const LinkIndex link_index
     return m_world_H_fixedLink*base_H_fixed.inverse()*base_H_link;
 }
 
+Transform SimpleLeggedOdometry::getWorldFrameTransform(const LinkIndex frame_index)
+{
+    if( !this->m_kinematicsUpdated || !this->m_isOdometryInitialized  )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "getWorldFrameTransform",
+                    "getWorldLinkTransform was called, but the kinematics update or the odometry init was never setted.");
+        return Transform::Identity();
+    }
 
+    if( !this->m_model.isValidFrameIndex(frame_index) )
+    {
+        reportError("SimpleLeggedOdometry",
+                    "getWorldFrameTransform",
+                    "getWorldLinkTransform was called, but the request linkindex is not part of the model");
+        return Transform::Identity();
+    }
+
+    LinkIndex linkIndex = this->m_model.getFrameLink(frame_index);
+    Transform fixedLink_H_fixedFrame = m_model.getFrameTransform(frame_index);
+    return getWorldLinkTransform(linkIndex) * fixedLink_H_fixedFrame;
 }
 
+}


### PR DESCRIPTION
This PR is related to #524
In details it implements:
* `getWorldFrameTransform()` in order to overcome the limitation of `getWorldLinkTransform()`;
* a new version of `changeFixedFrame()`  to set a desired homogeneous transformation for the fixed frame.  

cc @traversaro @prashanthr05 @S-Dafarra 