### PR TITLE
Add exportFirstBaseLinkAdditionalFrameAsFakeURDFBase option to ModelExporter

### DIFF
--- a/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
@@ -43,6 +43,19 @@ public:
     std::string baseLink;
 
     /**
+     * Select if the first additional frame of the base link is exported as fake base link.
+     *
+     * The URDF exporter by default exports the first additional frame of the base link as
+     * a parent "fake" link to the actual base link, as a workaround for https://github.com/ros/kdl_parser/issues/27).
+     * By setting this option to false, is possible to disable this behaviour, for more info see iDynTree::ModelExporter docs.
+     * This option is ignored in non-URDF exporter.
+     *
+     * Default value: true.
+     * Supported formats: urdf.
+     */
+    bool exportFirstBaseLinkAdditionalFrameAsFakeURDFBase{true};
+
+    /**
      * Constructor.
      */
     ModelExporterOptions();
@@ -84,9 +97,10 @@ public:
  *
  * Furthermore, it is widespread use in URDF models to never use a real link (with mass) as the root link of a model, mainly
  * due to workaround a bug in official %KDL parser used in ROS (see https://github.com/ros/kdl_parser/issues/27 for more info). For this reason,
- * if the selected base_link has at least one additional frame, the first additional frame of the base link is added as a **parent** fake URDF link,
+ * if the selected base_link has at least one additional frame, by default the first additional frame of the base link is added as a **parent** fake URDF link,
  * instead as a **child** fake URDF link as done with the rest of %iDynTree's additional frames. If no additional frame is available for the base link,
  * the base link of the URDF will have a mass, and will generate a warning then used with the ROS's [`kdl_parser`](https://github.com/ros/kdl_parser) .
+ * This behaviour can be disabled by setting to false the `exportFirstBaseLinkAdditionalFrameAsFakeURDFBase` attribute of ModelExporterOptions.
  *
  */
 class ModelExporter

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -347,6 +347,10 @@ bool URDFStringFromModel(const iDynTree::Model & model,
     // If the base link has at least an additional frame, add it as parent URDF link
     // as a workaround for https://github.com/ros/kdl_parser/issues/27, unless
     // options.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase is set to false
+    // If options.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase is set to false,
+    // baseFakeLinkFrameIndex remains set to FRAME_INVALID_INDEX, a
+    // and all the additional frames of the base link get exported as child fake links 
+    // in the loop and the end of this function
     FrameIndex baseFakeLinkFrameIndex = FRAME_INVALID_INDEX;
     std::vector<FrameIndex> frameIndices;
     ok = model.getLinkAdditionalFrames(baseLinkIndex, frameIndices);

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -345,11 +345,12 @@ bool URDFStringFromModel(const iDynTree::Model & model,
     }
 
     // If the base link has at least an additional frame, add it as parent URDF link
-    // as a workaround for https://github.com/ros/kdl_parser/issues/27
+    // as a workaround for https://github.com/ros/kdl_parser/issues/27, unless
+    // options.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase is set to false
     FrameIndex baseFakeLinkFrameIndex = FRAME_INVALID_INDEX;
     std::vector<FrameIndex> frameIndices;
     ok = model.getLinkAdditionalFrames(baseLinkIndex, frameIndices);
-    if (ok && frameIndices.size() >= 1) {
+    if (ok && frameIndices.size() >= 1 && options.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase) {
         baseFakeLinkFrameIndex = frameIndices[0];
         ok = ok && exportAdditionalFrame(model.getFrameName(baseFakeLinkFrameIndex),
                                          model.getFrameTransform(baseFakeLinkFrameIndex),


### PR DESCRIPTION
Even if the fast majority of URDF models embed a "fake" base link in the form of a parent URDF link with no inertia to workaround https://github.com/ros/kdl_parser/issues/27 , some models existing in the wild, such as the ROS-Industrial KUKA robots (see for example https://github.com/ros-industrial/kuka_experimental/blob/indigo-devel/kuka_kr16_support/urdf/kr16_2.urdf) actually have a root URDF link with a mass and inertia, and just add additional frames as child frames, i.e. : 
~~~xml
  <link name="base_link">
    <inertial>
      <origin rpy="0 0 0" xyz="0 0 0"/>
      <mass value="2"/>
      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
    </inertial>
    <!-- ... -->
  </link>
  <!-- ROS base_link to KUKA $ROBROOT coordinate system transform -->
  <link name="base"/>
  <joint name="base_link-base" type="fixed">
    <origin rpy="0 0 0" xyz="0 0 0"/>
    <parent link="base_link"/>
    <child link="base"/>
  </joint>
~~~
to generate URDF models in this form, it is necessary to add an explicit option to the URDF ModelExporter, to decide how to generate the URDF "fake link" corresponding to the first additional frame of the base link.