### PR TITLE
Add ModelExporter class and add preliminary support for  exporting URDF from iDynTree::Model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(iDynTree CXX)
+project(iDynTree C CXX)
 
 # Disable in source build, unless Eclipse is used
 if( ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}") AND

--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -55,6 +55,9 @@ KinDynComputations finally reached feature parity with respect to DynamicsComput
 ### `Model`
 * Implement `getTotalMass()` method for Model class
 
+### `modelio`
+* Added `iDynTree::ModelExporter` class to export `iDynTree::Model` instances to URDF files (https://github.com/robotology/idyntree/pull/554).
+
 ### `yarprobotstatepublisher`
 * Add `tf-prefix` and `jointstates-topic` options for the tf prefixes and ROS topic.
 * `robot` option is deprecated, and replaced by `name-prefix`.

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -13,3 +13,11 @@ if( (IDYNTREE_USES_OCTAVE OR IDYNTREE_USES_MATLAB OR IDYNTREE_GENERATE_MATLAB) A
     # We save the location of MOxUnit in a variable that is then accessible to the test
     set(IDYNTREE_INTERNAL_MOXUNIT_PATH "${CMAKE_CURRENT_LIST_DIR}/MOxUnit/MOxUnit" PARENT_SCOPE)
 endif()
+
+# fpconv ( https://github.com/night-shift/fpconv ) is a small implementation of a shortest exact representation of double to string
+# as of C++14, it has no equivalent in the C++ standaard, as using stringstream with setprecision(17) result
+# in printing long numbers (such as 1.000000000000000000000) even when there is a short equivalent representation (1.0)
+# This can be removed once std::to_chars from the charconv header introduced in C++17 becomes widely available
+# We imported the MIT-licensed source code from https://github.com/night-shift/fpconv/tree/4a087d1b2df765baa409536931916a2c082cdda4
+add_library(idyntree-private-fpconv OBJECT fpconv/fpconv.c)
+target_include_directories(idyntree-private-fpconv PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/fpconv)

--- a/extern/fpconv/fpconv.c
+++ b/extern/fpconv/fpconv.c
@@ -1,0 +1,355 @@
+// The MIT License
+//
+// Copyright (c) 2013 Andreas Samoljuk
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "fpconv.h"
+#include "powers.h"
+
+#define fracmask  0x000FFFFFFFFFFFFFU
+#define expmask   0x7FF0000000000000U
+#define hiddenbit 0x0010000000000000U
+#define signmask  0x8000000000000000U
+#define expbias   (1023 + 52)
+
+#define absv(n) ((n) < 0 ? -(n) : (n))
+#define minv(a, b) ((a) < (b) ? (a) : (b))
+
+static uint64_t tens[] = {
+    10000000000000000000U, 1000000000000000000U, 100000000000000000U,
+    10000000000000000U, 1000000000000000U, 100000000000000U,
+    10000000000000U, 1000000000000U, 100000000000U,
+    10000000000U, 1000000000U, 100000000U,
+    10000000U, 1000000U, 100000U,
+    10000U, 1000U, 100U,
+    10U, 1U
+};
+
+static inline uint64_t get_dbits(double d)
+{
+    union {
+        double   dbl;
+        uint64_t i;
+    } dbl_bits = { d };
+
+    return dbl_bits.i;
+}
+
+static Fp build_fp(double d)
+{
+    uint64_t bits = get_dbits(d);
+
+    Fp fp;
+    fp.frac = bits & fracmask;
+    fp.exp = (bits & expmask) >> 52;
+
+    if(fp.exp) {
+        fp.frac += hiddenbit;
+        fp.exp -= expbias;
+
+    } else {
+        fp.exp = -expbias + 1;
+    }
+
+    return fp;
+}
+
+static void normalize(Fp* fp)
+{
+    while ((fp->frac & hiddenbit) == 0) {
+        fp->frac <<= 1;
+        fp->exp--;
+    }
+
+    int shift = 64 - 52 - 1;
+    fp->frac <<= shift;
+    fp->exp -= shift;
+}
+
+static void get_normalized_boundaries(Fp* fp, Fp* lower, Fp* upper)
+{
+    upper->frac = (fp->frac << 1) + 1;
+    upper->exp  = fp->exp - 1;
+
+    while ((upper->frac & (hiddenbit << 1)) == 0) {
+        upper->frac <<= 1;
+        upper->exp--;
+    }
+
+    int u_shift = 64 - 52 - 2;
+
+    upper->frac <<= u_shift;
+    upper->exp = upper->exp - u_shift;
+
+
+    int l_shift = fp->frac == hiddenbit ? 2 : 1;
+
+    lower->frac = (fp->frac << l_shift) - 1;
+    lower->exp = fp->exp - l_shift;
+
+
+    lower->frac <<= lower->exp - upper->exp;
+    lower->exp = upper->exp;
+}
+
+static Fp multiply(Fp* a, Fp* b)
+{
+    const uint64_t lomask = 0x00000000FFFFFFFF;
+
+    uint64_t ah_bl = (a->frac >> 32)    * (b->frac & lomask);
+    uint64_t al_bh = (a->frac & lomask) * (b->frac >> 32);
+    uint64_t al_bl = (a->frac & lomask) * (b->frac & lomask);
+    uint64_t ah_bh = (a->frac >> 32)    * (b->frac >> 32);
+
+    uint64_t tmp = (ah_bl & lomask) + (al_bh & lomask) + (al_bl >> 32); 
+    /* round up */
+    tmp += 1U << 31;
+
+    Fp fp = {
+        ah_bh + (ah_bl >> 32) + (al_bh >> 32) + (tmp >> 32),
+        a->exp + b->exp + 64
+    };
+
+    return fp;
+}
+
+static void round_digit(char* digits, int ndigits, uint64_t delta, uint64_t rem, uint64_t kappa, uint64_t frac)
+{
+    while (rem < frac && delta - rem >= kappa &&
+           (rem + kappa < frac || frac - rem > rem + kappa - frac)) {
+
+        digits[ndigits - 1]--;
+        rem += kappa;
+    }
+}
+
+static int generate_digits(Fp* fp, Fp* upper, Fp* lower, char* digits, int* K)
+{
+    uint64_t wfrac = upper->frac - fp->frac;
+    uint64_t delta = upper->frac - lower->frac;
+
+    Fp one;
+    one.frac = 1ULL << -upper->exp;
+    one.exp  = upper->exp;
+
+    uint64_t part1 = upper->frac >> -one.exp;
+    uint64_t part2 = upper->frac & (one.frac - 1);
+
+    int idx = 0, kappa = 10;
+    uint64_t* divp;
+    /* 1000000000 */
+    for(divp = tens + 10; kappa > 0; divp++) {
+
+        uint64_t div = *divp;
+        unsigned digit = part1 / div;
+
+        if (digit || idx) {
+            digits[idx++] = digit + '0';
+        }
+
+        part1 -= digit * div;
+        kappa--;
+
+        uint64_t tmp = (part1 <<-one.exp) + part2;
+        if (tmp <= delta) {
+            *K += kappa;
+            round_digit(digits, idx, delta, tmp, div << -one.exp, wfrac);
+
+            return idx;
+        }
+    }
+
+    /* 10 */
+    uint64_t* unit = tens + 18;
+
+    while(true) {
+        part2 *= 10;
+        delta *= 10;
+        kappa--;
+
+        unsigned digit = part2 >> -one.exp;
+        if (digit || idx) {
+            digits[idx++] = digit + '0';
+        }
+
+        part2 &= one.frac - 1;
+        if (part2 < delta) {
+            *K += kappa;
+            round_digit(digits, idx, delta, part2, one.frac, wfrac * *unit);
+
+            return idx;
+        }
+
+        unit--;
+    }
+}
+
+static int grisu2(double d, char* digits, int* K)
+{
+    Fp w = build_fp(d);
+
+    Fp lower, upper;
+    get_normalized_boundaries(&w, &lower, &upper);
+
+    normalize(&w);
+
+    int k;
+    Fp cp = find_cachedpow10(upper.exp, &k);
+
+    w     = multiply(&w,     &cp);
+    upper = multiply(&upper, &cp);
+    lower = multiply(&lower, &cp);
+
+    lower.frac++;
+    upper.frac--;
+
+    *K = -k;
+
+    return generate_digits(&w, &upper, &lower, digits, K);
+}
+
+static int emit_digits(char* digits, int ndigits, char* dest, int K, bool neg)
+{
+    int exp = absv(K + ndigits - 1);
+
+    /* write plain integer */
+    if(K >= 0 && (exp < (ndigits + 7))) {
+        memcpy(dest, digits, ndigits);
+        memset(dest + ndigits, '0', K);
+
+        return ndigits + K;
+    }
+
+    /* write decimal w/o scientific notation */
+    if(K < 0 && (K > -7 || exp < 4)) {
+        int offset = ndigits - absv(K);
+        /* fp < 1.0 -> write leading zero */
+        if(offset <= 0) {
+            offset = -offset;
+            dest[0] = '0';
+            dest[1] = '.';
+            memset(dest + 2, '0', offset);
+            memcpy(dest + offset + 2, digits, ndigits);
+
+            return ndigits + 2 + offset;
+
+        /* fp > 1.0 */
+        } else {
+            memcpy(dest, digits, offset);
+            dest[offset] = '.';
+            memcpy(dest + offset + 1, digits + offset, ndigits - offset);
+
+            return ndigits + 1;
+        }
+    }
+
+    /* write decimal w/ scientific notation */
+    ndigits = minv(ndigits, 18 - neg);
+
+    int idx = 0;
+    dest[idx++] = digits[0];
+
+    if(ndigits > 1) {
+        dest[idx++] = '.';
+        memcpy(dest + idx, digits + 1, ndigits - 1);
+        idx += ndigits - 1;
+    }
+
+    dest[idx++] = 'e';
+
+    char sign = K + ndigits - 1 < 0 ? '-' : '+';
+    dest[idx++] = sign;
+
+    int cent = 0;
+
+    if(exp > 99) {
+        cent = exp / 100;
+        dest[idx++] = cent + '0';
+        exp -= cent * 100;
+    }
+    if(exp > 9) {
+        int dec = exp / 10;
+        dest[idx++] = dec + '0';
+        exp -= dec * 10;
+
+    } else if(cent) {
+        dest[idx++] = '0';
+    }
+
+    dest[idx++] = exp % 10 + '0';
+
+    return idx;
+}
+
+static int filter_special(double fp, char* dest)
+{
+    if(fp == 0.0) {
+        dest[0] = '0';
+        return 1;
+    }
+
+    uint64_t bits = get_dbits(fp);
+
+    bool nan = (bits & expmask) == expmask;
+
+    if(!nan) {
+        return 0;
+    }
+
+    if(bits & fracmask) {
+        dest[0] = 'n'; dest[1] = 'a'; dest[2] = 'n';
+
+    } else {
+        dest[0] = 'i'; dest[1] = 'n'; dest[2] = 'f';
+    }
+
+    return 3;
+}
+
+int idyntree_private_fpconv_dtoa(double d, char dest[24])
+{
+    char digits[18];
+
+    int str_len = 0;
+    bool neg = false;
+
+    if(get_dbits(d) & signmask) {
+        dest[0] = '-';
+        str_len++;
+        neg = true;
+    }
+
+    int spec = filter_special(d, dest + str_len);
+
+    if(spec) {
+        return str_len + spec;
+    }
+
+    int K = 0;
+    int ndigits = grisu2(d, digits, &K);
+
+    str_len += emit_digits(digits, ndigits, dest + str_len, K, neg);
+
+    return str_len;
+}

--- a/extern/fpconv/fpconv.h
+++ b/extern/fpconv/fpconv.h
@@ -1,0 +1,64 @@
+// The MIT License
+//
+// Copyright (c) 2013 Andreas Samoljuk
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef FPCONV_H
+#define FPCONV_H
+
+/* Fast and accurate double to string conversion based on Florian Loitsch's
+ * Grisu-algorithm[1].
+ *
+ * Input:
+ * fp -> the double to convert, dest -> destination buffer.
+ * The generated string will never be longer than 24 characters.
+ * Make sure to pass a pointer to at least 24 bytes of memory.
+ * The emitted string will not be null terminated.
+ *
+ * Output:
+ * The number of written characters.
+ *
+ * Exemplary usage:
+ *
+ * void print(double d)
+ * {
+ *      char buf[24 + 1] // plus null terminator
+ *      int str_len = fpconv_dtoa(d, buf);
+ *
+ *      buf[str_len] = '\0';
+ *      printf("%s", buf);
+ * }
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int idyntree_private_fpconv_dtoa(double fp, char dest[24]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/* [1] http://florian.loitsch.com/publications/dtoa-pldi2010.pdf */

--- a/extern/fpconv/powers.h
+++ b/extern/fpconv/powers.h
@@ -1,0 +1,111 @@
+// The MIT License
+//
+// Copyright (c) 2013 Andreas Samoljuk
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include <stdint.h>
+
+#define npowers     87
+#define steppowers  8
+#define firstpower -348 /* 10 ^ -348 */
+
+#define expmax     -32
+#define expmin     -60
+
+
+typedef struct Fp {
+    uint64_t frac;
+    int exp;
+} Fp;
+
+static Fp powers_ten[] = {
+    { 18054884314459144840U, -1220 }, { 13451937075301367670U, -1193 },
+    { 10022474136428063862U, -1166 }, { 14934650266808366570U, -1140 },
+    { 11127181549972568877U, -1113 }, { 16580792590934885855U, -1087 },
+    { 12353653155963782858U, -1060 }, { 18408377700990114895U, -1034 },
+    { 13715310171984221708U, -1007 }, { 10218702384817765436U, -980 },
+    { 15227053142812498563U, -954 },  { 11345038669416679861U, -927 },
+    { 16905424996341287883U, -901 },  { 12595523146049147757U, -874 },
+    { 9384396036005875287U,  -847 },  { 13983839803942852151U, -821 },
+    { 10418772551374772303U, -794 },  { 15525180923007089351U, -768 },
+    { 11567161174868858868U, -741 },  { 17236413322193710309U, -715 },
+    { 12842128665889583758U, -688 },  { 9568131466127621947U,  -661 },
+    { 14257626930069360058U, -635 },  { 10622759856335341974U, -608 },
+    { 15829145694278690180U, -582 },  { 11793632577567316726U, -555 },
+    { 17573882009934360870U, -529 },  { 13093562431584567480U, -502 },
+    { 9755464219737475723U,  -475 },  { 14536774485912137811U, -449 },
+    { 10830740992659433045U, -422 },  { 16139061738043178685U, -396 },
+    { 12024538023802026127U, -369 },  { 17917957937422433684U, -343 },
+    { 13349918974505688015U, -316 },  { 9946464728195732843U,  -289 },
+    { 14821387422376473014U, -263 },  { 11042794154864902060U, -236 },
+    { 16455045573212060422U, -210 },  { 12259964326927110867U, -183 },
+    { 18268770466636286478U, -157 },  { 13611294676837538539U, -130 },
+    { 10141204801825835212U, -103 },  { 15111572745182864684U, -77 },
+    { 11258999068426240000U, -50 },   { 16777216000000000000U, -24 },
+    { 12500000000000000000U,   3 },   { 9313225746154785156U,   30 },
+    { 13877787807814456755U,  56 },   { 10339757656912845936U,  83 },
+    { 15407439555097886824U, 109 },   { 11479437019748901445U, 136 },
+    { 17105694144590052135U, 162 },   { 12744735289059618216U, 189 },
+    { 9495567745759798747U,  216 },   { 14149498560666738074U, 242 },
+    { 10542197943230523224U, 269 },   { 15709099088952724970U, 295 },
+    { 11704190886730495818U, 322 },   { 17440603504673385349U, 348 },
+    { 12994262207056124023U, 375 },   { 9681479787123295682U,  402 },
+    { 14426529090290212157U, 428 },   { 10748601772107342003U, 455 },
+    { 16016664761464807395U, 481 },   { 11933345169920330789U, 508 },
+    { 17782069995880619868U, 534 },   { 13248674568444952270U, 561 },
+    { 9871031767461413346U,  588 },   { 14708983551653345445U, 614 },
+    { 10959046745042015199U, 641 },   { 16330252207878254650U, 667 },
+    { 12166986024289022870U, 694 },   { 18130221999122236476U, 720 },
+    { 13508068024458167312U, 747 },   { 10064294952495520794U, 774 },
+    { 14996968138956309548U, 800 },   { 11173611982879273257U, 827 },
+    { 16649979327439178909U, 853 },   { 12405201291620119593U, 880 },
+    { 9242595204427927429U,  907 },   { 13772540099066387757U, 933 },
+    { 10261342003245940623U, 960 },   { 15290591125556738113U, 986 },
+    { 11392378155556871081U, 1013 },  { 16975966327722178521U, 1039 },
+    { 12648080533535911531U, 1066 }
+};
+
+static Fp find_cachedpow10(int exp, int* k)
+{
+    const double one_log_ten = 0.30102999566398114;
+
+    int approx = -(exp + npowers) * one_log_ten;
+    int idx = (approx - firstpower) / steppowers;
+
+    while(1) {
+        int current = exp + powers_ten[idx].exp + 64;
+
+        if(current < expmin) {
+            idx++;
+            continue;
+        }
+
+        if(current > expmax) {
+            idx--;
+            continue;
+        }
+
+        *k = (firstpower + idx * steppowers);
+
+        return powers_ten[idx];
+    }
+}

--- a/src/model_io/urdf/CMakeLists.txt
+++ b/src/model_io/urdf/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 set(IDYNTREE_MODELIO_URDF_HEADERS include/iDynTree/ModelIO/URDFDofsImport.h
                                   include/iDynTree/ModelIO/ModelLoader.h
+                                  include/iDynTree/ModelIO/ModelExporter.h
                                   include/deprecated/iDynTree/ModelIO/URDFModelImport.h
                                   include/deprecated/iDynTree/ModelIO/URDFGenericSensorsImport.h
                                   include/deprecated/iDynTree/ModelIO/URDFSolidShapesImport.h)
@@ -29,7 +30,8 @@ set(IDYNTREE_MODELIO_URDF_PRIVATE_HEADERS include/private/URDFDocument.h
                                           include/private/MaterialElement.h
                                           include/private/VisualElement.h
                                           include/private/GeometryElement.h
-                                          include/private/URDFParsingUtils.h)
+                                          include/private/URDFParsingUtils.h
+                                          include/private/URDFModelExport.h)
 
 set(IDYNTREE_MODELIO_URDF_XMLELEMENTS_SOURCES src/URDFDocument.cpp
                                               src/InertialElement.cpp
@@ -41,14 +43,15 @@ set(IDYNTREE_MODELIO_URDF_XMLELEMENTS_SOURCES src/URDFDocument.cpp
                                               src/ForceTorqueSensorElement.cpp
                                               src/MaterialElement.cpp
                                               src/VisualElement.cpp
-                                              src/GeometryElement.cpp
-                                              )
+                                              src/GeometryElement.cpp)
 
 set(IDYNTREE_MODELIO_URDF_SOURCES src/URDFDofsImport.cpp
                                   src/ModelLoader.cpp
+                                  src/ModelExporter.cpp
                                   src/deprecated/URDFModelImport.cpp
                                   src/deprecated/URDFGenericSensorsImport.cpp
-                                  src/deprecated/URDFSolidShapesImport.cpp)
+                                  src/deprecated/URDFSolidShapesImport.cpp
+                                  src/URDFModelExport.cpp)
 
 SOURCE_GROUP("Source Files" FILES ${IDYNTREE_MODELIO_URDF_SOURCES})
 SOURCE_GROUP("Source Files\\XML Elements" FILES ${IDYNTREE_MODELIO_URDF_XMLELEMENTS_SOURCES})
@@ -60,7 +63,7 @@ list(APPEND IDYNTREE_MODELIO_URDF_SOURCES ${IDYNTREE_MODELIO_URDF_XMLELEMENTS_SO
 # share headers with all iDynTree targets
 set(libraryname idyntree-modelio-urdf)
 
-add_library(${libraryname} ${IDYNTREE_MODELIO_URDF_SOURCES} ${IDYNTREE_MODELIO_URDF_HEADERS} ${IDYNTREE_MODELIO_URDF_PRIVATE_HEADERS})
+add_library(${libraryname} ${IDYNTREE_MODELIO_URDF_SOURCES} ${IDYNTREE_MODELIO_URDF_HEADERS} ${IDYNTREE_MODELIO_URDF_PRIVATE_HEADERS} $<TARGET_OBJECTS:idyntree-private-fpconv>)
 
 target_compile_features(${libraryname} PRIVATE cxx_auto_type cxx_delegating_constructors cxx_final cxx_lambdas cxx_lambda_init_captures)
 
@@ -72,11 +75,14 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
                                                   ${LIBXML2_INCLUDE_DIR})
 
 target_link_libraries(${libraryname} LINK_PUBLIC idyntree-core idyntree-model idyntree-sensors idyntree-modelio-xml
-                                     LINK_PRIVATE ${TinyXML_LIBRARIES})
+                                     LINK_PRIVATE ${LIBXML2_LIBRARIES})
 
 target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS} ${LIBXML2_DEFINITIONS})
 
 target_include_directories(${libraryname} PRIVATE ${EIGEN3_INCLUDE_DIR})
+# See https://stackoverflow.com/questions/38832528/transitive-target-include-directories-on-object-libraries
+# Can be removed with CMake 3.12
+target_include_directories(${libraryname} PRIVATE $<TARGET_PROPERTY:idyntree-private-fpconv,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # Ensure that build include directories are always included before system ones
 get_property(IDYNTREE_TREE_INCLUDE_DIRS GLOBAL PROPERTY IDYNTREE_TREE_INCLUDE_DIRS)

--- a/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_MODEL_EXPORTER_H
+#define IDYNTREE_MODEL_EXPORTER_H
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Sensors/Sensors.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace iDynTree
+{
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Options for the iDynTree exporter.
+ */
+class ModelExporterOptions
+{
+public:
+    /**
+     * Specify the base link of the exported model.
+     *
+     * Differently from the iDynTree::Model class, some file formats (such as the URDF) represent the multibody structure
+     * using a directed tree representation, for which it is necessary to explicitly specify a base link.
+     *
+     * If this string is empty (default value), the default base link contained in the model will be used.
+     *
+     * Default value: "".
+     * Supported formats: urdf.
+     */
+    std::string baseLink;
+
+    /**
+     * Constructor.
+     */
+    ModelExporterOptions();
+
+};
+
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Helper class to export a model to the supported textual formats.
+ *
+ * Currently the only format supported for export is the URDF format,
+ * as it is described in http://wiki.ros.org/urdf/XML .
+ *
+ * Only iDynTree::Model classes that represent multibody system with no loops
+ * can be exported.
+ *
+ * Furthermore, currently the model exporter only exports a subset of the features
+ * supported in iDynTree::Model. In particular, the following features are not exported:
+ * * Additional frames
+ * * Visual and collision geometries
+ * * Sensors
+ * * Joint limits, damping and static friction.
+ *
+ *
+ */
+class ModelExporter
+{
+private:
+
+    class Pimpl;
+    std::unique_ptr<Pimpl> m_pimpl;
+
+public:
+
+    /**
+     * @name Constructor/Destructor
+     */
+    //@{
+
+    /**
+     * Constructor
+     */
+    ModelExporter();
+
+    ~ModelExporter();
+
+    //@}
+
+    /**
+     * @name Model exporting and definition methods
+     * This methods are used to export the structure of your model.
+     */
+    //@{
+    const ModelExporterOptions& exportingOptions() const;
+
+    void setExportingOptions(const ModelExporterOptions& options);
+
+    /**
+     * Specifies the model of the robot to export.
+     *
+     * @param[in] model The used model.
+     * @param[in] sensors The used sensors.
+     * @param[in] options The used options.
+     * @return true if all went well, false otherwise.
+     */
+    bool init(const Model& model,
+              const SensorsList& sensors=SensorsList(),
+              const ModelExporterOptions options=ModelExporterOptions());
+
+    /**
+     * Get the loaded model that will be exported.
+     *
+     */
+    const Model & model();
+
+    /**
+     * Get the loaded sensors that will be exported.
+     */
+    const SensorsList & sensors();
+
+    /**
+     * Return true if the model have been correctly loaded, and can be exported.
+     *
+     * @return True if the model was loaded correctly.
+     */
+    bool isValid();
+
+    /**
+     * Export the model of the robot to a string.
+     *
+     * @param modelString string containg the model of the robot.
+     * @param filetype type of the file to load, currently supporting only urdf type.
+     *
+     */
+    bool exportModelToString(std::string & modelString, const std::string filetype="urdf");
+
+    /**
+     * Export the model of the robot to an external file.
+     *
+     * @param filename path to the file to export.
+     *                 It can be either a relative filename with respect to the current working directory,
+     *                 or an absolute filename.
+     * @param filetype type of the file to load, currently supporting only urdf type.
+     *
+     */
+    bool exportModelToFile(const std::string & filename, const std::string filetype="urdf");
+    //@}
+};
+
+}
+
+#endif

--- a/src/model_io/urdf/include/private/URDFModelExport.h
+++ b/src/model_io/urdf/include/private/URDFModelExport.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef IDYNTREE_URDF_MODEL_EXPORT_H
+#define IDYNTREE_URDF_MODEL_EXPORT_H
+
+#include <string>
+
+#include <iDynTree/ModelIO/ModelExporter.h>
+
+namespace iDynTree
+
+{
+
+class Model;
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Export a iDynTree::Model object to a URDF file.
+ *
+ * @see iDynTree::ModelExporterOptions for more details on supported and default options.
+ *
+ * @warning This function does not support exporting sensor or solid shapes at the moment.
+ *
+ * @param[in] urdf_filename Path to the URDF file that will be created.
+ *                          It can be either a relative filename with respect to the current working directory,
+ *                          or an absolute filename.
+ * @param[in] options the iDynTree::ModelExporterOptions struct of options passed to the parser.
+ * @return true if all went ok, false otherwise.
+ */
+bool URDFFromModel(const iDynTree::Model & model,
+                   const std::string & urdf_filename,
+                   const ModelExporterOptions options=ModelExporterOptions());
+
+/**
+ * \ingroup iDynTreeModelIO
+ *
+ * Export a iDynTree::Model object to a URDF string.
+ *
+ * @see iDynTree::ModelExporterOptions for more details on supported and default options.
+ *
+ * @warning This function does not support exporting sensor or solid shapes at the moment.
+ *
+ * @param[in] options the iDynTree::ModelExporterOptions struct of options passed to the parser.
+ * @return true if all went ok, false otherwise.
+ */
+bool URDFStringFromModel(const iDynTree::Model & output,
+                         std::string & urdf_string,
+                         const ModelExporterOptions options=ModelExporterOptions());
+
+
+}
+
+#endif

--- a/src/model_io/urdf/src/ModelExporter.cpp
+++ b/src/model_io/urdf/src/ModelExporter.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#include "iDynTree/ModelIO/ModelExporter.h"
+
+#include "URDFModelExport.h"
+
+#include <string>
+#include <vector>
+
+namespace iDynTree
+{
+
+ModelExporterOptions::ModelExporterOptions()
+: baseLink("") {}
+
+
+class ModelExporter::Pimpl {
+public:
+    Model m_model;
+    SensorsList m_sensors;
+    bool m_isModelValid;
+    ModelExporterOptions m_options;
+
+    bool setModelAndSensors(const Model& _model, const SensorsList& _sensors);
+};
+
+bool ModelExporter::Pimpl::setModelAndSensors(const Model& _model,
+                                                           const SensorsList& _sensors)
+{
+
+    m_model = _model;
+    m_sensors = _sensors;
+
+    m_isModelValid = true;
+
+    return true;
+}
+
+ModelExporter::ModelExporter()
+: m_pimpl(new Pimpl())
+{
+    m_pimpl->m_isModelValid = false;
+}
+
+ModelExporter::~ModelExporter() {}
+
+const Model& ModelExporter::model()
+{
+    return m_pimpl->m_model;
+}
+
+const SensorsList& ModelExporter::sensors()
+{
+    return m_pimpl->m_sensors;
+}
+
+bool ModelExporter::isValid()
+{
+    return m_pimpl->m_isModelValid;
+}
+
+const ModelExporterOptions& ModelExporter::exportingOptions() const
+{
+    return m_pimpl->m_options;
+}
+
+void ModelExporter::setExportingOptions(const ModelExporterOptions& options)
+{
+    m_pimpl->m_options = options;
+}
+
+bool ModelExporter::init(const Model& model,
+                         const SensorsList& sensors,
+                         const ModelExporterOptions options)
+{
+    m_pimpl->m_options = options;
+    return m_pimpl->setModelAndSensors(model, sensors);
+}
+
+bool ModelExporter::exportModelToString(std::string & modelString, const std::string filetype)
+{
+    if (filetype != "urdf") {
+        std::stringstream error_msg;
+        error_msg << "Filetype " << filetype << " not supported. Only urdf format is currently supported.";
+        reportError("ModelExporter", "exportModelToString", error_msg.str().c_str());
+        return false;
+    }
+
+    return URDFStringFromModel(m_pimpl->m_model, modelString, m_pimpl->m_options);
+}
+
+/**
+ * Export the model of the robot to an external file.
+ *
+ * @param filename path to the file to export
+ * @param filetype type of the file to load, currently supporting only urdf type.
+ *
+ */
+bool ModelExporter::exportModelToFile(const std::string & filename, const std::string filetype)
+{
+    if (filetype != "urdf") {
+        std::stringstream error_msg;
+        error_msg << "Filetype " << filetype << " not supported. Only urdf format is currently supported.";
+        reportError("ModelExporter", "exportModelToFile", error_msg.str().c_str());
+        return false;
+    }
+
+    return URDFFromModel(m_pimpl->m_model, filename, m_pimpl->m_options);
+}
+
+}

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "URDFModelExport.h"
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Core/SpatialInertia.h>
+#include <iDynTree/Core/Transform.h>
+#include <iDynTree/Core/VectorFixSize.h>
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/Traversal.h>
+#include <iDynTree/Model/FixedJoint.h>
+#include <iDynTree/Model/PrismaticJoint.h>
+#include <iDynTree/Model/RevoluteJoint.h>
+
+#include "URDFParsingUtils.h"
+
+
+#include <iomanip>
+#include <fstream>
+#include <string>
+
+#include <libxml/tree.h>
+#include <libxml/parser.h>
+
+namespace iDynTree
+{
+
+/*
+ * Add a <origin> URDF element to the specified parent element with the specified transform.
+ *
+ * If parent_element contains a pointer to a tag <parent_element></parent_element>, this function
+ * modifies it to be something like:
+ * <parent_element>
+ *   <origin xyz="1.0 2.0 3.0" rpy="0.0 1.0 2.0" />
+ * </parent_element>
+ * where the actual values of the xyz and rpy attributes depend on the input trans argument.
+ */
+bool exportTransform(const Transform &trans, xmlNodePtr parent_element)
+{
+    bool ok = true;
+    xmlNodePtr origin = xmlNewChild(parent_element, NULL, BAD_CAST "origin", NULL);
+    std::string pose_xyz_str;
+    ok = ok && vectorToString(trans.getPosition(), pose_xyz_str);
+    std::string pose_rpy_str;
+    Vector3 pose_rpy = trans.getRotation().asRPY();
+    ok = ok && vectorToString(pose_rpy, pose_rpy_str);
+    xmlNewProp(origin, BAD_CAST "xyz", BAD_CAST pose_xyz_str.c_str());
+    xmlNewProp(origin, BAD_CAST "rpy", BAD_CAST pose_rpy_str.c_str());
+    return ok;
+}
+
+/*
+ * Add a <inertial> URDF element to the specified parent element with the specified 6D inertia.
+ *
+ * If parent_element contains a pointer to a tag <parent_element></parent_element>, this function modifies it to be something like:
+ * <parent_element>
+ *   <inertial>
+ *     <origin xyz="0 0 0.5" rpy="0 0 0"/>
+ *     <mass value="1"/>
+ *     <inertia ixx="100"  ixy="0"  ixz="0" iyy="100" iyz="0" izz="100" />
+ *   </inertial>
+ * </parent_element>
+ * where the actual values of the origin, mass and inertia element's attributes depend on the input inertia argument.
+ */
+bool exportInertial(const SpatialInertia &inertia, xmlNodePtr parent_element)
+{
+    bool ok=true;
+    std::string bufStr;
+    xmlNodePtr inertial = xmlNewChild(parent_element, NULL, BAD_CAST "inertial", NULL);
+
+
+    xmlNodePtr mass_xml = xmlNewChild(inertial, NULL, BAD_CAST "mass", NULL);
+    ok = ok && doubleToStringWithClassicLocale(inertia.getMass(), bufStr);
+    xmlNewProp(mass_xml, BAD_CAST "value", BAD_CAST bufStr.c_str());
+
+    ok = ok && exportTransform(Transform(Rotation::Identity(), inertia.getCenterOfMass()), inertial);
+
+    xmlNodePtr inertia_xml = xmlNewChild(inertial, NULL, BAD_CAST "inertia", NULL);
+    RotationalInertiaRaw rotInertia = inertia.getRotationalInertiaWrtCenterOfMass();
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(0, 0), bufStr);
+    xmlNewProp(inertia_xml, BAD_CAST "ixx", BAD_CAST bufStr.c_str());
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(0, 1), bufStr);
+    xmlNewProp(inertia_xml, BAD_CAST "ixy", BAD_CAST bufStr.c_str());
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(0, 2), bufStr);
+    xmlNewProp(inertia_xml, BAD_CAST "ixz", BAD_CAST bufStr.c_str());
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(1, 1), bufStr);
+    xmlNewProp(inertia_xml, BAD_CAST "iyy", BAD_CAST bufStr.c_str());
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(1, 2), bufStr);
+    xmlNewProp(inertia_xml, BAD_CAST "iyz", BAD_CAST bufStr.c_str());
+    ok = ok && doubleToStringWithClassicLocale(rotInertia(2, 2), bufStr);
+    xmlNewProp(inertia_xml, BAD_CAST "izz", BAD_CAST bufStr.c_str());
+
+    return ok;
+}
+
+/*
+ * Add a <link> URDF element to the specified parent element with the specified link info.
+ *
+ * Currently this function does not export visual and collision elements.
+ *
+ * If parent_element contains a pointer to a tag <parent_element></parent_element>, this function modifies it to be something like:
+ *
+ * <parent_element>
+ *   <link name="my_link">
+ *     <inertial>
+ *       ...
+ *     </inertial>
+ *
+ *  </link>
+ * <parent_element/>
+ *
+ * where the actual values of the added element and attributes depend on the input link and linkName arguments.
+ */
+bool exportLink(const Link &link, const std::string linkName, xmlNodePtr parent_element)
+{
+    bool ok = true;
+    xmlNodePtr link_xml = xmlNewChild(parent_element, NULL, BAD_CAST "link", NULL);
+    xmlNewProp(link_xml, BAD_CAST "name", BAD_CAST linkName.c_str());
+
+    ok = ok && exportInertial(link.getInertia(), link_xml);
+
+    /* TODO(traversaro) : support solid shapes
+    for (std::size_t i = 0 ; i < link.visual_array.size() ; ++i)
+        exportVisual(*link.visual_array[i], link_xml);
+    for (std::size_t i = 0 ; i < link.collision_array.size() ; ++i)
+        exportCollision(*link.collision_array[i], link_xml);
+    */
+
+    return ok;
+}
+
+/**
+ * Add a <joint> URDF element to the specified parent element with the specified joint info.
+ *
+ * At the moment, only the URDF joint of types revolute, continuous, prismatic and fixed are supported, as they are the only one supported
+ * in the iDynTree::Model class. Furthermore, it is not supported the export of joint limits and friction.
+ *
+ * If parent_element contains a pointer to a tag <parent_element></parent_element>, this function modifies it to be something like:
+ *
+ * <parent_element>
+ *   <joint name="my_joint" type="floating">
+ *      <origin xyz="0 0 1" rpy="0 0 3.1416"/>
+ *      <parent link="link1"/>
+ *      <child link="link2"/>
+ *      <calibration rising="0.0"/>
+ *      <dynamics damping="0.0" friction="0.0"/>
+ *      <limit effort="30" velocity="1.0" lower="-2.2" upper="0.7" />
+ *   </joint>
+ * <parent_element/>
+ *
+ * where the actual values of the added element and attributes depend on the input joint, parentLink and childLink arguments.
+ */
+bool exportJoint(IJointConstPtr joint, LinkConstPtr parentLink, LinkConstPtr childLink, const Model& model, xmlNodePtr parent_element)
+{
+    bool ok=true;
+    xmlNodePtr joint_xml = xmlNewChild(parent_element, NULL, BAD_CAST "joint", NULL);
+    xmlNewProp(joint_xml, BAD_CAST "name", BAD_CAST model.getJointName(joint->getIndex()).c_str());
+
+    if (dynamic_cast<const FixedJoint*>(joint))
+    {
+        xmlNewProp(joint_xml, BAD_CAST "type", BAD_CAST "fixed");
+    }
+    else if (dynamic_cast<const RevoluteJoint*>(joint))
+    {
+        if(joint->hasPosLimits())
+        {
+            xmlNewProp(joint_xml, BAD_CAST "type", BAD_CAST "revolute");
+        }
+        else
+        {
+            xmlNewProp(joint_xml, BAD_CAST "type", BAD_CAST "continuous");
+        }
+    }
+    else if (dynamic_cast<const PrismaticJoint*>(joint))
+    {
+        xmlNewProp(joint_xml, BAD_CAST "type", BAD_CAST "prismatic");
+    }
+    else
+    {
+        std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint of type "
+                  <<  typeid(joint).name() << " to a URDF joint " << std::endl;
+        return false;
+    }
+
+    // origin
+    exportTransform(joint->getRestTransform(parentLink->getIndex(), childLink->getIndex()), joint_xml);
+
+    if (joint->getNrOfDOFs() != 0)
+    {
+        Axis axis;
+
+        // Check that the axis of the joint is supported by URDF
+        if (dynamic_cast<const RevoluteJoint*>(joint))
+        {
+            const RevoluteJoint* revJoint = dynamic_cast<const RevoluteJoint*>(joint);
+            axis = revJoint->getAxis(childLink->getIndex());
+        }
+        else if (dynamic_cast<const PrismaticJoint*>(joint))
+        {
+            const PrismaticJoint* prismJoint = dynamic_cast<const PrismaticJoint*>(joint);
+            axis = prismJoint->getAxis(childLink->getIndex());
+        }
+        else
+        {
+            std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint of type "
+                      <<  typeid(joint).name() << " to a URDF joint " << std::endl;
+            return false;
+        }
+
+        // Check that the axis is URDF-compatible
+        if (toEigen(axis.getOrigin()).norm() > 1e-7)
+        {
+            std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint "
+                      <<   model.getJointName(joint->getIndex()) << " to a URDF joint without moving the link frame of link "
+                      << model.getLinkName(childLink->getIndex()) << " , because its origin is "
+                      << axis.getOrigin().toString()  << std::endl;
+            return false;
+        }
+
+        // axis
+        xmlNodePtr axis_xml = xmlNewChild(joint_xml, NULL, BAD_CAST "axis", NULL);
+        std::string bufStr;
+        ok = ok && vectorToString(axis.getDirection(), bufStr);
+        xmlNewProp(axis_xml, BAD_CAST "xyz", BAD_CAST bufStr.c_str());
+    }
+
+    // parent
+    xmlNodePtr parent_xml = xmlNewChild(joint_xml, NULL, BAD_CAST "parent", NULL);
+    xmlNewProp(parent_xml, BAD_CAST "link", BAD_CAST model.getLinkName(parentLink->getIndex()).c_str());
+
+    // child
+    xmlNodePtr child_xml = xmlNewChild(joint_xml, NULL, BAD_CAST "child", NULL);
+    xmlNewProp(child_xml, BAD_CAST "link", BAD_CAST model.getLinkName(childLink->getIndex()).c_str());
+
+    // TODO(traversaro) : handle joint limits and friction
+
+    return ok;
+}
+
+bool URDFStringFromModel(const iDynTree::Model & model,
+                         std::string & urdf_string,
+                         const ModelExporterOptions options)
+{
+    bool ok = true;
+
+    xmlDocPtr urdf_xml = xmlNewDoc(BAD_CAST "1.0");
+    xmlNodePtr robot = xmlNewNode(NULL, BAD_CAST "robot");
+    // TODO(traversaro) properly export this :)
+    xmlNewProp(robot, BAD_CAST "name", BAD_CAST "iDynTreeURDFModelExportModelName");
+    xmlDocSetRootElement(urdf_xml, robot);
+
+    // TODO(traversaro) : We are assuming that the model has no loops,
+    //                    we should add a check for this
+
+    // URDF assumes a directed tree of the multibody model structure, so we need to assume that a given link is
+    // the base
+    std::string baseLink = options.baseLink;
+    if (baseLink.empty())
+    {
+        baseLink = model.getLinkName(model.getDefaultBaseLink());
+    }
+
+    LinkIndex baseLinkIndex = model.getLinkIndex(baseLink);
+    if (baseLinkIndex == LINK_INVALID_INDEX)
+    {
+        std::cerr << "[ERROR] URDFStringFromModel : specified baseLink " << baseLink << " is not part of the model" << std::endl;
+        xmlFreeDoc(urdf_xml);
+        return false;
+    }
+
+    // Create a Traversal
+    Traversal exportTraversal;
+    if (!model.computeFullTreeTraversal(exportTraversal, baseLinkIndex))
+    {
+        std::cerr << "[ERROR] URDFStringFromModel : error in computeFullTreeTraversal" << std::endl;
+        xmlFreeDoc(urdf_xml);
+        return false;
+    }
+
+
+    // Export links and joints following the traversal
+    for (TraversalIndex trvIdx=0; trvIdx < static_cast<TraversalIndex>(exportTraversal.getNrOfVisitedLinks()); trvIdx++)
+    {
+        LinkConstPtr visitedLink = exportTraversal.getLink(trvIdx);
+        std::string visitedLinkName = model.getLinkName(visitedLink->getIndex());
+
+        // Export parent joint, if this is not the base
+        if (trvIdx != 0)
+        {
+            LinkConstPtr parentLink = exportTraversal.getParentLink(trvIdx);
+            IJointConstPtr parentJoint = exportTraversal.getParentJoint(trvIdx);
+            ok = ok && exportJoint(parentJoint, parentLink, visitedLink,  model, robot);
+        }
+
+        // Export link
+        ok = ok && exportLink(*visitedLink, visitedLinkName, robot);
+    }
+
+    // TODO(traversaro) : export additional frames
+
+    xmlChar *xmlbuff=0;
+    int buffersize=0;
+    xmlDocDumpFormatMemory(urdf_xml, &xmlbuff, &buffersize, 1);
+    urdf_string.resize(buffersize);
+    std::memcpy((void*)urdf_string.data(), (void*)xmlbuff, buffersize);
+
+    xmlFree(xmlbuff);
+    xmlFreeDoc(urdf_xml);
+
+    return ok;
+}
+
+
+bool URDFFromModel(const iDynTree::Model & model,
+                   const std::string & urdf_filename,
+                   const ModelExporterOptions options)
+{
+    std::ofstream ofs(urdf_filename.c_str());
+
+    if( !ofs.is_open() )
+    {
+        std::cerr << "[ERROR] iDynTree::URDFFromModel : error opening file "
+                  << urdf_filename << std::endl;
+        return false;
+    }
+
+    std::string xml_string;
+    if (!URDFStringFromModel(model, xml_string, options))
+    {
+        return false;
+    }
+
+    // Write string to file
+    ofs << xml_string;
+    ofs.close();
+
+    return true;
+}
+
+
+}

--- a/src/model_io/urdf/tests/CMakeLists.txt
+++ b/src/model_io/urdf/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ macro(add_modelio_urdf_unit_test classname)
 endmacro()
 
 add_modelio_urdf_unit_test(URDFModelImport)
+add_modelio_urdf_unit_test(ModelExporter)
 add_modelio_urdf_unit_test(URDFGenericSensorImport)
 add_modelio_urdf_unit_test(PredictSensorsMeasurement)
 add_modelio_urdf_unit_test(icubSensorURDF)

--- a/src/model_io/urdf/tests/ModelExporterUnitTest.cpp
+++ b/src/model_io/urdf/tests/ModelExporterUnitTest.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2017 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Silvio Traversaro
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include "testModels.h"
+
+#include <iDynTree/Core/TestUtils.h>
+
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/ModelIO/ModelExporter.h>
+
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <algorithm>
+#include <fstream>
+
+using namespace iDynTree;
+
+
+void checkImportExportURDF(std::string fileName)
+{
+    // Import, export and re-import a URDF file, and check that the key properties of the model are mantained
+    ModelLoader mdlLoader;
+    bool ok = mdlLoader.loadModelFromFile(fileName, "urdf");
+    Model model = mdlLoader.model();
+    ASSERT_IS_TRUE(ok);
+
+    std::cerr << "Model loaded from " << fileName << std::endl;
+    std::ifstream original_urdf(fileName);
+
+    if (original_urdf.is_open()) {
+        std::cout << original_urdf.rdbuf();
+    }
+
+    std::string urdfString;
+    ModelExporter mdlExporter;
+    ok = mdlExporter.init(model, SensorsList());
+    ASSERT_IS_TRUE(ok);
+    ok = mdlExporter.exportModelToString(urdfString);
+    ASSERT_IS_TRUE(ok);
+
+    std::cerr << "Model serialized back to xml " << std::endl << urdfString << std::endl;
+
+    ModelLoader mdlLoaderReloaded;
+
+    ok = mdlLoaderReloaded.loadModelFromString(urdfString);
+    ASSERT_IS_TRUE(ok);
+    Model modelReloaded = mdlLoaderReloaded.model();
+
+    ASSERT_EQUAL_DOUBLE(model.getNrOfLinks(), modelReloaded.getNrOfLinks());
+    ASSERT_EQUAL_DOUBLE(model.getNrOfJoints(), modelReloaded.getNrOfJoints());
+    ASSERT_EQUAL_DOUBLE(model.getNrOfDOFs(), modelReloaded.getNrOfDOFs());
+
+    // TODO(traversaro) : uncomment the following line when frames are correctly handled by the exporter
+    // ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(), modelReloaded.getNrOfLinks());
+
+    // Verify that the link correspond (note that the serialization could have changed)
+    for(int lnkIndex=0; lnkIndex < model.getNrOfLinks(); lnkIndex++) {
+        LinkIndex lnkIndexInReloaded = modelReloaded.getLinkIndex(model.getLinkName(lnkIndex));
+        ASSERT_IS_TRUE(lnkIndexInReloaded != LINK_INVALID_INDEX);
+        ASSERT_IS_TRUE(model.getLinkName(lnkIndex) == modelReloaded.getLinkName(lnkIndexInReloaded));
+        SpatialInertia inertia = model.getLink(lnkIndex)->getInertia();
+        SpatialInertia inertiaReloaded = modelReloaded.getLink(lnkIndexInReloaded)->getInertia();
+        std::cerr << "Testing inertia of link " << model.getLinkName(lnkIndex) << std::endl;
+        ASSERT_EQUAL_MATRIX(inertia.asMatrix(), inertiaReloaded.asMatrix());
+    }
+
+}
+
+
+int main()
+{
+    for(unsigned int mdl = 0; mdl < IDYNTREE_TESTS_URDFS_NR; mdl++ )
+    {
+        if (std::string(IDYNTREE_TESTS_URDFS[mdl]) == "bigman.urdf")
+        {
+            // walkman model fails this test due to https://github.com/robotology/idyntree/issues/247
+            continue;
+        }
+
+        std::string urdfFileName = getAbsModelPath(std::string(IDYNTREE_TESTS_URDFS[mdl]));
+        std::cout << "Checking URDF import/export test on " << urdfFileName << std::endl;
+        checkImportExportURDF(urdfFileName);
+    }
+
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add `iDynTree::ModelExporter` class and related tests. 

Currently the only format supported for export is the URDF format.

Currently the model exporter only exports a subset of the features supported in iDynTree::Model. In particular, the following features are **not supported**:
* Additional frames
* Visual and Collision Geometries
* Sensors
* Joint limits, friction parameters
* Automatically change link frames location for link whose origin does not lay on the rotation/translation axis of the parent joint, as requested by URDF
* Wrapping the ModelExporter in bindings

The PR is composed by the following two commits:  
* https://github.com/robotology/idyntree/commit/59821242669598d6e6f2578ed3e5e70b1d6e533e : Add [fpconv](https://github.com/night-shift/fpconv) as a MIT-licensed vendored dependency, to support double - shortest string exact conversion, that is currently not supported in the STL. This will be removed as soon as we can depend on [C++17's `std::to_chars`](https://en.cppreference.com/w/cpp/utility/to_chars) 
* https://github.com/robotology/idyntree/pull/554/commits/047ef63cfdd8cf78db5e6d5bf4884f4977bcc320 : Add ModelExporter class, support for exporting URDF, and tests.

My idea is to implement most of the missing features before 0.12 release, but as the limitations are currently documented, I think it make sense to first review this initial PR, and then the other features can be added in future PRs. 

This PR is based on the old closed PR https://github.com/robotology/idyntree/pull/382 .

