### PR TITLE
Add definition of namespaced targets even for the build tree

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -109,6 +109,7 @@ include_directories(include/iDynTree/Core)
 set(libraryname idyntree-core)
 
 add_library(${libraryname} ${IDYNTREE_CORE_EXP_SOURCES} ${IDYNTREE_CORE_EXP_HEADERS} ${IDYNTREE_CORE_EXP_PRIVATE_INCLUDES})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 if (DEFINED CMAKE_COMPILER_IS_GNUCXX)
   if(${CMAKE_COMPILER_IS_GNUCXX} AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5)

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -47,6 +47,7 @@ SOURCE_GROUP("Header Files" FILES ${IDYNTREE_ESTIMATION_HEADERS})
 set(libraryname idyntree-estimation)
 
 add_library(${libraryname} ${IDYNTREE_ESTIMATION_SOURCES} ${IDYNTREE_ESTIMATION_HEADERS} ${IDYNTREE_ESTIMATION_PRIVATE_INCLUDES})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/src/high-level/CMakeLists.txt
+++ b/src/high-level/CMakeLists.txt
@@ -18,6 +18,7 @@ SOURCE_GROUP("Header Files" FILES ${IDYNTREE_HIGH_LEVEL_HEADERS})
 set(libraryname idyntree-high-level)
 
 add_library(${libraryname} ${IDYNTREE_HIGH_LEVEL_SOURCES} ${IDYNTREE_HIGH_LEVEL_HEADERS} ${IDYNTREE_HIGH_LEVEL_PRIVATE_INCLUDES})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/src/icub/CMakeLists.txt
+++ b/src/icub/CMakeLists.txt
@@ -25,6 +25,7 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/bin"
 
 set(libraryname idyntree-icub)
 add_library(${libraryname} ${iDynTree_ICUB_source} ${iDynTree_ICUB_header})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 # Ensure that build include directories are always included before system ones
 get_property(IDYNTREE_TREE_INCLUDE_DIRS GLOBAL PROPERTY IDYNTREE_TREE_INCLUDE_DIRS)

--- a/src/inverse-kinematics/CMakeLists.txt
+++ b/src/inverse-kinematics/CMakeLists.txt
@@ -23,6 +23,7 @@ source_group("Private\\Source Files" FILES ${PRIVATE_IDYN_TREE_IK_SOURCES})
 
 add_library(${libraryname} ${IDYN_TREE_IK_HEADERS} ${IDYN_TREE_IK_SOURCES}
                            ${PRIVATE_IDYN_TREE_IK_SOURCES} ${PRIVATE_IDYN_TREE_IK_HEADERS})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/src/model_io/urdf/CMakeLists.txt
+++ b/src/model_io/urdf/CMakeLists.txt
@@ -66,6 +66,7 @@ list(APPEND IDYNTREE_MODELIO_URDF_SOURCES ${IDYNTREE_MODELIO_URDF_XMLELEMENTS_SO
 set(libraryname idyntree-modelio-urdf)
 
 add_library(${libraryname} ${IDYNTREE_MODELIO_URDF_SOURCES} ${IDYNTREE_MODELIO_URDF_HEADERS} ${IDYNTREE_MODELIO_URDF_PRIVATE_HEADERS} $<TARGET_OBJECTS:idyntree-private-fpconv>)
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_compile_features(${libraryname} PRIVATE cxx_auto_type cxx_delegating_constructors cxx_final cxx_lambdas cxx_lambda_init_captures)
 

--- a/src/model_io/xml/CMakeLists.txt
+++ b/src/model_io/xml/CMakeLists.txt
@@ -32,6 +32,7 @@ SOURCE_GROUP("Private Header Files" FILES ${IDYNTREE_MODELIO_XML_PRIVATE_HEADERS
 set(libraryname idyntree-modelio-xml)
 
 add_library(${libraryname} ${IDYNTREE_MODELIO_XML_SOURCES} ${IDYNTREE_MODELIO_XML_HEADERS} ${IDYNTREE_MODELIO_XML_PRIVATE_HEADERS})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 # Test if this works:
 # We want to include the same-library header files directly (in the implementation), but with the full prefix in the .h (as this will be public)

--- a/src/optimalcontrol/CMakeLists.txt
+++ b/src/optimalcontrol/CMakeLists.txt
@@ -109,6 +109,8 @@ else()
 endif()
 
 add_library(${libraryname} ${PUBLIC_HEADERS} ${INTEGRATORS_PUBLIC_HEADERS} ${OCSOLVERS_PUBLIC_HEADERS} ${OPTIMIZERS_HEADERS} ${SOURCES} ${OPTIMIZERS_SOURCES})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
+
 target_include_directories(${libraryname} SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
 target_include_directories(${libraryname} SYSTEM PRIVATE ${INCLUDE_LIST})
 target_include_directories(${libraryname} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/src/regressors/CMakeLists.txt
+++ b/src/regressors/CMakeLists.txt
@@ -36,6 +36,7 @@ set(libraryname idyntree-regressors)
 
 add_library(${libraryname} ${IDYNTREE_REGRESSORS_SOURCES}     ${IDYNTREE_REGRESSORS_HEADERS}
                                 ${IDYNTREE_REGRESSORS_SOURCES_EXP} ${IDYNTREE_REGRESSORS_HEADERS_EXP})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -41,6 +41,7 @@ SOURCE_GROUP("Header Files" FILES ${IDYNTREE_SENSORS_HEADERS})
 set(libraryname idyntree-sensors)
 
 add_library(${libraryname} ${IDYNTREE_SENSORS_SOURCES} ${IDYNTREE_SENSORS_HEADERS} ${IDYNTREE_SENSORS_PRIVATE_INCLUDES})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>"

--- a/src/solid-shapes/CMakeLists.txt
+++ b/src/solid-shapes/CMakeLists.txt
@@ -4,6 +4,7 @@ set(IDYNTREE_SOLID_SHAPES_SOURCES src/InertialParametersSolidShapesHelpers.cpp)
 set(IDYNTREE_SOLID_SHAPES_HEADERS include/iDynTree/InertialParametersSolidShapesHelpers.h)
 
 add_library(${libraryname} ${IDYNTREE_SOLID_SHAPES_HEADERS} ${IDYNTREE_SOLID_SHAPES_SOURCES})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -46,6 +46,7 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/bin"
 set(libraryname idyntree-visualization)
 add_library(${libraryname} ${iDynTree_visualization_source} ${iDynTree_visualization_header}
                            ${iDynTree_visualization_private_source} ${iDynTree_visualization_private_headers})
+add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 set_target_properties(${libraryname} PROPERTIES PUBLIC_HEADER "${iDynTree_visualization_header}")
 

--- a/src/yarp/CMakeLists.txt
+++ b/src/yarp/CMakeLists.txt
@@ -30,6 +30,7 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/bin"
 
 
 add_library(idyntree-yarp ${iDynTree_YARP_source} ${iDynTree_YARP_header})
+add_library(iDynTree::idyntree-yarp ALIAS idyntree-yarp)
 
 set_target_properties(idyntree-yarp PROPERTIES PUBLIC_HEADER "${iDynTree_YARP_header}")
 


### PR DESCRIPTION
It is useful to define an alias of the iDynTree libraries with the scope of the exported
library itself (i.e. iDynTree::<lib>) because (1) you can link against it with the exact same syntax
of an imported library, that is useful when iDynTree is used in a bigger project
via add_subdirectory and (2) because names having a double-colon (::) are
always treated as the name of either an alias or imported target. Any attempt
to use such a name for a different target type will result in an error.

Related to https://github.com/robotology/idyntree/issues/397 .