### PR TITLE
Ensure that the link_H_geometry transform is always valid

### DIFF
--- a/doc/releases/v0_11_2.md
+++ b/doc/releases/v0_11_2.md
@@ -15,9 +15,9 @@ Bug Fixes
   getFrameBiasAcc method always returned the bias acceleration corresponding to the first call to setRobotState.
 * Fixed getBiasAcc method in KinDynComputations to take into account the effect of non-zero and non-parallel
   linear and angular base velocity, described in https://github.com/robotology/idyntree/issues/370 .
-* Fixed compilation on 32-bit Windows ( https://github.com/robotology/idyntree/pull/506 ).
-* Fixed a URDF parser regression introduced in iDynTree 0.11 in URDF parser for which collision geometeries were also loaded as visual geometries, and viceversa (https://github.com/robotology/idyntree/issues/497, https://github.com/robotology/idyntree/pull/559).
-* Fixed a URDF parser regression introduced in iDynTree 0.11 in URDF parser for which geometries element without origin tag were not correctly parsed (https://github.com/robotology/idyntree/issues/496, https://github.com/robotology/idyntree/pull/564).
+* Fixed compilation on 32-bit Windows ( https://github.com/robotology/idyntree/pull/506 )
+* Fixed a URDF parser regression introduced in iDynTree 0.11 for which collision geometries were also loaded as visual geometries, and viceversa (https://github.com/robotology/idyntree/issues/497, https://github.com/robotology/idyntree/pull/559).
+* Fixed a URDF parser regression introduced in iDynTree 0.11 for which geometry elements without origin tag were not correctly parsed (https://github.com/robotology/idyntree/issues/496, https://github.com/robotology/idyntree/pull/564).
 
 New features
 ------------

--- a/doc/releases/v0_11_2.md
+++ b/doc/releases/v0_11_2.md
@@ -17,6 +17,7 @@ Bug Fixes
   linear and angular base velocity, described in https://github.com/robotology/idyntree/issues/370 .
 * Fixed compilation on 32-bit Windows ( https://github.com/robotology/idyntree/pull/506 ).
 * Fixed a URDF parser regression introduced in iDynTree 0.11 in URDF parser for which collision geometeries were also loaded as visual geometries, and viceversa (https://github.com/robotology/idyntree/issues/497, https://github.com/robotology/idyntree/pull/559).
+* Fixed a URDF parser regression introduced in iDynTree 0.11 in URDF parser for which geometries element without origin tag were not correctly parsed (https://github.com/robotology/idyntree/issues/496, https://github.com/robotology/idyntree/pull/564).
 
 New features
 ------------

--- a/src/model_io/urdf/include/private/VisualElement.h
+++ b/src/model_io/urdf/include/private/VisualElement.h
@@ -36,7 +36,7 @@ class iDynTree::VisualElement: public iDynTree::XMLElement
 public:
     struct VisualInfo {
         std::string m_name;
-        iDynTree::Transform m_origin;
+        iDynTree::Transform m_origin{iDynTree::Transform::Identity()};
         std::shared_ptr<SolidShape> m_solidShape;
         std::shared_ptr<MaterialElement::MaterialInfo> m_material;
     };


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/496 .