### PR TITLE
Make IDYNTREE_TREE_INCLUDE_DIRS a private include

### DIFF
--- a/src/model_io/xml/CMakeLists.txt
+++ b/src/model_io/xml/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>"
                                           PRIVATE ${EIGEN3_INCLUDE_DIR}
                                                   ${LIBXML2_INCLUDE_DIR}
-						  ${IDYNTREE_TREE_INCLUDE_DIRS})
+                                                  ${IDYNTREE_TREE_INCLUDE_DIRS})
 
 target_link_libraries(${libraryname} LINK_PUBLIC 
                                      LINK_PRIVATE ${LIBXML2_LIBRARIES} idyntree-core)

--- a/src/model_io/xml/CMakeLists.txt
+++ b/src/model_io/xml/CMakeLists.txt
@@ -39,9 +39,9 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/iDynTree>"
 												 "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/private>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>"
-                                                  ${IDYNTREE_TREE_INCLUDE_DIRS}
                                           PRIVATE ${EIGEN3_INCLUDE_DIR}
-                                                  ${LIBXML2_INCLUDE_DIR})
+                                                  ${LIBXML2_INCLUDE_DIR}
+						  ${IDYNTREE_TREE_INCLUDE_DIRS})
 
 target_link_libraries(${libraryname} LINK_PUBLIC 
                                      LINK_PRIVATE ${LIBXML2_LIBRARIES} idyntree-core)


### PR DESCRIPTION
`IDYNTREE_TREE_INCLUDE_DIRS` contains the internal iDynTree includes, that should not be exported