### PR TITLE
Add operator[] to iDynTree Vectors

### DIFF
--- a/doc/releases/v0_12.md
+++ b/doc/releases/v0_12.md
@@ -67,6 +67,8 @@ to normalize errors or as initial points of a nonlinear optimization procedure.
 * Fixed implementation of Transform::log() method (https://github.com/robotology/idyntree/pull/562)
 * Fixed implementation of SpatialMotionVector::exp() method (https://github.com/robotology/idyntree/pull/562)
 * Add nameIsValid attribute to iDynTree::SolidShape class.
+* Add operator[] method to `iDynTree::VectorDynSize` (https://github.com/robotology/idyntree/pull/596)
+* Add operator[] method to `iDynTree::VectorFixSize` (https://github.com/robotology/idyntree/pull/596)
 
 ### `Model`
 * Implement `getTotalMass()` method for Model class

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -119,6 +119,10 @@ namespace iDynTree
 
         double& operator()(const unsigned int index);
 
+        double operator[](const unsigned int index) const;
+
+        double& operator[](const unsigned int index);
+
         double getVal(const unsigned int index) const;
 
         bool setVal(const unsigned int index, const double new_el);

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -63,6 +63,10 @@ namespace iDynTree
 
         double& operator()(const unsigned int index);
 
+        double operator[](const unsigned int index) const;
+
+        double& operator[](const unsigned int index);
+
         double getVal(const unsigned int index) const;
 
         bool setVal(const unsigned int index, const double new_el);
@@ -144,7 +148,7 @@ namespace iDynTree
     template<unsigned int VecSize>
     VectorFixSize<VecSize>::VectorFixSize()
     {
-        
+
     }
 
 
@@ -214,6 +218,19 @@ namespace iDynTree
         return this->m_data[index];
     }
 
+    template<unsigned int VecSize>
+    double VectorFixSize<VecSize>::operator[](const unsigned int index) const
+    {
+        assert(index < VecSize);
+        return this->m_data[index];
+    }
+
+    template<unsigned int VecSize>
+    double & VectorFixSize<VecSize>::operator[](const unsigned int index)
+    {
+        assert(index < VecSize);
+        return this->m_data[index];
+    }
 
     template<unsigned int VecSize>
     double VectorFixSize<VecSize>::getVal(const unsigned int index) const

--- a/src/core/src/VectorDynSize.cpp
+++ b/src/core/src/VectorDynSize.cpp
@@ -153,6 +153,18 @@ double VectorDynSize::operator()(unsigned int index) const
     return this->m_data[index];
 }
 
+double& VectorDynSize::operator[](unsigned int index)
+{
+    assert(index < this->size());
+    return this->m_data[index];
+}
+
+double VectorDynSize::operator[](unsigned int index) const
+{
+    assert(index < this->size());
+    return this->m_data[index];
+}
+
 double VectorDynSize::getVal(const unsigned int index) const
 {
     if( index >= this->size() )


### PR DESCRIPTION
This PR is related to issue #595, in details:
* define `operator[]` for `iDynTree::VectorDynSize` 
* define `operator[]` for `iDynTree::VectorFixSize`
* update the changelog 

@traversaro 