### PR TITLE
Change compatibility of CMake config files from SameMajorVersion to AnyNewerVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2020-01-14
+
+### Fixed
+- Change CMake version compatibility from [SameMajorVersion to AnyNewerVersion](https://cmake.org/cmake/help/v3.12/module/CMakePackageConfigHelpers.html#generating-a-package-version-file), as API breakage between major version will be limited, and to avoid breaking the compatibility of any downstream project that request a minimum version of iDynTree as in `find_package(iDynTree 0.11 REQUIRED)` (https://github.com/robotology/idyntree/pull/629).
+
 ## [1.0.0] - 2020-01-14
 
 ### Added
@@ -45,7 +50,7 @@ to normalize errors or as initial points of a nonlinear optimization procedure.
 - Add nameIsValid attribute to iDynTree::SolidShape class.
 - Add operator[] method to `iDynTree::VectorDynSize` (https://github.com/robotology/idyntree/pull/596)
 - Add operator[] method to `iDynTree::VectorFixSize` (https://github.com/robotology/idyntree/pull/596)
-- Implement `getTotalMass()` method for Model class
+- Implement `getTotalMass()` method for Model class(
 - Enable the installation of the `ModelTestUtils.h` file (https://github.com/robotology/idyntree/pull/607)
 - Added `iDynTree::ModelExporter` class to export `iDynTree::Model` instances to URDF files (https://github.com/robotology/idyntree/pull/554).
 - Added support in the URDF parser to correctly parse the optional name parameter of visual and collision elements.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if(NOT IDYNTREE_ONLY_DOCS)
     include(InstallBasicPackageFiles)
     install_basic_package_files(iDynTree VARS_PREFIX ${VARS_PREFIX}
                                          VERSION ${${VARS_PREFIX}_VERSION}
-                                         COMPATIBILITY SameMajorVersion
+                                         COMPATIBILITY AnyNewerVersion
                                          TARGETS_PROPERTY ${VARS_PREFIX}_TARGETS
                                          NO_CHECK_REQUIRED_COMPONENTS_MACRO
                                          ENABLE_COMPATIBILITY_VARS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(VARS_PREFIX "iDynTree")
 
 set(${VARS_PREFIX}_MAJOR_VERSION 1)
 set(${VARS_PREFIX}_MINOR_VERSION 0)
-set(${VARS_PREFIX}_PATCH_VERSION 0)
+set(${VARS_PREFIX}_PATCH_VERSION 1)
 set(${VARS_PREFIX}_VERSION ${${VARS_PREFIX}_MAJOR_VERSION}.${${VARS_PREFIX}_MINOR_VERSION}.${${VARS_PREFIX}_PATCH_VERSION})
 
 # Pick up our CMake scripts - they are all in the cmake subdirectory.


### PR DESCRIPTION
Even if in the future major version can be breaking, for the main classes it would be 
relatively easy to have a codebase that is compatible with multiple iDynTree major versions. 
For this reason, I think it make sense to switch the CMake policy to `AnyNewerVersion` .
If any downstream user wants to use a different policy, it can always manually check inspect the `iDynTree_VERSION` CMake variable.