### PR TITLE
Feature: yarprobotstatepublisher reduced model tf optional parameter

### DIFF
--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -58,3 +58,4 @@ KinDynComputations finally reached feature parity with respect to DynamicsComput
 ### `yarprobotstatepublisher`
 * Add `tf-prefix` and `jointstates-topic` options for the tf prefixes and ROS topic.
 * `robot` option is deprecated, and replaced by `name-prefix`.
+* Add `reduced-model` optional parameter to stream only the link transformations to transform server. By default, tranformations from all the frames are streamed to the transform server.

--- a/src/tools/yarprobotstatepublisher/include/robotstatepublisher.h
+++ b/src/tools/yarprobotstatepublisher/include/robotstatepublisher.h
@@ -54,6 +54,9 @@ class YARPRobotStatePublisherModule : public yarp::os::RFModule
     bool m_usingNetworkClock;
     yarp::os::NetworkClock m_netClock;
 
+    // Reduced flag option
+    bool reducedModelOption;
+
     // Class for computing forward kinematics
    iDynTree::KinDynComputations m_kinDynComp;
    iDynTree::VectorDynSize m_jointPos;

--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -38,8 +38,8 @@ int main(int argc, char *argv[])
         cout<<"\t--name-prefix            <name-prefix> : prefix of the yarprobotstatepublisher ports (default no prefix)"<<endl;
         cout<<"\t--tf-prefix              <tf-prefix>   : prefix of the published TFs (default no prefix)"<<endl;
         cout<<"\t--model                  <file-name>   : file name of the model to load at startup"<<endl;
-        cout<<"\t--reduced-model          <boolean-flag>: set true to stream only the link TFs\n"
-              "                                           \t The default value is false and TFs of all the frames in the model are streamed"<<endl;
+        cout<<"\t--reduced-model          <boolean-flag>: use the option to stream only the link TFs\n"
+              "                                           \t By default TFs of all the frames in the model are streamed"<<endl;
         cout<<"\t--base-frame             <frame-name>  : specify the base frame of the published tf tree"<<endl;
         cout<<"\t--jointstates-topic      <topic-name>  : source ROS topic that streams the joint state (default /joint_states)"<<endl;
         return EXIT_SUCCESS;

--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -35,11 +35,13 @@ int main(int argc, char *argv[])
     if (rf.check("help"))
     {
         cout<<"Options"<<endl;
-        cout<<"\t--name-prefix            <name-prefix>: prefix of the yarprobotstatepublisher ports (default no prefix)"<<endl;
-        cout<<"\t--tf-prefix              <tf-prefix>: prefix of the published TFs (default no prefix)"<<endl;
-        cout<<"\t--model                  <file-name>: file name of the model to load at startup"<<endl;
-        cout<<"\t--base-frame             <frame-name>: specify the base frame of the published tf tree"<<endl;
-        cout<<"\t--jointstates-topic      <topic-name>: source ROS topic that streams the joint state (default /joint_states)"<<endl;
+        cout<<"\t--name-prefix            <name-prefix> : prefix of the yarprobotstatepublisher ports (default no prefix)"<<endl;
+        cout<<"\t--tf-prefix              <tf-prefix>   : prefix of the published TFs (default no prefix)"<<endl;
+        cout<<"\t--model                  <file-name>   : file name of the model to load at startup"<<endl;
+        cout<<"\t--reduced-model          <boolean-flag>: set true to stream only the link TFs\n"
+              "                                           \t The default value is false and TFs of all the frames in the model are streamed"<<endl;
+        cout<<"\t--base-frame             <frame-name>  : specify the base frame of the published tf tree"<<endl;
+        cout<<"\t--jointstates-topic      <topic-name>  : source ROS topic that streams the joint state (default /joint_states)"<<endl;
         return EXIT_SUCCESS;
     }
 

--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
         cout<<"\t--name-prefix            <name-prefix> : prefix of the yarprobotstatepublisher ports (default no prefix)"<<endl;
         cout<<"\t--tf-prefix              <tf-prefix>   : prefix of the published TFs (default no prefix)"<<endl;
         cout<<"\t--model                  <file-name>   : file name of the model to load at startup"<<endl;
-        cout<<"\t--reduced-model          <boolean-flag>: use the option to stream only the link TFs\n"
+        cout<<"\t--reduced-model                        : use the option to stream only the link TFs\n"
               "                                           \t By default TFs of all the frames in the model are streamed"<<endl;
         cout<<"\t--base-frame             <frame-name>  : specify the base frame of the published tf tree"<<endl;
         cout<<"\t--jointstates-topic      <topic-name>  : source ROS topic that streams the joint state (default /joint_states)"<<endl;

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -151,9 +151,9 @@ bool YARPRobotStatePublisherModule::configure(ResourceFinder &rf)
     }
 
     // Set reduced model option
-    // The default value is false and considers streaming TFs of all the frames in the model
-    // If set to true, only the TFs of the links are streamed to transform server
-    this->reducedModelOption=rf.check("reduced-model",Value(0)).asBool();
+    // By default TFs of all the frames in the model are streamed
+    // If the option is present, only the TFs of the links are streamed to transform server
+    this->reducedModelOption=rf.check("reduced-model");
 
     // Setup the topic and configureisValid the onRead callback
     string jointStatesTopicName = rf.check("jointstates-topic",Value("/joint_states")).asString();

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -150,6 +150,11 @@ bool YARPRobotStatePublisherModule::configure(ResourceFinder &rf)
         return false;
     }
 
+    // Set reduced model option
+    // The default value is false and considers streaming TFs of all the frames in the model
+    // If set to true, only the TFs of the links are streamed to transform server
+    this->reducedModelOption=rf.check("reduced-model",Value(0)).asBool();
+
     // Setup the topic and configureisValid the onRead callback
     string jointStatesTopicName = rf.check("jointstates-topic",Value("/joint_states")).asString();
     m_jointStateSubscriber.reset(new JointStateSubscriber());
@@ -239,7 +244,18 @@ void YARPRobotStatePublisherModule::onRead(yarp::rosmsg::sensor_msgs::JointState
     // Set the updated joint positions
     m_kinDynComp.setJointPos(m_jointPos);
 
-    for (size_t frameIdx=0; frameIdx < model.getNrOfFrames(); frameIdx++)
+    // Set the size of the tf frames to be published
+    size_t sizeOfTFFrames;
+    if (this->reducedModelOption)
+    {
+        sizeOfTFFrames = model.getNrOfLinks();
+    }
+    else
+    {
+        sizeOfTFFrames = model.getNrOfFrames();
+    }
+
+    for (size_t frameIdx=0; frameIdx < sizeOfTFFrames; frameIdx++)
     {
         if(m_baseFrameIndex == frameIdx)    // skip self-tranform
             continue;


### PR DESCRIPTION
Currently, `yarprobotstatepublisher` publishes the transforms (TFs) of [all the frames](https://github.com/robotology/idyntree/blob/devel/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp#L242) present in a model passed as argument. This frames include also the frames that are associated with sensors e.g. [skin sensor frame](https://github.com/robotology/icub-models/blob/master/iCub/robots/iCubGenova04/model.urdf#L186). These frames without any geometrical properties are not necessary for rviz visualization and we can safely ignore to send the TF associated with these frames from `yarprobotstatepublisher`. This will help to speed up rviz visualization and solves [problems like drop in frame rate](https://github.com/robotology/human-dynamics-estimation/issues/134) due to huge number of TFs present in the transform server. In case of iCub, the total number of frames (including the sensor frames) are **262** while the total number of links that have geometrical properties for rviz visualization are only **39**. 

This PR adds an addition optional boolean parameter `--reduced-model` to `yarprobotstatepublisher`. The default value is **false** and `yarprobotstatepublisher` streams TFs of all the frames present in the urdf model. If set to **true**, only the TFs of links are streamed.

@traversaro @diegoferigo @lrapetti @DanielePucci 