### PR TITLE
Deprecate semantics support in core data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ to normalize errors or as initial points of a nonlinear optimization procedure.
 - The changelog has been migrated to the format described in https://keepachangelog.com/en/1.0.0/ .
 - The CMake config files are now installed in ${CMAKE_INSTALL_PREFIX}/lib/cmake/iDynTree also in Windows.
 
+### Deprecated
+- All the classes and methods that end in Semantics are deprecated, and will be removed in iDynTree 2.0, see https://github.com/robotology/idyntree/pull/622 for more info.
+- The CMake option IDYNTREE_USES_KDL and all the classes available when enabling it are deprecated, and will be removed in iDynTree 2.0 .
+
 ### Fixed
 - Fixed missing `DOF_ACCELLERATION` data in dynamic variable cache ordering
 (https://github.com/robotology/idyntree/pull/587)

--- a/src/core/include/iDynTree/Core/AngularForceVector3.h
+++ b/src/core/include/iDynTree/Core/AngularForceVector3.h
@@ -13,6 +13,7 @@
 
 #include <iDynTree/Core/ForceVector3.h>
 #include <iDynTree/Core/PrivateMotionForceVertorAssociations.h>
+#include <iDynTree/Core/Utils.h>
 
 namespace iDynTree
 {
@@ -24,7 +25,8 @@ namespace iDynTree
     /**
      * Class providing the semantics for any angular force vector (torque or angular momentum).
      */
-    class AngularForceVector3Semantics: public ForceVector3Semantics<AngularForceVector3Semantics>
+    class
+    AngularForceVector3Semantics: public ForceVector3Semantics<AngularForceVector3Semantics>
     {
     protected:
         int point;
@@ -34,17 +36,21 @@ namespace iDynTree
          * Constructors:
          */
         inline AngularForceVector3Semantics() {}
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         AngularForceVector3Semantics(int _point, int _body, int _refBody, int _coordinateFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         AngularForceVector3Semantics(const AngularForceVector3Semantics & other);
 
         /**
          * Semantics operations
          * Compute the semantics of the result given the semantics of the operands.
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         bool changePoint(const PositionSemantics & newPoint,
                          const LinearForceVector3Semantics & otherLinear,
                          AngularForceVector3Semantics & resultAngular) const;
 
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         static bool compose(const AngularForceVector3Semantics & op1,
                             const AngularForceVector3Semantics & op2,
                             AngularForceVector3Semantics & result);

--- a/src/core/include/iDynTree/Core/AngularMotionVector3.h
+++ b/src/core/include/iDynTree/Core/AngularMotionVector3.h
@@ -13,6 +13,7 @@
 
 #include <iDynTree/Core/MotionVector3.h>
 #include <iDynTree/Core/PrivateMotionForceVertorAssociations.h>
+#include <iDynTree/Core/Utils.h>
 
 namespace iDynTree
 {
@@ -26,7 +27,9 @@ namespace iDynTree
          * Constructors:
          */
         AngularMotionVector3Semantics();
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         AngularMotionVector3Semantics(int _body, int _refBody, int _coordinateFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         AngularMotionVector3Semantics(const AngularMotionVector3Semantics & other);
     };
 

--- a/src/core/include/iDynTree/Core/GeomVector3.h
+++ b/src/core/include/iDynTree/Core/GeomVector3.h
@@ -14,6 +14,7 @@
 #include <iDynTree/Core/VectorFixSize.h>
 #include <iDynTree/Core/Rotation.h>
 #include <iDynTree/Core/PrivateMotionForceVertorAssociations.h>
+#include <iDynTree/Core/Utils.h>
 
 #define GEOMVECTOR3SEMANTICS_TEMPLATE_HDR \
 template <class MotionForceSemanticsT>
@@ -41,7 +42,9 @@ namespace iDynTree
          * Constructors:
          */
         inline GeomVector3Semantics() {}
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         GeomVector3Semantics(int _body, int _refBody, int _coordinateFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         GeomVector3Semantics(const GeomVector3Semantics & other);
 
         void setToUnknown();
@@ -97,7 +100,9 @@ namespace iDynTree
         /**
          * Getters & setters
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         const MotionForceSemanticsT& getSemantics() const;
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setSemantics(MotionForceSemanticsT& _semantics);
 
         /**

--- a/src/core/include/iDynTree/Core/LinearForceVector3.h
+++ b/src/core/include/iDynTree/Core/LinearForceVector3.h
@@ -26,7 +26,9 @@ namespace iDynTree
          * Constructors:
          */
         inline LinearForceVector3Semantics() {}
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         LinearForceVector3Semantics(int _body, int _refBody, int _coordinateFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         LinearForceVector3Semantics(const LinearForceVector3Semantics & other);
     };
 

--- a/src/core/include/iDynTree/Core/LinearMotionVector3.h
+++ b/src/core/include/iDynTree/Core/LinearMotionVector3.h
@@ -34,17 +34,21 @@ namespace iDynTree
          * Constructors:
          */
         inline LinearMotionVector3Semantics() {}
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         LinearMotionVector3Semantics(int _point, int _body, int _refBody, int _coordinateFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         LinearMotionVector3Semantics(const LinearMotionVector3Semantics & other);
 
         /**
          * Semantics operations
          * Compute the semantics of the result given the semantics of the operands.
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         bool changePoint(const PositionSemantics & newPoint,
                          const AngularMotionVector3Semantics & otherAngular,
                          LinearMotionVector3Semantics & resultLinear) const;
 
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         static bool compose(const LinearMotionVector3Semantics & op1,
                             const LinearMotionVector3Semantics & op2,
                             LinearMotionVector3Semantics & result);

--- a/src/core/include/iDynTree/Core/Position.h
+++ b/src/core/include/iDynTree/Core/Position.h
@@ -74,11 +74,13 @@ namespace iDynTree
         /**
          * Semantic getter
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         PositionSemantics& getSemantics();
 
         /**
          * Const Semantic getter
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         const PositionSemantics& getSemantics() const;
 
         /**

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -91,11 +91,13 @@ namespace iDynTree
         /**
          * Semantic getter
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         RotationSemantics& getSemantics();
 
         /**
          * Semantic getter
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         const RotationSemantics& getSemantics() const;
 
         /**

--- a/src/core/include/iDynTree/Core/RotationSemantics.h
+++ b/src/core/include/iDynTree/Core/RotationSemantics.h
@@ -13,6 +13,8 @@
 
 #include <string>
 
+#include <iDynTree/Core/Utils.h>
+
 namespace iDynTree
 {
     class PositionSemantics;
@@ -22,7 +24,8 @@ namespace iDynTree
      *
      * \ingroup iDynTreeCore
      */
-    class RotationSemantics
+    class
+    RotationSemantics
     {
     protected:
         int orientationFrame;
@@ -54,13 +57,16 @@ namespace iDynTree
          * Constructor: initialize semantics from individual parameters
          *
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         RotationSemantics(int _orientationFrame, int _body, int _refOrientationFrame, int _refBody);
 
         /**
          * Copy constructor: create a RotationSemantics from another RotationSemantics
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         RotationSemantics(const RotationSemantics & other);
 
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setToUnknown();
 
         /**
@@ -68,16 +74,26 @@ namespace iDynTree
          *  Semantics setters and getters.
          */
         ///@{
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         int getOrientationFrame() const;
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         int getBody() const;
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         int getReferenceOrientationFrame() const;
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         int getRefBody() const;
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         int getCoordinateFrame() const;
 
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setOrientationFrame(int _orientationFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setBody(int _body);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setReferenceOrientationFrame(int _refOrientationFrame);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setRefBody(int _refBody);
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         void setCoordinateFrame(int _coordinateFrame);
     ///@}
 

--- a/src/core/include/iDynTree/Core/SpatialVector.h
+++ b/src/core/include/iDynTree/Core/SpatialVector.h
@@ -47,6 +47,7 @@ SpatialVectorSemantics<LinearVec3SemanticsT, AngularVec3SemanticsT>
          */
         SpatialVectorSemantics(LinearVec3SemanticsT & linearVec3, AngularVec3SemanticsT & angularVec3);
 
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         bool check_linear2angularConsistency(const LinearVec3SemanticsT & linearVec3, const AngularVec3SemanticsT & angularVec3);
 
         /**

--- a/src/core/include/iDynTree/Core/Transform.h
+++ b/src/core/include/iDynTree/Core/Transform.h
@@ -134,11 +134,13 @@ namespace iDynTree
         /**
          * Semantic accessor
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         TransformSemantics & getSemantics();
 
         /**
          * Const semantic getter
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         const TransformSemantics & getSemantics() const;
 
         /**

--- a/src/core/include/iDynTree/Core/TransformSemantics.h
+++ b/src/core/include/iDynTree/Core/TransformSemantics.h
@@ -13,6 +13,8 @@
 
 #include <string>
 
+#include <iDynTree/Core/Utils.h>
+
 namespace iDynTree
 {
     class PositionSemantics;
@@ -44,12 +46,14 @@ namespace iDynTree
         /**
          * Constructor: initialize all semantics from a Transform object (create links)
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         TransformSemantics(PositionSemantics & position, RotationSemantics & rotation);
 
 
         /**
          * Get the rotation part of the transform
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         const RotationSemantics & getRotationSemantics() const;
 
         /**
@@ -60,11 +64,13 @@ namespace iDynTree
         /**
          * Set the rotation part of the transform
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         bool setRotationSemantics(const RotationSemantics & rotation);
 
         /**
          * Set the translation part of the transform
          */
+        IDYNTREE_DEPRECATED_WITH_MSG("All iDynTree semantics class and  methods will be removed in iDynTree 2.0")
         bool setPositionSemantics(const PositionSemantics & position);
 
         /**

--- a/src/core/include/iDynTree/Core/Utils.h
+++ b/src/core/include/iDynTree/Core/Utils.h
@@ -20,31 +20,24 @@
  */
 #define IDYNTREE_UNUSED(var) ((void)var)
 
+
+// Note: we set IDYNTREE_DEPRECATED to nothing when compiling idyntree-core and
+// idyntree-high-level because some deprecated functions (mainly related to semantics)
+// need still too be used, as they are going to be removed without any replacement
+// When this functions will be removed as part of iDynTree 2.0, we can remove this special case
+// Furthermore, SWIG has some problems with this attributes, so until we use a recent SWIG version
+// we also disabled them for SWIG
 /**
  * \brief Macro to deprecate functions and methods
  *
  * see https://blog.samat.io/2017/02/27/Deprecating-functions-and-methods-in-Cplusplus/
  */
-// C++14
-#if __cplusplus >= 201402L
-  #if defined(__has_cpp_attribute)
-    #if __has_cpp_attribute(deprecated)
-      #define IDYNTREE_DEPRECATED [[deprecated]]
-      #define IDYNTREE_DEPRECATED_WITH_MSG(msg) [[deprecated(msg)]]
-    #endif
-  #endif
-// Earlier standards
+#if defined(idyntree_core_EXPORTS) || defined(idyntree_high_level_EXPORTS) || defined(SWIG)
+#define IDYNTREE_DEPRECATED
+#define IDYNTREE_DEPRECATED_WITH_MSG(msg)
 #else
-  #if defined(__GNUC__) || defined(__clang__)
-    #define IDYNTREE_DEPRECATED __attribute__((deprecated))
-    #define IDYNTREE_DEPRECATED_WITH_MSG(msg) __attribute__((deprecated(msg)))
-  #elif defined(_MSC_VER)
-    #define IDYNTREE_DEPRECATED __declspec(deprecated)
-    #define IDYNTREE_DEPRECATED_WITH_MSG(msg) __declspec(deprecated(msg))
-  #else
-    #define IDYNTREE_DEPRECATED
-    #define IDYNTREE_DEPRECATED_WITH_MSG(msg)
-  #endif
+#define IDYNTREE_DEPRECATED [[deprecated]]
+#define IDYNTREE_DEPRECATED_WITH_MSG(msg) [[deprecated(msg)]]
 #endif
 
 namespace iDynTree

--- a/src/core/include/iDynTree/Core/Wrench.h
+++ b/src/core/include/iDynTree/Core/Wrench.h
@@ -20,7 +20,6 @@ namespace iDynTree
      *
      * \ingroup iDynTreeCore
      *
-     * Currently this class does not support semantics.
      */
     class Wrench: public SpatialForceVector
     {


### PR DESCRIPTION
The idea of optionally embed semantics information in the core data structures of iDynTree (in which frame a position is expressed, w.r.t. to which frame the derivative of a velocities is taken) was something we worked back in 2015 with @nunoguedelha, see the "Semantics check" section in https://github.com/robotology/idyntree/issues/29 .

While being an interesting feature that address a clear user need, it was never effectivly used for the following reasons: 
* A lot of computations in estimators/controllers does not use iDynTree classes, but rather Matlab code or semantics-less C++ libraries such as Eigen . 
* The semantics was only provided for position and velocities, and we then realized that it would be non-trivial to properly extend them to forces, inertia and accelerations that are the quantities tipically used in Dynamics. 

While the presence of this code is mostly harmless at the moment, it drastically complicates the readability of the library both for new users of iDynTree interesting in contributing functionalities, and also for experienced users that may want to refactor the core of iDynTree to add new functionalities such as auto-diff. For this reason, as discussed with @nunoguedelha even if it makes me sad the best choice is to deprecated this code in iDynTree 1.0, and remove it in iDynTree 2.0 .  

This PR deprecates all the methods of the classes that end in `Semantics`, and all the methods that return semantics classes such as `getSemantics` or `setSemantics` . The actual code will be removed during the iDynTree 2.0 development. 