### PR TITLE
Add libqt5charts5-dev package in GitHub Action and fix YARP Thrift include problem.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
-                             libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev \
+                             libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5charts5-dev \
                              libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev
         
     - name: Source-based Dependencies [Windows] 

--- a/src/tools/plotter/include/ChartsManager.h
+++ b/src/tools/plotter/include/ChartsManager.h
@@ -2,8 +2,8 @@
 #define IDYNTREE_PLOTTER_CHARTSMANAGER_H
 
 
-#include "thrifts/ChartsService.h"
-#include "thrifts/RealTimeStreamData.h"
+#include <ChartsService.h>
+#include <RealTimeStreamData.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/sig/Vector.h>


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/624 . It would be nice to get this merged as it is currently creating a failure in robotology-superbuild CI. 