### PR TITLE
Add thrift from the include path of thrift-generated files

### DIFF
--- a/src/tools/plotter/include/ChartsManager.h
+++ b/src/tools/plotter/include/ChartsManager.h
@@ -2,8 +2,8 @@
 #define IDYNTREE_PLOTTER_CHARTSMANAGER_H
 
 
-#include <ChartsService.h>
-#include <RealTimeStreamData.h>
+#include <thrifts/ChartsService.h>
+#include <thrifts/RealTimeStreamData.h>
 #include <yarp/os/Port.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/sig/Vector.h>


### PR DESCRIPTION
It solves https://github.com/robotology/idyntree/issues/630 by reverting the changes done in https://github.com/robotology/idyntree/pull/625.