### PR TITLE
Add support for exporting additional frames in ModelExporter

### DIFF
--- a/src/model/include/iDynTree/Model/Model.h
+++ b/src/model/include/iDynTree/Model/Model.h
@@ -418,6 +418,18 @@ namespace iDynTree
         LinkIndex getFrameLink(const FrameIndex frameIndex) const;
 
         /**
+         * Get the additional frames of a specified link.
+         *
+         * @note The vector of returned frame index is ordered according to the frame index.
+         * @warning This method searches linearly over all the frames.
+         *
+         * @param[in] link a LinkIndex of the specified link,
+         * @param[out] frames a vector of FrameIndex of the frame indeces attached to the specified link index,
+         * @return true if the specified link is a valid link, false otherwise.
+         */
+        bool getLinkAdditionalFrames(const LinkIndex lnkIndex, std::vector<FrameIndex>& frameIndeces) const;
+
+        /**
          * Get the nr of neighbors of a given link.
          */
         unsigned int getNrOfNeighbors(const LinkIndex link) const;

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -703,6 +703,29 @@ LinkIndex Model::getFrameLink(const FrameIndex frameIndex) const
     return LINK_INVALID_INDEX;
 }
 
+bool Model::getLinkAdditionalFrames(const LinkIndex lnkIndex, std::vector<FrameIndex>& frameIndices) const
+{
+    if (!isValidLinkIndex(lnkIndex)) {
+        std::stringstream ss;
+        ss << "LinkIndex " << lnkIndex << " is not valid, should be between 0 and " << this->getNrOfLinks()-1;
+        reportError("Model", "getLinkAdditionalFrames", ss.str().c_str());
+        return false;
+    }
+
+    frameIndices.resize(0);
+    // FrameIndex from 0 to this->getNrOfLinks()-1 are reserved for implicit frame of Links
+    // with the corresponding LinkIndex, while the frameIndex from getNrOfLinks() to getNrOfFrames()-1
+    // are the one of actual additional frames. See iDynTree::Model docs for more details
+    for (FrameIndex frameIndex=this->getNrOfLinks(); frameIndex < this->getNrOfFrames(); frameIndex++) {
+        if (this->getFrameLink(frameIndex) == lnkIndex) {
+            frameIndices.push_back(frameIndex);
+        }
+    }
+
+    return true;
+}
+
+
 
 unsigned int Model::getNrOfNeighbors(const LinkIndex link) const
 {

--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -289,12 +289,24 @@ void checkSimpleModel()
 
         model.addJoint("fixedJoint",&fixJoint);
 
+        model.addAdditionalFrameToLink("link0", "frame0_0", iDynTree::Transform::Identity());
+        model.addAdditionalFrameToLink("link1", "frame1_0", iDynTree::Transform::Identity());
+        model.addAdditionalFrameToLink("link1", "frame1_1", iDynTree::Transform::Identity());
+
+
         ASSERT_EQUAL_DOUBLE(model.getNrOfLinks(),2);
         ASSERT_EQUAL_DOUBLE(model.getNrOfJoints(),1);
         ASSERT_EQUAL_DOUBLE(model.getNrOfNeighbors(0),1);
         ASSERT_EQUAL_DOUBLE(model.getNrOfNeighbors(1),1);
         ASSERT_EQUAL_DOUBLE(model.getNeighbor(0,0).neighborLink,1);
         ASSERT_EQUAL_DOUBLE(model.getNeighbor(1,0).neighborLink,0);
+        std::vector<FrameIndex> link0_frames;
+        model.getLinkAdditionalFrames(0, link0_frames);
+        ASSERT_EQUAL_DOUBLE(link0_frames.size(), 1);
+        std::vector<FrameIndex> link1_frames;
+        model.getLinkAdditionalFrames(1, link1_frames);
+        ASSERT_EQUAL_DOUBLE(link1_frames.size(), 2);
+        ASSERT_IS_TRUE(link1_frames[0] < link1_frames[1]);
 
         createCopyAndDestroy(model);
         checkComputeTraversal(model);

--- a/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
@@ -63,11 +63,30 @@ public:
  *
  * Furthermore, currently the model exporter only exports a subset of the features
  * supported in iDynTree::Model. In particular, the following features are not exported:
- * * Additional frames
+ *
  * * Visual and collision geometries
  * * Sensors
  * * Joint limits, damping and static friction.
  *
+ * # Format documentation
+ *
+ * The following format are  supported  by the exporter.
+ *
+ * | Format | Extendend Name | Website |  String for filetype argument  |
+ * |:-----------------------------:|:-------:|:-------:|:--------:|
+ * | URDF | Unified Robot Description Format  | http://wiki.ros.org/urdf | `urdf` |
+ *
+ * ## URDF
+ *
+ * As the URDF format does not distinguish between frames and links (see https://discourse.ros.org/t/urdf-ng-link-and-frame-concepts/56
+ * for an extensive discussion on this) the URDF model exporter converts iDynTree's *additional frames* to mass-less and shape-less
+ * *fake* URDF links that are connected as child links via `fixed` joints to the corresponding **real** URDF links.
+ *
+ * Furthermore, it is widespread use in URDF models to never use a real link (with mass) as the root link of a model, mainly
+ * due to workaround a bug in official %KDL parser used in ROS (see https://github.com/ros/kdl_parser/issues/27 for more info). For this reason,
+ * if the selected base_link has at least one additional frame, the first additional frame of the base link is added as a **parent** fake URDF link,
+ * instead as a **child** fake URDF link as done with the rest of %iDynTree's additional frames. If no additional frame is available for the base link,
+ * the base link of the URDF will have a mass, and will generate a warning then used with the ROS's [`kdl_parser`](https://github.com/ros/kdl_parser) .
  *
  */
 class ModelExporter

--- a/src/model_io/urdf/tests/ModelExporterUnitTest.cpp
+++ b/src/model_io/urdf/tests/ModelExporterUnitTest.cpp
@@ -57,9 +57,7 @@ void checkImportExportURDF(std::string fileName)
     ASSERT_EQUAL_DOUBLE(model.getNrOfLinks(), modelReloaded.getNrOfLinks());
     ASSERT_EQUAL_DOUBLE(model.getNrOfJoints(), modelReloaded.getNrOfJoints());
     ASSERT_EQUAL_DOUBLE(model.getNrOfDOFs(), modelReloaded.getNrOfDOFs());
-
-    // TODO(traversaro) : uncomment the following line when frames are correctly handled by the exporter
-    // ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(), modelReloaded.getNrOfLinks());
+    ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(), modelReloaded.getNrOfFrames());
 
     // Verify that the link correspond (note that the serialization could have changed)
     for(int lnkIndex=0; lnkIndex < model.getNrOfLinks(); lnkIndex++) {
@@ -70,6 +68,16 @@ void checkImportExportURDF(std::string fileName)
         SpatialInertia inertiaReloaded = modelReloaded.getLink(lnkIndexInReloaded)->getInertia();
         std::cerr << "Testing inertia of link " << model.getLinkName(lnkIndex) << std::endl;
         ASSERT_EQUAL_MATRIX(inertia.asMatrix(), inertiaReloaded.asMatrix());
+    }
+
+    // Verify that the frame correspond (note that the serialization could have changed)
+    for(FrameIndex frameIndex=model.getNrOfLinks(); frameIndex < model.getNrOfFrames(); frameIndex++) {
+        FrameIndex frameIndexInReloaded = modelReloaded.getFrameIndex(model.getFrameName(frameIndex));
+        ASSERT_IS_TRUE(frameIndexInReloaded != FRAME_INVALID_INDEX);
+        ASSERT_IS_TRUE(model.getFrameName(frameIndex) == modelReloaded.getFrameName(frameIndexInReloaded));
+        Transform link_H_frame = model.getFrameTransform(frameIndex);
+        Transform link_H_frame_reloaded = modelReloaded.getFrameTransform(frameIndexInReloaded);
+        ASSERT_EQUAL_MATRIX(link_H_frame.asHomogeneousTransform(), link_H_frame_reloaded.asHomogeneousTransform());
     }
 
 }


### PR DESCRIPTION
~*This PR builds on the top of https://github.com/robotology/idyntree/pull/554, so it will not be ready to be merged until that  PR is merged before.*~ 

Relevant commits: 
* https://github.com/robotology/idyntree/pull/557/commits/5fab70295e96cffbbe76428ae95077d0fbf30be4 : Add `Model::getLinkAdditionalFrames` method 
* https://github.com/robotology/idyntree/pull/557/commits/b77faa53f95136e8b1585c1ad9512b2019bda498 : Add support for exporting additional frames in ModelExporter 

All addition come with the respective unit tests and documentation. 