### PR TITLE
 Implement RPYRightTrivializedDerivativeRateOfChange() and RPYRightTrivializedDerivativeInverseRateOfChange() into Rotation class

### DIFF
--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -50,6 +50,7 @@ KinDynComputations finally reached feature parity with respect to DynamicsComput
 * Fixed compatibility of `Span` with SWIG bindings compilation (https://github.com/robotology/idyntree/pull/522)
 * Added bindings for the class `Span` with the name `DynamicSpan` (https://github.com/robotology/idyntree/pull/522)
 * Added basic tests for `Span` (https://github.com/robotology/idyntree/pull/522)
+* Implement `RPYRightTrivializedDerivativeRateOfChange()` and `RPYRightTrivializedDerivativeInverseRateOfChange()` into `Rotation` class
 
 ### `Model`
 * Implement `getTotalMass()` method for Model class

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -366,12 +366,33 @@ namespace iDynTree
         static Matrix3x3 RPYRightTrivializedDerivative(const double roll, const double pitch, const double yaw);
 
         /**
+         * Return the rate of change of the right-trivialized derivative of the RPY function.
+         *
+         * If we indicate with \f$ rpy \in \mathbb{R}^3 \f$ the roll pitch yaw vector,
+         * and with \f$  RPY(rpy) : \mathbb{R}^3 \mapsto SO(3) \f$ the function implemented
+         * in the Rotation::RPY method, this method returns the right-trivialized partial
+         * derivative of Rotation::RPY, i.e. :
+         * \f[
+         *    (RPY(rpy) \frac{d}{d t}\frac{\partial RPY(rpy)}{\partial rpy})^\vee
+         * \f]
+         */
+        static Matrix3x3 RPYRightTrivializedDerivativeRateOfChange(const double roll, const double pitch, const double yaw, const double rollDot, const double pitchDot, const double yawDot);
+
+        /**
          * Return the inverse of the right-trivialized derivative of the RPY function.
          *
          * See RPYRightTrivializedDerivative for a detailed description of the method.
          *
          */
         static Matrix3x3 RPYRightTrivializedDerivativeInverse(const double roll, const double pitch, const double yaw);
+
+        /**
+         * Return the inverse of the rate of change of right-trivialized derivative of the RPY function.
+         *
+         * See RPYRightTrivializedDerivativeRateOfChange for a detailed description of the method.
+         *
+         */
+        static Matrix3x3 RPYRightTrivializedDerivativeInverseRateOfChange(const double roll, const double pitch, const double yaw, const double rollDot, const double pitchDot, const double yawDot);
 
         /**
          * Return the right-trivialized derivative of the Quaternion function.

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -387,7 +387,7 @@ namespace iDynTree
         static Matrix3x3 RPYRightTrivializedDerivativeInverse(const double roll, const double pitch, const double yaw);
 
         /**
-         * Return the inverse of the rate of change of right-trivialized derivative of the RPY function.
+         *  Return the rate of change of the inverse of the right-trivialized derivative of the RPY function.
          *
          * See RPYRightTrivializedDerivativeRateOfChange for a detailed description of the method.
          *

--- a/src/core/src/Rotation.cpp
+++ b/src/core/src/Rotation.cpp
@@ -517,6 +517,28 @@ namespace iDynTree
         return map;
     }
 
+    Matrix3x3 Rotation::RPYRightTrivializedDerivativeRateOfChange(const double /*roll*/, const double pitch, const double yaw, const double /*rollDot*/, const double pitchDot, const double yawDot)
+    {
+        Matrix3x3 map;
+
+        double sp = std::sin(pitch);
+        double cp = std::cos(pitch);
+        double sy = std::sin(yaw);
+        double cy = std::cos(yaw);
+
+        map(0, 0) = -sp * cy * pitchDot - cp * sy * yawDot;
+        map(1, 0) = -sp * sy * pitchDot + cy * cp * yawDot;
+        map(2, 0) = -cp * pitchDot;
+        map(0, 1) = -cy * yawDot;
+        map(1, 1) = -sy * yawDot;
+        map(2, 1) = 0.0;
+        map(0, 2) = 0.0;
+        map(1, 2) = 0.0;
+        map(2, 2) = 0.0;
+
+        return map;
+    }
+
     Matrix3x3 Rotation::RPYRightTrivializedDerivativeInverse(const double /*roll*/, const double pitch, const double yaw)
     {
         // See doc/symbolic/RPYExpressionReference.py
@@ -537,6 +559,29 @@ namespace iDynTree
         map(0, 2) = 0.0;
         map(1, 2) = 0.0;
         map(2, 2) = 1.0;
+
+        return map;
+    }
+
+    Matrix3x3 Rotation::RPYRightTrivializedDerivativeInverseRateOfChange(const double /*roll*/, const double pitch, const double yaw, const double /*rollDot*/, const double pitchDot, const double yawDot)
+    {
+        Matrix3x3 map;
+
+        double sp = std::sin(pitch);
+        double cp = std::cos(pitch);
+        double sy = std::sin(yaw);
+        double cy = std::cos(yaw);
+        double tp = std::tan(pitch);
+
+        map(0, 0) = (-sy * cp * yawDot + cy * sp * pitchDot) / std::pow(cp, 2);
+        map(1, 0) = -cy * yawDot;
+        map(2, 0) = -sy * tp * yawDot + cy * pitchDot / std::pow(cp, 2);
+        map(0, 1) = (cy * cp * yawDot + sy * sp * pitchDot) / std::pow(cp, 2);
+        map(1, 1) = -sy * yawDot;
+        map(2, 1) = cy * tp * yawDot + sy * pitchDot / std::pow(cp, 2);
+        map(0, 2) = 0.0;
+        map(1, 2) = 0.0;
+        map(2, 2) = 0.0;
 
         return map;
     }


### PR DESCRIPTION
This PR implement `RPYRightTrivializedDerivativeRateOfChange()` and `RPYRightTrivializedDerivativeInverseRateOfChange()` methods into `Rotation` class. 

I also implemented the test for testing the aforementioned methods.  

Close #540 

cc @MiladShafiee @S-Dafarra @traversaro 