### PR TITLE
Fix typo IDYNTREE_USES_ICUB/IDYNTREE_USES_ICUB_MAIN in iDynTreeDependencies

### DIFF
--- a/cmake/iDynTreeDependencies.cmake
+++ b/cmake/iDynTreeDependencies.cmake
@@ -39,7 +39,7 @@ endif ()
 
 find_package(ICUB QUIET)
 option(IDYNTREE_USES_ICUB_MAIN "Build the part of iDynTree that depends on package ICUB" ${ICUB_FOUND})
-if (IDYNTREE_USES_ICUB)
+if (IDYNTREE_USES_ICUB_MAIN)
   find_package(ICUB REQUIRED)
 endif ()
 


### PR DESCRIPTION
Probably everything was working because `find_package(ICUB REQUIRED)` is also called inside some subdirectory.