### PR TITLE
Fix URDF parser bug for which collision geometeries were also loaded as visual geometries, and viceversa

### DIFF
--- a/doc/releases/v0_11_2.md
+++ b/doc/releases/v0_11_2.md
@@ -15,7 +15,8 @@ Bug Fixes
   getFrameBiasAcc method always returned the bias acceleration corresponding to the first call to setRobotState.
 * Fixed getBiasAcc method in KinDynComputations to take into account the effect of non-zero and non-parallel
   linear and angular base velocity, described in https://github.com/robotology/idyntree/issues/370 .
-* Fixed compilation on 32-bit Windows ( https://github.com/robotology/idyntree/pull/506 ).   
+* Fixed compilation on 32-bit Windows ( https://github.com/robotology/idyntree/pull/506 ).
+* Fixed a URDF parser regression introduced in iDynTree 0.11 in URDF parser for which collision geometeries were also loaded as visual geometries, and viceversa (https://github.com/robotology/idyntree/issues/497, https://github.com/robotology/idyntree/pull/559).
 
 New features
 ------------

--- a/src/model_io/urdf/include/private/VisualElement.h
+++ b/src/model_io/urdf/include/private/VisualElement.h
@@ -45,7 +45,7 @@ private:
     VisualInfo m_info;
 
 public:
-    VisualElement();
+    VisualElement(const std::string& name);
 
     const VisualInfo& visualInfo() const;
 

--- a/src/model_io/urdf/src/LinkElement.cpp
+++ b/src/model_io/urdf/src/LinkElement.cpp
@@ -55,9 +55,9 @@ namespace iDynTree {
         if (name == "inertial") {
             return std::make_shared<InertialElement>(m_link);
         } else if (name == "visual") {
-            return std::make_shared<VisualElement>();
+            return std::make_shared<VisualElement>("visual");
         } else if (name == "collision") {
-            return std::make_shared<VisualElement>();
+            return std::make_shared<VisualElement>("collision");
         }
         return std::make_shared<iDynTree::XMLElement>(name);
     }

--- a/src/model_io/urdf/src/URDFDocument.cpp
+++ b/src/model_io/urdf/src/URDFDocument.cpp
@@ -150,7 +150,7 @@ namespace iDynTree {
             reportError("URDFDocument", "documentHasBeenParsed", "Failed to add visual elements to model");
         }
         if (!addVisualPropertiesToModel(m_model,
-                                        m_buffers.visuals,
+                                        m_buffers.collisions,
                                         m_buffers.materials,
                                         m_model.collisionSolidShapes())) {
             reportError("URDFDocument", "documentHasBeenParsed", "Failed to add collision elements to model");

--- a/src/model_io/urdf/src/VisualElement.cpp
+++ b/src/model_io/urdf/src/VisualElement.cpp
@@ -21,9 +21,8 @@
 
 namespace iDynTree {
 
-    // !!!: this might be also collision. Should we specify the name or an enum ?
-    VisualElement::VisualElement()
-    : iDynTree::XMLElement("visual"){}
+    VisualElement::VisualElement(const std::string& name)
+    : iDynTree::XMLElement(name){}
 
     const VisualElement::VisualInfo& VisualElement::visualInfo() const
     {

--- a/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
+++ b/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
@@ -34,11 +34,31 @@ void checkParsingOfDofsFromURDF(std::string fileName,
     ASSERT_EQUAL_DOUBLE(dofsNameList.size(),expectedNrOfDOFs);
 }
 
+unsigned int getNrOfVisuals(const iDynTree::Model& model)
+{
+    unsigned int nrOfVisuals = 0;
+    for (LinkIndex index = 0; index < model.getNrOfLinks(); ++index) {
+        nrOfVisuals += model.visualSolidShapes().linkSolidShapes[index].size();
+    }
+    return nrOfVisuals;
+}
+
+unsigned int getNrOfCollisions(const iDynTree::Model& model)
+{
+    unsigned int nrOfCollisions = 0;
+    for (LinkIndex index = 0; index < model.getNrOfLinks(); ++index) {
+        nrOfCollisions += model.collisionSolidShapes().linkSolidShapes[index].size();
+    }
+    return nrOfCollisions;
+}
+
 void checkURDF(std::string fileName,
                   unsigned int expectedNrOfLinks,
                   unsigned int expectedNrOfJoints,
                   unsigned int expectedNrOfDOFs,
                   unsigned int expectedNrOfFrames,
+                  unsigned int expectedNrOfVisuals,
+                  unsigned int expectedNrOfCollisions,
                   std::string expectedDefaultBase)
 {
     ModelLoader loader;
@@ -53,6 +73,8 @@ void checkURDF(std::string fileName,
     ASSERT_EQUAL_DOUBLE(model.getNrOfJoints(),expectedNrOfJoints);
     ASSERT_EQUAL_DOUBLE(model.getNrOfDOFs(),expectedNrOfDOFs);
     ASSERT_EQUAL_DOUBLE(model.getNrOfFrames(),expectedNrOfFrames);
+    ASSERT_EQUAL_DOUBLE(getNrOfVisuals(model), expectedNrOfVisuals);
+    ASSERT_EQUAL_DOUBLE(getNrOfCollisions(model), expectedNrOfCollisions);
     ASSERT_EQUAL_STRING(model.getLinkName(model.getDefaultBaseLink()),expectedDefaultBase);
 
     checkParsingOfDofsFromURDF(fileName,expectedNrOfDOFs);
@@ -67,6 +89,8 @@ void checkURDF(std::string fileName,
     ASSERT_EQUAL_DOUBLE(modelCopyConstruced.getNrOfJoints(),expectedNrOfJoints);
     ASSERT_EQUAL_DOUBLE(modelCopyConstruced.getNrOfDOFs(),expectedNrOfDOFs);
     ASSERT_EQUAL_DOUBLE(modelCopyConstruced.getNrOfFrames(),expectedNrOfFrames);
+    ASSERT_EQUAL_DOUBLE(getNrOfVisuals(modelCopyConstruced), expectedNrOfVisuals);
+    ASSERT_EQUAL_DOUBLE(getNrOfCollisions(modelCopyConstruced), expectedNrOfCollisions);
     ASSERT_EQUAL_STRING(modelCopyConstruced.getLinkName(modelCopyConstruced.getDefaultBaseLink()),expectedDefaultBase);
 
     // Check that the copy assignent works fine
@@ -82,6 +106,8 @@ void checkURDF(std::string fileName,
     ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfJoints(),expectedNrOfJoints);
     ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfDOFs(),expectedNrOfDOFs);
     ASSERT_EQUAL_DOUBLE(modelCopyAssigned.getNrOfFrames(),expectedNrOfFrames);
+    ASSERT_EQUAL_DOUBLE(getNrOfVisuals(modelCopyAssigned), expectedNrOfVisuals);
+    ASSERT_EQUAL_DOUBLE(getNrOfCollisions(modelCopyAssigned), expectedNrOfCollisions);
     ASSERT_EQUAL_STRING(modelCopyAssigned.getLinkName(modelCopyAssigned.getDefaultBaseLink()),expectedDefaultBase);
 }
 
@@ -198,12 +224,12 @@ void checkLoadReducedModelOrderIsKept(std::string urdfFileName)
 
 int main()
 {
-    checkURDF(getAbsModelPath("/simple_model.urdf"),1,0,0,1,"link1");
-    checkURDF(getAbsModelPath("/oneLink.urdf"),1,0,0,7,"link1");
-    checkURDF(getAbsModelPath("twoLinks.urdf"),2,1,1,6,"link1");
-    checkURDF(getAbsModelPath("icub_skin_frames.urdf"),39,38,32,62,"root_link");
-    checkURDF(getAbsModelPath("iCubGenova02.urdf"),33,32,26,111,"root_link");
-    checkURDF(getAbsModelPath("icalibrate.urdf"), 6, 5, 3, 7,"base");
+    checkURDF(getAbsModelPath("/simple_model.urdf"),1,0,0,1, 1, 0, "link1");
+    checkURDF(getAbsModelPath("/oneLink.urdf"),1,0,0,7,0,0,"link1");
+    checkURDF(getAbsModelPath("twoLinks.urdf"),2,1,1,6,0,0,"link1");
+    checkURDF(getAbsModelPath("icub_skin_frames.urdf"),39,38,32,62, 28, 28,"root_link");
+    checkURDF(getAbsModelPath("iCubGenova02.urdf"),33,32,26,111, 33, 33, "root_link");
+    checkURDF(getAbsModelPath("icalibrate.urdf"), 6, 5, 3, 7, 6, 6,"base");
 
     checkModelLoderForURDFFile(getAbsModelPath("/oneLink.urdf"));
     checkModelLoaderFromURDFString("this is not an xml", false);


### PR DESCRIPTION
Fix URDF parser bug for which collision geometeries were also loaded as visual geometries, and viceversa (see https://github.com/robotology/idyntree/issues/497).

This behaviour was actually the combined effect given by two different bugs:
* All URDF geometries (collision and visual) were only parsed as visual geometries
* When building the iDynTree::Model, visual geometries were assigned both to visual and to collision

In this commit, test are also added to catch this kind of regressions.