### PR TITLE
Fix missing includes in WorhpInterface.h

### DIFF
--- a/src/optimalcontrol/include/iDynTree/Optimizers/WorhpInterface.h
+++ b/src/optimalcontrol/include/iDynTree/Optimizers/WorhpInterface.h
@@ -19,6 +19,9 @@
 
 #include <iDynTree/Optimizer.h>
 
+#include <memory>
+#include <string>
+
 namespace iDynTree {
 
     class VectorDynSize;


### PR DESCRIPTION
`string` is necessary for the use of `std::string`, while memory for the use of `std::shared_ptr`. 