### PR TITLE
Feature: yarprobotstatepublisher update joints size check

### DIFF
--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -59,3 +59,6 @@ KinDynComputations finally reached feature parity with respect to DynamicsComput
 * Add `tf-prefix` and `jointstates-topic` options for the tf prefixes and ROS topic.
 * `robot` option is deprecated, and replaced by `name-prefix`.
 * Add `reduced-model` optional parameter to stream only the link transformations to transform server. By default, tranformations from all the frames are streamed to the transform server.
+* Remove joint size check between model joints and joints in ROS topic given through `jointstates-topic` parameter.
+* Initialize the model joint positions values to zero and update the joint positions values in run time if the values are
+available in ROS topic given through `jointstates-topic` parameter.

--- a/src/tools/yarprobotstatepublisher/src/main.cpp
+++ b/src/tools/yarprobotstatepublisher/src/main.cpp
@@ -41,7 +41,10 @@ int main(int argc, char *argv[])
         cout<<"\t--reduced-model                        : use the option to stream only the link TFs\n"
               "                                           \t By default TFs of all the frames in the model are streamed"<<endl;
         cout<<"\t--base-frame             <frame-name>  : specify the base frame of the published tf tree"<<endl;
-        cout<<"\t--jointstates-topic      <topic-name>  : source ROS topic that streams the joint state (default /joint_states)"<<endl;
+        cout<<"\t--jointstates-topic      <topic-name>  : source ROS topic that streams the joint state (default /joint_states)\n"
+              "                                           \t The position values of the model joints are initilized to Zero\n"
+              "                                           \t In runtime, the joint values from the ROS topic are used to set\n"
+              "                                           \t the position values of some of the model joints."<<endl;
         return EXIT_SUCCESS;
     }
 

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -128,6 +128,9 @@ bool YARPRobotStatePublisherModule::configure(ResourceFinder &rf)
     // Resize the joint pos buffer
     m_jointPos.resize(m_kinDynComp.model().getNrOfPosCoords());
 
+    // Initilize the joint pos buffer to Zero
+    m_jointPos.zero();
+
     // Get the base frame information
     if (rf.check("base-frame"))
     {

--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -217,14 +217,6 @@ void YARPRobotStatePublisherModule::onRead(yarp::rosmsg::sensor_msgs::JointState
         return;
     }
 
-    // Check if joint states contain at least as many joints of the model
-    if (v.name.size() < m_jointPos.size())
-    {
-        yError() << "Size mismatch. Model has " << m_jointPos.size()
-                 << " joints, while the received JointState message has " << v.name.size() << " joints.";
-        return;
-    }
-
     // TODO: this part can be drastically speed up.
     //      Possible improvements:
     //        * Add a map string --> indeces


### PR DESCRIPTION
This PR addressed the segmentation fault that happens when trying to get the robot joint index based on the joint name present in the `/joint_states` topic.
https://github.com/robotology/idyntree/blob/2cbb75f67a8a9b93428d93d941c8d1b65ba6a415/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp#L236

On the real robot (`iCubGenova04`), the `/joint_states` topic consists of **50** joints, including the joint values of the fingers, where as the `model.urdf` of `iCubGenova04` doesn;t have the hands. So, when trying to retrieve a finger joint based from the mode, segmentation fault occurs.

Also, this PR removes the joint size check https://github.com/robotology/idyntree/blob/devel/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp#L220

@traversaro 