### PR TITLE
Do not search for mscgen

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -34,19 +34,6 @@ if(DOXYGEN_FOUND)
     set(DOX_PATTERNS "*.h *.dox *.cpp *.hpp")
     set(DOX_GENERATE_MAN NO)
 
-    # search mscgen program
-    # for setting the MSCGEN_PATH variable in the Doxyfile
-    find_program(MSCGEN_EXECUTABLE mscgen)
-
-    if( MSCGEN_EXECUTABLE STREQUAL "MSCGEN_EXECUTABLE-NOTFOUND" )
-        message(STATUS "mscgen program not found")
-        set(MSCGEN_PATH "")
-    else()
-        # set the MSCGEN_PATH variable by stripping the name (mscgen)
-        # from the MSCGEN_EXECUTABLE
-        string(REGEX REPLACE "mscgen$" "" MSCGEN_PATH ${MSCGEN_EXECUTABLE})
-    endif()
-
     # search dot program
     # for setting the DOT_PATH variable in the Doxyfile
     find_program(DOT_EXECUTABLE dot)


### PR DESCRIPTION
The mscgen check was added to use the mscgen tool, then was never actually used, see https://github.com/robotology/idyntree/issues/114 .