### PR TITLE
Feature: Add COM_ACCELEROMETER_SENSOR to berdy helper class

### DIFF
--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -287,6 +287,15 @@ inline void setSubVector(VectorDynSize& vec,
 
 inline void setSubVector(VectorDynSize& vec,
                          const IndexRange range,
+                         const LinearMotionVector3& linMotionVector)
+{
+    assert(range.size==3);
+    toEigen(vec).segment(range.offset, range.size) = toEigen(linMotionVector);
+    return;
+}
+
+inline void setSubVector(VectorDynSize& vec,
+                         const IndexRange range,
                          const SpatialForceVector& wrench)
 {
     assert(range.size==6);

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-find_package(iDynTree REQUIRED)
-
 project(iDynTree_Estimation CXX)
 
 set(IDYNTREE_ESTIMATION_HEADERS include/iDynTree/Estimation/BerdyHelper.h
@@ -54,7 +52,7 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")
 target_include_directories(${libraryname} PRIVATE SYSTEM ${EIGEN3_INCLUDE_DIR})
 
-target_link_libraries(${libraryname} idyntree-core idyntree-model idyntree-sensors idyntree-modelio-urdf iDynTree::idyntree-high-level)
+target_link_libraries(${libraryname} idyntree-core idyntree-model idyntree-sensors idyntree-modelio-urdf idyntree-high-level)
 
 # Ensure that build include directories are always included before system ones
 get_property(IDYNTREE_TREE_INCLUDE_DIRS GLOBAL PROPERTY IDYNTREE_TREE_INCLUDE_DIRS)

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -6,6 +6,8 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
+find_package(iDynTree REQUIRED)
+
 project(iDynTree_Estimation CXX)
 
 set(IDYNTREE_ESTIMATION_HEADERS include/iDynTree/Estimation/BerdyHelper.h
@@ -52,7 +54,7 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")
 target_include_directories(${libraryname} PRIVATE SYSTEM ${EIGEN3_INCLUDE_DIR})
 
-target_link_libraries(${libraryname} idyntree-core idyntree-model idyntree-sensors idyntree-modelio-urdf)
+target_link_libraries(${libraryname} idyntree-core idyntree-model idyntree-sensors idyntree-modelio-urdf iDynTree::idyntree-high-level)
 
 # Ensure that build include directories are always included before system ones
 get_property(IDYNTREE_TREE_INCLUDE_DIRS GLOBAL PROPERTY IDYNTREE_TREE_INCLUDE_DIRS)

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -215,6 +215,12 @@ public:
     bool includeCoMAccelerometerAsSensor;
 
     /**
+     * Vector of link indexes that are considered for rate of change of momentum constraint using CoM accelerometer sensor
+     * The default value is set to contains all the links present in the model
+     */
+    std::vector<LinkIndex> comConstraintLinkIndexVector;
+
+    /**
      * If includeNetExternalWrenchesAsSensors is true and the
      * variant is ORIGINAL_BERDY_FIXED_BASE, if this is
      * true the external wrench acting on the base fixed link

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -128,7 +128,10 @@ enum BerdySensorTypes
     /**
      * Non-physical sensor that measures the wrench trasmitted by a joint.
      */
-    JOINT_WRENCH_SENSOR     = 1003
+    JOINT_WRENCH_SENSOR     = 1003,
+
+    // CoM Accelerometer sensor
+    COM_ACCELEROMETER_SENSOR = 1004
 };
 
 bool isLinkBerdyDynamicVariable(const BerdyDynamicVariablesTypes dynamicVariableType);
@@ -152,6 +155,7 @@ public:
                      includeAllJointAccelerationsAsSensors(true),
                      includeAllJointTorquesAsSensors(false),
                      includeAllNetExternalWrenchesAsSensors(true),
+                     includeCoMAccelerometerAsSensor(false),
                      includeFixedBaseExternalWrench(false),
                      baseLink("")
     {
@@ -201,6 +205,14 @@ public:
      * Default value: true .
      */
     bool includeAllNetExternalWrenchesAsSensors;
+
+    /*
+     * If true, includes the CoM accelerometer in the sensors vector.
+     * It is compatible only with floating base variant of BERDY
+     *
+     * Default value: false .
+     */
+    bool includeCoMAccelerometerAsSensor;
 
     /**
      * If includeNetExternalWrenchesAsSensors is true and the
@@ -459,6 +471,7 @@ class BerdyHelper
         size_t dofTorquesOffset;
         size_t netExtWrenchOffset;
         size_t jointWrenchOffset;
+        size_t comAccelerationOffset;
     } berdySensorTypeOffsets;
 
     /**
@@ -488,6 +501,12 @@ class BerdyHelper
      * and the link frames.
      */
     std::vector<Transform> m_link_H_externalWrenchMeasurementFrame;
+
+    /*
+     * Vector containing the transforms between the base and the model links
+     *
+     */
+    std::vector<Transform> base_H_m_links;
 
 
 public:

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -626,6 +626,8 @@ public:
     IndexRange getRangeDOFSensorVariable(const BerdySensorTypes sensorType, const DOFIndex idx) const;
     IndexRange getRangeJointSensorVariable(const BerdySensorTypes sensorType, const JointIndex idx) const;
     IndexRange getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx) const;
+    IndexRange getRangeCoMAccelerometerSensorVariable(const BerdySensorTypes sensorType) const;
+
 
     /**
      * Ranges of dynamic variables

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -506,7 +506,7 @@ class BerdyHelper
      * Vector containing the transforms between the base and the model links
      *
      */
-    std::vector<Transform> base_H_m_links;
+    std::vector<Transform> base_H_links;
 
 
 public:

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -503,10 +503,10 @@ class BerdyHelper
     std::vector<Transform> m_link_H_externalWrenchMeasurementFrame;
 
     /*
-     * Vector containing the transforms between the base and the model links
+     * LinkPositions variable containing the transforms between the base and the model links
      *
      */
-    std::vector<Transform> base_H_links;
+    LinkPositions base_H_links;
 
 
 public:

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -423,6 +423,9 @@ class BerdyHelper
     std::vector<BerdySensor> m_sensorsOrdering; /*!< Sensor ordering. Created on init */
     std::vector<BerdyDynamicVariable> m_dynamicVariablesOrdering; /*!< Dynamic variable ordering. Created on init */
 
+    std::vector<BerdySensor> m_task1SensorsOrdering; /*!< task1 Sensor ordering. Created on init */
+    std::vector<BerdyDynamicVariable> m_task1DynamicVariablesOrdering; /*!< task1 Dynamic variable ordering. Created on init */
+
     /**
      * Helpers method for initialization.
      */
@@ -488,6 +491,14 @@ class BerdyHelper
         size_t jointWrenchOffset;
         size_t comAccelerationOffset;
     } berdySensorTypeOffsets;
+
+    /**
+     * Helper for mapping sensors measurements to the task1 Y1 vector.
+     */
+    struct {
+        size_t netExtWrenchOffset;
+        size_t comAccelerationOffset;
+    } task1BerdySensorTypeOffsets;
 
     /**
      * Helper of additional sensors.
@@ -673,13 +684,25 @@ public:
     const std::vector<BerdySensor>& getSensorsOrdering() const;
 
     /**
+     * Return the internal ordering of the sensors - new method
+     *
+     * Measurements are expected to respect the internal sensors ordering
+     * Use this function to obtain the sensors ordering.
+     *
+     * @return the sensors ordering
+     */
+    const std::vector<BerdySensor>& getSensorsOrdering(const bool& task1) const;
+
+    /**
      * Get the range of the specified sensor in
      */
     IndexRange getRangeSensorVariable(const SensorType type, const unsigned int sensorIdx) const;
     IndexRange getRangeDOFSensorVariable(const BerdySensorTypes sensorType, const DOFIndex idx) const;
     IndexRange getRangeJointSensorVariable(const BerdySensorTypes sensorType, const JointIndex idx) const;
     IndexRange getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx) const;
-    IndexRange getRangeCoMAccelerometerSensorVariable(const BerdySensorTypes sensorType) const;
+    IndexRange getRangeCoMAccelerometerSensorVariable(const BerdySensorTypes sensorType, const bool task1) const;
+
+    IndexRange getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx, const bool task1) const;
 
 
     /**
@@ -690,6 +713,7 @@ public:
     IndexRange getRangeDOFVariable(const BerdyDynamicVariablesTypes dynamicVariableType, const DOFIndex idx) const;
 
     const std::vector<BerdyDynamicVariable>& getDynamicVariablesOrdering() const;
+    const std::vector<BerdyDynamicVariable>& getDynamicVariablesOrdering(const bool& task1) const;
 
     /**
      * Serialized dynamic variables from the separate buffers

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -656,6 +656,7 @@ public:
                                   JointDOFsDoubleArray    & jointTorques,
                                   JointDOFsDoubleArray    & jointAccs,
                                   LinkInternalWrenches    & linkJointWrenches,
+                                  LinearMotionVector3     & comAcceleration,
                                   VectorDynSize& y);
 
 

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -387,6 +387,11 @@ class BerdyHelper
     size_t m_nrOfDynamicEquations;
     size_t m_nrOfSensorsMeasurements;
 
+    // variables for task1 of stack of tasks berdy
+    size_t m_task1_nrOfDynamicalVariables;
+    size_t m_task1_nrOfDynamicEquations;
+    size_t m_task1_nrOfSensorsMeasurements;
+
     /**
      * Buffer of link-specific body velocities.
      */
@@ -446,6 +451,10 @@ class BerdyHelper
     bool computeBerdyDynamicsMatricesFixedBase(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD);
     bool computeBerdyDynamicsMatricesFloatingBase(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD);
 
+    // Methods for task 1 sub matrices for stack of tasks berdy
+    bool computeTask1SensorMatrices(SparseMatrix<iDynTree::ColumnMajor>& task1_Y, VectorDynSize& task1_bY);
+    bool computeTask1BerdyDynamicsMatricesFloatingBase(SparseMatrix<iDynTree::ColumnMajor>& task1_D, VectorDynSize& task1_bD);
+
     // Helper method
     Matrix6x1 getBiasTermJointAccelerationPropagation(IJointConstPtr joint,
                                                       const LinkIndex parentLinkIdx,
@@ -501,6 +510,9 @@ class BerdyHelper
 
     Triplets matrixDElements;
     Triplets matrixYElements;
+
+    Triplets task1_matrixDElements;
+    Triplets task1_matrixYElements;
 
     /**
      * Transform between the frame in which the external net wrench measurements are expressed
@@ -588,6 +600,23 @@ public:
     size_t getNrOfSensorsMeasurements() const;
 
     /**
+     * Get the number of columns of the D matrix.
+     * This depends on the Berdy variant selected.
+     */
+    size_t getNrOfDynamicVariables(const bool& task1) const;
+
+    /**
+     * Get the number of dynamics equations used in the Berdy
+     * equations
+     */
+    size_t getNrOfDynamicEquations(const bool& task1) const;
+
+    /**
+     * Get the number of sensors measurements.
+     */
+    size_t getNrOfSensorsMeasurements(const bool& task1) const;
+
+    /**
      * Resize and set to zero Berdy matrices.
      */
     bool resizeAndZeroBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize &bD,
@@ -601,10 +630,28 @@ public:
                                     MatrixDynSize & Y, VectorDynSize & bY);
 
     /**
+     * Get Berdy matrices - new method
+     */
+    bool getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize &bD,
+                          SparseMatrix<iDynTree::ColumnMajor>& Y, VectorDynSize &bY,
+                          bool task1);
+
+    /**
      * Get Berdy matrices
      */
     bool getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize &bD,
                           SparseMatrix<iDynTree::ColumnMajor>& Y, VectorDynSize &bY);
+
+    /**
+     * Get Berdy matrices - new method
+     *
+     * \note internally this function uses sparse matrices
+     * Prefer the use of resizeAndZeroBerdyMatrices(SparseMatrix &, VectorDynSize &, SparseMatrix &, VectorDynSize &)
+     */
+    bool getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
+                          MatrixDynSize & Y, VectorDynSize & bY,
+                          bool task1);
+
     /**
      * Get Berdy matrices
      *

--- a/src/estimation/include/iDynTree/Estimation/BerdySparseMAPSolver.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdySparseMAPSolver.h
@@ -45,6 +45,12 @@ namespace iDynTree {
         void setDynamicsRegularizationPriorExpectedValue(const iDynTree::VectorDynSize& expectedValue);
         void setMeasurementsPriorCovariance(const iDynTree::SparseMatrix<iDynTree::ColumnMajor>& covariance);
 
+        // New methods with additional bool flag for task1
+        void setDynamicsConstraintsPriorCovariance(const iDynTree::SparseMatrix<iDynTree::ColumnMajor> & covariance, const bool& task1);
+        void setDynamicsRegularizationPriorCovariance(const iDynTree::SparseMatrix<iDynTree::ColumnMajor>& covariance, const bool& task1);
+        void setDynamicsRegularizationPriorExpectedValue(const iDynTree::VectorDynSize& expectedValue, const bool& task1);
+        void setMeasurementsPriorCovariance(const iDynTree::SparseMatrix<iDynTree::ColumnMajor>& covariance, const bool& task1);
+
         const iDynTree::SparseMatrix<iDynTree::ColumnMajor>& dynamicsConstraintsPriorCovarianceInverse() const; // Sigma_D^-1
         iDynTree::SparseMatrix<iDynTree::ColumnMajor>& dynamicsConstraintsPriorCovarianceInverse(); // Sigma_D^-1
         const iDynTree::SparseMatrix<iDynTree::ColumnMajor>& dynamicsRegularizationPriorCovarianceInverse() const; // Sigma_d^-1
@@ -70,7 +76,15 @@ namespace iDynTree {
                                                    const Vector3& bodyAngularVelocityOfSpecifiedFrame,
                                                    const VectorDynSize& measurements);
 
+        void updateEstimateInformationFloatingBase(const JointPosDoubleArray& jointsConfiguration,
+                                                   const JointDOFsDoubleArray& jointsVelocity,
+                                                   const FrameIndex floatingFrame,
+                                                   const Vector3& bodyAngularVelocityOfSpecifiedFrame,
+                                                   const VectorDynSize& measurements,
+                                                   bool& task1);
+
         bool doEstimate();
+        bool doEstimate(const bool& task1);
 
         void getLastEstimate(iDynTree::VectorDynSize& lastEstimate) const;
         const iDynTree::VectorDynSize& getLastEstimate() const;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -287,7 +287,7 @@ bool BerdyHelper::initSensorsMeasurements()
     // Add CoM accelerometer sensor
     if (m_options.includeCoMAccelerometerAsSensor)
     {
-        std::cout << "Berdy helper : Considering CoM accelerometer sensor in initSensorsMeasurements" << std::endl;
+        //std::cout << "Berdy helper : Considering CoM accelerometer sensor in initSensorsMeasurements" << std::endl;
         berdySensorTypeOffsets.comAccelerationOffset = m_nrOfSensorsMeasurements;
         m_nrOfSensorsMeasurements += 3;
     }
@@ -1392,12 +1392,15 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
     ////////////////////////////////////////////////////////////////////////
     if (m_options.includeCoMAccelerometerAsSensor)
     {
-        // Compute forward kinematics
+
+        // Get the row index corresponding to the com accelerometer sensor
+        // TODO: Correct the link index pssed here
+        IndexRange comAccelerometerRange = this->getRangeLinkSensorVariable(COM_ACCELEROMETER_SENSOR, 0);
 
         for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
         {
-            IndexRange sensorRange = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
-            IndexRange netExtWrenchRange = this->getRangeLinkVariable(NET_EXT_WRENCH,idx);
+            // Get the column index corresponding to the net link external wrench sensor
+            IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
 
             iDynTree::Rotation base_R_m_link = base_H_m_links.at(idx).getRotation();
 
@@ -1416,8 +1419,8 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
 //            base_R_m_link_eigen_matrix.setVal(2, 2, base_R_m_link.getVal(2,2));
 
             // Get link to base rotation
-            matrixYElements.addSubMatrix(sensorRange.offset,
-                                         netExtWrenchRange.offset,
+            matrixYElements.addSubMatrix(comAccelerometerRange.offset,
+                                         netExternalWrenchSensor.offset,
                                          base_R_m_link);
 
         }
@@ -1597,7 +1600,7 @@ bool BerdyHelper::updateKinematicsFromFloatingBase(const JointPosDoubleArray& jo
      for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
      {
          base_H_m_links.at(idx) = kinDynComputations.getRelativeTransform(idx, m_model.getLinkIndex(m_options.baseLink));
-         std::cout << "Berdy helper : updated transform for the link " << m_model.getLinkName(idx) << " with the transform : " << base_H_m_links.at(idx).toString().c_str() << std::endl;
+         //std::cout << "Berdy helper : updated transform for the link " << m_model.getLinkName(idx) << " with the transform : " << base_H_m_links.at(idx).toString().c_str() << std::endl;
      }
 
     m_kinematicsUpdated = ok;
@@ -1749,19 +1752,19 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
 
         if(m_options.includeCoMAccelerometerAsSensor) {
 
-            std::cout << "Berdy helper : Considering CoM accelerometer sensor inside cacheSensorOrdering";
+            //std::cout << "Berdy helper : Considering CoM accelerometer sensor inside cacheSensorOrdering";
             IndexRange sensorRange = this->getRangeLinkSensorVariable(COM_ACCELEROMETER_SENSOR, m_model.getLinkIndex(m_options.baseLink));
 
             BerdySensor linkSensor;
             linkSensor.type = COM_ACCELEROMETER_SENSOR;
             linkSensor.id = m_options.baseLink;
-            std::cout << "Berdy helper : CoM accelerometer sensor id " << linkSensor.id << std::endl;
+            //std::cout << "Berdy helper : CoM accelerometer sensor id " << linkSensor.id << std::endl;
             linkSensor.range = sensorRange;
-            std::cout << "Berdy helper : CoM accelerometer sensor size : " << linkSensor.range.size << " offset : " << linkSensor.range.offset << std::endl;
+            //std::cout << "Berdy helper : CoM accelerometer sensor size : " << linkSensor.range.size << " offset : " << linkSensor.range.offset << std::endl;
             m_sensorsOrdering.push_back(linkSensor);
         }
 
-        std::cout << "Berdy helper : sensor ordering vector size : " << m_sensorsOrdering.size() << std::endl;
+        //std::cout << "Berdy helper : sensor ordering vector size : " << m_sensorsOrdering.size() << std::endl;
 
         //To avoid any problem, sort m_sensorsOrdering by range.offset
         std::sort(m_sensorsOrdering.begin(), m_sensorsOrdering.end());

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1746,7 +1746,7 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
 
         if(m_options.includeCoMAccelerometerAsSensor) {
 
-            IndexRange sensorRange = this->getRangeLinkSensorVariable(COM_ACCELEROMETER_SENSOR, m_model.getLinkIndex(m_options.baseLink));
+            IndexRange sensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
 
             BerdySensor linkSensor;
             linkSensor.type = COM_ACCELEROMETER_SENSOR;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -287,7 +287,6 @@ bool BerdyHelper::initSensorsMeasurements()
     // Add CoM accelerometer sensor
     if (m_options.includeCoMAccelerometerAsSensor)
     {
-        //std::cout << "Berdy helper : Considering CoM accelerometer sensor in initSensorsMeasurements" << std::endl;
         berdySensorTypeOffsets.comAccelerationOffset = m_nrOfSensorsMeasurements;
         m_nrOfSensorsMeasurements += 3;
     }
@@ -1596,12 +1595,11 @@ bool BerdyHelper::updateKinematicsFromFloatingBase(const JointPosDoubleArray& jo
                                      m_jointVel,
                                      m_gravity);
 
-    // TODO: Update base_H_m_links transformations
-     for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
-     {
-         base_H_m_links.at(idx) = kinDynComputations.getRelativeTransform(idx, m_model.getLinkIndex(m_options.baseLink));
-         //std::cout << "Berdy helper : updated transform for the link " << m_model.getLinkName(idx) << " with the transform : " << base_H_m_links.at(idx).toString().c_str() << std::endl;
-     }
+    // Update base_H_m_links transformations
+    for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
+    {
+        base_H_m_links.at(idx) = kinDynComputations.getRelativeTransform(idx, m_model.getLinkIndex(m_options.baseLink));
+    }
 
     m_kinematicsUpdated = ok;
     return ok;
@@ -1752,19 +1750,15 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
 
         if(m_options.includeCoMAccelerometerAsSensor) {
 
-            //std::cout << "Berdy helper : Considering CoM accelerometer sensor inside cacheSensorOrdering";
             IndexRange sensorRange = this->getRangeLinkSensorVariable(COM_ACCELEROMETER_SENSOR, m_model.getLinkIndex(m_options.baseLink));
 
             BerdySensor linkSensor;
             linkSensor.type = COM_ACCELEROMETER_SENSOR;
             linkSensor.id = m_options.baseLink;
-            //std::cout << "Berdy helper : CoM accelerometer sensor id " << linkSensor.id << std::endl;
             linkSensor.range = sensorRange;
-            //std::cout << "Berdy helper : CoM accelerometer sensor size : " << linkSensor.range.size << " offset : " << linkSensor.range.offset << std::endl;
+
             m_sensorsOrdering.push_back(linkSensor);
         }
-
-        //std::cout << "Berdy helper : sensor ordering vector size : " << m_sensorsOrdering.size() << std::endl;
 
         //To avoid any problem, sort m_sensorsOrdering by range.offset
         std::sort(m_sensorsOrdering.begin(), m_sensorsOrdering.end());

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -651,12 +651,27 @@ IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensor
         }
     }
 
+    assert(ret.isValid());
+    return ret;
+}
 
-    if (sensorType == COM_ACCELEROMETER_SENSOR && m_options.berdyVariant == BERDY_FLOATING_BASE)
+IndexRange BerdyHelper::getRangeCoMAccelerometerSensorVariable(const BerdySensorTypes sensorType) const
+{
+    IndexRange ret = IndexRange::InvalidRange();
+
+    if (sensorType != COM_ACCELEROMETER_SENSOR)
     {
-        ret.size = 3;
-        ret.offset = berdySensorTypeOffsets.comAccelerationOffset;
+        iDynTree::reportWarning("BerdyHelpers","getRangeCoMAccelerometerSensorVariable","Wrong sensor types passed for retrieving sensor range");
     }
+
+    if (m_options.berdyVariant != BERDY_FLOATING_BASE)
+    {
+        iDynTree::reportWarning("BerdyHelpers","getRangeCoMAccelerometerSensorVariable","CoM Accelerometer sensor is only available in BERDY_FLOATING_BASE");
+    }
+
+    // Set sensor size and offset
+    ret.size = 3;
+    ret.offset = berdySensorTypeOffsets.comAccelerationOffset;
 
     assert(ret.isValid());
     return ret;
@@ -1393,8 +1408,7 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
     {
 
         // Get the row index corresponding to the com accelerometer sensor
-        // TODO: Correct the link index pssed here
-        IndexRange comAccelerometerRange = this->getRangeLinkSensorVariable(COM_ACCELEROMETER_SENSOR, 0);
+        IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
 
         for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
         {

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -182,7 +182,7 @@ bool BerdyHelper::init(const Model& model,
     m_link_H_externalWrenchMeasurementFrame.resize(m_model.getNrOfLinks(),Transform::Identity());
 
     // Initialize links to base transform to identity
-    base_H_m_links.resize(m_model.getNrOfLinks(), Transform::Identity());
+    base_H_links.resize(m_model.getNrOfLinks(), Transform::Identity());
 
     bool res = m_options.checkConsistency();
 
@@ -1415,14 +1415,14 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
             // Get the column index corresponding to the net link external wrench sensor
             IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
 
-            iDynTree::Rotation base_R_m_link = base_H_m_links.at(idx).getRotation();
-            iDynTree::Matrix3x3 base_R_m_link_M33;
-            iDynTree::toEigen(base_R_m_link_M33) = iDynTree::toEigen(base_R_m_link);
+            iDynTree::Rotation base_R_link = base_H_links.at(idx).getRotation();
+            iDynTree::Matrix3x3 base_R_link_M33;
+            iDynTree::toEigen(base_R_link_M33) = iDynTree::toEigen(base_R_link);
 
             // Get link to base rotation
             matrixYElements.addSubMatrix(comAccelerometerRange.offset,
                                          netExternalWrenchSensor.offset,
-                                         base_R_m_link_M33);
+                                         base_R_link_M33);
 
         }
 
@@ -1597,10 +1597,10 @@ bool BerdyHelper::updateKinematicsFromFloatingBase(const JointPosDoubleArray& jo
                                      m_jointVel,
                                      m_gravity);
 
-    // Update base_H_m_links transformations
+    // Update base_H_links transformations
     for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
     {
-        base_H_m_links.at(idx) = kinDynComputations.getRelativeTransform(idx, m_model.getLinkIndex(m_options.baseLink));
+        base_H_links.at(idx) = kinDynComputations.getRelativeTransform(m_model.getLinkIndex(m_options.baseLink), idx);
     }
 
     m_kinematicsUpdated = ok;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1409,11 +1409,14 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
         // Get the row index corresponding to the com accelerometer sensor
         IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
 
-        for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_options.comConstraintLinkIndexVector.size()); idx++)
+        for(size_t i = 0; i < m_options.comConstraintLinkIndexVector.size(); i++)
         {
+            // Get link index from the vector
+            LinkIndex idx = m_options.comConstraintLinkIndexVector.at(i);
+
             // Get the column index corresponding to the net link external wrench sensor
             IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR,
-                                                                                  static_cast<LinkIndex>(m_options.comConstraintLinkIndexVector.at(idx)));
+                                                                                  idx);
 
             iDynTree::Rotation base_R_link = base_H_links(idx).getRotation();
             iDynTree::Matrix3x3 base_R_link_M33;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1416,25 +1416,13 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
             IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
 
             iDynTree::Rotation base_R_m_link = base_H_m_links.at(idx).getRotation();
-
-//            Matrix3x3 base_R_m_link_eigen_matrix;
-
-//            base_R_m_link_eigen_matrix.setVal(0, 0, base_R_m_link.getVal(0,0));
-//            base_R_m_link_eigen_matrix.setVal(0, 1, base_R_m_link.getVal(0,1));
-//            base_R_m_link_eigen_matrix.setVal(0, 2, base_R_m_link.getVal(0,2));
-
-//            base_R_m_link_eigen_matrix.setVal(1, 0, base_R_m_link.getVal(1,0));
-//            base_R_m_link_eigen_matrix.setVal(1, 1, base_R_m_link.getVal(1,1));
-//            base_R_m_link_eigen_matrix.setVal(1, 2, base_R_m_link.getVal(2,2));
-
-//            base_R_m_link_eigen_matrix.setVal(2, 0, base_R_m_link.getVal(2,0));
-//            base_R_m_link_eigen_matrix.setVal(2, 1, base_R_m_link.getVal(2,1));
-//            base_R_m_link_eigen_matrix.setVal(2, 2, base_R_m_link.getVal(2,2));
+            iDynTree::Matrix3x3 base_R_m_link_M33;
+            iDynTree::toEigen(base_R_m_link_M33) = iDynTree::toEigen(base_R_m_link);
 
             // Get link to base rotation
             matrixYElements.addSubMatrix(comAccelerometerRange.offset,
                                          netExternalWrenchSensor.offset,
-                                         base_R_m_link);
+                                         base_R_m_link_M33);
 
         }
 

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1399,10 +1399,26 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
             IndexRange sensorRange = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
             IndexRange netExtWrenchRange = this->getRangeLinkVariable(NET_EXT_WRENCH,idx);
 
+            iDynTree::Rotation base_R_m_link = base_H_m_links.at(idx).getRotation();
+
+//            Matrix3x3 base_R_m_link_eigen_matrix;
+
+//            base_R_m_link_eigen_matrix.setVal(0, 0, base_R_m_link.getVal(0,0));
+//            base_R_m_link_eigen_matrix.setVal(0, 1, base_R_m_link.getVal(0,1));
+//            base_R_m_link_eigen_matrix.setVal(0, 2, base_R_m_link.getVal(0,2));
+
+//            base_R_m_link_eigen_matrix.setVal(1, 0, base_R_m_link.getVal(1,0));
+//            base_R_m_link_eigen_matrix.setVal(1, 1, base_R_m_link.getVal(1,1));
+//            base_R_m_link_eigen_matrix.setVal(1, 2, base_R_m_link.getVal(2,2));
+
+//            base_R_m_link_eigen_matrix.setVal(2, 0, base_R_m_link.getVal(2,0));
+//            base_R_m_link_eigen_matrix.setVal(2, 1, base_R_m_link.getVal(2,1));
+//            base_R_m_link_eigen_matrix.setVal(2, 2, base_R_m_link.getVal(2,2));
+
             // Get link to base rotation
             matrixYElements.addSubMatrix(sensorRange.offset,
                                          netExtWrenchRange.offset,
-                                         base_H_m_links.at(idx).asAdjointTransformWrench());
+                                         base_R_m_link);
 
         }
 

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1406,14 +1406,14 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
     ////////////////////////////////////////////////////////////////////////
     if (m_options.includeCoMAccelerometerAsSensor)
     {
-
         // Get the row index corresponding to the com accelerometer sensor
         IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
 
-        for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
+        for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_options.comConstraintLinkIndexVector.size()); idx++)
         {
             // Get the column index corresponding to the net link external wrench sensor
-            IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
+            IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR,
+                                                                                  static_cast<LinkIndex>(m_options.comConstraintLinkIndexVector.at(idx)));
 
             iDynTree::Rotation base_R_link = base_H_links(idx).getRotation();
             iDynTree::Matrix3x3 base_R_link_M33;
@@ -1446,6 +1446,15 @@ bool BerdyHelper::initBerdyFloatingBase()
     // The dynamics equations considered by floating berdy are the acceleration propagation for each joint and the
     // Newton-Euler equations for each link
     m_nrOfDynamicEquations   = 6*m_model.getNrOfLinks() + 6*m_model.getNrOfJoints();
+
+    // check comConstraintLinkIndexVector is correctly set
+    if (m_options.includeCoMAccelerometerAsSensor) {
+        if (m_options.comConstraintLinkIndexVector.size() == 0)
+        {
+            reportError("BerdyHelpers","initBerdyFloatingBase","comConstraintLinkIndexVector is not initialized correctly, the size is 0");
+            res = false;
+        }
+    }
 
     initSensorsMeasurements();
 

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -2094,6 +2094,7 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
                                            JointDOFsDoubleArray& jointTorques,
                                            JointDOFsDoubleArray& jointAccs,
                                            LinkInternalWrenches& linkJointWrenches,
+                                           LinearMotionVector3& comAcceleration,
                                            VectorDynSize& y)
 {
     bool ret=true;
@@ -2165,8 +2166,15 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
         setSubVector(y,sensorRange,toEigen(linkJointWrenches(childLink)));
     }
 
-    // TODO: Handle CoM acceleration sensor
+    ////////////////////////////////////////////////////////////////////////
+    ///// COM ACCELERATION
+    ////////////////////////////////////////////////////////////////////////
+    if (m_options.includeCoMAccelerometerAsSensor && m_options.berdyVariant == BERDY_FLOATING_BASE)
+    {
+        IndexRange sensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
 
+        setSubVector(y, sensorRange, comAcceleration);
+    }
 
     return ret;
 }

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -251,6 +251,10 @@ bool BerdyHelper::initSensorsMeasurements()
         m_nrOfSensorsMeasurements += this->m_model.getNrOfDOFs();
     }
 
+    // Initialize task1 number of measurements variable
+    m_task1_nrOfSensorsMeasurements = 0;
+    task1BerdySensorTypeOffsets.netExtWrenchOffset = m_task1_nrOfSensorsMeasurements;
+
     berdySensorTypeOffsets.netExtWrenchOffset = m_nrOfSensorsMeasurements;
     if( m_options.includeAllNetExternalWrenchesAsSensors )
     {
@@ -261,7 +265,7 @@ bool BerdyHelper::initSensorsMeasurements()
         m_nrOfSensorsMeasurements += 6 * numOfExternalWrenches;
 
         // TODO: Double check if this can be handled better
-        m_task1_nrOfSensorsMeasurements = 6*numOfExternalWrenches;
+        m_task1_nrOfSensorsMeasurements += 6*numOfExternalWrenches;
     }
 
     berdySensorTypeOffsets.jointWrenchOffset = m_nrOfSensorsMeasurements;
@@ -292,6 +296,8 @@ bool BerdyHelper::initSensorsMeasurements()
     {
         berdySensorTypeOffsets.comAccelerationOffset = m_nrOfSensorsMeasurements;
         m_nrOfSensorsMeasurements += 3;
+
+        task1BerdySensorTypeOffsets.comAccelerationOffset = m_task1_nrOfSensorsMeasurements;
         m_task1_nrOfSensorsMeasurements += 3;
     }
 
@@ -627,6 +633,43 @@ IndexRange BerdyHelper::getRangeJointSensorVariable(const BerdySensorTypes senso
     return ret;
 }
 
+IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx, const bool task1) const
+{
+    IndexRange ret = IndexRange::InvalidRange();
+
+    if( sensorType == NET_EXT_WRENCH_SENSOR )
+    {
+        ret.size = 6;
+
+        if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
+        {
+            TraversalIndex trvIdx = m_dynamicsTraversal.getTraversalIndexFromLinkIndex(idx);
+
+            if (m_options.includeFixedBaseExternalWrench)
+            {
+                ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*trvIdx;
+            }
+            else
+            {
+                ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*(trvIdx-1);
+            }
+        }
+        else
+        {
+            assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+            if (task1) {
+                ret.offset = task1BerdySensorTypeOffsets.netExtWrenchOffset + 6*idx;
+            }
+            else {
+                ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*idx;
+            }
+        }
+    }
+
+    assert(ret.isValid());
+    return ret;
+}
+
 IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx) const
 {
     IndexRange ret = IndexRange::InvalidRange();
@@ -659,7 +702,7 @@ IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensor
     return ret;
 }
 
-IndexRange BerdyHelper::getRangeCoMAccelerometerSensorVariable(const BerdySensorTypes sensorType) const
+IndexRange BerdyHelper::getRangeCoMAccelerometerSensorVariable(const BerdySensorTypes sensorType, const bool task1) const
 {
     IndexRange ret = IndexRange::InvalidRange();
 
@@ -675,7 +718,13 @@ IndexRange BerdyHelper::getRangeCoMAccelerometerSensorVariable(const BerdySensor
 
     // Set sensor size and offset
     ret.size = 3;
-    ret.offset = berdySensorTypeOffsets.comAccelerationOffset;
+
+    if (task1) {
+        ret.offset = task1BerdySensorTypeOffsets.comAccelerationOffset;
+    }
+    else {
+        ret.offset = berdySensorTypeOffsets.comAccelerationOffset;
+    }
 
     assert(ret.isValid());
     return ret;
@@ -1176,7 +1225,7 @@ bool BerdyHelper::computeTask1SensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
     if (m_options.includeCoMAccelerometerAsSensor)
     {
         // Get the row index corresponding to the com accelerometer sensor
-        IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
+        IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR, true);
 
         for(size_t i = 0; i < m_options.comConstraintLinkIndexVector.size(); i++)
         {
@@ -1185,7 +1234,7 @@ bool BerdyHelper::computeTask1SensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
 
             // Get the column index corresponding to the net link external wrench sensor
             IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR,
-                                                                                  idx);
+                                                                                  idx, true);
 
             iDynTree::Rotation base_R_link = base_H_links(idx).getRotation();
             iDynTree::Matrix3x3 base_R_link_M33;
@@ -1511,7 +1560,7 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
     if (m_options.includeCoMAccelerometerAsSensor)
     {
         // Get the row index corresponding to the com accelerometer sensor
-        IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
+        IndexRange comAccelerometerRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR, false);
 
         for(size_t i = 0; i < m_options.comConstraintLinkIndexVector.size(); i++)
         {
@@ -1520,7 +1569,7 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
 
             // Get the column index corresponding to the net link external wrench sensor
             IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR,
-                                                                                  idx);
+                                                                                  idx, false);
 
             iDynTree::Rotation base_R_link = base_H_links(idx).getRotation();
             iDynTree::Matrix3x3 base_R_link_M33;
@@ -1877,6 +1926,9 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
         m_sensorsOrdering.clear();
         m_sensorsOrdering.reserve(size);
 
+        m_task1SensorsOrdering.clear();
+        m_task1SensorsOrdering.reserve(size);
+
         //To be a bit more flexible, rely on getRangeSensorVariable to have the order of
         //the URDF sensors
         //???: Isn't this a loop in some way??
@@ -1940,6 +1992,16 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
                 {
                     continue;
                 }
+
+                // Task1 sensor ordering
+                IndexRange task1SensorRange = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx, true);
+                BerdySensor task1LinkSens;
+                task1LinkSens.type = NET_EXT_WRENCH_SENSOR;
+                task1LinkSens.id = m_model.getLinkName(idx);
+                task1LinkSens.range = task1SensorRange;
+
+                m_task1SensorsOrdering.push_back(task1LinkSens);
+
                 IndexRange sensorRange = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
                 BerdySensor linkSens;
                 linkSens.type = NET_EXT_WRENCH_SENSOR;
@@ -1963,7 +2025,16 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
 
         if(m_options.includeCoMAccelerometerAsSensor) {
 
-            IndexRange sensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
+            IndexRange task1SensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR, true);
+
+            BerdySensor task1LinkSensor;
+            task1LinkSensor.type = COM_ACCELEROMETER_SENSOR;
+            task1LinkSensor.id = m_options.baseLink;
+            task1LinkSensor.range = task1SensorRange;
+
+            m_task1SensorsOrdering.push_back(task1LinkSensor);
+
+            IndexRange sensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR, false);
 
             BerdySensor linkSensor;
             linkSensor.type = COM_ACCELEROMETER_SENSOR;
@@ -1975,6 +2046,8 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
 
         //To avoid any problem, sort m_sensorsOrdering by range.offset
         std::sort(m_sensorsOrdering.begin(), m_sensorsOrdering.end());
+
+        std::sort(m_task1SensorsOrdering.begin(), m_task1SensorsOrdering.end());
     }
 
     void BerdyHelper::cacheDynamicVariablesOrderingFixedBase()
@@ -2049,6 +2122,7 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
 
         //To avoid any problem, sort m_dynamicVariablesOrdering by range.offset
         std::sort(m_dynamicVariablesOrdering.begin(), m_dynamicVariablesOrdering.end());
+
     }
 
     void BerdyHelper::cacheDynamicVariablesOrderingFloatingBase()
@@ -2056,6 +2130,9 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
         m_dynamicVariablesOrdering.clear();
         unsigned size = 0;
         m_dynamicVariablesOrdering.reserve(size);
+
+        m_task1DynamicVariablesOrdering.clear();
+        m_task1DynamicVariablesOrdering.reserve(size);
 
         /*
          * Ordering:
@@ -2081,6 +2158,14 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
 
             m_dynamicVariablesOrdering.push_back(acceleration);
             m_dynamicVariablesOrdering.push_back(netExtWrench);
+
+            // Task1
+            BerdyDynamicVariable task1NetExternalWrench;
+            task1NetExternalWrench.type = NET_EXT_WRENCH;
+            task1NetExternalWrench.id = linkName;
+            task1NetExternalWrench.range = getRangeLinkVariable(task1NetExternalWrench.type, link);
+
+            m_task1DynamicVariablesOrdering.push_back(task1NetExternalWrench);
         }
 
         for (JointIndex jntIdx = 0; jntIdx < static_cast<JointIndex>(m_model.getNrOfJoints()); ++jntIdx)
@@ -2112,6 +2197,8 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
 
         //To avoid any problem, sort m_dynamicVariablesOrdering by range.offset
         std::sort(m_dynamicVariablesOrdering.begin(), m_dynamicVariablesOrdering.end());
+
+        std::sort(m_task1DynamicVariablesOrdering.begin(), m_task1DynamicVariablesOrdering.end());
     }
 
     const std::vector<BerdySensor>& BerdyHelper::getSensorsOrdering() const
@@ -2119,9 +2206,29 @@ bool BerdyHelper::getBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
         return m_sensorsOrdering;
     }
 
+    const std::vector<BerdySensor>& BerdyHelper::getSensorsOrdering(const bool& task1) const
+    {
+        if (task1) {
+            return m_task1SensorsOrdering;
+        }
+        else {
+            return m_sensorsOrdering;
+        }
+    }
+
     const std::vector<BerdyDynamicVariable>& BerdyHelper::getDynamicVariablesOrdering() const
     {
         return m_dynamicVariablesOrdering;
+    }
+
+    const std::vector<BerdyDynamicVariable>& BerdyHelper::getDynamicVariablesOrdering(const bool& task1) const
+    {
+        if (task1) {
+            return m_task1DynamicVariablesOrdering;
+        }
+        else {
+            return m_dynamicVariablesOrdering;
+        }
     }
 
 bool BerdyHelper::serializeDynamicVariables(LinkProperAccArray& properAccs,
@@ -2382,7 +2489,7 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
     ////////////////////////////////////////////////////////////////////////
     if (m_options.includeCoMAccelerometerAsSensor && m_options.berdyVariant == BERDY_FLOATING_BASE)
     {
-        IndexRange sensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR);
+        IndexRange sensorRange = this->getRangeCoMAccelerometerSensorVariable(COM_ACCELEROMETER_SENSOR, true);
 
         setSubVector(y, sensorRange, comAcceleration);
     }

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -20,9 +20,11 @@
 #include <iDynTree/Model/Traversal.h>
 #include <iDynTree/Sensors/Sensors.h>
 #include <iDynTree/Sensors/AllSensorsTypes.h>
+#include <iDynTree/KinDynComputations.h>
 
 #include <iDynTree/Estimation/ExternalWrenchesEstimation.h>
 
+#include <memory>
 #include <sstream>
 #include <algorithm>
 
@@ -179,6 +181,9 @@ bool BerdyHelper::init(const Model& model,
     m_linkVels.resize(m_model);
     m_link_H_externalWrenchMeasurementFrame.resize(m_model.getNrOfLinks(),Transform::Identity());
 
+    // Initialize links to base transform to identity
+    base_H_m_links.resize(m_model.getNrOfLinks(), Transform::Identity());
+
     bool res = m_options.checkConsistency();
 
     if( !res )
@@ -277,6 +282,14 @@ bool BerdyHelper::initSensorsMeasurements()
         berdySensorsInfo.wrenchSensors.push_back(jntIdx);
         berdySensorsInfo.jntIdxToOffset[jntIdx] = m_nrOfSensorsMeasurements;
         m_nrOfSensorsMeasurements += 6;
+    }
+
+    // Add CoM accelerometer sensor
+    if (m_options.includeCoMAccelerometerAsSensor)
+    {
+        std::cout << "Berdy helper : Considering CoM accelerometer sensor in initSensorsMeasurements" << std::endl;
+        berdySensorTypeOffsets.comAccelerationOffset = m_nrOfSensorsMeasurements;
+        m_nrOfSensorsMeasurements += 3;
     }
 
     //Create sensor ordering vector
@@ -614,10 +627,11 @@ IndexRange BerdyHelper::getRangeJointSensorVariable(const BerdySensorTypes senso
 IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx) const
 {
     IndexRange ret = IndexRange::InvalidRange();
-    ret.size = 6;
 
     if( sensorType == NET_EXT_WRENCH_SENSOR )
     {
+        ret.size = 6;
+
         if (m_options.berdyVariant == ORIGINAL_BERDY_FIXED_BASE)
         {
             TraversalIndex trvIdx = m_dynamicsTraversal.getTraversalIndexFromLinkIndex(idx);
@@ -636,6 +650,13 @@ IndexRange BerdyHelper::getRangeLinkSensorVariable(const BerdySensorTypes sensor
             assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
             ret.offset = berdySensorTypeOffsets.netExtWrenchOffset + 6*idx;
         }
+    }
+
+
+    if (sensorType == COM_ACCELEROMETER_SENSOR && m_options.berdyVariant == BERDY_FLOATING_BASE)
+    {
+        ret.size = 3;
+        ret.offset = berdySensorTypeOffsets.comAccelerationOffset;
     }
 
     assert(ret.isValid());
@@ -1366,6 +1387,29 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
         // bY for the joint wrenches is zero
     }
 
+    ////////////////////////////////////////////////////////////////////////
+    ///// COM ACCELERATION SENSOR
+    ////////////////////////////////////////////////////////////////////////
+    if (m_options.includeCoMAccelerometerAsSensor)
+    {
+        // Compute forward kinematics
+
+        for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
+        {
+            IndexRange sensorRange = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
+            IndexRange netExtWrenchRange = this->getRangeLinkVariable(NET_EXT_WRENCH,idx);
+
+            // Get link to base rotation
+            matrixYElements.addSubMatrix(sensorRange.offset,
+                                         netExtWrenchRange.offset,
+                                         base_H_m_links.at(idx).asAdjointTransformWrench());
+
+        }
+
+
+        // bY for the com acceleratio sensor is zeor
+    }
+
     Y.setFromTriplets(matrixYElements);
     return true;
 }
@@ -1526,6 +1570,20 @@ bool BerdyHelper::updateKinematicsFromFloatingBase(const JointPosDoubleArray& jo
     m_jointPos = jointPos;
     m_jointVel = jointVel;
 
+    // Update kinDyn computation
+    iDynTree::KinDynComputations kinDynComputations;
+    kinDynComputations.loadRobotModel(m_model);
+    kinDynComputations.setRobotState(m_jointPos,
+                                     m_jointVel,
+                                     m_gravity);
+
+    // TODO: Update base_H_m_links transformations
+     for(LinkIndex idx = 0; idx < static_cast<LinkIndex>(m_model.getNrOfLinks()); idx++)
+     {
+         base_H_m_links.at(idx) = kinDynComputations.getRelativeTransform(idx, m_model.getLinkIndex(m_options.baseLink));
+         std::cout << "Berdy helper : updated transform for the link " << m_model.getLinkName(idx) << " with the transform : " << base_H_m_links.at(idx).toString().c_str() << std::endl;
+     }
+
     m_kinematicsUpdated = ok;
     return ok;
 }
@@ -1672,6 +1730,22 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
             jointSens.range = sensorRange;
             m_sensorsOrdering.push_back(jointSens);
         }
+
+        if(m_options.includeCoMAccelerometerAsSensor) {
+
+            std::cout << "Berdy helper : Considering CoM accelerometer sensor inside cacheSensorOrdering";
+            IndexRange sensorRange = this->getRangeLinkSensorVariable(COM_ACCELEROMETER_SENSOR, m_model.getLinkIndex(m_options.baseLink));
+
+            BerdySensor linkSensor;
+            linkSensor.type = COM_ACCELEROMETER_SENSOR;
+            linkSensor.id = m_options.baseLink;
+            std::cout << "Berdy helper : CoM accelerometer sensor id " << linkSensor.id << std::endl;
+            linkSensor.range = sensorRange;
+            std::cout << "Berdy helper : CoM accelerometer sensor size : " << linkSensor.range.size << " offset : " << linkSensor.range.offset << std::endl;
+            m_sensorsOrdering.push_back(linkSensor);
+        }
+
+        std::cout << "Berdy helper : sensor ordering vector size : " << m_sensorsOrdering.size() << std::endl;
 
         //To avoid any problem, sort m_sensorsOrdering by range.offset
         std::sort(m_sensorsOrdering.begin(), m_sensorsOrdering.end());
@@ -2075,6 +2149,8 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
         LinkIndex childLink = m_dynamicsTraversal.getChildLinkIndexFromJointIndex(m_model,berdySensorsInfo.wrenchSensors[i]);
         setSubVector(y,sensorRange,toEigen(linkJointWrenches(childLink)));
     }
+
+    // TODO: Handle CoM acceleration sensor
 
 
     return ret;


### PR DESCRIPTION
This PR addresses #570 by adding a `COM_ACCELEROMETER_SENSOR` to berdy helper class. Additional details will be added soon.

- The information related to the constraint that is related to the `COM_ACCELEROMETER_SENSOR` is updated in  https://github.com/robotology/idyntree/issues/570#issuecomment-530346665
- The corresponding changes to the berdy matrices are updated in https://github.com/robotology/idyntree/issues/570#issuecomment-530347743

@traversaro please review it 

CC @DanielePucci @claudia-lat @kouroshD @lrapetti 