### PR TITLE
 Add ModelExporter and InertialParametersSolidShapesHelpers to the SWIG bindings

### DIFF
--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -108,6 +108,7 @@
 #include "iDynTree/ModelIO/URDFDofsImport.h"
 #include "iDynTree/ModelIO/URDFGenericSensorsImport.h"
 #include "iDynTree/ModelIO/ModelLoader.h"
+#include "iDynTree/ModelIO/ModelExporter.h"
 
 // Estimation related classes
 #include "iDynTree/Estimation/ExternalWrenchesEstimation.h"
@@ -119,6 +120,9 @@
 #include "iDynTree/Estimation/AttitudeMahonyFilter.h"
 #include "iDynTree/Estimation/ExtendedKalmanFilter.h"
 #include "iDynTree/Estimation/AttitudeQuaternionEKF.h"
+
+// SolidShapes related classes
+#include "iDynTree/InertialParametersSolidShapesHelpers.h"
 
 // Regressors related data structures
 #include "iDynTree/Regressors/DynamicsRegressorParameters.h"
@@ -312,6 +316,7 @@ TEMPLATE_WRAP_MOTION_FORCE(ForceVector3, WRAP_FORCE, SET_NAME_FOR_WRAPPER,,)
 %include "iDynTree/ModelIO/URDFDofsImport.h"
 %include "iDynTree/ModelIO/URDFGenericSensorsImport.h"
 %include "iDynTree/ModelIO/ModelLoader.h"
+%include "iDynTree/ModelIO/ModelExporter.h"
 
 // Estimation related classes
 %include "iDynTree/Estimation/ExternalWrenchesEstimation.h"
@@ -323,6 +328,9 @@ TEMPLATE_WRAP_MOTION_FORCE(ForceVector3, WRAP_FORCE, SET_NAME_FOR_WRAPPER,,)
 %include "iDynTree/Estimation/AttitudeMahonyFilter.h"
 %include "iDynTree/Estimation/ExtendedKalmanFilter.h"
 %include "iDynTree/Estimation/AttitudeQuaternionEKF.h"
+
+// SolidShapes related classes
+%include "iDynTree/InertialParametersSolidShapesHelpers.h"
 
 // Regressors related data structures
 %include "iDynTree/Regressors/DynamicsRegressorParameters.h"

--- a/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
@@ -7,58 +7,58 @@ classdef AccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1369, varargin{:});
+        tmp = iDynTreeMEX(1377, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1370, self);
+        iDynTreeMEX(1378, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1371, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1372, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1373, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1374, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1375, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1376, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1377, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1378, self, varargin{:});
-    end
-    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1379, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1380, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1381, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1382, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1383, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1384, self, varargin{:});
+    end
+    function varargout = getParentLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1385, self, varargin{:});
+    end
+    function varargout = getParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1386, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1387, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1388, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1389, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1390, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1391, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1392, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = ArticulatedBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1284, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1292, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
@@ -9,58 +9,18 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1262, varargin{:});
+        tmp = iDynTreeMEX(1270, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1263, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1271, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1264, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1272, self, varargin{:});
     end
     function varargout = S(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1265, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1266, self, varargin{1});
-      end
-    end
-    function varargout = U(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1267, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1268, self, varargin{1});
-      end
-    end
-    function varargout = D(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1269, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1270, self, varargin{1});
-      end
-    end
-    function varargout = u(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1271, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1272, self, varargin{1});
-      end
-    end
-    function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -70,7 +30,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1274, self, varargin{1});
       end
     end
-    function varargout = linksBiasAcceleration(self, varargin)
+    function varargout = U(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -80,7 +40,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1276, self, varargin{1});
       end
     end
-    function varargout = linksAccelerations(self, varargin)
+    function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -90,7 +50,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1278, self, varargin{1});
       end
     end
-    function varargout = linkABIs(self, varargin)
+    function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -100,7 +60,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1280, self, varargin{1});
       end
     end
-    function varargout = linksBiasWrench(self, varargin)
+    function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -110,9 +70,49 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1282, self, varargin{1});
       end
     end
+    function varargout = linksBiasAcceleration(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1283, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1284, self, varargin{1});
+      end
+    end
+    function varargout = linksAccelerations(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1285, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1286, self, varargin{1});
+      end
+    end
+    function varargout = linkABIs(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1287, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1288, self, varargin{1});
+      end
+    end
+    function varargout = linksBiasWrench(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1289, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1290, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1283, self);
+        iDynTreeMEX(1291, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
@@ -7,30 +7,30 @@ classdef AttitudeEstimatorState < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1694, self);
+        varargout{1} = iDynTreeMEX(1653, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1695, self, varargin{1});
+        iDynTreeMEX(1654, self, varargin{1});
       end
     end
     function varargout = m_angular_velocity(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1696, self);
+        varargout{1} = iDynTreeMEX(1655, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1697, self, varargin{1});
+        iDynTreeMEX(1656, self, varargin{1});
       end
     end
     function varargout = m_gyroscope_bias(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1698, self);
+        varargout{1} = iDynTreeMEX(1657, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1699, self, varargin{1});
+        iDynTreeMEX(1658, self, varargin{1});
       end
     end
     function self = AttitudeEstimatorState(varargin)
@@ -39,14 +39,14 @@ classdef AttitudeEstimatorState < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1700, varargin{:});
+        tmp = iDynTreeMEX(1659, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1701, self);
+        iDynTreeMEX(1660, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
@@ -7,68 +7,68 @@ classdef AttitudeMahonyFilter < iDynTree.IAttitudeEstimator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1651, varargin{:});
+        tmp = iDynTreeMEX(1684, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = useMagnetoMeterMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
     end
     function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1653, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
     end
     function varargout = setGainkp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1654, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1687, self, varargin{:});
     end
     function varargout = setGainki(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1655, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1688, self, varargin{:});
     end
     function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1656, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1689, self, varargin{:});
     end
     function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1657, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1690, self, varargin{:});
     end
     function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1658, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1691, self, varargin{:});
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1659, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1692, self, varargin{:});
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1660, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1693, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1661, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1694, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1662, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1663, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1664, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1665, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1666, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1667, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1668, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1669, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1670, self);
+        iDynTreeMEX(1703, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
@@ -7,50 +7,50 @@ classdef AttitudeMahonyFilterParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1639, self);
+        varargout{1} = iDynTreeMEX(1672, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1640, self, varargin{1});
+        iDynTreeMEX(1673, self, varargin{1});
       end
     end
     function varargout = kp(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1641, self);
+        varargout{1} = iDynTreeMEX(1674, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1642, self, varargin{1});
+        iDynTreeMEX(1675, self, varargin{1});
       end
     end
     function varargout = ki(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1643, self);
+        varargout{1} = iDynTreeMEX(1676, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1644, self, varargin{1});
+        iDynTreeMEX(1677, self, varargin{1});
       end
     end
     function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1645, self);
+        varargout{1} = iDynTreeMEX(1678, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1646, self, varargin{1});
+        iDynTreeMEX(1679, self, varargin{1});
       end
     end
     function varargout = confidence_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1647, self);
+        varargout{1} = iDynTreeMEX(1680, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1648, self, varargin{1});
+        iDynTreeMEX(1681, self, varargin{1});
       end
     end
     function self = AttitudeMahonyFilterParameters(varargin)
@@ -59,14 +59,14 @@ classdef AttitudeMahonyFilterParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1649, varargin{:});
+        tmp = iDynTreeMEX(1682, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1650, self);
+        iDynTreeMEX(1683, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
@@ -11,74 +11,74 @@ classdef AttitudeQuaternionEKF < iDynTree.IAttitudeEstimator & iDynTree.Discrete
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1724, varargin{:});
+        tmp = iDynTreeMEX(1749, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1725, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1750, self, varargin{:});
     end
     function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1726, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1751, self, varargin{:});
     end
     function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1727, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1752, self, varargin{:});
     end
     function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1728, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1753, self, varargin{:});
     end
     function varargout = setBiasCorrelationTimeFactor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1729, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1754, self, varargin{:});
     end
     function varargout = useMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1730, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1755, self, varargin{:});
     end
     function varargout = setMeasurementNoiseVariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1731, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1756, self, varargin{:});
     end
     function varargout = setSystemNoiseVariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1757, self, varargin{:});
     end
     function varargout = setInitialStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1758, self, varargin{:});
     end
     function varargout = initializeFilter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1738, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1739, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1740, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1741, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1742, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1743, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1744, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1745, self);
+        iDynTreeMEX(1770, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
@@ -7,100 +7,100 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1702, self);
+        varargout{1} = iDynTreeMEX(1727, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1703, self, varargin{1});
+        iDynTreeMEX(1728, self, varargin{1});
       end
     end
     function varargout = bias_correlation_time_factor(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1704, self);
+        varargout{1} = iDynTreeMEX(1729, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1705, self, varargin{1});
+        iDynTreeMEX(1730, self, varargin{1});
       end
     end
     function varargout = accelerometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1706, self);
+        varargout{1} = iDynTreeMEX(1731, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1707, self, varargin{1});
+        iDynTreeMEX(1732, self, varargin{1});
       end
     end
     function varargout = magnetometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1708, self);
+        varargout{1} = iDynTreeMEX(1733, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1709, self, varargin{1});
+        iDynTreeMEX(1734, self, varargin{1});
       end
     end
     function varargout = gyroscope_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1710, self);
+        varargout{1} = iDynTreeMEX(1735, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1711, self, varargin{1});
+        iDynTreeMEX(1736, self, varargin{1});
       end
     end
     function varargout = gyro_bias_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1712, self);
+        varargout{1} = iDynTreeMEX(1737, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1713, self, varargin{1});
+        iDynTreeMEX(1738, self, varargin{1});
       end
     end
     function varargout = initial_orientation_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1714, self);
+        varargout{1} = iDynTreeMEX(1739, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1715, self, varargin{1});
+        iDynTreeMEX(1740, self, varargin{1});
       end
     end
     function varargout = initial_ang_vel_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1716, self);
+        varargout{1} = iDynTreeMEX(1741, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1717, self, varargin{1});
+        iDynTreeMEX(1742, self, varargin{1});
       end
     end
     function varargout = initial_gyro_bias_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1718, self);
+        varargout{1} = iDynTreeMEX(1743, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1719, self, varargin{1});
+        iDynTreeMEX(1744, self, varargin{1});
       end
     end
     function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1720, self);
+        varargout{1} = iDynTreeMEX(1745, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1721, self, varargin{1});
+        iDynTreeMEX(1746, self, varargin{1});
       end
     end
     function self = AttitudeQuaternionEKFParameters(varargin)
@@ -109,14 +109,14 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1722, varargin{:});
+        tmp = iDynTreeMEX(1747, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1723, self);
+        iDynTreeMEX(1748, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
@@ -7,37 +7,37 @@ classdef BerdyDynamicVariable < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1570, self);
+        varargout{1} = iDynTreeMEX(1595, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1571, self, varargin{1});
+        iDynTreeMEX(1596, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1572, self);
+        varargout{1} = iDynTreeMEX(1597, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1573, self, varargin{1});
+        iDynTreeMEX(1598, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1574, self);
+        varargout{1} = iDynTreeMEX(1599, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1575, self, varargin{1});
+        iDynTreeMEX(1600, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1576, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1577, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1602, self, varargin{:});
     end
     function self = BerdyDynamicVariable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdyDynamicVariable < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1578, varargin{:});
+        tmp = iDynTreeMEX(1603, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1579, self);
+        iDynTreeMEX(1604, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
@@ -9,104 +9,104 @@ classdef BerdyHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1580, varargin{:});
+        tmp = iDynTreeMEX(1605, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1581, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1582, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1583, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1584, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1585, self, varargin{:});
-    end
-    function varargout = getOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1586, self, varargin{:});
-    end
-    function varargout = getNrOfDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1587, self, varargin{:});
-    end
-    function varargout = getNrOfDynamicEquations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1588, self, varargin{:});
-    end
-    function varargout = getNrOfSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1589, self, varargin{:});
-    end
-    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1590, self, varargin{:});
-    end
-    function varargout = getBerdyMatrices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1591, self, varargin{:});
-    end
-    function varargout = getSensorsOrdering(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
-    end
-    function varargout = getRangeSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1593, self, varargin{:});
-    end
-    function varargout = getRangeDOFSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1594, self, varargin{:});
-    end
-    function varargout = getRangeJointSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1595, self, varargin{:});
-    end
-    function varargout = getRangeLinkSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1596, self, varargin{:});
-    end
-    function varargout = getRangeLinkVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1597, self, varargin{:});
-    end
-    function varargout = getRangeJointVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
-    end
-    function varargout = getRangeDOFVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1599, self, varargin{:});
-    end
-    function varargout = getDynamicVariablesOrdering(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
-    end
-    function varargout = serializeDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
-    end
-    function varargout = serializeSensorVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1602, self, varargin{:});
-    end
-    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1603, self, varargin{:});
-    end
-    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1604, self, varargin{:});
-    end
-    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1605, self, varargin{:});
-    end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
     end
-    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1608, self, varargin{:});
     end
-    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1609, self, varargin{:});
     end
-    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1610, self, varargin{:});
+    end
+    function varargout = getOptions(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1611, self, varargin{:});
+    end
+    function varargout = getNrOfDynamicVariables(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1612, self, varargin{:});
+    end
+    function varargout = getNrOfDynamicEquations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1613, self, varargin{:});
+    end
+    function varargout = getNrOfSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1614, self, varargin{:});
+    end
+    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1615, self, varargin{:});
+    end
+    function varargout = getBerdyMatrices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
+    end
+    function varargout = getSensorsOrdering(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
+    end
+    function varargout = getRangeSensorVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1618, self, varargin{:});
+    end
+    function varargout = getRangeDOFSensorVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1619, self, varargin{:});
+    end
+    function varargout = getRangeJointSensorVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1620, self, varargin{:});
+    end
+    function varargout = getRangeLinkSensorVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
+    end
+    function varargout = getRangeLinkVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
+    end
+    function varargout = getRangeJointVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
+    end
+    function varargout = getRangeDOFVariable(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
+    end
+    function varargout = getDynamicVariablesOrdering(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
+    end
+    function varargout = serializeDynamicVariables(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
+    end
+    function varargout = serializeSensorVariables(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
+    end
+    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
+    end
+    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
+    end
+    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
+    end
+    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
+    end
+    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1611, self);
+        iDynTreeMEX(1636, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
@@ -9,7 +9,7 @@ classdef BerdyOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1541, varargin{:});
+        tmp = iDynTreeMEX(1566, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,88 +18,88 @@ classdef BerdyOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1542, self);
+        varargout{1} = iDynTreeMEX(1567, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1543, self, varargin{1});
+        iDynTreeMEX(1568, self, varargin{1});
       end
     end
     function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1544, self);
+        varargout{1} = iDynTreeMEX(1569, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1545, self, varargin{1});
+        iDynTreeMEX(1570, self, varargin{1});
       end
     end
     function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1546, self);
+        varargout{1} = iDynTreeMEX(1571, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1547, self, varargin{1});
+        iDynTreeMEX(1572, self, varargin{1});
       end
     end
     function varargout = includeAllJointTorquesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1548, self);
+        varargout{1} = iDynTreeMEX(1573, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1549, self, varargin{1});
+        iDynTreeMEX(1574, self, varargin{1});
       end
     end
     function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1550, self);
+        varargout{1} = iDynTreeMEX(1575, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1551, self, varargin{1});
+        iDynTreeMEX(1576, self, varargin{1});
       end
     end
     function varargout = includeFixedBaseExternalWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1552, self);
+        varargout{1} = iDynTreeMEX(1577, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1553, self, varargin{1});
+        iDynTreeMEX(1578, self, varargin{1});
       end
     end
     function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1554, self);
+        varargout{1} = iDynTreeMEX(1579, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1555, self, varargin{1});
+        iDynTreeMEX(1580, self, varargin{1});
       end
     end
     function varargout = baseLink(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1556, self);
+        varargout{1} = iDynTreeMEX(1581, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1557, self, varargin{1});
+        iDynTreeMEX(1582, self, varargin{1});
       end
     end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1558, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1583, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1559, self);
+        iDynTreeMEX(1584, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
@@ -7,37 +7,37 @@ classdef BerdySensor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1560, self);
+        varargout{1} = iDynTreeMEX(1585, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1561, self, varargin{1});
+        iDynTreeMEX(1586, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1562, self);
+        varargout{1} = iDynTreeMEX(1587, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1563, self, varargin{1});
+        iDynTreeMEX(1588, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1564, self);
+        varargout{1} = iDynTreeMEX(1589, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1565, self, varargin{1});
+        iDynTreeMEX(1590, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1566, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1591, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1567, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdySensor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1568, varargin{:});
+        tmp = iDynTreeMEX(1593, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1569, self);
+        iDynTreeMEX(1594, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
@@ -9,58 +9,58 @@ classdef BerdySparseMAPSolver < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1612, varargin{:});
+        tmp = iDynTreeMEX(1637, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1613, self);
+        iDynTreeMEX(1638, self);
         self.SwigClear();
       end
     end
     function varargout = setDynamicsConstraintsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1614, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1639, self, varargin{:});
     end
     function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1615, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1640, self, varargin{:});
     end
     function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1641, self, varargin{:});
     end
     function varargout = setMeasurementsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1642, self, varargin{:});
     end
     function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1618, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1643, self, varargin{:});
     end
     function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1619, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
     end
     function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1620, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
     end
     function varargout = measurementsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
     end
     function varargout = initialize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
     end
     function varargout = updateEstimateInformationFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
     end
     function varargout = updateEstimateInformationFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
     end
     function varargout = doEstimate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
     end
     function varargout = getLastEstimate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Box.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Box.m
@@ -2,41 +2,41 @@ classdef Box < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1110, self);
+        iDynTreeMEX(1116, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1117, self, varargin{:});
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1112, self);
+        varargout{1} = iDynTreeMEX(1118, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1113, self, varargin{1});
+        iDynTreeMEX(1119, self, varargin{1});
       end
     end
     function varargout = y(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1114, self);
+        varargout{1} = iDynTreeMEX(1120, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1115, self, varargin{1});
+        iDynTreeMEX(1121, self, varargin{1});
       end
     end
     function varargout = z(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1116, self);
+        varargout{1} = iDynTreeMEX(1122, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1117, self, varargin{1});
+        iDynTreeMEX(1123, self, varargin{1});
       end
     end
     function self = Box(varargin)
@@ -46,7 +46,7 @@ classdef Box < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1118, varargin{:});
+        tmp = iDynTreeMEX(1124, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,40 +7,40 @@ classdef ColorViz < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1855, self);
+        varargout{1} = iDynTreeMEX(1881, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1856, self, varargin{1});
+        iDynTreeMEX(1882, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1857, self);
+        varargout{1} = iDynTreeMEX(1883, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1858, self, varargin{1});
+        iDynTreeMEX(1884, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1859, self);
+        varargout{1} = iDynTreeMEX(1885, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1860, self, varargin{1});
+        iDynTreeMEX(1886, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1861, self);
+        varargout{1} = iDynTreeMEX(1887, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1862, self, varargin{1});
+        iDynTreeMEX(1888, self, varargin{1});
       end
     end
     function self = ColorViz(varargin)
@@ -49,14 +49,14 @@ classdef ColorViz < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1863, varargin{:});
+        tmp = iDynTreeMEX(1889, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1864, self);
+        iDynTreeMEX(1890, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = CompositeRigidBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1261, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1269, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentum(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1258, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1266, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentumDerivativeBias(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1259, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1267, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
@@ -4,13 +4,13 @@ classdef ContactWrench < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = contactId(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
     end
     function varargout = contactPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1239, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1240, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
     end
     function self = ContactWrench(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -18,14 +18,14 @@ classdef ContactWrench < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1241, varargin{:});
+        tmp = iDynTreeMEX(1249, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1242, self);
+        iDynTreeMEX(1250, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
@@ -2,31 +2,31 @@ classdef Cylinder < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1119, self);
+        iDynTreeMEX(1125, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1120, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1126, self, varargin{:});
     end
     function varargout = length(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1121, self);
+        varargout{1} = iDynTreeMEX(1127, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1122, self, varargin{1});
+        iDynTreeMEX(1128, self, varargin{1});
       end
     end
     function varargout = radius(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1123, self);
+        varargout{1} = iDynTreeMEX(1129, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1124, self, varargin{1});
+        iDynTreeMEX(1130, self, varargin{1});
       end
     end
     function self = Cylinder(varargin)
@@ -36,7 +36,7 @@ classdef Cylinder < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1125, varargin{:});
+        tmp = iDynTreeMEX(1131, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialForceArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1193, varargin{:});
+        tmp = iDynTreeMEX(1201, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1202, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1203, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1196, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1197, self);
+        iDynTreeMEX(1205, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialMotionArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1198, varargin{:});
+        tmp = iDynTreeMEX(1206, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1207, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1200, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1201, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1202, self);
+        iDynTreeMEX(1210, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(847);
+    varargout{1} = iDynTreeMEX(851);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(848,varargin{1});
+    iDynTreeMEX(852,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(849);
+    varargout{1} = iDynTreeMEX(853);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(850,varargin{1});
+    iDynTreeMEX(854,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
@@ -4,65 +4,65 @@ classdef DiscreteExtendedKalmanFilterHelper < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = ekf_f(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1671, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
     end
     function varargout = ekf_h(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1672, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
     end
     function varargout = ekfComputeJacobianF(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1673, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
     end
     function varargout = ekfComputeJacobianH(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1674, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1707, self, varargin{:});
     end
     function varargout = ekfPredict(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1675, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1708, self, varargin{:});
     end
     function varargout = ekfUpdate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1676, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1709, self, varargin{:});
     end
     function varargout = ekfInit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1677, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1710, self, varargin{:});
     end
     function varargout = ekfReset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1678, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1711, self, varargin{:});
     end
     function varargout = ekfSetMeasurementVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1679, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1712, self, varargin{:});
     end
     function varargout = ekfSetInputVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1713, self, varargin{:});
     end
     function varargout = ekfSetInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1714, self, varargin{:});
     end
     function varargout = ekfSetStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1715, self, varargin{:});
     end
     function varargout = ekfSetSystemNoiseCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1716, self, varargin{:});
     end
     function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1717, self, varargin{:});
     end
     function varargout = ekfSetStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1718, self, varargin{:});
     end
     function varargout = ekfSetInputSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1719, self, varargin{:});
     end
     function varargout = ekfSetOutputSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1687, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1720, self, varargin{:});
     end
     function varargout = ekfGetStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1688, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1721, self, varargin{:});
     end
     function varargout = ekfGetStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1689, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1722, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1690, self);
+        iDynTreeMEX(1723, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
@@ -9,78 +9,78 @@ classdef DynamicSpan < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(818, varargin{:});
+        tmp = iDynTreeMEX(822, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(819, self);
+        iDynTreeMEX(823, self);
         self.SwigClear();
       end
     end
     function varargout = first(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(820, self, varargin{:});
-    end
-    function varargout = last(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(821, self, varargin{:});
-    end
-    function varargout = subspan(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
-    end
-    function varargout = size_bytes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
     end
-    function varargout = empty(self,varargin)
+    function varargout = last(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(825, self, varargin{:});
     end
-    function varargout = brace(self,varargin)
+    function varargout = subspan(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(826, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(827, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = size_bytes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(828, self, varargin{:});
     end
-    function varargout = at(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(829, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(830, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(831, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(832, self, varargin{:});
     end
-    function varargout = cbegin(self,varargin)
+    function varargout = at(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(833, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(834, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(835, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(836, self, varargin{:});
     end
-    function varargout = crbegin(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(837, self, varargin{:});
     end
-    function varargout = crend(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(838, self, varargin{:});
+    end
+    function varargout = rbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(839, self, varargin{:});
+    end
+    function varargout = rend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(840, self, varargin{:});
+    end
+    function varargout = crbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(841, self, varargin{:});
+    end
+    function varargout = crend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(842, self, varargin{:});
     end
   end
   methods(Static)
     function v = extent()
-      v = iDynTreeMEX(817);
+      v = iDynTreeMEX(821);
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsComputations.m
@@ -9,118 +9,118 @@ classdef DynamicsComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1945, varargin{:});
+        tmp = iDynTreeMEX(1971, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1946, self);
+        iDynTreeMEX(1972, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
-    end
-    function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
-    end
-    function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
-    end
-    function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
-    end
-    function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
-    end
-    function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1958, self, varargin{:});
-    end
-    function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1959, self, varargin{:});
-    end
-    function varargout = getJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
-    end
-    function varargout = getJointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1961, self, varargin{:});
-    end
-    function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1962, self, varargin{:});
-    end
-    function varargout = getFrameName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1963, self, varargin{:});
-    end
-    function varargout = getWorldTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1964, self, varargin{:});
-    end
-    function varargout = getRelativeTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1965, self, varargin{:});
-    end
-    function varargout = getFrameTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1966, self, varargin{:});
-    end
-    function varargout = getFrameTwistInWorldOrient(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
-    end
-    function varargout = getFrameProperSpatialAcceleration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
-    end
-    function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
-    end
-    function varargout = getLinkInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
-    end
-    function varargout = getJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1971, self, varargin{:});
-    end
-    function varargout = getJointName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1972, self, varargin{:});
-    end
-    function varargout = getJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
     end
-    function varargout = getFreeFloatingMassMatrix(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
     end
-    function varargout = getFrameJacobian(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
     end
-    function varargout = getDynamicsRegressor(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
     end
-    function varargout = getModelDynamicsParameters(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
     end
-    function varargout = getCenterOfMass(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
+    end
+    function varargout = getFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
+    end
+    function varargout = setFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
+    end
+    function varargout = setRobotState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
+    end
+    function varargout = getWorldBaseTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
+    end
+    function varargout = getBaseTwist(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
+    end
+    function varargout = getJointPos(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
+    end
+    function varargout = getJointVel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
+    end
+    function varargout = getFrameIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
+    end
+    function varargout = getFrameName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
+    end
+    function varargout = getWorldTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
+    end
+    function varargout = getRelativeTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
+    end
+    function varargout = getFrameTwist(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
+    end
+    function varargout = getFrameTwistInWorldOrient(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
+    end
+    function varargout = getFrameProperSpatialAcceleration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1994, self, varargin{:});
+    end
+    function varargout = getLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1995, self, varargin{:});
+    end
+    function varargout = getLinkInertia(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1996, self, varargin{:});
+    end
+    function varargout = getJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1997, self, varargin{:});
+    end
+    function varargout = getJointName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
+    end
+    function varargout = getJointLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
+    end
+    function varargout = inverseDynamics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
+    end
+    function varargout = getFreeFloatingMassMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
+    end
+    function varargout = getFrameJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
+    end
+    function varargout = getDynamicsRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2003, self, varargin{:});
+    end
+    function varargout = getModelDynamicsParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2004, self, varargin{:});
+    end
+    function varargout = getCenterOfMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
+    end
+    function varargout = getCenterOfMassJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorGenerator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorGenerator.m
@@ -9,100 +9,100 @@ classdef DynamicsRegressorGenerator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1766, varargin{:});
+        tmp = iDynTreeMEX(1792, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1767, self);
+        iDynTreeMEX(1793, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotAndSensorsModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
-    end
-    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
-    end
-    function varargout = loadRegressorStructureFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
-    end
-    function varargout = loadRegressorStructureFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
-    end
-    function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
-    end
-    function varargout = getNrOfOutputs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
-    end
-    function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
-    end
-    function varargout = getDescriptionOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
-    end
-    function varargout = getDescriptionOfOutput(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
-    end
-    function varargout = getDescriptionOfOutputs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
-    end
-    function varargout = getDescriptionOfLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
-    end
-    function varargout = getDescriptionOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
-    end
-    function varargout = getNrOfFakeLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
-    end
-    function varargout = getBaseLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
-    end
-    function varargout = getSensorsModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
-    end
-    function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
-    end
-    function varargout = getSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
-    end
-    function varargout = setTorqueSensorMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
-    end
-    function varargout = computeRegressor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
-    end
-    function varargout = getModelParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1792, self, varargin{:});
-    end
-    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
-    end
-    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
     end
-    function varargout = generate_random_regressors(self,varargin)
+    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
+    end
+    function varargout = loadRegressorStructureFromFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
+    end
+    function varargout = loadRegressorStructureFromString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
+    end
+    function varargout = getNrOfParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
+    end
+    function varargout = getNrOfOutputs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
+    end
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
+    end
+    function varargout = getDescriptionOfParameter(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
+    end
+    function varargout = getDescriptionOfParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
+    end
+    function varargout = getDescriptionOfOutput(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
+    end
+    function varargout = getDescriptionOfOutputs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
+    end
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
+    end
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
+    end
+    function varargout = getDescriptionOfLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
+    end
+    function varargout = getDescriptionOfLinks(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
+    end
+    function varargout = getNrOfLinks(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
+    end
+    function varargout = getNrOfFakeLinks(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
+    end
+    function varargout = getBaseLinkName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
+    end
+    function varargout = getSensorsModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
+    end
+    function varargout = setRobotState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
+    end
+    function varargout = getSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
+    end
+    function varargout = setTorqueSensorMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
+    end
+    function varargout = computeRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
+    end
+    function varargout = getModelParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
+    end
+    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
+    end
+    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
+    end
+    function varargout = generate_random_regressors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParameter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParameter.m
@@ -7,40 +7,40 @@ classdef DynamicsRegressorParameter < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1746, self);
+        varargout{1} = iDynTreeMEX(1772, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1747, self, varargin{1});
+        iDynTreeMEX(1773, self, varargin{1});
       end
     end
     function varargout = elemIndex(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1748, self);
+        varargout{1} = iDynTreeMEX(1774, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1749, self, varargin{1});
+        iDynTreeMEX(1775, self, varargin{1});
       end
     end
     function varargout = type(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1750, self);
+        varargout{1} = iDynTreeMEX(1776, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1751, self, varargin{1});
+        iDynTreeMEX(1777, self, varargin{1});
       end
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1752, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1753, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
     end
     function varargout = ne(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1754, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
     end
     function self = DynamicsRegressorParameter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -48,14 +48,14 @@ classdef DynamicsRegressorParameter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1755, varargin{:});
+        tmp = iDynTreeMEX(1781, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1756, self);
+        iDynTreeMEX(1782, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParametersList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParametersList.m
@@ -7,26 +7,26 @@ classdef DynamicsRegressorParametersList < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1757, self);
+        varargout{1} = iDynTreeMEX(1783, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1758, self, varargin{1});
+        iDynTreeMEX(1784, self, varargin{1});
       end
     end
     function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
     end
     function varargout = addParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
     end
     function varargout = addList(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
     end
     function varargout = findParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
     end
     function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
     end
     function self = DynamicsRegressorParametersList(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -34,14 +34,14 @@ classdef DynamicsRegressorParametersList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1764, varargin{:});
+        tmp = iDynTreeMEX(1790, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1765, self);
+        iDynTreeMEX(1791, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
@@ -9,52 +9,52 @@ classdef ExtWrenchesAndJointTorquesEstimator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1513, varargin{:});
+        tmp = iDynTreeMEX(1537, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1514, self);
+        iDynTreeMEX(1538, self);
         self.SwigClear();
       end
     end
     function varargout = setModelAndSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1515, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1539, self, varargin{:});
     end
     function varargout = loadModelAndSensorsFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1516, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1540, self, varargin{:});
     end
     function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1517, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1541, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1518, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1542, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1519, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1543, self, varargin{:});
     end
     function varargout = submodels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1520, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1544, self, varargin{:});
     end
     function varargout = updateKinematicsFromFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1521, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1545, self, varargin{:});
     end
     function varargout = updateKinematicsFromFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1522, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1546, self, varargin{:});
     end
     function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1523, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1547, self, varargin{:});
     end
     function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1524, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1548, self, varargin{:});
     end
     function varargout = checkThatTheModelIsStill(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1525, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1549, self, varargin{:});
     end
     function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1526, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1550, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
@@ -2,31 +2,31 @@ classdef ExternalMesh < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1126, self);
+        iDynTreeMEX(1132, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1127, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1133, self, varargin{:});
     end
     function varargout = filename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1128, self);
+        varargout{1} = iDynTreeMEX(1134, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1129, self, varargin{1});
+        iDynTreeMEX(1135, self, varargin{1});
       end
     end
     function varargout = scale(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1130, self);
+        varargout{1} = iDynTreeMEX(1136, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1131, self, varargin{1});
+        iDynTreeMEX(1137, self, varargin{1});
       end
     end
     function self = ExternalMesh(varargin)
@@ -36,7 +36,7 @@ classdef ExternalMesh < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1132, varargin{:});
+        tmp = iDynTreeMEX(1138, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(851);
+    varargout{1} = iDynTreeMEX(855);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(852,varargin{1});
+    iDynTreeMEX(856,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(853);
+    varargout{1} = iDynTreeMEX(857);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(854,varargin{1});
+    iDynTreeMEX(858,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
@@ -7,103 +7,103 @@ classdef FixedJoint < iDynTree.IJoint
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(937, varargin{:});
+        tmp = iDynTreeMEX(941, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(938, self);
+        iDynTreeMEX(942, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(939, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(940, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(941, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(942, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(943, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(944, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(945, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(946, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(947, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(948, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(949, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(950, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(951, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(952, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(953, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(954, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(955, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(956, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(964, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(966, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1256, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1264, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardBiasAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1257, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1265, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1254, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1262, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1255, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1263, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPositionKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1252, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1260, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1253, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1261, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef FrameFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1203, varargin{:});
+        tmp = iDynTreeMEX(1211, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1212, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1205, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1206, self);
+        iDynTreeMEX(1214, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
@@ -9,26 +9,26 @@ classdef FreeFloatingAcc < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1232, varargin{:});
+        tmp = iDynTreeMEX(1240, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1233, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1241, self, varargin{:});
     end
     function varargout = baseAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1234, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
     end
     function varargout = jointAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1235, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1236, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1237, self);
+        iDynTreeMEX(1245, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
@@ -9,26 +9,26 @@ classdef FreeFloatingGeneralizedTorques < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1220, varargin{:});
+        tmp = iDynTreeMEX(1228, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1221, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1229, self, varargin{:});
     end
     function varargout = baseWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1222, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1230, self, varargin{:});
     end
     function varargout = jointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1223, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1231, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1224, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1232, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1225, self);
+        iDynTreeMEX(1233, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
@@ -7,17 +7,17 @@ classdef FreeFloatingMassMatrix < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1211, varargin{:});
+        tmp = iDynTreeMEX(1219, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1212, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1220, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1213, self);
+        iDynTreeMEX(1221, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
@@ -9,26 +9,26 @@ classdef FreeFloatingPos < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1214, varargin{:});
+        tmp = iDynTreeMEX(1222, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1215, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1223, self, varargin{:});
     end
     function varargout = worldBasePos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1216, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1224, self, varargin{:});
     end
     function varargout = jointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1217, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1225, self, varargin{:});
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1218, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1226, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1219, self);
+        iDynTreeMEX(1227, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
@@ -9,26 +9,26 @@ classdef FreeFloatingVel < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1226, varargin{:});
+        tmp = iDynTreeMEX(1234, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1227, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1235, self, varargin{:});
     end
     function varargout = baseVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1228, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1236, self, varargin{:});
     end
     function varargout = jointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1229, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1237, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1230, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1231, self);
+        iDynTreeMEX(1239, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
@@ -7,58 +7,58 @@ classdef GyroscopeSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1385, varargin{:});
+        tmp = iDynTreeMEX(1393, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1386, self);
+        iDynTreeMEX(1394, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1387, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1388, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1389, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1390, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1391, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1392, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1393, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1394, self, varargin{:});
-    end
-    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1395, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1396, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1397, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1398, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1399, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1400, self, varargin{:});
+    end
+    function varargout = getParentLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1401, self, varargin{:});
+    end
+    function varargout = getParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1402, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1403, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1404, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1405, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1406, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1407, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1408, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
@@ -5,39 +5,39 @@ classdef IAttitudeEstimator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1628, self);
+        iDynTreeMEX(1661, self);
         self.SwigClear();
       end
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1662, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1663, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1664, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1665, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1666, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1667, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1668, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1669, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1637, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1670, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1638, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1671, self, varargin{:});
     end
     function self = IAttitudeEstimator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,18 +5,18 @@ classdef ICamera < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1851, self);
+        iDynTreeMEX(1877, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
     end
     function varargout = setTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
     end
     function varargout = setUpVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,33 +5,33 @@ classdef IEnvironment < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1879, self);
+        iDynTreeMEX(1905, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
     end
     function varargout = setElementVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
     end
     function varargout = setBackgroundColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
     end
     function varargout = setAmbientLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
     end
     function varargout = getLights(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
     end
     function varargout = addLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
     end
     function varargout = lightViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
     end
     function varargout = removeLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1888, self);
+        iDynTreeMEX(1914, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
     end
     function varargout = getNrOfJets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
     end
     function varargout = getJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
     end
     function varargout = setJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
     end
     function varargout = setJetColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
     end
     function varargout = setJetsDimensions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
     end
     function varargout = setJetsIntensity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJoint.m
@@ -5,108 +5,108 @@ classdef IJoint < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(903, self);
+        iDynTreeMEX(907, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(905, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(906, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(915, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(916, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(921, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(922, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(925, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(928, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(929, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(930, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(931, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
     end
-    function varargout = isRevoluteJoint(self,varargin)
+    function varargout = getPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
     end
-    function varargout = isFixedJoint(self,varargin)
+    function varargout = getMinPosLimit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(934, self, varargin{:});
     end
-    function varargout = asRevoluteJoint(self,varargin)
+    function varargout = getMaxPosLimit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(935, self, varargin{:});
     end
-    function varargout = asFixedJoint(self,varargin)
+    function varargout = setPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(936, self, varargin{:});
+    end
+    function varargout = isRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(937, self, varargin{:});
+    end
+    function varargout = isFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(938, self, varargin{:});
+    end
+    function varargout = asRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(939, self, varargin{:});
+    end
+    function varargout = asFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(940, self, varargin{:});
     end
     function self = IJoint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1865, self);
+        iDynTreeMEX(1891, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1866, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
     end
     function varargout = setType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
     end
     function varargout = getType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
     end
     function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1896, self, varargin{:});
     end
     function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
     end
     function varargout = setAmbientColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
     end
     function varargout = getAmbientColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1900, self, varargin{:});
     end
     function varargout = setSpecularColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
     end
     function varargout = getSpecularColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
     end
     function varargout = setDiffuseColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1903, self, varargin{:});
     end
     function varargout = getDiffuseColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,57 +5,57 @@ classdef IModelVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1903, self);
+        iDynTreeMEX(1929, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
     end
     function varargout = setLinkPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
     end
     function varargout = getInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
     function varargout = setModelVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
     end
     function varargout = setModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
     end
     function varargout = resetModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
     end
     function varargout = setLinkColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
     end
     function varargout = resetLinkColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
     end
     function varargout = getLinkNames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
     function varargout = setLinkVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
     function varargout = getFeatures(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
     end
     function varargout = setFeatureVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
     function varargout = jets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
     end
     function varargout = getWorldModelTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
     end
     function varargout = getWorldLinkTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,27 +5,27 @@ classdef IVectorsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1896, self);
+        iDynTreeMEX(1922, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
     end
     function varargout = getNrOfVectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
     end
     function varargout = getVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
     end
     function varargout = updateVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1900, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
     end
     function varargout = setVectorColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
     end
     function varargout = setVectorsAspect(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
@@ -1,3 +1,3 @@
 function varargout = InverseDynamicsInertialParametersRegressor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1285, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1293, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(843);
+    varargout{1} = iDynTreeMEX(847);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(844,varargin{1});
+    iDynTreeMEX(848,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(845);
+    varargout{1} = iDynTreeMEX(849);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(846,varargin{1});
+    iDynTreeMEX(850,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointDOFsDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1189, varargin{:});
+        tmp = iDynTreeMEX(1197, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1191, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1192, self);
+        iDynTreeMEX(1200, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointPosDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1185, varargin{:});
+        tmp = iDynTreeMEX(1193, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1188, self);
+        iDynTreeMEX(1196, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
@@ -2,24 +2,24 @@ classdef JointSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1299, self);
+        iDynTreeMEX(1307, self);
         self.SwigClear();
       end
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1300, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
     end
     function varargout = getParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1301, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
     end
     function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1302, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
     end
     function varargout = setParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1303, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1304, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
     end
     function self = JointSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -9,175 +9,175 @@ classdef KinDynComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1796, varargin{:});
+        tmp = iDynTreeMEX(1822, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1797, self);
+        iDynTreeMEX(1823, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
-    end
-    function varargout = setFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
-    end
-    function varargout = getFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
-    end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
-    end
-    function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
-    end
-    function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
-    end
-    function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
-    end
-    function varargout = getRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
-    end
-    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
-    end
-    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
-    end
-    function varargout = setJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
-    end
-    function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
-    end
-    function varargout = getRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
-    end
-    function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
-    end
-    function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
-    end
-    function varargout = getJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
-    end
-    function varargout = getJointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
-    end
-    function varargout = getModelVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
-    end
-    function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
-    end
-    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = loadRobotModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
     end
-    function varargout = getRelativeTransformExplicit(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
     end
-    function varargout = getFrameVel(self,varargin)
+    function varargout = setFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
     end
-    function varargout = getFrameAcc(self,varargin)
+    function varargout = getFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobian(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
     end
-    function varargout = getRelativeJacobian(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
     end
-    function varargout = getRelativeJacobianExplicit(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
     end
-    function varargout = getFrameBiasAcc(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
     end
-    function varargout = getCenterOfMassPosition(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
     end
-    function varargout = getCenterOfMassVelocity(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
     end
-    function varargout = getCenterOfMassBiasAcc(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
     end
-    function varargout = getAverageVelocity(self,varargin)
+    function varargout = getRobotModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
     end
-    function varargout = getAverageVelocityJacobian(self,varargin)
+    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocity(self,varargin)
+    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
+    function varargout = setJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentum(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentumJacobian(self,varargin)
+    function varargout = getRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
     end
-    function varargout = getCentroidalTotalMomentum(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
     end
-    function varargout = getFreeFloatingMassMatrix(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
     end
-    function varargout = generalizedBiasForces(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
     end
-    function varargout = generalizedGravityForces(self,varargin)
+    function varargout = getModelVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
     end
-    function varargout = generalizedExternalForces(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
     end
-    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
+    end
+    function varargout = getWorldTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
+    end
+    function varargout = getRelativeTransformExplicit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
+    end
+    function varargout = getRelativeTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
+    end
+    function varargout = getFrameVel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
+    end
+    function varargout = getFrameAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1855, self, varargin{:});
+    end
+    function varargout = getFrameFreeFloatingJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1856, self, varargin{:});
+    end
+    function varargout = getRelativeJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1857, self, varargin{:});
+    end
+    function varargout = getRelativeJacobianExplicit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1858, self, varargin{:});
+    end
+    function varargout = getFrameBiasAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1859, self, varargin{:});
+    end
+    function varargout = getCenterOfMassPosition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1860, self, varargin{:});
+    end
+    function varargout = getCenterOfMassVelocity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1861, self, varargin{:});
+    end
+    function varargout = getCenterOfMassJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1862, self, varargin{:});
+    end
+    function varargout = getCenterOfMassBiasAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1863, self, varargin{:});
+    end
+    function varargout = getAverageVelocity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1864, self, varargin{:});
+    end
+    function varargout = getAverageVelocityJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1865, self, varargin{:});
+    end
+    function varargout = getCentroidalAverageVelocity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1866, self, varargin{:});
+    end
+    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
+    end
+    function varargout = getLinearAngularMomentum(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
+    end
+    function varargout = getLinearAngularMomentumJacobian(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
+    end
+    function varargout = getCentroidalTotalMomentum(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
+    end
+    function varargout = getFreeFloatingMassMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
+    end
+    function varargout = inverseDynamics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
+    end
+    function varargout = generalizedBiasForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
+    end
+    function varargout = generalizedGravityForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
+    end
+    function varargout = generalizedExternalForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
+    end
+    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(839);
+    varargout{1} = iDynTreeMEX(843);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(840,varargin{1});
+    iDynTreeMEX(844,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(841);
+    varargout{1} = iDynTreeMEX(845);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(842,varargin{1});
+    iDynTreeMEX(846,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Link.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Link.m
@@ -9,29 +9,29 @@ classdef Link < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(896, varargin{:});
+        tmp = iDynTreeMEX(900, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = inertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
     end
     function varargout = setInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
     end
     function varargout = getInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(899, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(905, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(902, self);
+        iDynTreeMEX(906, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
@@ -9,29 +9,29 @@ classdef LinkAccArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(889, varargin{:});
+        tmp = iDynTreeMEX(893, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(891, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(892, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(895, self);
+        iDynTreeMEX(899, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
@@ -9,23 +9,23 @@ classdef LinkArticulatedBodyInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(877, varargin{:});
+        tmp = iDynTreeMEX(881, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(882, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(880, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(881, self);
+        iDynTreeMEX(885, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
@@ -9,35 +9,35 @@ classdef LinkContactWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1243, varargin{:});
+        tmp = iDynTreeMEX(1251, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
     end
     function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1245, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
     end
     function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1255, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1256, self, varargin{:});
     end
     function varargout = computeNetWrenches(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1249, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1257, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1258, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1251, self);
+        iDynTreeMEX(1259, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
@@ -9,23 +9,23 @@ classdef LinkInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(872, varargin{:});
+        tmp = iDynTreeMEX(876, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(873, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(874, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(875, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(876, self);
+        iDynTreeMEX(880, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
@@ -9,29 +9,29 @@ classdef LinkPositions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(857, varargin{:});
+        tmp = iDynTreeMEX(861, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(858, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(859, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(860, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(864, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(861, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(863, self);
+        iDynTreeMEX(867, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
@@ -2,30 +2,30 @@ classdef LinkSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1305, self);
+        iDynTreeMEX(1313, self);
         self.SwigClear();
       end
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1307, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1319, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
     end
     function self = LinkSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
@@ -9,41 +9,41 @@ classdef LinkUnknownWrenchContacts < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1478, varargin{:});
+        tmp = iDynTreeMEX(1502, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1479, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1503, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1480, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1504, self, varargin{:});
     end
     function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1481, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1505, self, varargin{:});
     end
     function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1482, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1506, self, varargin{:});
     end
     function varargout = addNewContactForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1483, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1507, self, varargin{:});
     end
     function varargout = addNewContactInFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1484, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1508, self, varargin{:});
     end
     function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1485, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1509, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1486, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1510, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1487, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1511, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1488, self);
+        iDynTreeMEX(1512, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
@@ -9,29 +9,29 @@ classdef LinkVelArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(882, varargin{:});
+        tmp = iDynTreeMEX(886, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(887, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(885, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(886, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(887, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(891, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(888, self);
+        iDynTreeMEX(892, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
@@ -9,32 +9,32 @@ classdef LinkWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(864, varargin{:});
+        tmp = iDynTreeMEX(868, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(867, self, varargin{:});
-    end
-    function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
+    end
+    function varargout = getNrOfLinks(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(873, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(874, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(871, self);
+        iDynTreeMEX(875, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Model.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Model.m
@@ -9,127 +9,133 @@ classdef Model < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1146, varargin{:});
+        tmp = iDynTreeMEX(1152, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = copy(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1147, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1153, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1148, self);
+        iDynTreeMEX(1154, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1149, self, varargin{:});
-    end
-    function varargout = getLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1150, self, varargin{:});
-    end
-    function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1151, self, varargin{:});
-    end
-    function varargout = isValidLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1152, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1153, self, varargin{:});
-    end
-    function varargout = addLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1154, self, varargin{:});
-    end
-    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1155, self, varargin{:});
     end
-    function varargout = getJointName(self,varargin)
+    function varargout = getLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
     end
-    function varargout = getJointIndex(self,varargin)
+    function varargout = getLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1157, self, varargin{:});
     end
-    function varargout = getJoint(self,varargin)
+    function varargout = isValidLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1158, self, varargin{:});
     end
-    function varargout = isValidJointIndex(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
     end
-    function varargout = isLinkNameUsed(self,varargin)
+    function varargout = addLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1160, self, varargin{:});
     end
-    function varargout = isJointNameUsed(self,varargin)
+    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1161, self, varargin{:});
     end
-    function varargout = isFrameNameUsed(self,varargin)
+    function varargout = getJointName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1162, self, varargin{:});
     end
-    function varargout = addJoint(self,varargin)
+    function varargout = getTotalMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
     end
-    function varargout = addJointAndLink(self,varargin)
+    function varargout = getJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
     end
-    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
+    function varargout = getJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1165, self, varargin{:});
     end
-    function varargout = getNrOfPosCoords(self,varargin)
+    function varargout = isValidJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1166, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = isLinkNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1167, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = isJointNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1168, self, varargin{:});
     end
-    function varargout = addAdditionalFrameToLink(self,varargin)
+    function varargout = isFrameNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1169, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = addJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1170, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = addJointAndLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1171, self, varargin{:});
     end
-    function varargout = isValidFrameIndex(self,varargin)
+    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
     end
-    function varargout = getFrameLink(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1174, self, varargin{:});
     end
-    function varargout = getNrOfNeighbors(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1175, self, varargin{:});
     end
-    function varargout = getNeighbor(self,varargin)
+    function varargout = addAdditionalFrameToLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1176, self, varargin{:});
     end
-    function varargout = setDefaultBaseLink(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1177, self, varargin{:});
     end
-    function varargout = getDefaultBaseLink(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
     end
-    function varargout = computeFullTreeTraversal(self,varargin)
+    function varargout = isValidFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
     end
-    function varargout = getInertialParameters(self,varargin)
+    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
     end
-    function varargout = updateInertialParameters(self,varargin)
+    function varargout = getFrameLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
     end
-    function varargout = visualSolidShapes(self,varargin)
+    function varargout = getLinkAdditionalFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
     end
-    function varargout = collisionSolidShapes(self,varargin)
+    function varargout = getNrOfNeighbors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getNeighbor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
+    end
+    function varargout = setDefaultBaseLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
+    end
+    function varargout = getDefaultBaseLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
+    end
+    function varargout = computeFullTreeTraversal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
+    end
+    function varargout = getInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
+    end
+    function varargout = updateInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
+    end
+    function varargout = visualSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
+    end
+    function varargout = collisionSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1191, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1192, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
@@ -1,0 +1,50 @@
+classdef ModelExporter < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function self = ModelExporter(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(1480, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(1481, self);
+        self.SwigClear();
+      end
+    end
+    function varargout = exportingOptions(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1482, self, varargin{:});
+    end
+    function varargout = setExportingOptions(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1483, self, varargin{:});
+    end
+    function varargout = init(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1484, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1485, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1486, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1487, self, varargin{:});
+    end
+    function varargout = exportModelToString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1488, self, varargin{:});
+    end
+    function varargout = exportModelToFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1489, self, varargin{:});
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
@@ -1,0 +1,46 @@
+classdef ModelExporterOptions < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = baseLink(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1474, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1475, self, varargin{1});
+      end
+    end
+    function varargout = exportFirstBaseLinkAdditionalFrameAsFakeURDFBase(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1476, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1477, self, varargin{1});
+      end
+    end
+    function self = ModelExporterOptions(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(1478, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(1479, self);
+        self.SwigClear();
+      end
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
@@ -9,46 +9,46 @@ classdef ModelLoader < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1454, varargin{:});
+        tmp = iDynTreeMEX(1462, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1455, self);
+        iDynTreeMEX(1463, self);
         self.SwigClear();
       end
     end
     function varargout = parsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1456, self, varargin{:});
-    end
-    function varargout = setParsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1457, self, varargin{:});
-    end
-    function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1458, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1459, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromFullModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1460, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1461, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1462, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1463, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1464, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setParsingOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1465, self, varargin{:});
+    end
+    function varargout = loadModelFromString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1466, self, varargin{:});
+    end
+    function varargout = loadModelFromFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1467, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromFullModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1468, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1469, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1470, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1471, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1472, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1473, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
@@ -7,20 +7,20 @@ classdef ModelParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1448, self);
+        varargout{1} = iDynTreeMEX(1456, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1449, self, varargin{1});
+        iDynTreeMEX(1457, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1450, self);
+        varargout{1} = iDynTreeMEX(1458, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1451, self, varargin{1});
+        iDynTreeMEX(1459, self, varargin{1});
       end
     end
     function self = ModelParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef ModelParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1452, varargin{:});
+        tmp = iDynTreeMEX(1460, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1453, self);
+        iDynTreeMEX(1461, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
@@ -9,34 +9,34 @@ classdef ModelSolidShapes < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1133, varargin{:});
+        tmp = iDynTreeMEX(1139, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1134, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1140, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1135, self);
+        iDynTreeMEX(1141, self);
         self.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1136, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1142, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1137, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1143, self, varargin{:});
     end
     function varargout = linkSolidShapes(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1138, self);
+        varargout{1} = iDynTreeMEX(1144, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1139, self, varargin{1});
+        iDynTreeMEX(1145, self, varargin{1});
       end
     end
   end

--- a/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef MomentumFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1207, varargin{:});
+        tmp = iDynTreeMEX(1215, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1216, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1217, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1210, self);
+        iDynTreeMEX(1218, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl1 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(968, self);
+        iDynTreeMEX(972, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(978, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
     end
     function self = MovableJointImpl1(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl2 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(977, self);
+        iDynTreeMEX(981, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(978, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(985, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
     end
     function self = MovableJointImpl2(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl3 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(986, self);
+        iDynTreeMEX(990, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(996, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
     end
     function self = MovableJointImpl3(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl4 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(995, self);
+        iDynTreeMEX(999, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(996, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1003, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
     end
     function self = MovableJointImpl4(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl5 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1004, self);
+        iDynTreeMEX(1008, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1008, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
     end
     function self = MovableJointImpl5(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl6 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1013, self);
+        iDynTreeMEX(1017, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
     end
     function self = MovableJointImpl6(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
@@ -1,3 +1,3 @@
 function v = NR_OF_SENSOR_TYPES()
-  v = iDynTreeMEX(1286);
+  v = iDynTreeMEX(1294);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
@@ -7,20 +7,20 @@ classdef Neighbor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1140, self);
+        varargout{1} = iDynTreeMEX(1146, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1141, self, varargin{1});
+        iDynTreeMEX(1147, self, varargin{1});
       end
     end
     function varargout = neighborJoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1142, self);
+        varargout{1} = iDynTreeMEX(1148, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1143, self, varargin{1});
+        iDynTreeMEX(1149, self, varargin{1});
       end
     end
     function self = Neighbor(varargin)
@@ -29,14 +29,14 @@ classdef Neighbor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1144, varargin{:});
+        tmp = iDynTreeMEX(1150, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1145, self);
+        iDynTreeMEX(1151, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
@@ -7,85 +7,85 @@ classdef PrismaticJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1047, varargin{:});
+        tmp = iDynTreeMEX(1051, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1048, self);
+        iDynTreeMEX(1052, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
-    end
-    function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
     end
-    function varargout = getAxis(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1057, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1058, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1060, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1061, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1062, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1063, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1064, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1073, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
@@ -1,3 +1,3 @@
 function varargout = RNEADynamicPhase(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1260, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1268, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
@@ -7,85 +7,85 @@ classdef RevoluteJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1022, varargin{:});
+        tmp = iDynTreeMEX(1026, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1023, self);
+        iDynTreeMEX(1027, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
-    end
-    function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
     end
-    function varargout = getAxis(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1032, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1033, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1038, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1041, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1047, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Rotation.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Rotation.m
@@ -52,14 +52,14 @@ classdef Rotation < iDynTree.RotationRaw
       [varargout{1:nargout}] = iDynTreeMEX(760, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(773, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(774, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(778, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(775, self);
+        iDynTreeMEX(779, self);
         self.SwigClear();
       end
     end
@@ -92,20 +92,32 @@ classdef Rotation < iDynTree.RotationRaw
     function varargout = RPYRightTrivializedDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(767, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
+    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(768, varargin{:});
     end
-    function varargout = QuaternionRightTrivializedDerivative(varargin)
+    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(769, varargin{:});
     end
-    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
+    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(770, varargin{:});
     end
-    function varargout = Identity(varargin)
+    function varargout = QuaternionRightTrivializedDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(771, varargin{:});
     end
-    function varargout = RotationFromQuaternion(varargin)
+    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(772, varargin{:});
+    end
+    function varargout = Identity(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(773, varargin{:});
+    end
+    function varargout = RotationFromQuaternion(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(774, varargin{:});
+    end
+    function varargout = leftJacobian(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(775, varargin{:});
+    end
+    function varargout = leftJacobianInverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(776, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Sensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sensor.m
@@ -5,33 +5,33 @@ classdef Sensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1290, self);
+        iDynTreeMEX(1298, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1291, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1299, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1292, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1300, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1293, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1301, self, varargin{:});
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1294, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1302, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1295, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1303, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1296, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1304, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1297, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1305, self, varargin{:});
     end
     function varargout = updateIndeces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1298, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
     end
     function self = Sensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
@@ -9,61 +9,61 @@ classdef SensorsList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1313, varargin{:});
+        tmp = iDynTreeMEX(1321, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1314, self);
+        iDynTreeMEX(1322, self);
         self.SwigClear();
       end
     end
     function varargout = addSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
-    end
-    function varargout = setSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
-    end
-    function varargout = getSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
-    end
-    function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
-    end
-    function varargout = getSensorIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1319, self, varargin{:});
-    end
-    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
-    end
-    function varargout = getSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1321, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1322, self, varargin{:});
-    end
-    function varargout = removeSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
     end
-    function varargout = removeAllSensorsOfType(self,varargin)
+    function varargout = setSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
     end
-    function varargout = getSixAxisForceTorqueSensor(self,varargin)
+    function varargout = getSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
     end
-    function varargout = getAccelerometerSensor(self,varargin)
+    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
     end
-    function varargout = getGyroscopeSensor(self,varargin)
+    function varargout = getSensorIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1327, self, varargin{:});
     end
-    function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
+    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1328, self, varargin{:});
     end
-    function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
+    function varargout = getSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
+    end
+    function varargout = isConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1330, self, varargin{:});
+    end
+    function varargout = removeSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1331, self, varargin{:});
+    end
+    function varargout = removeAllSensorsOfType(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
+    end
+    function varargout = getSixAxisForceTorqueSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
+    end
+    function varargout = getAccelerometerSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
+    end
+    function varargout = getGyroscopeSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
+    end
+    function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
+    end
+    function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
@@ -9,37 +9,37 @@ classdef SensorsMeasurements < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1330, varargin{:});
+        tmp = iDynTreeMEX(1338, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1331, self);
+        iDynTreeMEX(1339, self);
         self.SwigClear();
       end
     end
     function varargout = setNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1340, self, varargin{:});
     end
     function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
     end
     function varargout = toVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
     end
     function varargout = setMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1344, self, varargin{:});
     end
     function varargout = getMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1345, self, varargin{:});
     end
     function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1338, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
@@ -9,43 +9,46 @@ classdef SimpleLeggedOdometry < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1527, varargin{:});
+        tmp = iDynTreeMEX(1551, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1528, self);
+        iDynTreeMEX(1552, self);
         self.SwigClear();
       end
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1529, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1553, self, varargin{:});
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1530, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1554, self, varargin{:});
     end
     function varargout = loadModelFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1531, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1555, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1532, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1556, self, varargin{:});
     end
     function varargout = updateKinematics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1533, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1557, self, varargin{:});
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1534, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1558, self, varargin{:});
     end
     function varargout = changeFixedFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1535, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1559, self, varargin{:});
     end
     function varargout = getCurrentFixedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1536, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1560, self, varargin{:});
     end
     function varargout = getWorldLinkTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1537, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1561, self, varargin{:});
+    end
+    function varargout = getWorldFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1562, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
@@ -7,100 +7,100 @@ classdef SixAxisForceTorqueSensor < iDynTree.JointSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1339, varargin{:});
+        tmp = iDynTreeMEX(1347, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1340, self);
+        iDynTreeMEX(1348, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
-    end
-    function varargout = setFirstLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
-    end
-    function varargout = setSecondLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
-    end
-    function varargout = getFirstLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1344, self, varargin{:});
-    end
-    function varargout = getSecondLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1345, self, varargin{:});
-    end
-    function varargout = setFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
-    end
-    function varargout = setSecondLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1347, self, varargin{:});
-    end
-    function varargout = getFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1348, self, varargin{:});
-    end
-    function varargout = getSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1349, self, varargin{:});
     end
-    function varargout = setParentJoint(self,varargin)
+    function varargout = setFirstLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1350, self, varargin{:});
     end
-    function varargout = setParentJointIndex(self,varargin)
+    function varargout = setSecondLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
     end
-    function varargout = setAppliedWrenchLink(self,varargin)
+    function varargout = getFirstLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = getSecondLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1353, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = setFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1354, self, varargin{:});
     end
-    function varargout = getParentJoint(self,varargin)
+    function varargout = setSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1355, self, varargin{:});
     end
-    function varargout = getParentJointIndex(self,varargin)
+    function varargout = getFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1356, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1357, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1358, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = setParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1359, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = setAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1360, self, varargin{:});
     end
-    function varargout = getAppliedWrenchLink(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1361, self, varargin{:});
     end
-    function varargout = isLinkAttachedToSensor(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1362, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1363, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLink(self,varargin)
+    function varargout = getParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1364, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1365, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1366, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = updateIndices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1367, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1368, self, varargin{:});
+    end
+    function varargout = getAppliedWrenchLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1369, self, varargin{:});
+    end
+    function varargout = isLinkAttachedToSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1370, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1371, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1372, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1373, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1374, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1375, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1376, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
@@ -5,34 +5,14 @@ classdef SolidShape < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1089, self);
+        iDynTreeMEX(1093, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
     end
     function varargout = name(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1091, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1092, self, varargin{1});
-      end
-    end
-    function varargout = link_H_geometry(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1093, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1094, self, varargin{1});
-      end
-    end
-    function varargout = material(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -42,29 +22,59 @@ classdef SolidShape < SwigRef
         iDynTreeMEX(1096, self, varargin{1});
       end
     end
+    function varargout = nameIsValid(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1097, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1098, self, varargin{1});
+      end
+    end
+    function varargout = link_H_geometry(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1099, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1100, self, varargin{1});
+      end
+    end
+    function varargout = material(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1101, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1102, self, varargin{1});
+      end
+    end
     function varargout = isSphere(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1097, self, varargin{:});
-    end
-    function varargout = isBox(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
-    end
-    function varargout = isCylinder(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1099, self, varargin{:});
-    end
-    function varargout = isExternalMesh(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
-    end
-    function varargout = asSphere(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1101, self, varargin{:});
-    end
-    function varargout = asBox(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1102, self, varargin{:});
-    end
-    function varargout = asCylinder(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
     end
-    function varargout = asExternalMesh(self,varargin)
+    function varargout = isBox(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
+    end
+    function varargout = isCylinder(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1105, self, varargin{:});
+    end
+    function varargout = isExternalMesh(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1106, self, varargin{:});
+    end
+    function varargout = asSphere(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1107, self, varargin{:});
+    end
+    function varargout = asBox(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1108, self, varargin{:});
+    end
+    function varargout = asCylinder(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1109, self, varargin{:});
+    end
+    function varargout = asExternalMesh(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1110, self, varargin{:});
     end
     function self = SolidShape(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/Sphere.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sphere.m
@@ -2,21 +2,21 @@ classdef Sphere < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1105, self);
+        iDynTreeMEX(1111, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1106, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
     end
     function varargout = radius(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1107, self);
+        varargout{1} = iDynTreeMEX(1113, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1108, self, varargin{1});
+        iDynTreeMEX(1114, self, varargin{1});
       end
     end
     function self = Sphere(varargin)
@@ -26,7 +26,7 @@ classdef Sphere < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1109, varargin{:});
+        tmp = iDynTreeMEX(1115, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = TRAVERSAL_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(855);
+    varargout{1} = iDynTreeMEX(859);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(856,varargin{1});
+    iDynTreeMEX(860,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef ThreeAxisAngularAccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1401, varargin{:});
+        tmp = iDynTreeMEX(1409, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1402, self);
+        iDynTreeMEX(1410, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1403, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1404, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1405, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1406, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1407, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1408, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1409, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1410, self, varargin{:});
-    end
-    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1411, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1412, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1413, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1414, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1415, self, varargin{:});
+    end
+    function varargout = getSensorType(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1416, self, varargin{:});
+    end
+    function varargout = getParentLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1417, self, varargin{:});
+    end
+    function varargout = getParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1418, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1419, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1420, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1421, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1422, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1423, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
@@ -7,64 +7,64 @@ classdef ThreeAxisForceTorqueContactSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1416, varargin{:});
+        tmp = iDynTreeMEX(1424, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1417, self);
+        iDynTreeMEX(1425, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1418, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1419, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1420, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1421, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1422, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1423, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1424, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1425, self, varargin{:});
-    end
-    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1426, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1427, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1428, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1429, self, varargin{:});
     end
-    function varargout = setLoadCellLocations(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1430, self, varargin{:});
     end
-    function varargout = getLoadCellLocations(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1431, self, varargin{:});
     end
-    function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1432, self, varargin{:});
     end
-    function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1433, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1434, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1435, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1436, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1437, self, varargin{:});
+    end
+    function varargout = setLoadCellLocations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1438, self, varargin{:});
+    end
+    function varargout = getLoadCellLocations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1439, self, varargin{:});
+    end
+    function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1440, self, varargin{:});
+    end
+    function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1441, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Transform.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Transform.m
@@ -9,69 +9,69 @@ classdef Transform < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(784, varargin{:});
+        tmp = iDynTreeMEX(788, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(785, self, varargin{:});
-    end
-    function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(786, self, varargin{:});
-    end
-    function varargout = getRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
-    end
-    function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
-    end
-    function varargout = setRotation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
     end
-    function varargout = setPosition(self,varargin)
+    function varargout = getSemantics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
     end
-    function varargout = inverse(self,varargin)
+    function varargout = getRotation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(791, self, varargin{:});
+    end
+    function varargout = getPosition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(792, self, varargin{:});
+    end
+    function varargout = setRotation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(793, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(794, self, varargin{:});
     end
-    function varargout = asHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(796, self, varargin{:});
-    end
-    function varargout = asAdjointTransform(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(797, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrench(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(798, self, varargin{:});
     end
-    function varargout = log(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(799, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
+    function varargout = asHomogeneousTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(800, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = asAdjointTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(801, self, varargin{:});
+    end
+    function varargout = asAdjointTransformWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(802, self, varargin{:});
+    end
+    function varargout = log(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(803, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(804, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(805, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(802, self);
+        iDynTreeMEX(806, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(791, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(795, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(792, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(796, varargin{:});
     end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(795, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(799, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
@@ -9,51 +9,51 @@ classdef TransformDerivative < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(803, varargin{:});
+        tmp = iDynTreeMEX(807, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(804, self);
+        iDynTreeMEX(808, self);
         self.SwigClear();
       end
     end
     function varargout = getRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(805, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(809, self, varargin{:});
     end
     function varargout = getPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(806, self, varargin{:});
-    end
-    function varargout = setRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(807, self, varargin{:});
-    end
-    function varargout = setPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(808, self, varargin{:});
-    end
-    function varargout = asHomogeneousTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(810, self, varargin{:});
     end
-    function varargout = asAdjointTransformDerivative(self,varargin)
+    function varargout = setRotationDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+    function varargout = setPositionDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(812, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(813, self, varargin{:});
-    end
-    function varargout = derivativeOfInverse(self,varargin)
+    function varargout = asHomogeneousTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(814, self, varargin{:});
     end
-    function varargout = transform(self,varargin)
+    function varargout = asAdjointTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(815, self, varargin{:});
+    end
+    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(816, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(817, self, varargin{:});
+    end
+    function varargout = derivativeOfInverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(818, self, varargin{:});
+    end
+    function varargout = transform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(819, self, varargin{:});
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(809, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(813, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformSemantics.m
@@ -9,32 +9,32 @@ classdef TransformSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(776, varargin{:});
+        tmp = iDynTreeMEX(780, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
-    end
-    function varargout = getPositionSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(778, self, varargin{:});
-    end
-    function varargout = setRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(779, self, varargin{:});
-    end
-    function varargout = setPositionSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(780, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(781, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = getPositionSemantics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(782, self, varargin{:});
+    end
+    function varargout = setRotationSemantics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(783, self, varargin{:});
+    end
+    function varargout = setPositionSemantics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(785, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(786, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(783, self);
+        iDynTreeMEX(787, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Traversal.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Traversal.m
@@ -9,61 +9,61 @@ classdef Traversal < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1072, varargin{:});
+        tmp = iDynTreeMEX(1076, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1073, self);
+        iDynTreeMEX(1077, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfVisitedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
-    end
-    function varargout = getBaseLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
-    end
-    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
     end
-    function varargout = getParentLinkFromLinkIndex(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
     end
-    function varargout = getParentJointFromLinkIndex(self,varargin)
+    function varargout = getBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
     end
-    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
     end
-    function varargout = reset(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1082, self, varargin{:});
     end
-    function varargout = addTraversalBase(self,varargin)
+    function varargout = getParentLinkFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1083, self, varargin{:});
     end
-    function varargout = addTraversalElement(self,varargin)
+    function varargout = getParentJointFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1084, self, varargin{:});
     end
-    function varargout = isParentOf(self,varargin)
+    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
     end
-    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+    function varargout = reset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
     end
-    function varargout = getParentLinkIndexFromJointIndex(self,varargin)
+    function varargout = addTraversalBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1087, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = addTraversalElement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1088, self, varargin{:});
+    end
+    function varargout = isParentOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
+    end
+    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
+    end
+    function varargout = getParentLinkIndexFromJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1091, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1092, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/URDFParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/URDFParserOptions.m
@@ -7,20 +7,20 @@ classdef URDFParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1436, self);
+        varargout{1} = iDynTreeMEX(1444, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1437, self, varargin{1});
+        iDynTreeMEX(1445, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1438, self);
+        varargout{1} = iDynTreeMEX(1446, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1439, self, varargin{1});
+        iDynTreeMEX(1447, self, varargin{1});
       end
     end
     function self = URDFParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef URDFParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1440, varargin{:});
+        tmp = iDynTreeMEX(1448, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1441, self);
+        iDynTreeMEX(1449, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
+++ b/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
@@ -9,7 +9,7 @@ classdef UnknownWrenchContact < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1466, varargin{:});
+        tmp = iDynTreeMEX(1490, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,55 +18,55 @@ classdef UnknownWrenchContact < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1467, self);
+        varargout{1} = iDynTreeMEX(1491, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1468, self, varargin{1});
+        iDynTreeMEX(1492, self, varargin{1});
       end
     end
     function varargout = contactPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1469, self);
+        varargout{1} = iDynTreeMEX(1493, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1470, self, varargin{1});
+        iDynTreeMEX(1494, self, varargin{1});
       end
     end
     function varargout = forceDirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1471, self);
+        varargout{1} = iDynTreeMEX(1495, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1472, self, varargin{1});
+        iDynTreeMEX(1496, self, varargin{1});
       end
     end
     function varargout = knownWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1473, self);
+        varargout{1} = iDynTreeMEX(1497, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1474, self, varargin{1});
+        iDynTreeMEX(1498, self, varargin{1});
       end
     end
     function varargout = contactId(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1475, self);
+        varargout{1} = iDynTreeMEX(1499, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1476, self, varargin{1});
+        iDynTreeMEX(1500, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1477, self);
+        iDynTreeMEX(1501, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,55 +9,55 @@ classdef Visualizer < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1930, varargin{:});
+        tmp = iDynTreeMEX(1956, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1931, self);
+        iDynTreeMEX(1957, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1958, self, varargin{:});
     end
     function varargout = getNrOfVisualizedModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1959, self, varargin{:});
     end
     function varargout = getModelInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
     end
     function varargout = getModelInstanceIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1961, self, varargin{:});
     end
     function varargout = addModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1962, self, varargin{:});
     end
     function varargout = modelViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1963, self, varargin{:});
     end
     function varargout = camera(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1964, self, varargin{:});
     end
     function varargout = enviroment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1965, self, varargin{:});
     end
     function varargout = vectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1966, self, varargin{:});
     end
     function varargout = run(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
     end
     function varargout = draw(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
     end
     function varargout = drawToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
     end
     function varargout = close(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,40 +7,40 @@ classdef VisualizerOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1920, self);
+        varargout{1} = iDynTreeMEX(1946, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1921, self, varargin{1});
+        iDynTreeMEX(1947, self, varargin{1});
       end
     end
     function varargout = winWidth(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1922, self);
+        varargout{1} = iDynTreeMEX(1948, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1923, self, varargin{1});
+        iDynTreeMEX(1949, self, varargin{1});
       end
     end
     function varargout = winHeight(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1924, self);
+        varargout{1} = iDynTreeMEX(1950, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1925, self, varargin{1});
+        iDynTreeMEX(1951, self, varargin{1});
       end
     end
     function varargout = rootFrameArrowsDimension(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1926, self);
+        varargout{1} = iDynTreeMEX(1952, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1927, self, varargin{1});
+        iDynTreeMEX(1953, self, varargin{1});
       end
     end
     function self = VisualizerOptions(varargin)
@@ -49,14 +49,14 @@ classdef VisualizerOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1928, varargin{:});
+        tmp = iDynTreeMEX(1954, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1929, self);
+        iDynTreeMEX(1955, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
@@ -1,3 +1,3 @@
 function varargout = computeLinkNetWrenchesWithoutGravity(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1511, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1535, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1444, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1452, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1445, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1453, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
@@ -1,3 +1,3 @@
 function v = dynamic_extent()
-  v = iDynTreeMEX(816);
+  v = iDynTreeMEX(820);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1509, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1533, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1510, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1534, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1508, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1532, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
@@ -9,86 +9,86 @@ classdef estimateExternalWrenchesBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1489, varargin{:});
+        tmp = iDynTreeMEX(1513, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1490, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1514, self, varargin{:});
     end
     function varargout = getNrOfSubModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1491, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1515, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1492, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1516, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1493, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1517, self, varargin{:});
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1494, self);
+        varargout{1} = iDynTreeMEX(1518, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1495, self, varargin{1});
+        iDynTreeMEX(1519, self, varargin{1});
       end
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1496, self);
+        varargout{1} = iDynTreeMEX(1520, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1497, self, varargin{1});
+        iDynTreeMEX(1521, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1498, self);
+        varargout{1} = iDynTreeMEX(1522, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1499, self, varargin{1});
+        iDynTreeMEX(1523, self, varargin{1});
       end
     end
     function varargout = pinvA(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1500, self);
+        varargout{1} = iDynTreeMEX(1524, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1501, self, varargin{1});
+        iDynTreeMEX(1525, self, varargin{1});
       end
     end
     function varargout = b_contacts_subtree(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1502, self);
+        varargout{1} = iDynTreeMEX(1526, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1503, self, varargin{1});
+        iDynTreeMEX(1527, self, varargin{1});
       end
     end
     function varargout = subModelBase_H_link(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1504, self);
+        varargout{1} = iDynTreeMEX(1528, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1505, self, varargin{1});
+        iDynTreeMEX(1529, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1506, self);
+        iDynTreeMEX(1530, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenchesWithoutInternalFT(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1507, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1531, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
@@ -1,0 +1,3 @@
+function varargout = estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(varargin)
+  [varargout{1:nargout}] = iDynTreeMEX(1771, varargin{:});
+end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateLinkContactWrenchesFromLinkNetExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1512, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1536, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
@@ -1,3 +1,3 @@
 function varargout = getSensorTypeSize(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1289, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1297, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
@@ -1,3 +1,3 @@
 function v = input_dimensions()
-  v = iDynTreeMEX(1693);
+  v = iDynTreeMEX(1726);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isDOFBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1540, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1565, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isJointBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1539, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1564, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
@@ -1,3 +1,3 @@
 function varargout = isJointSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1288, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1296, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isLinkBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1538, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1563, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
@@ -1,3 +1,3 @@
 function varargout = isLinkSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1287, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1295, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/modelFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/modelFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1442, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1450, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/modelFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/modelFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1443, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1451, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_with_magnetometer()
-  v = iDynTreeMEX(1691);
+  v = iDynTreeMEX(1724);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_without_magnetometer()
-  v = iDynTreeMEX(1692);
+  v = iDynTreeMEX(1725);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurements(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1434, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1442, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurementsFromRawBuffers(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1435, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1443, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1446, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1454, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1447, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1455, varargin{:});
 end


### PR DESCRIPTION
The only real commit of this PR is https://github.com/robotology/idyntree/commit/1ec37f8ad391bf3dda08cd7fe66599d3807d483b, that adds the recently added ModelExporter class and InertialParametersSolidShapesHelpers functions to the SWIG bindings. 

The other commit in this PR is https://github.com/robotology/idyntree/commit/10d2856a85b2b1406e693fe8b0625522e8c43bf3, that just contains the automatically generated bindings, generated as documented in https://github.com/robotology/idyntree/blob/master/doc/dev/faqs.md#how-to-add-wrap-a-new-class-or-function-with-swig . 