### PR TITLE
[AttitudeEstimator] Fix quaternion propagation

### DIFF
--- a/src/estimation/include/iDynTree/Estimation/AttitudeEstimatorUtils.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeEstimatorUtils.h
@@ -147,4 +147,48 @@ iDynTree::UnitQuaternion composeQuaternion2(const iDynTree::UnitQuaternion &q1, 
  */
 iDynTree::UnitQuaternion pureQuaternion(const iDynTree::Vector3& bodyFixedFrameVelocityInInertialFrame);
 
+
+/**
+ * @brief exponential map for quaternion - maps angular velocities to quaternion
+ *
+ * \f$ \text{exp}(\omega) = \begin{bmatrix} \text{cos}(\frac{||\omega||}{2}) \\ \text{sin}(\frac{||\omega||}{2})\frac{\omega}{||\omega||}  \end{bmatrix} \f$
+ *
+ * @param[in] omega angular velocity
+ * @return iDynTree::UnitQuaternion
+ */
+inline iDynTree::UnitQuaternion expQuaternion(iDynTree::Vector3 omega)
+{
+    iDynTree::UnitQuaternion q;
+    q.zero();
+    q(0) = 1.0;
+    using iDynTree::toEigen;
+    double norm{toEigen(omega).norm()};
+
+    if (norm == 0)
+    {
+        return q;
+    }
+
+    double c = std::cos(norm/2);
+    double s = std::sin(norm/2)/norm;
+
+    q(0) = c;
+    q(1) = omega(0)*s;
+    q(2) = omega(1)*s;
+    q(3) = omega(2)*s;
+
+    return q;
+}
+
+template<class T>
+inline bool check_are_almost_equal(const T& x, const T& y, int units_in_last_place)
+{
+    if (!( std::abs(x- y) <= std::numeric_limits<T>::epsilon()*std::max(std::abs(x), std::abs(y))*units_in_last_place))
+    {
+        return false;
+    }
+
+    return true;
+}
+
 #endif

--- a/src/estimation/include/iDynTree/Estimation/AttitudeQuaternionEKF.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeQuaternionEKF.h
@@ -76,7 +76,7 @@ namespace iDynTree
      * @note: we will drop the subscripts and superscripts in the rest of the documentation for convenience
      *
      * Discretized dynamics during the prediction step,
-     * \f[ \hat{{x}}_{k+1} = \begin{bmatrix} q_k + \Delta t. \frac{1}{2}q_k  \circ \begin{bmatrix} 0 \\ \omega^b_{k+1} \end{bmatrix} \\ y_{gyro_{k}} - b_{k} \\ (1 - \lambda_{b} \Delta t)b_k \end{bmatrix} \f]
+     * \f[ \hat{{x}}_{k+1} = \begin{bmatrix} q_{k} \otimes \text{exp}(\omega \Delta T) \\ y_{gyro_{k}} - b_{k} \\ (1 - \lambda_{b} \Delta t)b_k \end{bmatrix} \f]
      *
      * Measurement model for accelerometer is given as,
      * \f[ h_{acc}(\hat{x}_{k+1}) = \begin{bmatrix} 2(q_1q_3 - q_0q_2) \\ 2(q_2q_3 - q_0q_1) \\ q_0^2 - q_1^2 - q_2^2 + q_3^2 \end{bmatrix} \f]
@@ -230,7 +230,7 @@ namespace iDynTree
          * discrete system propagation \f$ f(X, u) = f(X, y_gyro) \f$
          * where \f$ X = \begin{bmatrix} q_0 &  q_1 & q_2 & q_3 & \omega_x & \omega_y & \omega_z & \b_x & \b_y & \b_z \end{bmatrix}^T \f$
          * \f$ u = \begin{bmatrix} y_{gyro}_x & y_{gyro}_y & y_{gyro}_z \end{bmatrix}^T \f$
-         * \f$ f(X, u) = \begin{bmatrix} q + \Delta t. \frac{1}{2}q \circ \begin{bmatrix} 0 \\ \omega^b \end{bmatrix} \\ y_{gyro} - b \\ (1 - \lambda_{b} \Delta t)b \end{bmatrix}\f$
+         * \f$ f(X, u) = \begin{bmatrix} q_{k} \otimes \text{exp}(\omega \Delta T) \\ y_{gyro} - b \\ (1 - \lambda_{b} \Delta t)b \end{bmatrix}\f$
          */
         bool ekf_f(const iDynTree::VectorDynSize& x_k,
                const iDynTree::VectorDynSize& u_k,

--- a/src/estimation/src/AttitudeEstimatorUtils.cpp
+++ b/src/estimation/src/AttitudeEstimatorUtils.cpp
@@ -18,7 +18,7 @@ bool checkValidMeasurement(const iDynTree::Vector3& in, const std::string& measu
     {
         if (isZeroVector(in))
         {
-            iDynTree::reportError("AttitudeMahonyFilter", "checkValidMeasurement",
+            iDynTree::reportError("AttitudeEstimator", "checkValidMeasurement",
                                   (measurement_type + " measurements are invalid. Expecting a non-zero vector.").c_str());
             return false;
         }
@@ -26,7 +26,7 @@ bool checkValidMeasurement(const iDynTree::Vector3& in, const std::string& measu
 
     if (isVectorNaN(in))
     {
-        iDynTree::reportError("AttitudeMahonyFilter", "checkValidMeasurement",
+        iDynTree::reportError("AttitudeEstimator", "checkValidMeasurement",
                               (measurement_type + " measurements are invalid. Has NaN elements.").c_str());
         return false;
     }

--- a/src/estimation/src/ExtendedKalmanFilter.cpp
+++ b/src/estimation/src/ExtendedKalmanFilter.cpp
@@ -144,8 +144,8 @@ bool iDynTree::DiscreteExtendedKalmanFilterHelper::ekfUpdate()
     auto xhat(toEigen(m_xhat));
     auto y(toEigen(m_y) - toEigen(z));        ///< innovation \f$ \tilde{y}_{k+1} = y_{k+1} - z_{k+1} \f$
 
-    S = H*Phat*H.transpose() + R;             ///< \f$ S_{k+1} = H_{k+1} \hat{P}_{k+1} H_{k+1}^T + R \f$
-    K = Phat*H.transpose()*S.inverse();       ///< \f$ K_{k+1} = \hat{P}_{k+1} H_{k+1}^T S_{k+1}^{-1} \f$
+    S = H*Phat*(H.transpose()) + R;             ///< \f$ S_{k+1} = H_{k+1} \hat{P}_{k+1} H_{k+1}^T + R \f$
+    K = Phat*(H.transpose())*(S.inverse());       ///< \f$ K_{k+1} = \hat{P}_{k+1} H_{k+1}^T S_{k+1}^{-1} \f$
     P = Phat - (K*H*Phat);                    ///< \f$ P_{k+1} = \hat{P}_{k+1} - (K_{k+1} H \hat{P}_{k+1}) \f$
     x = xhat + K*y;                           ///< \f$ x_{k+1} = \hat{x}_{k+1} + K_{k+1} \tilde{y}_{k+1} \f$
 


### PR DESCRIPTION
This PR fixes the quaternion propagation using an exponential map.

Fix the discrete propagation of quaternion.
$q_{n+1} = q_{n} \otimes \text{exp}(\omega \Delta T)$

where 
- $\omega$ is the left trivialized angular velocity (angular velocity of the moving frame with respect to a fixed frame, expressed in the moving frame.)
- $\text{exp}(\omega) = \begin{bmatrix} \text{cos}(\frac{||\omega||}{2}) \\\\ \text{sin}(\frac{||\omega||}{2})\frac{\omega}{||\omega||}  \end{bmatrix} $