### PR TITLE
[tools][yarprobotstatepublisher] fix missing <memory> header

### DIFF
--- a/src/tools/yarprobotstatepublisher/include/robotstatepublisher.h
+++ b/src/tools/yarprobotstatepublisher/include/robotstatepublisher.h
@@ -23,6 +23,7 @@
 #include <iDynTree/KinDynComputations.h>
 
 #include <yarp/rosmsg/sensor_msgs/JointState.h>
+#include <memory>
 
 class YARPRobotStatePublisherModule;
 


### PR DESCRIPTION
Fixes compilation error due to missing <memory> header.