### PR TITLE
Use ipopt from homebrew core in installation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ you need to add `${VCPKG_ROOT}/installed/x64-windows` and `${VCPKG_ROOT}/install
 ##### macOS
 You can install most of the required and optional dependencies of iDynTree using [homebrew](https://brew.sh/) with the following command:
 ~~~
-brew install eigen qt5 dartsim/dart/ipopt
+brew install eigen qt5 ipopt
 ~~~
 
 


### PR DESCRIPTION
Related issue: https://github.com/dartsim/homebrew-dart/issues/76