### PR TITLE
Remove generic never called methods for SparseMatrix

### DIFF
--- a/src/core/src/SparseMatrix.cpp
+++ b/src/core/src/SparseMatrix.cpp
@@ -312,42 +312,6 @@ namespace iDynTree {
         return it;
     }
 
-    // MARK: - Methods to be explicitly implemented (thus asserted false)
-
-    template <iDynTree::MatrixStorageOrdering ordering>
-    SparseMatrix<ordering>::SparseMatrix(unsigned rows, unsigned cols, const iDynTree::VectorDynSize& memoryReserveDescription)
-    : m_allocatedSize(0)
-    , m_rows(rows)
-    , m_columns(cols)
-    {
-        UNUSED(memoryReserveDescription);
-        assert(false);
-    }
-
-    template <iDynTree::MatrixStorageOrdering ordering>
-    double SparseMatrix<ordering>::operator()(unsigned int, unsigned int) const
-    {
-        assert(false);
-    }
-
-    template <iDynTree::MatrixStorageOrdering ordering>
-    double& SparseMatrix<ordering>::operator()(unsigned int, unsigned int)
-    {
-        assert(false);
-    }
-
-    template <iDynTree::MatrixStorageOrdering ordering>
-    void SparseMatrix<ordering>::resize(unsigned, unsigned, const iDynTree::VectorDynSize&)
-    {
-        assert(false);
-    }
-
-    template <iDynTree::MatrixStorageOrdering ordering>
-    void SparseMatrix<ordering>::setFromTriplets(iDynTree::Triplets&)
-    {
-        assert(false);
-    }
-
     // MARK: - Row-Major implementation
     template <>
     SparseMatrix<iDynTree::RowMajor>::SparseMatrix(unsigned rows, unsigned cols, const iDynTree::VectorDynSize& memoryReserveDescription)


### PR DESCRIPTION
Some methods of SparseMatrix need to be implemented specifically for the
required ordering, and are never instantiated for an order different from
either iDynTree::RowMajor or iDynTree::ColumnMajor.
By removing them, we reduce the amount of useless code, and we avoid spurious warnings.

Fix https://github.com/robotology/idyntree/issues/605