### PR TITLE
implement Model::getTotalMass()

### DIFF
--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -50,3 +50,6 @@ KinDynComputations finally reached feature parity with respect to DynamicsComput
 * Fixed compatibility of `Span` with SWIG bindings compilation (https://github.com/robotology/idyntree/pull/522)
 * Added bindings for the class `Span` with the name `DynamicSpan` (https://github.com/robotology/idyntree/pull/522)
 * Added basic tests for `Span` (https://github.com/robotology/idyntree/pull/522)
+
+### `Model`
+* Implement `getTotalMass()` method for Model class

--- a/src/model/include/iDynTree/Model/Model.h
+++ b/src/model/include/iDynTree/Model/Model.h
@@ -218,6 +218,11 @@ namespace iDynTree
         std::string getJointName(const JointIndex index) const;
 
         /**
+         * Get the total mass of the robot
+         */
+        double getTotalMass() const;
+
+        /**
          * Get the index of a joint, given a jointName.
          * If the jointName is not found in the model,
          * return JOINT_INVALID_INDEX .

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -132,6 +132,18 @@ LinkIndex Model::getLinkIndex(const std::string& linkName) const
     return LINK_INVALID_INDEX;
 }
 
+double Model::getTotalMass() const
+{
+    double totalMass = 0.0;
+
+    for(size_t l=0; l < this->getNrOfLinks(); l++)
+    {
+        totalMass += this->getLink(l)->getInertia().getMass();
+    }
+
+    return totalMass;
+}
+
 bool Model::isValidLinkIndex(const LinkIndex index) const
 {
     return (index != LINK_INVALID_INDEX) &&


### PR DESCRIPTION
This PR implements the method `getTotalMass()` in the `Model` class