### PR TITLE
Update matlab bindings adding inverse-kinematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `bindings` for `InverseKinematics` (https://github.com/robotology/idyntree/pull/633)
+
 ### Fixed 
 - Remove spurious inclusion of Eigen headers in ExtendedKalmanFilter.h public header, that could create probles when using that header in a downstream project that does not use Eigen (https://github.com/robotology/idyntree/pull/639).
 

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -136,6 +136,10 @@
 // Visualization
 #include "iDynTree/Visualizer.h"
 
+// Inverse Kinematics
+#include "iDynTree/ConvexHullHelpers.h"
+#include "iDynTree/InverseKinematics.h"
+
 // Legacy high level interfaces
 #include "iDynTree/HighLevel/DynamicsComputations.h"
 
@@ -344,6 +348,10 @@ TEMPLATE_WRAP_MOTION_FORCE(ForceVector3, WRAP_FORCE, SET_NAME_FOR_WRAPPER,,)
 
 // Visualization
 %include "iDynTree/Visualizer.h"
+
+// Inverse Kinematics
+%include "iDynTree/ConvexHullHelpers.h"
+%include "iDynTree/InverseKinematics.h"
 
 // Legacy high level interfaces
 %include "iDynTree/HighLevel/DynamicsComputations.h"

--- a/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
@@ -7,58 +7,58 @@ classdef AccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1377, varargin{:});
+        tmp = iDynTreeMEX(1383, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1378, self);
+        iDynTreeMEX(1384, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1379, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1380, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1381, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1382, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1383, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1384, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1385, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1386, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1387, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1388, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1389, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1390, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1391, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1392, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1393, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1394, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1395, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1396, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1397, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1398, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3.m
@@ -7,17 +7,17 @@ classdef AngularForceVector3 < iDynTree.ForceVector3__AngularForceVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(519, varargin{:});
+        tmp = iDynTreeMEX(525, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(520, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(526, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(521, self);
+        iDynTreeMEX(527, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef AngularForceVector3Semantics < iDynTree.ForceVector3Semantics__AngularF
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(515, varargin{:});
+        tmp = iDynTreeMEX(521, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(516, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(522, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(518, self);
+        iDynTreeMEX(524, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(517, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(523, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3.m
@@ -7,17 +7,17 @@ classdef AngularMotionVector3 < iDynTree.MotionVector3__AngularMotionVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(508, varargin{:});
+        tmp = iDynTreeMEX(514, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = exp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(509, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(515, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(510, self);
+        iDynTreeMEX(516, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3Semantics.m
@@ -7,14 +7,14 @@ classdef AngularMotionVector3Semantics < iDynTree.GeomVector3Semantics__AngularM
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(506, varargin{:});
+        tmp = iDynTreeMEX(512, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(507, self);
+        iDynTreeMEX(513, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = ArticulatedBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1292, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1298, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
@@ -9,48 +9,18 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1270, varargin{:});
+        tmp = iDynTreeMEX(1276, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1271, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1277, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1272, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1278, self, varargin{:});
     end
     function varargout = S(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1273, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1274, self, varargin{1});
-      end
-    end
-    function varargout = U(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1275, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1276, self, varargin{1});
-      end
-    end
-    function varargout = D(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1277, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1278, self, varargin{1});
-      end
-    end
-    function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -60,7 +30,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1280, self, varargin{1});
       end
     end
-    function varargout = linksVel(self, varargin)
+    function varargout = U(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -70,7 +40,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1282, self, varargin{1});
       end
     end
-    function varargout = linksBiasAcceleration(self, varargin)
+    function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -80,7 +50,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1284, self, varargin{1});
       end
     end
-    function varargout = linksAccelerations(self, varargin)
+    function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -90,7 +60,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1286, self, varargin{1});
       end
     end
-    function varargout = linkABIs(self, varargin)
+    function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -100,7 +70,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1288, self, varargin{1});
       end
     end
-    function varargout = linksBiasWrench(self, varargin)
+    function varargout = linksBiasAcceleration(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -110,9 +80,39 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1290, self, varargin{1});
       end
     end
+    function varargout = linksAccelerations(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1291, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1292, self, varargin{1});
+      end
+    end
+    function varargout = linkABIs(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1293, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1294, self, varargin{1});
+      end
+    end
+    function varargout = linksBiasWrench(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1295, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1296, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1291, self);
+        iDynTreeMEX(1297, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyInertia.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyInertia.m
@@ -9,57 +9,57 @@ classdef ArticulatedBodyInertia < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(678, varargin{:});
+        tmp = iDynTreeMEX(684, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearLinearSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(679, self, varargin{:});
-    end
-    function varargout = getLinearAngularSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(680, self, varargin{:});
-    end
-    function varargout = getAngularAngularSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(681, self, varargin{:});
-    end
-    function varargout = applyInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(683, self, varargin{:});
-    end
-    function varargout = asMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(684, self, varargin{:});
-    end
-    function varargout = getInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(685, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = getLinearAngularSubmatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(686, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = getAngularAngularSubmatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(687, self, varargin{:});
     end
+    function varargout = applyInverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(689, self, varargin{:});
+    end
+    function varargout = asMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(690, self, varargin{:});
+    end
+    function varargout = getInverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(691, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(692, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(693, self, varargin{:});
+    end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(688, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(694, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(689, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(695, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(692, self);
+        iDynTreeMEX(698, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(682, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(688, varargin{:});
     end
     function varargout = ABADyadHelper(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(690, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(696, varargin{:});
     end
     function varargout = ABADyadHelperLin(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(691, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(697, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
@@ -7,30 +7,30 @@ classdef AttitudeEstimatorState < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1662, self);
+        varargout{1} = iDynTreeMEX(1668, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1663, self, varargin{1});
+        iDynTreeMEX(1669, self, varargin{1});
       end
     end
     function varargout = m_angular_velocity(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1664, self);
+        varargout{1} = iDynTreeMEX(1670, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1665, self, varargin{1});
+        iDynTreeMEX(1671, self, varargin{1});
       end
     end
     function varargout = m_gyroscope_bias(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1666, self);
+        varargout{1} = iDynTreeMEX(1672, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1667, self, varargin{1});
+        iDynTreeMEX(1673, self, varargin{1});
       end
     end
     function self = AttitudeEstimatorState(varargin)
@@ -39,14 +39,14 @@ classdef AttitudeEstimatorState < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1668, varargin{:});
+        tmp = iDynTreeMEX(1674, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1669, self);
+        iDynTreeMEX(1675, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
@@ -7,68 +7,68 @@ classdef AttitudeMahonyFilter < iDynTree.IAttitudeEstimator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1693, varargin{:});
+        tmp = iDynTreeMEX(1699, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = useMagnetoMeterMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1694, self, varargin{:});
-    end
-    function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
-    end
-    function varargout = setGainkp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
-    end
-    function varargout = setGainki(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
-    end
-    function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
-    end
-    function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
-    end
-    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
     end
-    function varargout = getParameters(self,varargin)
+    function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
     end
-    function varargout = updateFilterWithMeasurements(self,varargin)
+    function varargout = setGainkp(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
     end
-    function varargout = propagateStates(self,varargin)
+    function varargout = setGainki(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
+    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
+    function varargout = setGravityDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = getParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1707, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = updateFilterWithMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1708, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1709, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1710, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1711, self, varargin{:});
+    end
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1712, self, varargin{:});
+    end
+    function varargout = getInternalStateSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1713, self, varargin{:});
+    end
+    function varargout = getInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1714, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1715, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1716, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1717, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1712, self);
+        iDynTreeMEX(1718, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
@@ -7,43 +7,13 @@ classdef AttitudeMahonyFilterParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1681, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1682, self, varargin{1});
-      end
-    end
-    function varargout = kp(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1683, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1684, self, varargin{1});
-      end
-    end
-    function varargout = ki(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1685, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1686, self, varargin{1});
-      end
-    end
-    function varargout = use_magnetometer_measurements(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1687, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1688, self, varargin{1});
       end
     end
-    function varargout = confidence_magnetometer_measurements(self, varargin)
+    function varargout = kp(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -53,20 +23,50 @@ classdef AttitudeMahonyFilterParameters < SwigRef
         iDynTreeMEX(1690, self, varargin{1});
       end
     end
+    function varargout = ki(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1691, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1692, self, varargin{1});
+      end
+    end
+    function varargout = use_magnetometer_measurements(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1693, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1694, self, varargin{1});
+      end
+    end
+    function varargout = confidence_magnetometer_measurements(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1695, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1696, self, varargin{1});
+      end
+    end
     function self = AttitudeMahonyFilterParameters(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1691, varargin{:});
+        tmp = iDynTreeMEX(1697, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1692, self);
+        iDynTreeMEX(1698, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
@@ -11,74 +11,74 @@ classdef AttitudeQuaternionEKF < iDynTree.IAttitudeEstimator & iDynTree.Discrete
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1758, varargin{:});
+        tmp = iDynTreeMEX(1764, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
-    end
-    function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
-    end
-    function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
-    end
-    function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
-    end
-    function varargout = setBiasCorrelationTimeFactor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
-    end
-    function varargout = useMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
-    end
-    function varargout = setMeasurementNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
     end
-    function varargout = setSystemNoiseVariance(self,varargin)
+    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
     end
-    function varargout = setInitialStateCovariance(self,varargin)
+    function varargout = setGravityDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
     end
-    function varargout = initializeFilter(self,varargin)
+    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
     end
-    function varargout = updateFilterWithMeasurements(self,varargin)
+    function varargout = setBiasCorrelationTimeFactor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
     end
-    function varargout = propagateStates(self,varargin)
+    function varargout = useMagnetometerMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
+    function varargout = setMeasurementNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
+    function varargout = setSystemNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = setInitialStateCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = initializeFilter(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = updateFilterWithMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
+    end
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
+    end
+    function varargout = getInternalStateSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
+    end
+    function varargout = getInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1779, self);
+        iDynTreeMEX(1785, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
@@ -7,43 +7,13 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1736, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1737, self, varargin{1});
-      end
-    end
-    function varargout = bias_correlation_time_factor(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1738, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1739, self, varargin{1});
-      end
-    end
-    function varargout = accelerometer_noise_variance(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1740, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1741, self, varargin{1});
-      end
-    end
-    function varargout = magnetometer_noise_variance(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1742, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1743, self, varargin{1});
       end
     end
-    function varargout = gyroscope_noise_variance(self, varargin)
+    function varargout = bias_correlation_time_factor(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -53,7 +23,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1745, self, varargin{1});
       end
     end
-    function varargout = gyro_bias_noise_variance(self, varargin)
+    function varargout = accelerometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -63,7 +33,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1747, self, varargin{1});
       end
     end
-    function varargout = initial_orientation_error_variance(self, varargin)
+    function varargout = magnetometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -73,7 +43,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1749, self, varargin{1});
       end
     end
-    function varargout = initial_ang_vel_error_variance(self, varargin)
+    function varargout = gyroscope_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -83,7 +53,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1751, self, varargin{1});
       end
     end
-    function varargout = initial_gyro_bias_error_variance(self, varargin)
+    function varargout = gyro_bias_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -93,7 +63,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1753, self, varargin{1});
       end
     end
-    function varargout = use_magnetometer_measurements(self, varargin)
+    function varargout = initial_orientation_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -103,20 +73,50 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1755, self, varargin{1});
       end
     end
+    function varargout = initial_ang_vel_error_variance(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1756, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1757, self, varargin{1});
+      end
+    end
+    function varargout = initial_gyro_bias_error_variance(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1758, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1759, self, varargin{1});
+      end
+    end
+    function varargout = use_magnetometer_measurements(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1760, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1761, self, varargin{1});
+      end
+    end
     function self = AttitudeQuaternionEKFParameters(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1756, varargin{:});
+        tmp = iDynTreeMEX(1762, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1757, self);
+        iDynTreeMEX(1763, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Axis.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Axis.m
@@ -9,62 +9,62 @@ classdef Axis < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(630, varargin{:});
+        tmp = iDynTreeMEX(636, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(631, self, varargin{:});
-    end
-    function varargout = getOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(632, self, varargin{:});
-    end
-    function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(633, self, varargin{:});
-    end
-    function varargout = setOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(634, self, varargin{:});
-    end
-    function varargout = getRotationTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(635, self, varargin{:});
-    end
-    function varargout = getRotationTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(636, self, varargin{:});
-    end
-    function varargout = getRotationTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(637, self, varargin{:});
     end
-    function varargout = getRotationSpatialAcc(self,varargin)
+    function varargout = getOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(638, self, varargin{:});
     end
-    function varargout = getTranslationTransform(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(639, self, varargin{:});
     end
-    function varargout = getTranslationTransformDerivative(self,varargin)
+    function varargout = setOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(640, self, varargin{:});
     end
-    function varargout = getTranslationTwist(self,varargin)
+    function varargout = getRotationTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(641, self, varargin{:});
     end
-    function varargout = getTranslationSpatialAcc(self,varargin)
+    function varargout = getRotationTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(642, self, varargin{:});
     end
-    function varargout = isParallel(self,varargin)
+    function varargout = getRotationTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(643, self, varargin{:});
     end
-    function varargout = reverse(self,varargin)
+    function varargout = getRotationSpatialAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(644, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getTranslationTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(645, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = getTranslationTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(646, self, varargin{:});
+    end
+    function varargout = getTranslationTwist(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(647, self, varargin{:});
+    end
+    function varargout = getTranslationSpatialAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(648, self, varargin{:});
+    end
+    function varargout = isParallel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(649, self, varargin{:});
+    end
+    function varargout = reverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(650, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(651, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(652, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(647, self);
+        iDynTreeMEX(653, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
@@ -7,37 +7,37 @@ classdef BerdyDynamicVariable < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1604, self);
+        varargout{1} = iDynTreeMEX(1610, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1605, self, varargin{1});
+        iDynTreeMEX(1611, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1606, self);
+        varargout{1} = iDynTreeMEX(1612, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1607, self, varargin{1});
+        iDynTreeMEX(1613, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1608, self);
+        varargout{1} = iDynTreeMEX(1614, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1609, self, varargin{1});
+        iDynTreeMEX(1615, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1610, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1611, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
     end
     function self = BerdyDynamicVariable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdyDynamicVariable < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1612, varargin{:});
+        tmp = iDynTreeMEX(1618, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1613, self);
+        iDynTreeMEX(1619, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
@@ -9,104 +9,104 @@ classdef BerdyHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1614, varargin{:});
+        tmp = iDynTreeMEX(1620, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1615, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1618, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1619, self, varargin{:});
-    end
-    function varargout = getOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1620, self, varargin{:});
-    end
-    function varargout = getNrOfDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
     end
-    function varargout = getNrOfDynamicEquations(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
     end
-    function varargout = getNrOfSensorsMeasurements(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
     end
-    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
     end
-    function varargout = getBerdyMatrices(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
     end
-    function varargout = getSensorsOrdering(self,varargin)
+    function varargout = getOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
     end
-    function varargout = getRangeSensorVariable(self,varargin)
+    function varargout = getNrOfDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
     end
-    function varargout = getRangeDOFSensorVariable(self,varargin)
+    function varargout = getNrOfDynamicEquations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
     end
-    function varargout = getRangeJointSensorVariable(self,varargin)
+    function varargout = getNrOfSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
     end
-    function varargout = getRangeLinkSensorVariable(self,varargin)
+    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
     end
-    function varargout = getRangeLinkVariable(self,varargin)
+    function varargout = getBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
     end
-    function varargout = getRangeJointVariable(self,varargin)
+    function varargout = getSensorsOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
     end
-    function varargout = getRangeDOFVariable(self,varargin)
+    function varargout = getRangeSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
     end
-    function varargout = getDynamicVariablesOrdering(self,varargin)
+    function varargout = getRangeDOFSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
     end
-    function varargout = serializeDynamicVariables(self,varargin)
+    function varargout = getRangeJointSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
     end
-    function varargout = serializeSensorVariables(self,varargin)
+    function varargout = getRangeLinkSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
     end
-    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
+    function varargout = getRangeLinkVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1637, self, varargin{:});
     end
-    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
+    function varargout = getRangeJointVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1638, self, varargin{:});
     end
-    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
+    function varargout = getRangeDOFVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1639, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+    function varargout = getDynamicVariablesOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1640, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = serializeDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1641, self, varargin{:});
     end
-    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+    function varargout = serializeSensorVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1642, self, varargin{:});
     end
-    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1643, self, varargin{:});
     end
-    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
+    end
+    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
+    end
+    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
+    end
+    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1645, self);
+        iDynTreeMEX(1651, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
@@ -9,42 +9,12 @@ classdef BerdyOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1575, varargin{:});
+        tmp = iDynTreeMEX(1581, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = berdyVariant(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1576, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1577, self, varargin{1});
-      end
-    end
-    function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1578, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1579, self, varargin{1});
-      end
-    end
-    function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1580, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1581, self, varargin{1});
-      end
-    end
-    function varargout = includeAllJointTorquesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -54,7 +24,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1583, self, varargin{1});
       end
     end
-    function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
+    function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -64,7 +34,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1585, self, varargin{1});
       end
     end
-    function varargout = includeFixedBaseExternalWrench(self, varargin)
+    function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -74,7 +44,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1587, self, varargin{1});
       end
     end
-    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
+    function varargout = includeAllJointTorquesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -84,7 +54,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1589, self, varargin{1});
       end
     end
-    function varargout = baseLink(self, varargin)
+    function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -94,12 +64,42 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1591, self, varargin{1});
       end
     end
+    function varargout = includeFixedBaseExternalWrench(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1592, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1593, self, varargin{1});
+      end
+    end
+    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1594, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1595, self, varargin{1});
+      end
+    end
+    function varargout = baseLink(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1596, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1597, self, varargin{1});
+      end
+    end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1593, self);
+        iDynTreeMEX(1599, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
@@ -7,37 +7,37 @@ classdef BerdySensor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1594, self);
+        varargout{1} = iDynTreeMEX(1600, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1595, self, varargin{1});
+        iDynTreeMEX(1601, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1596, self);
+        varargout{1} = iDynTreeMEX(1602, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1597, self, varargin{1});
+        iDynTreeMEX(1603, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1598, self);
+        varargout{1} = iDynTreeMEX(1604, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1599, self, varargin{1});
+        iDynTreeMEX(1605, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdySensor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1602, varargin{:});
+        tmp = iDynTreeMEX(1608, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1603, self);
+        iDynTreeMEX(1609, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
@@ -9,58 +9,58 @@ classdef BerdySparseMAPSolver < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1646, varargin{:});
+        tmp = iDynTreeMEX(1652, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1647, self);
+        iDynTreeMEX(1653, self);
         self.SwigClear();
       end
     end
     function varargout = setDynamicsConstraintsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
-    end
-    function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
-    end
-    function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
-    end
-    function varargout = setMeasurementsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
-    end
-    function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
-    end
-    function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1653, self, varargin{:});
-    end
-    function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1654, self, varargin{:});
     end
-    function varargout = measurementsPriorCovarianceInverse(self,varargin)
+    function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1655, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1656, self, varargin{:});
     end
-    function varargout = initialize(self,varargin)
+    function varargout = setMeasurementsPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1657, self, varargin{:});
     end
-    function varargout = updateEstimateInformationFixedBase(self,varargin)
+    function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1658, self, varargin{:});
     end
-    function varargout = updateEstimateInformationFloatingBase(self,varargin)
+    function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1659, self, varargin{:});
     end
-    function varargout = doEstimate(self,varargin)
+    function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1660, self, varargin{:});
     end
-    function varargout = getLastEstimate(self,varargin)
+    function varargout = measurementsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1661, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1662, self, varargin{:});
+    end
+    function varargout = initialize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1663, self, varargin{:});
+    end
+    function varargout = updateEstimateInformationFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1664, self, varargin{:});
+    end
+    function varargout = updateEstimateInformationFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1665, self, varargin{:});
+    end
+    function varargout = doEstimate(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1666, self, varargin{:});
+    end
+    function varargout = getLastEstimate(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1667, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Box.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Box.m
@@ -2,41 +2,41 @@ classdef Box < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1116, self);
+        iDynTreeMEX(1122, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1117, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1123, self, varargin{:});
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1118, self);
+        varargout{1} = iDynTreeMEX(1124, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1119, self, varargin{1});
+        iDynTreeMEX(1125, self, varargin{1});
       end
     end
     function varargout = y(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1120, self);
+        varargout{1} = iDynTreeMEX(1126, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1121, self, varargin{1});
+        iDynTreeMEX(1127, self, varargin{1});
       end
     end
     function varargout = z(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1122, self);
+        varargout{1} = iDynTreeMEX(1128, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1123, self, varargin{1});
+        iDynTreeMEX(1129, self, varargin{1});
       end
     end
     function self = Box(varargin)
@@ -46,7 +46,7 @@ classdef Box < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1124, varargin{:});
+        tmp = iDynTreeMEX(1130, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/ClassicalAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ClassicalAcc.m
@@ -7,30 +7,30 @@ classdef ClassicalAcc < iDynTree.Vector6
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(615, varargin{:});
+        tmp = iDynTreeMEX(621, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(616, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(622, self, varargin{:});
     end
     function varargout = fromSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(618, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(624, self, varargin{:});
     end
     function varargout = toSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(619, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(625, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(620, self);
+        iDynTreeMEX(626, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(617, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(623, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,40 +7,40 @@ classdef ColorViz < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1890, self);
+        varargout{1} = iDynTreeMEX(1896, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1891, self, varargin{1});
+        iDynTreeMEX(1897, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1892, self);
+        varargout{1} = iDynTreeMEX(1898, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1893, self, varargin{1});
+        iDynTreeMEX(1899, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1894, self);
+        varargout{1} = iDynTreeMEX(1900, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1895, self, varargin{1});
+        iDynTreeMEX(1901, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1896, self);
+        varargout{1} = iDynTreeMEX(1902, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1897, self, varargin{1});
+        iDynTreeMEX(1903, self, varargin{1});
       end
     end
     function self = ColorViz(varargin)
@@ -49,14 +49,14 @@ classdef ColorViz < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1898, varargin{:});
+        tmp = iDynTreeMEX(1904, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1899, self);
+        iDynTreeMEX(1905, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = CompositeRigidBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1269, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1275, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentum(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1266, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1272, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentumDerivativeBias(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1267, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1273, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
@@ -4,13 +4,13 @@ classdef ContactWrench < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = contactId(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
     end
     function varargout = contactPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
     end
     function self = ContactWrench(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -18,14 +18,14 @@ classdef ContactWrench < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1249, varargin{:});
+        tmp = iDynTreeMEX(1255, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1250, self);
+        iDynTreeMEX(1256, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
@@ -1,0 +1,140 @@
+classdef ConvexHullProjectionConstraint < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = setActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2004, self, varargin{:});
+    end
+    function varargout = isActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
+    end
+    function varargout = getNrOfConstraints(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
+    end
+    function varargout = projectedConvexHull(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2007, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2008, self, varargin{1});
+      end
+    end
+    function varargout = A(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2009, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2010, self, varargin{1});
+      end
+    end
+    function varargout = b(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2011, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2012, self, varargin{1});
+      end
+    end
+    function varargout = P(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2013, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2014, self, varargin{1});
+      end
+    end
+    function varargout = Pdirection(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2015, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2016, self, varargin{1});
+      end
+    end
+    function varargout = AtimesP(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2017, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2018, self, varargin{1});
+      end
+    end
+    function varargout = o(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2019, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2020, self, varargin{1});
+      end
+    end
+    function varargout = buildConvexHull(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2021, self, varargin{:});
+    end
+    function varargout = supportFrameIndices(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2022, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2023, self, varargin{1});
+      end
+    end
+    function varargout = absoluteFrame_X_supportFrame(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2024, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2025, self, varargin{1});
+      end
+    end
+    function varargout = project(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2026, self, varargin{:});
+    end
+    function varargout = computeMargin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2027, self, varargin{:});
+    end
+    function varargout = setProjectionAlongDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2028, self, varargin{:});
+    end
+    function varargout = projectAlongDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2029, self, varargin{:});
+    end
+    function self = ConvexHullProjectionConstraint(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(2030, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(2031, self);
+        self.SwigClear();
+      end
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
@@ -2,31 +2,31 @@ classdef Cylinder < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1125, self);
+        iDynTreeMEX(1131, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1126, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1132, self, varargin{:});
     end
     function varargout = length(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1127, self);
+        varargout{1} = iDynTreeMEX(1133, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1128, self, varargin{1});
+        iDynTreeMEX(1134, self, varargin{1});
       end
     end
     function varargout = radius(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1129, self);
+        varargout{1} = iDynTreeMEX(1135, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1130, self, varargin{1});
+        iDynTreeMEX(1136, self, varargin{1});
       end
     end
     function self = Cylinder(varargin)
@@ -36,7 +36,7 @@ classdef Cylinder < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1131, varargin{:});
+        tmp = iDynTreeMEX(1137, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialForceArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1201, varargin{:});
+        tmp = iDynTreeMEX(1207, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1202, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1203, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1210, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1205, self);
+        iDynTreeMEX(1211, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialMotionArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1206, varargin{:});
+        tmp = iDynTreeMEX(1212, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1207, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1214, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1215, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1210, self);
+        iDynTreeMEX(1216, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(851);
+    varargout{1} = iDynTreeMEX(857);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(852,varargin{1});
+    iDynTreeMEX(858,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(853);
+    varargout{1} = iDynTreeMEX(859);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(854,varargin{1});
+    iDynTreeMEX(860,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Direction.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Direction.m
@@ -7,39 +7,39 @@ classdef Direction < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(621, varargin{:});
+        tmp = iDynTreeMEX(627, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = Normalize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(622, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(628, self, varargin{:});
     end
     function varargout = isParallel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(623, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(629, self, varargin{:});
     end
     function varargout = isPerpendicular(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(624, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(630, self, varargin{:});
     end
     function varargout = reverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(625, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(631, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(626, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(632, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(627, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(633, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(629, self);
+        iDynTreeMEX(635, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Default(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(628, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(634, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
@@ -4,65 +4,65 @@ classdef DiscreteExtendedKalmanFilterHelper < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = ekf_f(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1713, self, varargin{:});
-    end
-    function varargout = ekf_h(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1714, self, varargin{:});
-    end
-    function varargout = ekfComputeJacobianF(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1715, self, varargin{:});
-    end
-    function varargout = ekfComputeJacobianH(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1716, self, varargin{:});
-    end
-    function varargout = ekfPredict(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1717, self, varargin{:});
-    end
-    function varargout = ekfUpdate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1718, self, varargin{:});
-    end
-    function varargout = ekfInit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1719, self, varargin{:});
     end
-    function varargout = ekfReset(self,varargin)
+    function varargout = ekf_h(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1720, self, varargin{:});
     end
-    function varargout = ekfSetMeasurementVector(self,varargin)
+    function varargout = ekfComputeJacobianF(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1721, self, varargin{:});
     end
-    function varargout = ekfSetInputVector(self,varargin)
+    function varargout = ekfComputeJacobianH(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1722, self, varargin{:});
     end
-    function varargout = ekfSetInitialState(self,varargin)
+    function varargout = ekfPredict(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1723, self, varargin{:});
     end
-    function varargout = ekfSetStateCovariance(self,varargin)
+    function varargout = ekfUpdate(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1724, self, varargin{:});
     end
-    function varargout = ekfSetSystemNoiseCovariance(self,varargin)
+    function varargout = ekfInit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1725, self, varargin{:});
     end
-    function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
+    function varargout = ekfReset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1726, self, varargin{:});
     end
-    function varargout = ekfSetStateSize(self,varargin)
+    function varargout = ekfSetMeasurementVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1727, self, varargin{:});
     end
-    function varargout = ekfSetInputSize(self,varargin)
+    function varargout = ekfSetInputVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1728, self, varargin{:});
     end
-    function varargout = ekfSetOutputSize(self,varargin)
+    function varargout = ekfSetInitialState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1729, self, varargin{:});
     end
-    function varargout = ekfGetStates(self,varargin)
+    function varargout = ekfSetStateCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1730, self, varargin{:});
     end
-    function varargout = ekfGetStateCovariance(self,varargin)
+    function varargout = ekfSetSystemNoiseCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1731, self, varargin{:});
+    end
+    function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
+    end
+    function varargout = ekfSetStateSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
+    end
+    function varargout = ekfSetInputSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
+    end
+    function varargout = ekfSetOutputSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
+    end
+    function varargout = ekfGetStates(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
+    end
+    function varargout = ekfGetStateCovariance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1732, self);
+        iDynTreeMEX(1738, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Dummy.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Dummy.m
@@ -9,14 +9,14 @@ classdef Dummy < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(582, varargin{:});
+        tmp = iDynTreeMEX(588, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(583, self);
+        iDynTreeMEX(589, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
@@ -9,78 +9,78 @@ classdef DynamicSpan < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(822, varargin{:});
+        tmp = iDynTreeMEX(828, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(823, self);
+        iDynTreeMEX(829, self);
         self.SwigClear();
       end
     end
     function varargout = first(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
-    end
-    function varargout = last(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(825, self, varargin{:});
-    end
-    function varargout = subspan(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(826, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(827, self, varargin{:});
-    end
-    function varargout = size_bytes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(828, self, varargin{:});
-    end
-    function varargout = empty(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(829, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(830, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = last(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(831, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = subspan(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(832, self, varargin{:});
     end
-    function varargout = at(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(833, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = size_bytes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(834, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(835, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(836, self, varargin{:});
     end
-    function varargout = cbegin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(837, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(838, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = at(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(839, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(840, self, varargin{:});
     end
-    function varargout = crbegin(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(841, self, varargin{:});
     end
-    function varargout = crend(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(842, self, varargin{:});
+    end
+    function varargout = cbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(843, self, varargin{:});
+    end
+    function varargout = cend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(844, self, varargin{:});
+    end
+    function varargout = rbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(845, self, varargin{:});
+    end
+    function varargout = rend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(846, self, varargin{:});
+    end
+    function varargout = crbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(847, self, varargin{:});
+    end
+    function varargout = crend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(848, self, varargin{:});
     end
   end
   methods(Static)
     function v = extent()
-      v = iDynTreeMEX(821);
+      v = iDynTreeMEX(827);
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsComputations.m
@@ -9,118 +9,118 @@ classdef DynamicsComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1980, varargin{:});
+        tmp = iDynTreeMEX(2097, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1981, self);
+        iDynTreeMEX(2098, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2099, self, varargin{:});
     end
     function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2100, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2101, self, varargin{:});
     end
     function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2102, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2103, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2104, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2105, self, varargin{:});
     end
     function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2106, self, varargin{:});
     end
     function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2107, self, varargin{:});
     end
     function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2108, self, varargin{:});
     end
     function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2109, self, varargin{:});
     end
     function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2110, self, varargin{:});
     end
     function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1994, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2111, self, varargin{:});
     end
     function varargout = getJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1995, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2112, self, varargin{:});
     end
     function varargout = getJointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1996, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2113, self, varargin{:});
     end
     function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1997, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2114, self, varargin{:});
     end
     function varargout = getFrameName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2115, self, varargin{:});
     end
     function varargout = getWorldTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2116, self, varargin{:});
     end
     function varargout = getRelativeTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2117, self, varargin{:});
     end
     function varargout = getFrameTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2118, self, varargin{:});
     end
     function varargout = getFrameTwistInWorldOrient(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2119, self, varargin{:});
     end
     function varargout = getFrameProperSpatialAcceleration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2003, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2120, self, varargin{:});
     end
     function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2004, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2121, self, varargin{:});
     end
     function varargout = getLinkInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2122, self, varargin{:});
     end
     function varargout = getJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2123, self, varargin{:});
     end
     function varargout = getJointName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2007, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2124, self, varargin{:});
     end
     function varargout = getJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2125, self, varargin{:});
     end
     function varargout = inverseDynamics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2009, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2126, self, varargin{:});
     end
     function varargout = getFreeFloatingMassMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2010, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2127, self, varargin{:});
     end
     function varargout = getFrameJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2011, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2128, self, varargin{:});
     end
     function varargout = getDynamicsRegressor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2012, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2129, self, varargin{:});
     end
     function varargout = getModelDynamicsParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2013, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2130, self, varargin{:});
     end
     function varargout = getCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2014, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2131, self, varargin{:});
     end
     function varargout = getCenterOfMassJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2015, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2132, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorGenerator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorGenerator.m
@@ -9,100 +9,100 @@ classdef DynamicsRegressorGenerator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1801, varargin{:});
+        tmp = iDynTreeMEX(1807, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1802, self);
+        iDynTreeMEX(1808, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotAndSensorsModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
-    end
-    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
-    end
-    function varargout = loadRegressorStructureFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
-    end
-    function varargout = loadRegressorStructureFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
-    end
-    function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
-    end
-    function varargout = getNrOfOutputs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
     end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
+    function varargout = loadRobotAndSensorsModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
     end
-    function varargout = getDescriptionOfParameter(self,varargin)
+    function varargout = loadRegressorStructureFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
     end
-    function varargout = getDescriptionOfParameters(self,varargin)
+    function varargout = loadRegressorStructureFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
     end
-    function varargout = getDescriptionOfOutput(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
     end
-    function varargout = getDescriptionOfOutputs(self,varargin)
+    function varargout = getNrOfParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = getNrOfOutputs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
     end
-    function varargout = getDescriptionOfLink(self,varargin)
+    function varargout = getDescriptionOfParameter(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
     end
-    function varargout = getDescriptionOfLinks(self,varargin)
+    function varargout = getDescriptionOfParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = getDescriptionOfOutput(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
     end
-    function varargout = getNrOfFakeLinks(self,varargin)
+    function varargout = getDescriptionOfOutputs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
     end
-    function varargout = getBaseLinkName(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
     end
-    function varargout = getSensorsModel(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = getDescriptionOfLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
     end
-    function varargout = getSensorsMeasurements(self,varargin)
+    function varargout = getDescriptionOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
     end
-    function varargout = setTorqueSensorMeasurement(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
     end
-    function varargout = computeRegressor(self,varargin)
+    function varargout = getNrOfFakeLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
     end
-    function varargout = getModelParameters(self,varargin)
+    function varargout = getBaseLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
     end
-    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
+    function varargout = getSensorsModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
     end
-    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
     end
-    function varargout = generate_random_regressors(self,varargin)
+    function varargout = getSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
+    end
+    function varargout = setTorqueSensorMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
+    end
+    function varargout = computeRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
+    end
+    function varargout = getModelParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
+    end
+    function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
+    end
+    function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
+    end
+    function varargout = generate_random_regressors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParameter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParameter.m
@@ -7,40 +7,40 @@ classdef DynamicsRegressorParameter < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1781, self);
+        varargout{1} = iDynTreeMEX(1787, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1782, self, varargin{1});
+        iDynTreeMEX(1788, self, varargin{1});
       end
     end
     function varargout = elemIndex(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1783, self);
+        varargout{1} = iDynTreeMEX(1789, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1784, self, varargin{1});
+        iDynTreeMEX(1790, self, varargin{1});
       end
     end
     function varargout = type(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1785, self);
+        varargout{1} = iDynTreeMEX(1791, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1786, self, varargin{1});
+        iDynTreeMEX(1792, self, varargin{1});
       end
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
     end
     function varargout = ne(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
     end
     function self = DynamicsRegressorParameter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -48,14 +48,14 @@ classdef DynamicsRegressorParameter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1790, varargin{:});
+        tmp = iDynTreeMEX(1796, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1791, self);
+        iDynTreeMEX(1797, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParametersList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParametersList.m
@@ -7,26 +7,26 @@ classdef DynamicsRegressorParametersList < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1792, self);
+        varargout{1} = iDynTreeMEX(1798, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1793, self, varargin{1});
+        iDynTreeMEX(1799, self, varargin{1});
       end
     end
     function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
     end
     function varargout = addParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
     end
     function varargout = addList(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
     end
     function varargout = findParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
     end
     function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
     end
     function self = DynamicsRegressorParametersList(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -34,14 +34,14 @@ classdef DynamicsRegressorParametersList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1799, varargin{:});
+        tmp = iDynTreeMEX(1805, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1800, self);
+        iDynTreeMEX(1806, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
@@ -9,52 +9,52 @@ classdef ExtWrenchesAndJointTorquesEstimator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1546, varargin{:});
+        tmp = iDynTreeMEX(1552, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1547, self);
+        iDynTreeMEX(1553, self);
         self.SwigClear();
       end
     end
     function varargout = setModelAndSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1548, self, varargin{:});
-    end
-    function varargout = loadModelAndSensorsFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1549, self, varargin{:});
-    end
-    function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1550, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1551, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1552, self, varargin{:});
-    end
-    function varargout = submodels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1553, self, varargin{:});
-    end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1554, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = loadModelAndSensorsFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1555, self, varargin{:});
     end
-    function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
+    function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1556, self, varargin{:});
     end
-    function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1557, self, varargin{:});
     end
-    function varargout = checkThatTheModelIsStill(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1558, self, varargin{:});
     end
-    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+    function varargout = submodels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1559, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1560, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1561, self, varargin{:});
+    end
+    function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1562, self, varargin{:});
+    end
+    function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1563, self, varargin{:});
+    end
+    function varargout = checkThatTheModelIsStill(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
+    end
+    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1565, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
@@ -2,31 +2,31 @@ classdef ExternalMesh < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1132, self);
+        iDynTreeMEX(1138, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1133, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
     end
     function varargout = filename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1134, self);
+        varargout{1} = iDynTreeMEX(1140, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1135, self, varargin{1});
+        iDynTreeMEX(1141, self, varargin{1});
       end
     end
     function varargout = scale(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1136, self);
+        varargout{1} = iDynTreeMEX(1142, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1137, self, varargin{1});
+        iDynTreeMEX(1143, self, varargin{1});
       end
     end
     function self = ExternalMesh(varargin)
@@ -36,7 +36,7 @@ classdef ExternalMesh < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1138, varargin{:});
+        tmp = iDynTreeMEX(1144, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(855);
+    varargout{1} = iDynTreeMEX(861);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(856,varargin{1});
+    iDynTreeMEX(862,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(857);
+    varargout{1} = iDynTreeMEX(863);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(858,varargin{1});
+    iDynTreeMEX(864,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
@@ -7,103 +7,103 @@ classdef FixedJoint < iDynTree.IJoint
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(941, varargin{:});
+        tmp = iDynTreeMEX(947, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(942, self);
+        iDynTreeMEX(948, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(943, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(944, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(945, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(946, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(947, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(948, self, varargin{:});
-    end
-    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(949, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(950, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(951, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(952, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(953, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(954, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(955, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(956, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(964, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(966, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
+    end
+    function varargout = hasPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
+    end
+    function varargout = enablePosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__AngularForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__AngularForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef ForceVector3Semantics__AngularForceVector3Semantics < iDynTree.GeomVect
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(485, varargin{:});
+        tmp = iDynTreeMEX(491, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(488, self);
+        iDynTreeMEX(494, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(486, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(492, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(487, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(493, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__LinearForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__LinearForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef ForceVector3Semantics__LinearForceVector3Semantics < iDynTree.GeomVecto
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(481, varargin{:});
+        tmp = iDynTreeMEX(487, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(484, self);
+        iDynTreeMEX(490, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(482, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(488, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(483, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(489, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3__AngularForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3__AngularForceVector3.m
@@ -7,14 +7,14 @@ classdef ForceVector3__AngularForceVector3 < iDynTree.GeomVector3__AngularForceV
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(497, varargin{:});
+        tmp = iDynTreeMEX(503, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(498, self);
+        iDynTreeMEX(504, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3__LinearForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3__LinearForceVector3.m
@@ -7,14 +7,14 @@ classdef ForceVector3__LinearForceVector3 < iDynTree.GeomVector3__LinearForceVec
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(495, varargin{:});
+        tmp = iDynTreeMEX(501, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(496, self);
+        iDynTreeMEX(502, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1264, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1270, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardBiasAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1265, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1271, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1262, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1268, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1263, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1269, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPositionKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1260, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1266, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1261, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1267, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef FrameFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1211, varargin{:});
+        tmp = iDynTreeMEX(1217, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1212, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1218, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1219, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1214, self);
+        iDynTreeMEX(1220, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
@@ -9,26 +9,26 @@ classdef FreeFloatingAcc < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1240, varargin{:});
+        tmp = iDynTreeMEX(1246, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1241, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
     end
     function varargout = baseAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
     end
     function varargout = jointAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1249, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1245, self);
+        iDynTreeMEX(1251, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
@@ -9,26 +9,26 @@ classdef FreeFloatingGeneralizedTorques < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1228, varargin{:});
+        tmp = iDynTreeMEX(1234, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1229, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1235, self, varargin{:});
     end
     function varargout = baseWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1230, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1236, self, varargin{:});
     end
     function varargout = jointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1231, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1237, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1232, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1233, self);
+        iDynTreeMEX(1239, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
@@ -7,17 +7,17 @@ classdef FreeFloatingMassMatrix < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1219, varargin{:});
+        tmp = iDynTreeMEX(1225, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1220, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1226, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1221, self);
+        iDynTreeMEX(1227, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
@@ -9,26 +9,26 @@ classdef FreeFloatingPos < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1222, varargin{:});
+        tmp = iDynTreeMEX(1228, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1223, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1229, self, varargin{:});
     end
     function varargout = worldBasePos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1224, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1230, self, varargin{:});
     end
     function varargout = jointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1225, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1231, self, varargin{:});
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1226, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1232, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1227, self);
+        iDynTreeMEX(1233, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
@@ -9,26 +9,26 @@ classdef FreeFloatingVel < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1234, varargin{:});
+        tmp = iDynTreeMEX(1240, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1235, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1241, self, varargin{:});
     end
     function varargout = baseVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1236, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
     end
     function varargout = jointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1237, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1239, self);
+        iDynTreeMEX(1245, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularForceVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__AngularForceVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(422, varargin{:});
+        tmp = iDynTreeMEX(428, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(423, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(429, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(424, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(430, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(425, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(431, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(426, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(432, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(427, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(433, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(428, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(434, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(431, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(437, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(432, self);
+        iDynTreeMEX(438, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(429, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(435, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(430, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(436, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularMotionVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__AngularMotionVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(400, varargin{:});
+        tmp = iDynTreeMEX(406, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(407, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(402, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(408, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(403, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(409, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(404, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(410, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(405, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(411, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(406, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(412, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(409, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(415, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(410, self);
+        iDynTreeMEX(416, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(407, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(413, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(408, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(414, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearForceVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__LinearForceVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(411, varargin{:});
+        tmp = iDynTreeMEX(417, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(412, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(418, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(413, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(419, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(414, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(420, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(415, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(421, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(416, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(422, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(417, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(423, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(420, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(426, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(421, self);
+        iDynTreeMEX(427, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(418, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(424, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(419, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(425, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearMotionVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__LinearMotionVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(389, varargin{:});
+        tmp = iDynTreeMEX(395, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(390, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(396, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(391, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(397, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(392, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(398, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(393, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(399, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(394, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(400, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(395, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(398, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(404, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(399, self);
+        iDynTreeMEX(405, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(396, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(402, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(397, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(403, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularForceVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__AngularForceVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(469, self);
+        varargout{1} = iDynTreeMEX(475, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(470, self, varargin{1});
+        iDynTreeMEX(476, self, varargin{1});
       end
     end
     function self = GeomVector3__AngularForceVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__AngularForceVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(471, varargin{:});
+        tmp = iDynTreeMEX(477, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(472, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(473, self, varargin{:});
-    end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(476, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(477, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(478, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(479, self, varargin{:});
+    end
+    function varargout = dot(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(482, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(483, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(484, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(485, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(480, self);
+        iDynTreeMEX(486, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(474, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(480, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(475, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(481, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularMotionVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__AngularMotionVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(445, self);
+        varargout{1} = iDynTreeMEX(451, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(446, self, varargin{1});
+        iDynTreeMEX(452, self, varargin{1});
       end
     end
     function self = GeomVector3__AngularMotionVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__AngularMotionVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(447, varargin{:});
+        tmp = iDynTreeMEX(453, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(448, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(449, self, varargin{:});
-    end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(452, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(453, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(454, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(455, self, varargin{:});
+    end
+    function varargout = dot(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(458, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(459, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(460, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(456, self);
+        iDynTreeMEX(462, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(450, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(456, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(451, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(457, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearForceVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__LinearForceVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(457, self);
+        varargout{1} = iDynTreeMEX(463, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(458, self, varargin{1});
+        iDynTreeMEX(464, self, varargin{1});
       end
     end
     function self = GeomVector3__LinearForceVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__LinearForceVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(459, varargin{:});
+        tmp = iDynTreeMEX(465, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(460, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
-    end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(464, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(465, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(466, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(467, self, varargin{:});
+    end
+    function varargout = dot(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(470, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(471, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(472, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(473, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(468, self);
+        iDynTreeMEX(474, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(462, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(468, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(463, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(469, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearMotionVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__LinearMotionVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(433, self);
+        varargout{1} = iDynTreeMEX(439, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(434, self, varargin{1});
+        iDynTreeMEX(440, self, varargin{1});
       end
     end
     function self = GeomVector3__LinearMotionVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__LinearMotionVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(435, varargin{:});
+        tmp = iDynTreeMEX(441, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(436, self, varargin{:});
-    end
-    function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(437, self, varargin{:});
-    end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(440, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(441, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(442, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(443, self, varargin{:});
+    end
+    function varargout = dot(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(446, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(447, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(448, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(449, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(444, self);
+        iDynTreeMEX(450, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(438, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(444, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(439, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(445, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
@@ -7,58 +7,58 @@ classdef GyroscopeSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1393, varargin{:});
+        tmp = iDynTreeMEX(1399, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1394, self);
+        iDynTreeMEX(1400, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1395, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1396, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1397, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1398, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1399, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1400, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1401, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1402, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1403, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1404, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1405, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1406, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1407, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1408, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1409, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1410, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1411, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1412, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1413, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1414, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
@@ -5,39 +5,39 @@ classdef IAttitudeEstimator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1670, self);
+        iDynTreeMEX(1676, self);
         self.SwigClear();
       end
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1671, self, varargin{:});
-    end
-    function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1672, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1673, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1674, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1675, self, varargin{:});
-    end
-    function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1676, self, varargin{:});
-    end
-    function varargout = getInternalState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1677, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1678, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1679, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
+    end
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
+    end
+    function varargout = getInternalStateSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
+    end
+    function varargout = getInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
     end
     function self = IAttitudeEstimator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,18 +5,18 @@ classdef ICamera < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1886, self);
+        iDynTreeMEX(1892, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
     end
     function varargout = setTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
     end
     function varargout = setUpVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,33 +5,33 @@ classdef IEnvironment < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1914, self);
+        iDynTreeMEX(1920, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
-    end
-    function varargout = setElementVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
-    end
-    function varargout = setBackgroundColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
-    end
-    function varargout = setAmbientLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
-    end
-    function varargout = getLights(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
-    end
-    function varargout = addLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
-    end
-    function varargout = lightViz(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
     end
-    function varargout = removeLight(self,varargin)
+    function varargout = setElementVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
+    end
+    function varargout = setBackgroundColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
+    end
+    function varargout = setAmbientLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
+    end
+    function varargout = getLights(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
+    end
+    function varargout = addLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
+    end
+    function varargout = lightViz(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
+    end
+    function varargout = removeLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1923, self);
+        iDynTreeMEX(1929, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
     end
     function varargout = getNrOfJets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
     end
     function varargout = getJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
     end
     function varargout = setJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
     function varargout = setJetColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
     end
     function varargout = setJetsDimensions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
     end
     function varargout = setJetsIntensity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJoint.m
@@ -5,108 +5,108 @@ classdef IJoint < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(907, self);
+        iDynTreeMEX(913, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
-    end
-    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(915, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(916, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(921, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(922, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(925, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(928, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(929, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(930, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(931, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(934, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(935, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(936, self, varargin{:});
     end
-    function varargout = isRevoluteJoint(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(937, self, varargin{:});
     end
-    function varargout = isFixedJoint(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(938, self, varargin{:});
     end
-    function varargout = asRevoluteJoint(self,varargin)
+    function varargout = getPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(939, self, varargin{:});
     end
-    function varargout = asFixedJoint(self,varargin)
+    function varargout = getMinPosLimit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(940, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(941, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(942, self, varargin{:});
+    end
+    function varargout = isRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(943, self, varargin{:});
+    end
+    function varargout = isFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(944, self, varargin{:});
+    end
+    function varargout = asRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(945, self, varargin{:});
+    end
+    function varargout = asFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(946, self, varargin{:});
     end
     function self = IJoint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1900, self);
+        iDynTreeMEX(1906, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
-    end
-    function varargout = setType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
-    end
-    function varargout = getType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1903, self, varargin{:});
-    end
-    function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
-    end
-    function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
-    end
-    function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
-    end
-    function varargout = getDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
     end
-    function varargout = setAmbientColor(self,varargin)
+    function varargout = setType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
     end
-    function varargout = getAmbientColor(self,varargin)
+    function varargout = getType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
     end
-    function varargout = setSpecularColor(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
     end
-    function varargout = getSpecularColor(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
     end
-    function varargout = setDiffuseColor(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
     end
-    function varargout = getDiffuseColor(self,varargin)
+    function varargout = getDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
+    end
+    function varargout = setAmbientColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
+    end
+    function varargout = getAmbientColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
+    end
+    function varargout = setSpecularColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
+    end
+    function varargout = getSpecularColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
+    end
+    function varargout = setDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
+    end
+    function varargout = getDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,57 +5,57 @@ classdef IModelVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1938, self);
+        iDynTreeMEX(1944, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
-    end
-    function varargout = setLinkPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
-    end
-    function varargout = getInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
-    end
-    function varargout = setModelVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
-    end
-    function varargout = setModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
-    end
-    function varargout = resetModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
     end
-    function varargout = setLinkColor(self,varargin)
+    function varargout = setLinkPositions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
     end
-    function varargout = resetLinkColor(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
     end
-    function varargout = getLinkNames(self,varargin)
+    function varargout = getInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
     end
-    function varargout = setLinkVisibility(self,varargin)
+    function varargout = setModelVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
     end
-    function varargout = getFeatures(self,varargin)
+    function varargout = setModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
     end
-    function varargout = setFeatureVisibility(self,varargin)
+    function varargout = resetModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
     end
-    function varargout = jets(self,varargin)
+    function varargout = setLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
     end
-    function varargout = getWorldModelTransform(self,varargin)
+    function varargout = resetLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = getLinkNames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
+    end
+    function varargout = setLinkVisibility(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
+    end
+    function varargout = getFeatures(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
+    end
+    function varargout = setFeatureVisibility(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
+    end
+    function varargout = jets(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1958, self, varargin{:});
+    end
+    function varargout = getWorldModelTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1959, self, varargin{:});
+    end
+    function varargout = getWorldLinkTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,27 +5,27 @@ classdef IVectorsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1931, self);
+        iDynTreeMEX(1937, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
     end
     function varargout = getNrOfVectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
     function varargout = getVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
     function varargout = updateVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
     end
     function varargout = setVectorColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
     function varargout = setVectorsAspect(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
@@ -1,3 +1,3 @@
 function varargout = InverseDynamicsInertialParametersRegressor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1293, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1299, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
@@ -1,0 +1,212 @@
+classdef InverseKinematics < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function self = InverseKinematics(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(2033, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(2034, self);
+        self.SwigClear();
+      end
+    end
+    function varargout = loadModelFromFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2035, self, varargin{:});
+    end
+    function varargout = setModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2036, self, varargin{:});
+    end
+    function varargout = setJointLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2037, self, varargin{:});
+    end
+    function varargout = getJointLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2038, self, varargin{:});
+    end
+    function varargout = clearProblem(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2039, self, varargin{:});
+    end
+    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2040, self, varargin{:});
+    end
+    function varargout = setRobotConfiguration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2041, self, varargin{:});
+    end
+    function varargout = setCurrentRobotConfiguration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2042, self, varargin{:});
+    end
+    function varargout = setJointConfiguration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2043, self, varargin{:});
+    end
+    function varargout = setRotationParametrization(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2044, self, varargin{:});
+    end
+    function varargout = rotationParametrization(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2045, self, varargin{:});
+    end
+    function varargout = setMaxIterations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2046, self, varargin{:});
+    end
+    function varargout = maxIterations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2047, self, varargin{:});
+    end
+    function varargout = setMaxCPUTime(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2048, self, varargin{:});
+    end
+    function varargout = maxCPUTime(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2049, self, varargin{:});
+    end
+    function varargout = setCostTolerance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2050, self, varargin{:});
+    end
+    function varargout = costTolerance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2051, self, varargin{:});
+    end
+    function varargout = setConstraintsTolerance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2052, self, varargin{:});
+    end
+    function varargout = constraintsTolerance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2053, self, varargin{:});
+    end
+    function varargout = setVerbosity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2054, self, varargin{:});
+    end
+    function varargout = linearSolverName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2055, self, varargin{:});
+    end
+    function varargout = setLinearSolverName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2056, self, varargin{:});
+    end
+    function varargout = addFrameConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2057, self, varargin{:});
+    end
+    function varargout = addFramePositionConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2058, self, varargin{:});
+    end
+    function varargout = addFrameRotationConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2059, self, varargin{:});
+    end
+    function varargout = activateFrameConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2060, self, varargin{:});
+    end
+    function varargout = deactivateFrameConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2061, self, varargin{:});
+    end
+    function varargout = isFrameConstraintActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2062, self, varargin{:});
+    end
+    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2063, self, varargin{:});
+    end
+    function varargout = getCenterOfMassProjectionMargin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2064, self, varargin{:});
+    end
+    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2065, self, varargin{:});
+    end
+    function varargout = addTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2066, self, varargin{:});
+    end
+    function varargout = addPositionTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2067, self, varargin{:});
+    end
+    function varargout = addRotationTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2068, self, varargin{:});
+    end
+    function varargout = updateTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2069, self, varargin{:});
+    end
+    function varargout = updatePositionTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2070, self, varargin{:});
+    end
+    function varargout = updateRotationTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2071, self, varargin{:});
+    end
+    function varargout = setDefaultTargetResolutionMode(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2072, self, varargin{:});
+    end
+    function varargout = defaultTargetResolutionMode(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2073, self, varargin{:});
+    end
+    function varargout = setTargetResolutionMode(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2074, self, varargin{:});
+    end
+    function varargout = targetResolutionMode(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2075, self, varargin{:});
+    end
+    function varargout = setDesiredJointConfiguration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2076, self, varargin{:});
+    end
+    function varargout = setDesiredFullJointsConfiguration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2077, self, varargin{:});
+    end
+    function varargout = setDesiredReducedJointConfiguration(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2078, self, varargin{:});
+    end
+    function varargout = setInitialCondition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2079, self, varargin{:});
+    end
+    function varargout = setFullJointsInitialCondition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2080, self, varargin{:});
+    end
+    function varargout = setReducedInitialCondition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2081, self, varargin{:});
+    end
+    function varargout = solve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2082, self, varargin{:});
+    end
+    function varargout = getSolution(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2083, self, varargin{:});
+    end
+    function varargout = getFullJointsSolution(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2084, self, varargin{:});
+    end
+    function varargout = getReducedSolution(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2085, self, varargin{:});
+    end
+    function varargout = getPoseForFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2086, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2087, self, varargin{:});
+    end
+    function varargout = fullModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2088, self, varargin{:});
+    end
+    function varargout = reducedModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2089, self, varargin{:});
+    end
+    function varargout = setCOMTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2090, self, varargin{:});
+    end
+    function varargout = setCOMAsConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2091, self, varargin{:});
+    end
+    function varargout = setCOMAsConstraintTolerance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2092, self, varargin{:});
+    end
+    function varargout = isCOMAConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2093, self, varargin{:});
+    end
+    function varargout = isCOMTargetActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2094, self, varargin{:});
+    end
+    function varargout = deactivateCOMTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2095, self, varargin{:});
+    end
+    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2096, self, varargin{:});
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationQuaternion.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationQuaternion.m
@@ -1,0 +1,7 @@
+function v = InverseKinematicsRotationParametrizationQuaternion()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 52);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationRollPitchYaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationRollPitchYaw.m
@@ -1,0 +1,7 @@
+function v = InverseKinematicsRotationParametrizationRollPitchYaw()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 53);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintFull.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintFull.m
@@ -1,0 +1,7 @@
+function v = InverseKinematicsTreatTargetAsConstraintFull()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 57);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintNone.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintNone.m
@@ -1,0 +1,7 @@
+function v = InverseKinematicsTreatTargetAsConstraintNone()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 54);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintPositionOnly.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintPositionOnly.m
@@ -1,0 +1,7 @@
+function v = InverseKinematicsTreatTargetAsConstraintPositionOnly()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 55);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintRotationOnly.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintRotationOnly.m
@@ -1,0 +1,7 @@
+function v = InverseKinematicsTreatTargetAsConstraintRotationOnly()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 56);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(847);
+    varargout{1} = iDynTreeMEX(853);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(848,varargin{1});
+    iDynTreeMEX(854,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(849);
+    varargout{1} = iDynTreeMEX(855);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(850,varargin{1});
+    iDynTreeMEX(856,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointDOFsDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1197, varargin{:});
+        tmp = iDynTreeMEX(1203, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1205, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1200, self);
+        iDynTreeMEX(1206, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointPosDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1193, varargin{:});
+        tmp = iDynTreeMEX(1199, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1200, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1201, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1196, self);
+        iDynTreeMEX(1202, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
@@ -2,24 +2,24 @@ classdef JointSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1307, self);
+        iDynTreeMEX(1313, self);
         self.SwigClear();
       end
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
     end
     function varargout = getParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
     end
     function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
     end
     function varargout = setParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
     end
     function self = JointSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -9,175 +9,175 @@ classdef KinDynComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1831, varargin{:});
+        tmp = iDynTreeMEX(1837, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1832, self);
+        iDynTreeMEX(1838, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
-    end
-    function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
-    end
-    function varargout = setFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
-    end
-    function varargout = getFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = loadRobotModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = loadRobotModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = setFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
     end
-    function varargout = getFloatingBase(self,varargin)
+    function varargout = getFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
     end
-    function varargout = setFloatingBase(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
     end
-    function varargout = getRobotModel(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
     end
-    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
     end
-    function varargout = setJointPos(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
     end
-    function varargout = getRobotState(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
     end
-    function varargout = getWorldBaseTransform(self,varargin)
+    function varargout = getRobotModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
     end
-    function varargout = getBaseTwist(self,varargin)
+    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
     end
-    function varargout = getJointPos(self,varargin)
+    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1855, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = setJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1856, self, varargin{:});
     end
-    function varargout = getModelVel(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1857, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1858, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1859, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1860, self, varargin{:});
     end
-    function varargout = getRelativeTransformExplicit(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1861, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1862, self, varargin{:});
     end
-    function varargout = getFrameVel(self,varargin)
+    function varargout = getModelVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1863, self, varargin{:});
     end
-    function varargout = getFrameAcc(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1864, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobian(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1865, self, varargin{:});
     end
-    function varargout = getRelativeJacobian(self,varargin)
+    function varargout = getWorldTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1866, self, varargin{:});
     end
-    function varargout = getRelativeJacobianExplicit(self,varargin)
+    function varargout = getRelativeTransformExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
     end
-    function varargout = getFrameBiasAcc(self,varargin)
+    function varargout = getRelativeTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
     end
-    function varargout = getCenterOfMassPosition(self,varargin)
+    function varargout = getFrameVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
     end
-    function varargout = getCenterOfMassVelocity(self,varargin)
+    function varargout = getFrameAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = getFrameFreeFloatingJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
     end
-    function varargout = getCenterOfMassBiasAcc(self,varargin)
+    function varargout = getRelativeJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
     end
-    function varargout = getAverageVelocity(self,varargin)
+    function varargout = getRelativeJacobianExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
     end
-    function varargout = getAverageVelocityJacobian(self,varargin)
+    function varargout = getFrameBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocity(self,varargin)
+    function varargout = getCenterOfMassPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
+    function varargout = getCenterOfMassVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentum(self,varargin)
+    function varargout = getCenterOfMassJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentumJacobian(self,varargin)
+    function varargout = getCenterOfMassBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
     end
-    function varargout = getCentroidalTotalMomentum(self,varargin)
+    function varargout = getAverageVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
     end
-    function varargout = getFreeFloatingMassMatrix(self,varargin)
+    function varargout = getAverageVelocityJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = getCentroidalAverageVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
     end
-    function varargout = generalizedBiasForces(self,varargin)
+    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
     end
-    function varargout = generalizedGravityForces(self,varargin)
+    function varargout = getLinearAngularMomentum(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
     end
-    function varargout = generalizedExternalForces(self,varargin)
+    function varargout = getLinearAngularMomentumJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
     end
-    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+    function varargout = getCentroidalTotalMomentum(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
+    end
+    function varargout = getFreeFloatingMassMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
+    end
+    function varargout = inverseDynamics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
+    end
+    function varargout = generalizedBiasForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
+    end
+    function varargout = generalizedGravityForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
+    end
+    function varargout = generalizedExternalForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
+    end
+    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(843);
+    varargout{1} = iDynTreeMEX(849);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(844,varargin{1});
+    iDynTreeMEX(850,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(845);
+    varargout{1} = iDynTreeMEX(851);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(846,varargin{1});
+    iDynTreeMEX(852,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3.m
@@ -7,14 +7,14 @@ classdef LinearForceVector3 < iDynTree.ForceVector3__LinearForceVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(513, varargin{:});
+        tmp = iDynTreeMEX(519, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(514, self);
+        iDynTreeMEX(520, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3Semantics.m
@@ -7,14 +7,14 @@ classdef LinearForceVector3Semantics < iDynTree.ForceVector3Semantics__LinearFor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(511, varargin{:});
+        tmp = iDynTreeMEX(517, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(512, self);
+        iDynTreeMEX(518, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3.m
@@ -7,17 +7,17 @@ classdef LinearMotionVector3 < iDynTree.MotionVector3__LinearMotionVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(503, varargin{:});
+        tmp = iDynTreeMEX(509, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(504, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(510, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(505, self);
+        iDynTreeMEX(511, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3Semantics.m
@@ -7,24 +7,24 @@ classdef LinearMotionVector3Semantics < iDynTree.GeomVector3Semantics__LinearMot
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(499, varargin{:});
+        tmp = iDynTreeMEX(505, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(500, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(506, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(502, self);
+        iDynTreeMEX(508, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(501, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(507, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Link.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Link.m
@@ -9,29 +9,29 @@ classdef Link < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(900, varargin{:});
+        tmp = iDynTreeMEX(906, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = inertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
     end
     function varargout = setInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
     end
     function varargout = getInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(905, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(906, self);
+        iDynTreeMEX(912, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
@@ -9,29 +9,29 @@ classdef LinkAccArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(893, varargin{:});
+        tmp = iDynTreeMEX(899, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(899, self);
+        iDynTreeMEX(905, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
@@ -9,23 +9,23 @@ classdef LinkArticulatedBodyInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(881, varargin{:});
+        tmp = iDynTreeMEX(887, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(882, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(885, self);
+        iDynTreeMEX(891, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
@@ -9,35 +9,35 @@ classdef LinkContactWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1251, varargin{:});
+        tmp = iDynTreeMEX(1257, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1258, self, varargin{:});
     end
     function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1259, self, varargin{:});
     end
     function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1260, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1255, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1261, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1256, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1262, self, varargin{:});
     end
     function varargout = computeNetWrenches(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1257, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1263, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1258, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1264, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1259, self);
+        iDynTreeMEX(1265, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
@@ -9,23 +9,23 @@ classdef LinkInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(876, varargin{:});
+        tmp = iDynTreeMEX(882, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(885, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(880, self);
+        iDynTreeMEX(886, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
@@ -9,29 +9,29 @@ classdef LinkPositions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(861, varargin{:});
+        tmp = iDynTreeMEX(867, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(864, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(867, self);
+        iDynTreeMEX(873, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
@@ -2,30 +2,30 @@ classdef LinkSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1313, self);
+        iDynTreeMEX(1319, self);
         self.SwigClear();
       end
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1321, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1322, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1319, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
     end
     function self = LinkSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
@@ -9,41 +9,41 @@ classdef LinkUnknownWrenchContacts < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1511, varargin{:});
+        tmp = iDynTreeMEX(1517, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1512, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1513, self, varargin{:});
-    end
-    function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1514, self, varargin{:});
-    end
-    function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1515, self, varargin{:});
-    end
-    function varargout = addNewContactForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1516, self, varargin{:});
-    end
-    function varargout = addNewContactInFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1517, self, varargin{:});
-    end
-    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1518, self, varargin{:});
     end
-    function varargout = contactWrench(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1519, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1520, self, varargin{:});
+    end
+    function varargout = setNrOfContactsForLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1521, self, varargin{:});
+    end
+    function varargout = addNewContactForLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1522, self, varargin{:});
+    end
+    function varargout = addNewContactInFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1523, self, varargin{:});
+    end
+    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1524, self, varargin{:});
+    end
+    function varargout = contactWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1525, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1526, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1521, self);
+        iDynTreeMEX(1527, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
@@ -9,29 +9,29 @@ classdef LinkVelArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(886, varargin{:});
+        tmp = iDynTreeMEX(892, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(887, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(891, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(892, self);
+        iDynTreeMEX(898, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
@@ -9,32 +9,32 @@ classdef LinkWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(868, varargin{:});
+        tmp = iDynTreeMEX(874, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(875, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(876, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(873, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(874, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(880, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(875, self);
+        iDynTreeMEX(881, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix10x16.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix10x16.m
@@ -9,53 +9,53 @@ classdef Matrix10x16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(265, varargin{:});
+        tmp = iDynTreeMEX(266, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(266, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(268, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(269, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(270, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(271, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(272, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(273, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(274, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(275, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(276, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(277, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(278, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(279, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(279, self);
+        iDynTreeMEX(280, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix1x6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix1x6.m
@@ -9,53 +9,53 @@ classdef Matrix1x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(175, varargin{:});
+        tmp = iDynTreeMEX(176, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(176, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(177, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(178, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(179, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(180, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(181, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(182, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(183, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(184, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(185, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(186, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(187, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(188, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(189, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(189, self);
+        iDynTreeMEX(190, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix2x3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix2x3.m
@@ -9,53 +9,53 @@ classdef Matrix2x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(190, varargin{:});
+        tmp = iDynTreeMEX(191, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(191, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(192, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(193, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(194, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(195, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(196, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(197, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(198, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(199, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(200, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(201, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(202, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(203, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(204, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(204, self);
+        iDynTreeMEX(205, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix3x3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix3x3.m
@@ -9,53 +9,53 @@ classdef Matrix3x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(205, varargin{:});
+        tmp = iDynTreeMEX(206, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(206, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(207, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(208, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(209, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(210, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(211, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(212, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(213, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(214, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(215, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(216, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(217, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(218, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(219, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(219, self);
+        iDynTreeMEX(220, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4.m
@@ -9,53 +9,53 @@ classdef Matrix4x4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(220, varargin{:});
+        tmp = iDynTreeMEX(221, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(221, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(222, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(223, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(224, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(225, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(226, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(227, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(228, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(229, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(230, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(231, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(232, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(233, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(234, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(234, self);
+        iDynTreeMEX(235, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix6x10.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix6x10.m
@@ -9,53 +9,53 @@ classdef Matrix6x10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(250, varargin{:});
+        tmp = iDynTreeMEX(251, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(251, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(252, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(253, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(254, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(255, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(256, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(257, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(258, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(259, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(260, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(261, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(262, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(263, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(264, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(264, self);
+        iDynTreeMEX(265, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix6x6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix6x6.m
@@ -9,53 +9,53 @@ classdef Matrix6x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(235, varargin{:});
+        tmp = iDynTreeMEX(236, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(236, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(237, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(238, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(239, self, varargin{:});
     end
-    function varargout = cols(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(240, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(241, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(242, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(243, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(244, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(245, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(246, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(247, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(248, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(249, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(249, self);
+        iDynTreeMEX(250, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Model.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Model.m
@@ -9,133 +9,133 @@ classdef Model < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1152, varargin{:});
+        tmp = iDynTreeMEX(1158, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = copy(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1153, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1154, self);
+        iDynTreeMEX(1160, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1155, self, varargin{:});
-    end
-    function varargout = getLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
-    end
-    function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1157, self, varargin{:});
-    end
-    function varargout = isValidLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1158, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
-    end
-    function varargout = addLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1160, self, varargin{:});
-    end
-    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1161, self, varargin{:});
     end
-    function varargout = getJointName(self,varargin)
+    function varargout = getLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1162, self, varargin{:});
     end
-    function varargout = getTotalMass(self,varargin)
+    function varargout = getLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
     end
-    function varargout = getJointIndex(self,varargin)
+    function varargout = isValidLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
     end
-    function varargout = getJoint(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1165, self, varargin{:});
     end
-    function varargout = isValidJointIndex(self,varargin)
+    function varargout = addLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1166, self, varargin{:});
     end
-    function varargout = isLinkNameUsed(self,varargin)
+    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1167, self, varargin{:});
     end
-    function varargout = isJointNameUsed(self,varargin)
+    function varargout = getJointName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1168, self, varargin{:});
     end
-    function varargout = isFrameNameUsed(self,varargin)
+    function varargout = getTotalMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1169, self, varargin{:});
     end
-    function varargout = addJoint(self,varargin)
+    function varargout = getJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1170, self, varargin{:});
     end
-    function varargout = addJointAndLink(self,varargin)
+    function varargout = getJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1171, self, varargin{:});
     end
-    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
+    function varargout = isValidJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
     end
-    function varargout = getNrOfPosCoords(self,varargin)
+    function varargout = isLinkNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = isJointNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1174, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = isFrameNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1175, self, varargin{:});
     end
-    function varargout = addAdditionalFrameToLink(self,varargin)
+    function varargout = addJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1176, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = addJointAndLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1177, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
     end
-    function varargout = isValidFrameIndex(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
     end
-    function varargout = getFrameLink(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
     end
-    function varargout = getLinkAdditionalFrames(self,varargin)
+    function varargout = addAdditionalFrameToLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
     end
-    function varargout = getNrOfNeighbors(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
     end
-    function varargout = getNeighbor(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
     end
-    function varargout = setDefaultBaseLink(self,varargin)
+    function varargout = isValidFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
     end
-    function varargout = getDefaultBaseLink(self,varargin)
+    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
     end
-    function varargout = computeFullTreeTraversal(self,varargin)
+    function varargout = getFrameLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
     end
-    function varargout = getInertialParameters(self,varargin)
+    function varargout = getLinkAdditionalFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
     end
-    function varargout = updateInertialParameters(self,varargin)
+    function varargout = getNrOfNeighbors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
     end
-    function varargout = visualSolidShapes(self,varargin)
+    function varargout = getNeighbor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
     end
-    function varargout = collisionSolidShapes(self,varargin)
+    function varargout = setDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1191, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1192, self, varargin{:});
+    end
+    function varargout = computeFullTreeTraversal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1193, self, varargin{:});
+    end
+    function varargout = getInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
+    end
+    function varargout = updateInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
+    end
+    function varargout = visualSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1196, self, varargin{:});
+    end
+    function varargout = collisionSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1197, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelCalibrationHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelCalibrationHelper.m
@@ -9,37 +9,37 @@ classdef ModelCalibrationHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1490, varargin{:});
+        tmp = iDynTreeMEX(1496, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1491, self);
+        iDynTreeMEX(1497, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1492, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1498, self, varargin{:});
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1493, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1499, self, varargin{:});
     end
     function varargout = updateModelInertialParametersToString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1494, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1500, self, varargin{:});
     end
     function varargout = updateModelInertialParametersToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1495, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1501, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1496, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1502, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1497, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1503, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1498, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1504, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
@@ -9,40 +9,40 @@ classdef ModelExporter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1480, varargin{:});
+        tmp = iDynTreeMEX(1486, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1481, self);
+        iDynTreeMEX(1487, self);
         self.SwigClear();
       end
     end
     function varargout = exportingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1482, self, varargin{:});
-    end
-    function varargout = setExportingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1483, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1484, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1485, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1486, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1487, self, varargin{:});
-    end
-    function varargout = exportModelToString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1488, self, varargin{:});
     end
-    function varargout = exportModelToFile(self,varargin)
+    function varargout = setExportingOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1489, self, varargin{:});
+    end
+    function varargout = init(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1490, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1491, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1492, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1493, self, varargin{:});
+    end
+    function varargout = exportModelToString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1494, self, varargin{:});
+    end
+    function varargout = exportModelToFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1495, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
@@ -7,20 +7,20 @@ classdef ModelExporterOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1474, self);
+        varargout{1} = iDynTreeMEX(1480, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1475, self, varargin{1});
+        iDynTreeMEX(1481, self, varargin{1});
       end
     end
     function varargout = exportFirstBaseLinkAdditionalFrameAsFakeURDFBase(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1476, self);
+        varargout{1} = iDynTreeMEX(1482, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1477, self, varargin{1});
+        iDynTreeMEX(1483, self, varargin{1});
       end
     end
     function self = ModelExporterOptions(varargin)
@@ -29,14 +29,14 @@ classdef ModelExporterOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1478, varargin{:});
+        tmp = iDynTreeMEX(1484, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1479, self);
+        iDynTreeMEX(1485, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
@@ -9,46 +9,46 @@ classdef ModelLoader < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1462, varargin{:});
+        tmp = iDynTreeMEX(1468, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1463, self);
+        iDynTreeMEX(1469, self);
         self.SwigClear();
       end
     end
     function varargout = parsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1464, self, varargin{:});
-    end
-    function varargout = setParsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1465, self, varargin{:});
-    end
-    function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1466, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1467, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromFullModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1468, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1469, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1470, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = setParsingOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1471, self, varargin{:});
     end
-    function varargout = sensors(self,varargin)
+    function varargout = loadModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1472, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1473, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromFullModel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1474, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1475, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1476, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1477, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1478, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1479, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
@@ -7,20 +7,20 @@ classdef ModelParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1456, self);
+        varargout{1} = iDynTreeMEX(1462, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1457, self, varargin{1});
+        iDynTreeMEX(1463, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1458, self);
+        varargout{1} = iDynTreeMEX(1464, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1459, self, varargin{1});
+        iDynTreeMEX(1465, self, varargin{1});
       end
     end
     function self = ModelParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef ModelParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1460, varargin{:});
+        tmp = iDynTreeMEX(1466, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1461, self);
+        iDynTreeMEX(1467, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
@@ -9,34 +9,34 @@ classdef ModelSolidShapes < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1139, varargin{:});
+        tmp = iDynTreeMEX(1145, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1140, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1146, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1141, self);
+        iDynTreeMEX(1147, self);
         self.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1142, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1148, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1143, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1149, self, varargin{:});
     end
     function varargout = linkSolidShapes(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1144, self);
+        varargout{1} = iDynTreeMEX(1150, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1145, self, varargin{1});
+        iDynTreeMEX(1151, self, varargin{1});
       end
     end
   end

--- a/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef MomentumFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1215, varargin{:});
+        tmp = iDynTreeMEX(1221, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1216, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1222, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1217, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1223, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1218, self);
+        iDynTreeMEX(1224, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MotionVector3__AngularMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MotionVector3__AngularMotionVector3.m
@@ -7,17 +7,17 @@ classdef MotionVector3__AngularMotionVector3 < iDynTree.GeomVector3__AngularMoti
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(492, varargin{:});
+        tmp = iDynTreeMEX(498, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(493, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(499, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(494, self);
+        iDynTreeMEX(500, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MotionVector3__LinearMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MotionVector3__LinearMotionVector3.m
@@ -7,17 +7,17 @@ classdef MotionVector3__LinearMotionVector3 < iDynTree.GeomVector3__LinearMotion
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(489, varargin{:});
+        tmp = iDynTreeMEX(495, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(490, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(496, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(491, self);
+        iDynTreeMEX(497, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl1 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(972, self);
+        iDynTreeMEX(978, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(978, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(985, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
     end
     function self = MovableJointImpl1(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl2 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(981, self);
+        iDynTreeMEX(987, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(985, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
     end
     function self = MovableJointImpl2(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl3 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(990, self);
+        iDynTreeMEX(996, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(996, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1003, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
     end
     function self = MovableJointImpl3(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl4 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(999, self);
+        iDynTreeMEX(1005, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1003, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1008, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
     end
     function self = MovableJointImpl4(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl5 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1008, self);
+        iDynTreeMEX(1014, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
     end
     function self = MovableJointImpl5(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl6 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1017, self);
+        iDynTreeMEX(1023, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
     end
     function self = MovableJointImpl6(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
@@ -1,3 +1,3 @@
 function v = NR_OF_SENSOR_TYPES()
-  v = iDynTreeMEX(1294);
+  v = iDynTreeMEX(1300);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
@@ -7,20 +7,20 @@ classdef Neighbor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1146, self);
+        varargout{1} = iDynTreeMEX(1152, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1147, self, varargin{1});
+        iDynTreeMEX(1153, self, varargin{1});
       end
     end
     function varargout = neighborJoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1148, self);
+        varargout{1} = iDynTreeMEX(1154, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1149, self, varargin{1});
+        iDynTreeMEX(1155, self, varargin{1});
       end
     end
     function self = Neighbor(varargin)
@@ -29,14 +29,14 @@ classdef Neighbor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1150, varargin{:});
+        tmp = iDynTreeMEX(1156, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1151, self);
+        iDynTreeMEX(1157, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon.m
@@ -1,0 +1,54 @@
+classdef Polygon < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = m_vertices(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1986, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1987, self, varargin{1});
+      end
+    end
+    function self = Polygon(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(1988, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function varargout = setNrOfVertices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
+    end
+    function varargout = getNrOfVertices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
+    end
+    function varargout = applyTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(1995, self);
+        self.SwigClear();
+      end
+    end
+  end
+  methods(Static)
+    function varargout = XYRectangleFromOffsets(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(1994, varargin{:});
+    end
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
@@ -1,0 +1,48 @@
+classdef Polygon2D < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = m_vertices(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1996, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1997, self, varargin{1});
+      end
+    end
+    function self = Polygon2D(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(1998, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function varargout = setNrOfVertices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
+    end
+    function varargout = getNrOfVertices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(2003, self);
+        self.SwigClear();
+      end
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/Position.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Position.m
@@ -7,60 +7,60 @@ classdef Position < iDynTree.PositionRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(373, varargin{:});
+        tmp = iDynTreeMEX(379, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(374, self, varargin{:});
-    end
-    function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(375, self, varargin{:});
-    end
-    function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(376, self, varargin{:});
-    end
-    function varargout = changeCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(377, self, varargin{:});
-    end
-    function varargout = changePointOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(380, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(381, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = changeRefPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(382, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(383, self, varargin{:});
     end
+    function varargout = changePointOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(386, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(387, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(388, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(389, self, varargin{:});
+    end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(384, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(390, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(385, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(391, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(386, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(392, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(388, self);
+        iDynTreeMEX(394, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(378, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(384, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(379, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(385, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(387, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(393, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PositionRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PositionRaw.m
@@ -7,39 +7,39 @@ classdef PositionRaw < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(345, varargin{:});
+        tmp = iDynTreeMEX(351, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(346, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(352, self, varargin{:});
     end
     function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(347, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(353, self, varargin{:});
     end
     function varargout = changePointOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(350, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(356, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(351, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(357, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(352, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(358, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(353, self);
+        iDynTreeMEX(359, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(348, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(354, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(349, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(355, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PositionSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PositionSemantics.m
@@ -9,69 +9,69 @@ classdef PositionSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(354, varargin{:});
+        tmp = iDynTreeMEX(360, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(355, self, varargin{:});
-    end
-    function varargout = getPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(356, self, varargin{:});
-    end
-    function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(357, self, varargin{:});
-    end
-    function varargout = getReferencePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(358, self, varargin{:});
-    end
-    function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(359, self, varargin{:});
-    end
-    function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(360, self, varargin{:});
-    end
-    function varargout = setPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(361, self, varargin{:});
     end
-    function varargout = setBody(self,varargin)
+    function varargout = getPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(362, self, varargin{:});
     end
-    function varargout = setReferencePoint(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(363, self, varargin{:});
     end
-    function varargout = setRefBody(self,varargin)
+    function varargout = getReferencePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(364, self, varargin{:});
     end
-    function varargout = setCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(365, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(366, self, varargin{:});
     end
-    function varargout = changeRefPoint(self,varargin)
+    function varargout = setPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(367, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = setBody(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(368, self, varargin{:});
+    end
+    function varargout = setReferencePoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(369, self, varargin{:});
+    end
+    function varargout = setRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(370, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = setCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(371, self, varargin{:});
+    end
+    function varargout = changePoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(372, self, varargin{:});
+    end
+    function varargout = changeRefPoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(373, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(376, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(377, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(372, self);
+        iDynTreeMEX(378, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(368, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(374, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(369, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(375, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
@@ -7,85 +7,85 @@ classdef PrismaticJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1051, varargin{:});
+        tmp = iDynTreeMEX(1057, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1052, self);
+        iDynTreeMEX(1058, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
-    end
-    function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1057, self, varargin{:});
-    end
-    function varargout = getSecondAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1058, self, varargin{:});
-    end
-    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1060, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1061, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1062, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1063, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1064, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1073, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
+    end
+    function varargout = hasPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
+    end
+    function varargout = enablePosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
@@ -1,3 +1,3 @@
 function varargout = RNEADynamicPhase(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1268, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1274, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
@@ -7,85 +7,85 @@ classdef RevoluteJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1026, varargin{:});
+        tmp = iDynTreeMEX(1032, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1027, self);
+        iDynTreeMEX(1033, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
-    end
-    function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1032, self, varargin{:});
-    end
-    function varargout = getSecondAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1033, self, varargin{:});
-    end
-    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1038, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1041, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1047, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
+    end
+    function varargout = hasPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
+    end
+    function varargout = enablePosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RigidBodyInertiaNonLinearParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RigidBodyInertiaNonLinearParametrization.m
@@ -7,65 +7,65 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(693, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(694, self, varargin{1});
-      end
-    end
-    function varargout = com(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(695, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(696, self, varargin{1});
-      end
-    end
-    function varargout = link_R_centroidal(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(697, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(698, self, varargin{1});
-      end
-    end
-    function varargout = centralSecondMomentOfMass(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(699, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(700, self, varargin{1});
       end
     end
+    function varargout = com(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(701, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(702, self, varargin{1});
+      end
+    end
+    function varargout = link_R_centroidal(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(703, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(704, self, varargin{1});
+      end
+    end
+    function varargout = centralSecondMomentOfMass(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(705, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(706, self, varargin{1});
+      end
+    end
     function varargout = getLinkCentroidalTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(701, self, varargin{:});
-    end
-    function varargout = fromRigidBodyInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(702, self, varargin{:});
-    end
-    function varargout = fromInertialParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(703, self, varargin{:});
-    end
-    function varargout = toRigidBodyInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(704, self, varargin{:});
-    end
-    function varargout = isPhysicallyConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(705, self, varargin{:});
-    end
-    function varargout = asVectorWithRotationAsVec(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(706, self, varargin{:});
-    end
-    function varargout = fromVectorWithRotationAsVec(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(707, self, varargin{:});
     end
-    function varargout = getGradientWithRotationAsVec(self,varargin)
+    function varargout = fromRigidBodyInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(708, self, varargin{:});
+    end
+    function varargout = fromInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(709, self, varargin{:});
+    end
+    function varargout = toRigidBodyInertia(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(710, self, varargin{:});
+    end
+    function varargout = isPhysicallyConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(711, self, varargin{:});
+    end
+    function varargout = asVectorWithRotationAsVec(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(712, self, varargin{:});
+    end
+    function varargout = fromVectorWithRotationAsVec(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(713, self, varargin{:});
+    end
+    function varargout = getGradientWithRotationAsVec(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(714, self, varargin{:});
     end
     function self = RigidBodyInertiaNonLinearParametrization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -73,14 +73,14 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(709, varargin{:});
+        tmp = iDynTreeMEX(715, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(710, self);
+        iDynTreeMEX(716, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Rotation.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Rotation.m
@@ -7,117 +7,117 @@ classdef Rotation < iDynTree.RotationRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(745, varargin{:});
+        tmp = iDynTreeMEX(751, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(746, self, varargin{:});
-    end
-    function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(747, self, varargin{:});
-    end
-    function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(748, self, varargin{:});
-    end
-    function varargout = changeCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(749, self, varargin{:});
-    end
-    function varargout = changeCoordFrameOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(752, self, varargin{:});
     end
-    function varargout = inverse(self,varargin)
+    function varargout = changeOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(753, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = changeRefOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(754, self, varargin{:});
     end
-    function varargout = log(self,varargin)
+    function varargout = changeCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(755, self, varargin{:});
     end
-    function varargout = fromQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(756, self, varargin{:});
-    end
-    function varargout = getRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(757, self, varargin{:});
-    end
-    function varargout = asRPY(self,varargin)
+    function varargout = changeCoordFrameOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(758, self, varargin{:});
     end
-    function varargout = getQuaternion(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(759, self, varargin{:});
     end
-    function varargout = asQuaternion(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(760, self, varargin{:});
     end
+    function varargout = log(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(761, self, varargin{:});
+    end
+    function varargout = fromQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(762, self, varargin{:});
+    end
+    function varargout = getRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(763, self, varargin{:});
+    end
+    function varargout = asRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(764, self, varargin{:});
+    end
+    function varargout = getQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(765, self, varargin{:});
+    end
+    function varargout = asQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(766, self, varargin{:});
+    end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(783, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(778, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(779, self);
+        iDynTreeMEX(785, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(750, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(756, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(751, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(757, varargin{:});
     end
     function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(761, varargin{:});
-    end
-    function varargout = RotY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(762, varargin{:});
-    end
-    function varargout = RotZ(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(763, varargin{:});
-    end
-    function varargout = RotAxis(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(764, varargin{:});
-    end
-    function varargout = RotAxisDerivative(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(765, varargin{:});
-    end
-    function varargout = RPY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(766, varargin{:});
-    end
-    function varargout = RPYRightTrivializedDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(767, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
+    function varargout = RotY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(768, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
+    function varargout = RotZ(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(769, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
+    function varargout = RotAxis(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(770, varargin{:});
     end
-    function varargout = QuaternionRightTrivializedDerivative(varargin)
+    function varargout = RotAxisDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(771, varargin{:});
     end
-    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
+    function varargout = RPY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(772, varargin{:});
     end
-    function varargout = Identity(varargin)
+    function varargout = RPYRightTrivializedDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(773, varargin{:});
     end
-    function varargout = RotationFromQuaternion(varargin)
+    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(774, varargin{:});
     end
-    function varargout = leftJacobian(varargin)
+    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(775, varargin{:});
     end
-    function varargout = leftJacobianInverse(varargin)
+    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(776, varargin{:});
+    end
+    function varargout = QuaternionRightTrivializedDerivative(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(777, varargin{:});
+    end
+    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(778, varargin{:});
+    end
+    function varargout = Identity(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(779, varargin{:});
+    end
+    function varargout = RotationFromQuaternion(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(780, varargin{:});
+    end
+    function varargout = leftJacobian(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(781, varargin{:});
+    end
+    function varargout = leftJacobianInverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(782, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationRaw.m
@@ -7,54 +7,54 @@ classdef RotationRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(711, varargin{:});
+        tmp = iDynTreeMEX(717, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(712, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(718, self, varargin{:});
     end
     function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(713, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(719, self, varargin{:});
     end
     function varargout = changeCoordFrameOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(716, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(722, self, varargin{:});
     end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(728, self, varargin{:});
+    end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(723, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(729, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(724, self);
+        iDynTreeMEX(730, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(714, varargin{:});
-    end
-    function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(715, varargin{:});
-    end
-    function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(717, varargin{:});
-    end
-    function varargout = RotY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(718, varargin{:});
-    end
-    function varargout = RotZ(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(719, varargin{:});
-    end
-    function varargout = RPY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(720, varargin{:});
     end
-    function varargout = Identity(varargin)
+    function varargout = inverse2(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(721, varargin{:});
+    end
+    function varargout = RotX(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(723, varargin{:});
+    end
+    function varargout = RotY(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(724, varargin{:});
+    end
+    function varargout = RotZ(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(725, varargin{:});
+    end
+    function varargout = RPY(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(726, varargin{:});
+    end
+    function varargout = Identity(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(727, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationSemantics.m
@@ -9,72 +9,72 @@ classdef RotationSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(725, varargin{:});
+        tmp = iDynTreeMEX(731, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(726, self, varargin{:});
-    end
-    function varargout = getOrientationFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(727, self, varargin{:});
-    end
-    function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(728, self, varargin{:});
-    end
-    function varargout = getReferenceOrientationFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(729, self, varargin{:});
-    end
-    function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(730, self, varargin{:});
-    end
-    function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(731, self, varargin{:});
-    end
-    function varargout = setOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(732, self, varargin{:});
     end
-    function varargout = setBody(self,varargin)
+    function varargout = getOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(733, self, varargin{:});
     end
-    function varargout = setReferenceOrientationFrame(self,varargin)
+    function varargout = getBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(734, self, varargin{:});
     end
-    function varargout = setRefBody(self,varargin)
+    function varargout = getReferenceOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(735, self, varargin{:});
     end
-    function varargout = setCoordinateFrame(self,varargin)
+    function varargout = getRefBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(736, self, varargin{:});
     end
-    function varargout = changeOrientFrame(self,varargin)
+    function varargout = getCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(737, self, varargin{:});
     end
-    function varargout = changeRefOrientFrame(self,varargin)
+    function varargout = setOrientationFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(738, self, varargin{:});
     end
-    function varargout = changeCoordFrameOf(self,varargin)
+    function varargout = setBody(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(739, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = setReferenceOrientationFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(740, self, varargin{:});
+    end
+    function varargout = setRefBody(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(741, self, varargin{:});
+    end
+    function varargout = setCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(742, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = changeOrientFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(743, self, varargin{:});
+    end
+    function varargout = changeRefOrientFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(744, self, varargin{:});
+    end
+    function varargout = changeCoordFrameOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(745, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(748, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(749, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(744, self);
+        iDynTreeMEX(750, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(740, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(746, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(741, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(747, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationalInertiaRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationalInertiaRaw.m
@@ -7,21 +7,21 @@ classdef RotationalInertiaRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(648, varargin{:});
+        tmp = iDynTreeMEX(654, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(650, self);
+        iDynTreeMEX(656, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(649, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(655, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Sensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sensor.m
@@ -5,33 +5,33 @@ classdef Sensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1298, self);
+        iDynTreeMEX(1304, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1299, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1300, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1301, self, varargin{:});
-    end
-    function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1302, self, varargin{:});
-    end
-    function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1303, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1304, self, varargin{:});
-    end
-    function varargout = updateIndices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1305, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1307, self, varargin{:});
+    end
+    function varargout = setName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
+    end
+    function varargout = isConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
+    end
+    function varargout = updateIndeces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
     end
     function self = Sensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
@@ -9,61 +9,61 @@ classdef SensorsList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1321, varargin{:});
+        tmp = iDynTreeMEX(1327, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1322, self);
+        iDynTreeMEX(1328, self);
         self.SwigClear();
       end
     end
     function varargout = addSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
-    end
-    function varargout = setSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
-    end
-    function varargout = getSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
-    end
-    function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
-    end
-    function varargout = getSensorIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1327, self, varargin{:});
-    end
-    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1328, self, varargin{:});
-    end
-    function varargout = getSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
     end
-    function varargout = isConsistent(self,varargin)
+    function varargout = setSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1330, self, varargin{:});
     end
-    function varargout = removeSensor(self,varargin)
+    function varargout = getSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1331, self, varargin{:});
     end
-    function varargout = removeAllSensorsOfType(self,varargin)
+    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
     end
-    function varargout = getSixAxisForceTorqueSensor(self,varargin)
+    function varargout = getSensorIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
     end
-    function varargout = getAccelerometerSensor(self,varargin)
+    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
     end
-    function varargout = getGyroscopeSensor(self,varargin)
+    function varargout = getSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
     end
-    function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
     end
-    function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
+    function varargout = removeSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
+    end
+    function varargout = removeAllSensorsOfType(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1338, self, varargin{:});
+    end
+    function varargout = getSixAxisForceTorqueSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1339, self, varargin{:});
+    end
+    function varargout = getAccelerometerSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1340, self, varargin{:});
+    end
+    function varargout = getGyroscopeSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
+    end
+    function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
+    end
+    function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
@@ -9,37 +9,37 @@ classdef SensorsMeasurements < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1338, varargin{:});
+        tmp = iDynTreeMEX(1344, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1339, self);
+        iDynTreeMEX(1345, self);
         self.SwigClear();
       end
     end
     function varargout = setNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1340, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
     end
     function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1347, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1348, self, varargin{:});
     end
     function varargout = toVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1349, self, varargin{:});
     end
     function varargout = setMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1344, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1350, self, varargin{:});
     end
     function varargout = getMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1345, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
     end
     function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
@@ -9,46 +9,46 @@ classdef SimpleLeggedOdometry < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1560, varargin{:});
+        tmp = iDynTreeMEX(1566, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1561, self);
+        iDynTreeMEX(1567, self);
         self.SwigClear();
       end
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1562, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1563, self, varargin{:});
-    end
-    function varargout = loadModelFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1565, self, varargin{:});
-    end
-    function varargout = updateKinematics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1566, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1567, self, varargin{:});
-    end
-    function varargout = changeFixedFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1568, self, varargin{:});
     end
-    function varargout = getCurrentFixedLink(self,varargin)
+    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1569, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = loadModelFromFileWithSpecifiedDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1570, self, varargin{:});
     end
-    function varargout = getWorldFrameTransform(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1571, self, varargin{:});
+    end
+    function varargout = updateKinematics(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1572, self, varargin{:});
+    end
+    function varargout = init(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1573, self, varargin{:});
+    end
+    function varargout = changeFixedFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1574, self, varargin{:});
+    end
+    function varargout = getCurrentFixedLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1575, self, varargin{:});
+    end
+    function varargout = getWorldLinkTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1576, self, varargin{:});
+    end
+    function varargout = getWorldFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1577, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
@@ -7,100 +7,100 @@ classdef SixAxisForceTorqueSensor < iDynTree.JointSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1347, varargin{:});
+        tmp = iDynTreeMEX(1353, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1348, self);
+        iDynTreeMEX(1354, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1349, self, varargin{:});
-    end
-    function varargout = setFirstLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1350, self, varargin{:});
-    end
-    function varargout = setSecondLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
-    end
-    function varargout = getFirstLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
-    end
-    function varargout = getSecondLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1353, self, varargin{:});
-    end
-    function varargout = setFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1354, self, varargin{:});
-    end
-    function varargout = setSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1355, self, varargin{:});
     end
-    function varargout = getFirstLinkName(self,varargin)
+    function varargout = setFirstLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1356, self, varargin{:});
     end
-    function varargout = getSecondLinkName(self,varargin)
+    function varargout = setSecondLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1357, self, varargin{:});
     end
-    function varargout = setParentJoint(self,varargin)
+    function varargout = getFirstLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1358, self, varargin{:});
     end
-    function varargout = setParentJointIndex(self,varargin)
+    function varargout = getSecondLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1359, self, varargin{:});
     end
-    function varargout = setAppliedWrenchLink(self,varargin)
+    function varargout = setFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1360, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = setSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1361, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = getFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1362, self, varargin{:});
     end
-    function varargout = getParentJoint(self,varargin)
+    function varargout = getSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1363, self, varargin{:});
     end
-    function varargout = getParentJointIndex(self,varargin)
+    function varargout = setParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1364, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1365, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = setAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1366, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1367, self, varargin{:});
     end
-    function varargout = updateIndeces(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1368, self, varargin{:});
     end
-    function varargout = getAppliedWrenchLink(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1369, self, varargin{:});
     end
-    function varargout = isLinkAttachedToSensor(self,varargin)
+    function varargout = getParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1370, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1371, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLink(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1372, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+    function varargout = updateIndices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1373, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+    function varargout = updateIndeces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1374, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1375, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = isLinkAttachedToSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1376, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1377, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1378, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1379, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1380, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1381, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1382, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
@@ -5,44 +5,14 @@ classdef SolidShape < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1093, self);
+        iDynTreeMEX(1099, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
     end
     function varargout = name(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1095, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1096, self, varargin{1});
-      end
-    end
-    function varargout = nameIsValid(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1097, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1098, self, varargin{1});
-      end
-    end
-    function varargout = link_H_geometry(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1099, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1100, self, varargin{1});
-      end
-    end
-    function varargout = material(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -52,29 +22,59 @@ classdef SolidShape < SwigRef
         iDynTreeMEX(1102, self, varargin{1});
       end
     end
+    function varargout = nameIsValid(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1103, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1104, self, varargin{1});
+      end
+    end
+    function varargout = link_H_geometry(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1105, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1106, self, varargin{1});
+      end
+    end
+    function varargout = material(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1107, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1108, self, varargin{1});
+      end
+    end
     function varargout = isSphere(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
-    end
-    function varargout = isBox(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
-    end
-    function varargout = isCylinder(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1105, self, varargin{:});
-    end
-    function varargout = isExternalMesh(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1106, self, varargin{:});
-    end
-    function varargout = asSphere(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1107, self, varargin{:});
-    end
-    function varargout = asBox(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1108, self, varargin{:});
-    end
-    function varargout = asCylinder(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1109, self, varargin{:});
     end
-    function varargout = asExternalMesh(self,varargin)
+    function varargout = isBox(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1110, self, varargin{:});
+    end
+    function varargout = isCylinder(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
+    end
+    function varargout = isExternalMesh(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
+    end
+    function varargout = asSphere(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1113, self, varargin{:});
+    end
+    function varargout = asBox(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1114, self, varargin{:});
+    end
+    function varargout = asCylinder(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1115, self, varargin{:});
+    end
+    function varargout = asExternalMesh(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
     end
     function self = SolidShape(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialAcc.m
@@ -7,23 +7,23 @@ classdef SpatialAcc < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(610, varargin{:});
+        tmp = iDynTreeMEX(616, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(611, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(617, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(612, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(618, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(613, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(619, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(614, self);
+        iDynTreeMEX(620, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVector.m
@@ -7,19 +7,19 @@ classdef SpatialForceVector < iDynTree.SpatialForceVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(591, varargin{:});
+        tmp = iDynTreeMEX(597, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(592, self);
+        iDynTreeMEX(598, self);
         self.SwigClear();
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(593, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(599, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialForceVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(557, varargin{:});
+        tmp = iDynTreeMEX(563, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(558, self, varargin{:});
-    end
-    function varargout = getAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(559, self, varargin{:});
-    end
-    function varargout = setLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(560, self, varargin{:});
-    end
-    function varargout = setAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(561, self, varargin{:});
-    end
-    function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(562, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(563, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(564, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(565, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setLinearVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(566, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = setAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(567, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(568, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
+    function varargout = getVal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(569, self, varargin{:});
+    end
+    function varargout = setVal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(570, self, varargin{:});
+    end
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(571, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(572, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(573, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(574, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(576, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(577, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(578, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(579, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = uminus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(580, self, varargin{:});
+    end
+    function varargout = asVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(582, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(583, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(584, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(585, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(586, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(581, self);
+        iDynTreeMEX(587, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(569, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(575, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(570, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(576, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(575, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(581, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorSemanticsBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorSemanticsBase.m
@@ -9,23 +9,23 @@ classdef SpatialForceVectorSemanticsBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(527, varargin{:});
+        tmp = iDynTreeMEX(533, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = check_linear2angularConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(528, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(529, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(535, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(530, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(536, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(531, self);
+        iDynTreeMEX(537, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialInertia.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialInertia.m
@@ -7,63 +7,63 @@ classdef SpatialInertia < iDynTree.SpatialInertiaRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(661, varargin{:});
+        tmp = iDynTreeMEX(667, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = asMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(663, self, varargin{:});
-    end
-    function varargout = applyInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
-    end
-    function varargout = getInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(665, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(666, self, varargin{:});
-    end
-    function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(667, self, varargin{:});
-    end
-    function varargout = biasWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(668, self, varargin{:});
-    end
-    function varargout = biasWrenchDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(669, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
+    function varargout = applyInverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(670, self, varargin{:});
+    end
+    function varargout = getInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(671, self, varargin{:});
     end
-    function varargout = fromVector(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(672, self, varargin{:});
     end
-    function varargout = isPhysicallyConsistent(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(673, self, varargin{:});
+    end
+    function varargout = biasWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(674, self, varargin{:});
+    end
+    function varargout = biasWrenchDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(675, self, varargin{:});
+    end
+    function varargout = asVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(677, self, varargin{:});
+    end
+    function varargout = fromVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(678, self, varargin{:});
+    end
+    function varargout = isPhysicallyConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(679, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(677, self);
+        iDynTreeMEX(683, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(662, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(668, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(670, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(676, varargin{:});
     end
     function varargout = momentumRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(674, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(680, varargin{:});
     end
     function varargout = momentumDerivativeRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(675, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(681, varargin{:});
     end
     function varargout = momentumDerivativeSlotineLiRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(676, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(682, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialInertiaRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialInertiaRaw.m
@@ -9,42 +9,42 @@ classdef SpatialInertiaRaw < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(651, varargin{:});
+        tmp = iDynTreeMEX(657, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromRotationalInertiaWrtCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(652, self, varargin{:});
-    end
-    function varargout = getMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(653, self, varargin{:});
-    end
-    function varargout = getCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(654, self, varargin{:});
-    end
-    function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(655, self, varargin{:});
-    end
-    function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(656, self, varargin{:});
-    end
-    function varargout = multiply(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(658, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = getMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(659, self, varargin{:});
+    end
+    function varargout = getCenterOfMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(660, self, varargin{:});
+    end
+    function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(661, self, varargin{:});
+    end
+    function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(662, self, varargin{:});
+    end
+    function varargout = multiply(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(665, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(660, self);
+        iDynTreeMEX(666, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(657, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(663, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMomentum.m
@@ -7,23 +7,23 @@ classdef SpatialMomentum < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(605, varargin{:});
+        tmp = iDynTreeMEX(611, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(606, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(612, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(607, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(613, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(608, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(614, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(609, self);
+        iDynTreeMEX(615, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVector.m
@@ -7,29 +7,29 @@ classdef SpatialMotionVector < iDynTree.SpatialMotionVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(584, varargin{:});
+        tmp = iDynTreeMEX(590, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(585, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(591, self, varargin{:});
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(586, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(592, self, varargin{:});
     end
     function varargout = asCrossProductMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(587, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(593, self, varargin{:});
     end
     function varargout = asCrossProductMatrixWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(588, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(594, self, varargin{:});
     end
     function varargout = exp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(589, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(595, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(590, self);
+        iDynTreeMEX(596, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialMotionVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(532, varargin{:});
+        tmp = iDynTreeMEX(538, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(533, self, varargin{:});
-    end
-    function varargout = getAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
-    end
-    function varargout = setLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(535, self, varargin{:});
-    end
-    function varargout = setAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(536, self, varargin{:});
-    end
-    function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(537, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(538, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(539, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(540, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setLinearVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(541, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = setAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(542, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(543, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
+    function varargout = getVal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(544, self, varargin{:});
+    end
+    function varargout = setVal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(545, self, varargin{:});
+    end
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(546, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(547, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(548, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(549, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(551, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(552, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(553, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(554, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = uminus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(555, self, varargin{:});
+    end
+    function varargout = asVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(557, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(558, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(559, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(560, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(561, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(556, self);
+        iDynTreeMEX(562, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(544, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(550, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(545, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(551, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(550, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(556, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorSemanticsBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorSemanticsBase.m
@@ -9,23 +9,23 @@ classdef SpatialMotionVectorSemanticsBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(522, varargin{:});
+        tmp = iDynTreeMEX(528, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = check_linear2angularConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(523, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(529, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(524, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(530, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(525, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(531, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(526, self);
+        iDynTreeMEX(532, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Sphere.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sphere.m
@@ -2,21 +2,21 @@ classdef Sphere < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1111, self);
+        iDynTreeMEX(1117, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1118, self, varargin{:});
     end
     function varargout = radius(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1113, self);
+        varargout{1} = iDynTreeMEX(1119, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1114, self, varargin{1});
+        iDynTreeMEX(1120, self, varargin{1});
       end
     end
     function self = Sphere(varargin)
@@ -26,7 +26,7 @@ classdef Sphere < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1115, varargin{:});
+        tmp = iDynTreeMEX(1121, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = TRAVERSAL_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(859);
+    varargout{1} = iDynTreeMEX(865);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(860,varargin{1});
+    iDynTreeMEX(866,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef ThreeAxisAngularAccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1409, varargin{:});
+        tmp = iDynTreeMEX(1415, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1410, self);
+        iDynTreeMEX(1416, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1411, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1412, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1413, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1414, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1415, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1416, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1417, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1418, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1419, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1420, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1421, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1422, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1423, self, varargin{:});
+    end
+    function varargout = getParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1424, self, varargin{:});
+    end
+    function varargout = getLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1425, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1426, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1427, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1428, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1429, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
@@ -7,64 +7,64 @@ classdef ThreeAxisForceTorqueContactSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1424, varargin{:});
+        tmp = iDynTreeMEX(1430, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1425, self);
+        iDynTreeMEX(1431, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1426, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1427, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1428, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1429, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1430, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1431, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1432, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1433, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1434, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1435, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1436, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1437, self, varargin{:});
     end
-    function varargout = setLoadCellLocations(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1438, self, varargin{:});
     end
-    function varargout = getLoadCellLocations(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1439, self, varargin{:});
     end
-    function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1440, self, varargin{:});
     end
-    function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1441, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1442, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1443, self, varargin{:});
+    end
+    function varargout = setLoadCellLocations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1444, self, varargin{:});
+    end
+    function varargout = getLoadCellLocations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1445, self, varargin{:});
+    end
+    function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1446, self, varargin{:});
+    end
+    function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1447, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Transform.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Transform.m
@@ -9,69 +9,69 @@ classdef Transform < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(788, varargin{:});
+        tmp = iDynTreeMEX(794, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(795, self, varargin{:});
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(796, self, varargin{:});
     end
     function varargout = getRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(791, self, varargin{:});
-    end
-    function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(792, self, varargin{:});
-    end
-    function varargout = setRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(793, self, varargin{:});
-    end
-    function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(794, self, varargin{:});
-    end
-    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(797, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(798, self, varargin{:});
     end
-    function varargout = asHomogeneousTransform(self,varargin)
+    function varargout = setRotation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(799, self, varargin{:});
+    end
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(800, self, varargin{:});
     end
-    function varargout = asAdjointTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(801, self, varargin{:});
-    end
-    function varargout = asAdjointTransformWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(802, self, varargin{:});
-    end
-    function varargout = log(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(803, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(804, self, varargin{:});
     end
+    function varargout = asHomogeneousTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(806, self, varargin{:});
+    end
+    function varargout = asAdjointTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(807, self, varargin{:});
+    end
+    function varargout = asAdjointTransformWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(808, self, varargin{:});
+    end
+    function varargout = log(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(809, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(810, self, varargin{:});
+    end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(805, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(806, self);
+        iDynTreeMEX(812, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(795, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(801, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(796, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(802, varargin{:});
     end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(799, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(805, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
@@ -9,51 +9,51 @@ classdef TransformDerivative < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(807, varargin{:});
+        tmp = iDynTreeMEX(813, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(808, self);
+        iDynTreeMEX(814, self);
         self.SwigClear();
       end
     end
     function varargout = getRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(809, self, varargin{:});
-    end
-    function varargout = getPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(810, self, varargin{:});
-    end
-    function varargout = setRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
-    end
-    function varargout = setPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(812, self, varargin{:});
-    end
-    function varargout = asHomogeneousTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(814, self, varargin{:});
-    end
-    function varargout = asAdjointTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(815, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+    function varargout = getPositionDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(816, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = setRotationDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(817, self, varargin{:});
     end
-    function varargout = derivativeOfInverse(self,varargin)
+    function varargout = setPositionDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(818, self, varargin{:});
     end
+    function varargout = asHomogeneousTransformDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(820, self, varargin{:});
+    end
+    function varargout = asAdjointTransformDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(821, self, varargin{:});
+    end
+    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
+    end
+    function varargout = derivativeOfInverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
+    end
     function varargout = transform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(819, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(825, self, varargin{:});
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(813, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(819, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformSemantics.m
@@ -9,32 +9,32 @@ classdef TransformSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(780, varargin{:});
+        tmp = iDynTreeMEX(786, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(781, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
     end
     function varargout = getPositionSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(782, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
     end
     function varargout = setRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(783, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
     end
     function varargout = setPositionSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(785, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(791, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(786, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(792, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(787, self);
+        iDynTreeMEX(793, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Traversal.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Traversal.m
@@ -9,61 +9,61 @@ classdef Traversal < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1076, varargin{:});
+        tmp = iDynTreeMEX(1082, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1077, self);
+        iDynTreeMEX(1083, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfVisitedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
-    end
-    function varargout = getBaseLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
-    end
-    function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1082, self, varargin{:});
-    end
-    function varargout = getParentLinkFromLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1083, self, varargin{:});
-    end
-    function varargout = getParentJointFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1084, self, varargin{:});
     end
-    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
     end
-    function varargout = reset(self,varargin)
+    function varargout = getBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
     end
-    function varargout = addTraversalBase(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1087, self, varargin{:});
     end
-    function varargout = addTraversalElement(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1088, self, varargin{:});
     end
-    function varargout = isParentOf(self,varargin)
+    function varargout = getParentLinkFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
     end
-    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+    function varargout = getParentJointFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
     end
-    function varargout = getParentLinkIndexFromJointIndex(self,varargin)
+    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1091, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = reset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1092, self, varargin{:});
+    end
+    function varargout = addTraversalBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1093, self, varargin{:});
+    end
+    function varargout = addTraversalElement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
+    end
+    function varargout = isParentOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1095, self, varargin{:});
+    end
+    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1096, self, varargin{:});
+    end
+    function varargout = getParentLinkIndexFromJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1097, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Twist.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Twist.m
@@ -7,26 +7,26 @@ classdef Twist < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(594, varargin{:});
+        tmp = iDynTreeMEX(600, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(595, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(601, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(596, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(602, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(597, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(603, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(598, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(604, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(599, self);
+        iDynTreeMEX(605, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/URDFParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/URDFParserOptions.m
@@ -7,20 +7,20 @@ classdef URDFParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1444, self);
+        varargout{1} = iDynTreeMEX(1450, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1445, self, varargin{1});
+        iDynTreeMEX(1451, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1446, self);
+        varargout{1} = iDynTreeMEX(1452, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1447, self, varargin{1});
+        iDynTreeMEX(1453, self, varargin{1});
       end
     end
     function self = URDFParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef URDFParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1448, varargin{:});
+        tmp = iDynTreeMEX(1454, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1449, self);
+        iDynTreeMEX(1455, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
+++ b/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
@@ -9,42 +9,12 @@ classdef UnknownWrenchContact < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1499, varargin{:});
+        tmp = iDynTreeMEX(1505, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = unknownType(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1500, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1501, self, varargin{1});
-      end
-    end
-    function varargout = contactPoint(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1502, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1503, self, varargin{1});
-      end
-    end
-    function varargout = forceDirection(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1504, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1505, self, varargin{1});
-      end
-    end
-    function varargout = knownWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -54,7 +24,7 @@ classdef UnknownWrenchContact < SwigRef
         iDynTreeMEX(1507, self, varargin{1});
       end
     end
-    function varargout = contactId(self, varargin)
+    function varargout = contactPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -64,9 +34,39 @@ classdef UnknownWrenchContact < SwigRef
         iDynTreeMEX(1509, self, varargin{1});
       end
     end
+    function varargout = forceDirection(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1510, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1511, self, varargin{1});
+      end
+    end
+    function varargout = knownWrench(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1512, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1513, self, varargin{1});
+      end
+    end
+    function varargout = contactId(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1514, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1515, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1510, self);
+        iDynTreeMEX(1516, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector10.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector10.m
@@ -9,47 +9,50 @@ classdef Vector10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(319, varargin{:});
+        tmp = iDynTreeMEX(323, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(320, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(321, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(322, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(323, self, varargin{:});
-    end
-    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(324, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(325, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(326, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(327, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(328, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(329, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(330, self, varargin{:});
+    end
+    function varargout = fillBuffer(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(331, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(332, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(333, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(334, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(335, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(331, self);
+        iDynTreeMEX(336, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector16.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector16.m
@@ -9,47 +9,50 @@ classdef Vector16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(332, varargin{:});
+        tmp = iDynTreeMEX(337, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(333, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(334, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(335, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(336, self, varargin{:});
-    end
-    function varargout = data(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(337, self, varargin{:});
-    end
-    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(338, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(339, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(340, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(341, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(342, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(343, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(344, self, varargin{:});
+    end
+    function varargout = fillBuffer(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(345, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(346, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(347, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(348, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(349, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(344, self);
+        iDynTreeMEX(350, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector3.m
@@ -9,47 +9,50 @@ classdef Vector3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(280, varargin{:});
+        tmp = iDynTreeMEX(281, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(281, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(282, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(283, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(284, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(285, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(286, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(287, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(288, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(289, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(290, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(291, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(292, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(293, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(292, self);
+        iDynTreeMEX(294, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector4.m
@@ -9,47 +9,50 @@ classdef Vector4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(293, varargin{:});
+        tmp = iDynTreeMEX(295, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(294, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(295, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(296, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(297, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(298, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(299, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(300, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(301, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(302, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(303, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(304, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(305, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(306, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(307, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(305, self);
+        iDynTreeMEX(308, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector6.m
@@ -9,47 +9,50 @@ classdef Vector6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(306, varargin{:});
+        tmp = iDynTreeMEX(309, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(307, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(308, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(309, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(310, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(311, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(312, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(313, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(314, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(315, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(316, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(317, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(318, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(319, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(320, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(321, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(318, self);
+        iDynTreeMEX(322, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/VectorDynSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VectorDynSize.m
@@ -23,47 +23,50 @@ classdef VectorDynSize < SwigRef
     function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(160, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(161, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(162, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(163, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(164, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(165, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(166, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(167, self, varargin{:});
     end
-    function varargout = shrink_to_fit(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(168, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = shrink_to_fit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(169, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = capacity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(170, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(171, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(172, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = display(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(173, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(174, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(175, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,55 +9,55 @@ classdef Visualizer < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1965, varargin{:});
+        tmp = iDynTreeMEX(1971, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1966, self);
+        iDynTreeMEX(1972, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
-    end
-    function varargout = getNrOfVisualizedModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
-    end
-    function varargout = getModelInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
-    end
-    function varargout = getModelInstanceIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
-    end
-    function varargout = addModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1971, self, varargin{:});
-    end
-    function varargout = modelViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1972, self, varargin{:});
-    end
-    function varargout = camera(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
     end
-    function varargout = enviroment(self,varargin)
+    function varargout = getNrOfVisualizedModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
     end
-    function varargout = vectors(self,varargin)
+    function varargout = getModelInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
     end
-    function varargout = run(self,varargin)
+    function varargout = getModelInstanceIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
     end
-    function varargout = draw(self,varargin)
+    function varargout = addModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
     end
-    function varargout = drawToFile(self,varargin)
+    function varargout = modelViz(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
     end
-    function varargout = close(self,varargin)
+    function varargout = camera(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
+    end
+    function varargout = enviroment(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
+    end
+    function varargout = vectors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
+    end
+    function varargout = run(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
+    end
+    function varargout = draw(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
+    end
+    function varargout = drawToFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
+    end
+    function varargout = close(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,40 +7,40 @@ classdef VisualizerOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1955, self);
+        varargout{1} = iDynTreeMEX(1961, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1956, self, varargin{1});
+        iDynTreeMEX(1962, self, varargin{1});
       end
     end
     function varargout = winWidth(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1957, self);
+        varargout{1} = iDynTreeMEX(1963, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1958, self, varargin{1});
+        iDynTreeMEX(1964, self, varargin{1});
       end
     end
     function varargout = winHeight(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1959, self);
+        varargout{1} = iDynTreeMEX(1965, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1960, self, varargin{1});
+        iDynTreeMEX(1966, self, varargin{1});
       end
     end
     function varargout = rootFrameArrowsDimension(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1961, self);
+        varargout{1} = iDynTreeMEX(1967, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1962, self, varargin{1});
+        iDynTreeMEX(1968, self, varargin{1});
       end
     end
     function self = VisualizerOptions(varargin)
@@ -49,14 +49,14 @@ classdef VisualizerOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1963, varargin{:});
+        tmp = iDynTreeMEX(1969, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1964, self);
+        iDynTreeMEX(1970, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Wrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Wrench.m
@@ -7,23 +7,23 @@ classdef Wrench < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(600, varargin{:});
+        tmp = iDynTreeMEX(606, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(601, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(607, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(602, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(608, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(603, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(609, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(604, self);
+        iDynTreeMEX(610, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
@@ -1,3 +1,3 @@
 function varargout = computeLinkNetWrenchesWithoutGravity(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1544, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1550, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1452, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1458, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1453, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1459, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
@@ -1,3 +1,3 @@
 function v = dynamic_extent()
-  v = iDynTreeMEX(820);
+  v = iDynTreeMEX(826);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1542, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1548, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1543, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1549, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1541, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1547, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
@@ -9,54 +9,24 @@ classdef estimateExternalWrenchesBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1522, varargin{:});
+        tmp = iDynTreeMEX(1528, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1523, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1529, self, varargin{:});
     end
     function varargout = getNrOfSubModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1524, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1530, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1525, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1531, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1526, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1532, self, varargin{:});
     end
     function varargout = A(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1527, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1528, self, varargin{1});
-      end
-    end
-    function varargout = x(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1529, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1530, self, varargin{1});
-      end
-    end
-    function varargout = b(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1531, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1532, self, varargin{1});
-      end
-    end
-    function varargout = pinvA(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -66,7 +36,7 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1534, self, varargin{1});
       end
     end
-    function varargout = b_contacts_subtree(self, varargin)
+    function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -76,7 +46,7 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1536, self, varargin{1});
       end
     end
-    function varargout = subModelBase_H_link(self, varargin)
+    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -86,9 +56,39 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1538, self, varargin{1});
       end
     end
+    function varargout = pinvA(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1539, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1540, self, varargin{1});
+      end
+    end
+    function varargout = b_contacts_subtree(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1541, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1542, self, varargin{1});
+      end
+    end
+    function varargout = subModelBase_H_link(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1543, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1544, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1539, self);
+        iDynTreeMEX(1545, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenchesWithoutInternalFT(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1540, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1546, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
@@ -1,3 +1,3 @@
 function varargout = estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1780, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1786, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateLinkContactWrenchesFromLinkNetExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1545, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1551, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
@@ -1,3 +1,3 @@
 function varargout = getSensorTypeSize(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1297, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1303, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
@@ -1,3 +1,3 @@
 function v = input_dimensions()
-  v = iDynTreeMEX(1735);
+  v = iDynTreeMEX(1741);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isDOFBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1574, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1580, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isJointBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1573, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1579, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
@@ -1,3 +1,3 @@
 function varargout = isJointSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1296, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1302, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isLinkBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1572, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1578, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
@@ -1,3 +1,3 @@
 function varargout = isLinkSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1295, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1301, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/modelFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/modelFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1450, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1456, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/modelFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/modelFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1451, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1457, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_with_magnetometer()
-  v = iDynTreeMEX(1733);
+  v = iDynTreeMEX(1739);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_without_magnetometer()
-  v = iDynTreeMEX(1734);
+  v = iDynTreeMEX(1740);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurements(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1442, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1448, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurementsFromRawBuffers(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1443, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1449, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1454, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1460, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1455, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1461, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
@@ -1,0 +1,3 @@
+function varargout = sizeOfRotationParametrization(varargin)
+  [varargout{1:nargout}] = iDynTreeMEX(2032, varargin{:});
+end

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,10 +20,10 @@ add_subdirectory(model_io)
 add_subdirectory(estimation)
 add_subdirectory(solid-shapes)
 add_subdirectory(high-level)
+add_subdirectory(inverse-kinematics)
 
 if (IDYNTREE_USES_IPOPT)
   set(IDYNTREE_BUILD_IK TRUE)
-  add_subdirectory(inverse-kinematics)
 endif()
 
 if (IDYNTREE_COMPILES_OPTIMALCONTROL)

--- a/src/inverse-kinematics/CMakeLists.txt
+++ b/src/inverse-kinematics/CMakeLists.txt
@@ -7,18 +7,22 @@ set(IDYN_TREE_IK_HEADERS include/iDynTree/ConvexHullHelpers.h
                          include/iDynTree/BoundingBoxHelpers.h
                          include/iDynTree/InverseKinematics.h)
 
-set(PRIVATE_IDYN_TREE_IK_SOURCES src/InverseKinematicsNLP.cpp
-                                 src/InverseKinematicsData.cpp
-                                 src/TransformConstraint.cpp)
-set(PRIVATE_IDYN_TREE_IK_HEADERS include/private/InverseKinematicsNLP.h
-                                 include/private/InverseKinematicsData.h
-                                 include/private/TransformConstraint.h)
+if(IDYNTREE_USES_IPOPT)
+    set(PRIVATE_IDYN_TREE_IK_SOURCES src/InverseKinematicsNLP.cpp
+                                     src/InverseKinematicsData.cpp
+                                     src/TransformConstraint.cpp)
+    set(PRIVATE_IDYN_TREE_IK_HEADERS include/private/InverseKinematicsNLP.h
+                                     include/private/InverseKinematicsData.h
+                                     include/private/TransformConstraint.h)
+    source_group("Private\\Header Files" FILES ${PRIVATE_IDYN_TREE_IK_HEADERS})
+    source_group("Private\\Source Files" FILES ${PRIVATE_IDYN_TREE_IK_SOURCES})
 
-source_group("Private\\Header Files" FILES ${PRIVATE_IDYN_TREE_IK_HEADERS})
-source_group("Private\\Source Files" FILES ${PRIVATE_IDYN_TREE_IK_SOURCES})
+    add_library(${libraryname} ${IDYN_TREE_IK_HEADERS} ${IDYN_TREE_IK_SOURCES}
+                               ${PRIVATE_IDYN_TREE_IK_SOURCES} ${PRIVATE_IDYN_TREE_IK_HEADERS})
+else()
+    add_library(${libraryname} ${IDYN_TREE_IK_HEADERS} ${IDYN_TREE_IK_SOURCES})
+endif()
 
-add_library(${libraryname} ${IDYN_TREE_IK_HEADERS} ${IDYN_TREE_IK_SOURCES}
-                           ${PRIVATE_IDYN_TREE_IK_SOURCES} ${PRIVATE_IDYN_TREE_IK_HEADERS})
 add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -28,11 +32,16 @@ target_include_directories(${libraryname} PRIVATE include/private)
 
 # Probably SYSTEM is not compatible with cmake 2.8.12, but I think as YARP requires
 # CMake 3.0 we can increase the min version
-target_include_directories(${libraryname} SYSTEM PUBLIC ${IPOPT_INCLUDE_DIRS})
-target_include_directories(${libraryname} SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
-target_link_libraries(${libraryname} idyntree-core idyntree-high-level ${IPOPT_LIBRARIES})
 
-target_compile_definitions(${libraryname} PRIVATE ${IPOPT_DEFINITIONS})
+target_include_directories(${libraryname} SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+target_link_libraries(${libraryname} PUBLIC idyntree-core idyntree-high-level)
+
+if(IDYNTREE_USES_IPOPT)
+    target_compile_definitions(${libraryname} PRIVATE IDYNTREE_USES_IPOPT)
+    target_compile_definitions(${libraryname} PRIVATE ${IPOPT_DEFINITIONS})
+    target_include_directories(${libraryname} PRIVATE ${IPOPT_INCLUDE_DIRS})
+    target_link_libraries(${libraryname} PRIVATE ${IPOPT_LIBRARIES})
+endif()
 
 set_property(TARGET ${libraryname} PROPERTY PUBLIC_HEADER ${IDYN_TREE_IK_HEADERS})
 
@@ -47,7 +56,7 @@ install(TARGETS ${libraryname}
 set_property(GLOBAL APPEND PROPERTY ${VARS_PREFIX}_TARGETS ${libraryname})
 
 
-if(IDYNTREE_COMPILE_TESTS)
+if(IDYNTREE_COMPILE_TESTS AND IDYNTREE_USES_IPOPT)
   add_subdirectory(tests)
 endif()
 

--- a/src/inverse-kinematics/src/InverseKinematics.cpp
+++ b/src/inverse-kinematics/src/InverseKinematics.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iDynTree/InverseKinematics.h>
+#ifdef IDYNTREE_USES_IPOPT
 #include "InverseKinematicsData.h"
 #include "TransformConstraint.h"
 
@@ -32,27 +33,44 @@
  * - IKNLP is an IPOPT NLP implementation. It manages only IPOPT related data
  *   and implements IPOPT related functions
  */
+#endif
 
 namespace iDynTree {
+
+#ifndef IDYNTREE_USES_IPOPT
+    bool missingIpoptErrorReport() {
+        reportError("InverseKinematics", "", "IDYNTREE_USES_IPOPT CMake option need to be set to ON to use InverseKinematics");
+        return false;
+    }
+#endif
 
     InverseKinematics::InverseKinematics()
     : m_pimpl(0)
     {
+#ifdef IDYNTREE_USES_IPOPT
         m_pimpl = new internal::kinematics::InverseKinematicsData();
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     InverseKinematics::~InverseKinematics()
     {
+#ifdef IDYNTREE_USES_IPOPT
         if (m_pimpl) {
             delete IK_PIMPL(m_pimpl);
             m_pimpl = 0;
         }
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::loadModelFromFile(const std::string & filename,
                                               const std::vector<std::string> &consideredJoints,
                                               const std::string & filetype)
     {
+#ifdef IDYNTREE_USES_IPOPT
         ModelLoader loader;
         if (!loader.loadModelFromFile(filename) || !loader.isValid()) {
             std::cerr << "[ERROR] iDynTree::InverseDynamics : Failed to load model from URDF file " << filename << std::endl;
@@ -60,170 +78,284 @@ namespace iDynTree {
         }
 
         return setModel(loader.model(), consideredJoints);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setModel(const iDynTree::Model &model,
                                      const std::vector<std::string> &consideredJoints)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->setModel(model, consideredJoints);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
     
     bool InverseKinematics::setJointLimits(std::vector<std::pair<double, double> >& jointLimits)
     {
+#ifdef IDYNTREE_USES_IPOPT
       assert(m_pimpl);
       return IK_PIMPL(m_pimpl)->setJointLimits(jointLimits);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
     
     bool InverseKinematics::getJointLimits(std::vector<std::pair<double, double> >& jointLimits)
     {
+#ifdef IDYNTREE_USES_IPOPT
       assert(m_pimpl);
       return IK_PIMPL(m_pimpl)->getJointLimits(jointLimits);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::clearProblem()
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         IK_PIMPL(m_pimpl)->clearProblem();
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setFloatingBaseOnFrameNamed(const std::string &floatingBaseFrameName)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->dynamics().setFloatingBase(floatingBaseFrameName);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setRobotConfiguration(const iDynTree::Transform& baseConfiguration, const iDynTree::VectorDynSize& jointConfiguration)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->setRobotConfiguration(baseConfiguration, jointConfiguration);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setCurrentRobotConfiguration(const iDynTree::Transform& baseConfiguration, const iDynTree::VectorDynSize& jointConfiguration)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->setRobotConfiguration(baseConfiguration, jointConfiguration);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
 
     bool InverseKinematics::setJointConfiguration(const std::string& jointName, const double jointConfiguration)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->setJointConfiguration(jointName, jointConfiguration);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setRotationParametrization(enum InverseKinematicsRotationParametrization parametrization)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         IK_PIMPL(m_pimpl)->setRotationParametrization(parametrization);
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     enum InverseKinematicsRotationParametrization InverseKinematics::rotationParametrization()
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->rotationParametrization();
+#else
+        missingIpoptErrorReport();
+        return InverseKinematicsRotationParametrizationQuaternion;
+#endif
     }
 
     void InverseKinematics::setMaxIterations(const int max_iter)
     {
+#ifdef IDYNTREE_USES_IPOPT
         if (max_iter>0)
             IK_PIMPL(m_pimpl)->m_maxIter = max_iter;
         else
             IK_PIMPL(m_pimpl)->m_maxIter = std::numeric_limits<int>::max();
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     int InverseKinematics::maxIterations() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         return IK_PIMPL(m_pimpl)->m_maxIter;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setMaxCPUTime(const double max_cpu_time)
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->m_maxCpuTime = max_cpu_time;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     double InverseKinematics::maxCPUTime() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         return IK_PIMPL(m_pimpl)->m_maxCpuTime;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setCostTolerance(const double tol)
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->m_tol = tol;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     double InverseKinematics::costTolerance() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         return IK_PIMPL(m_pimpl)->m_tol;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setConstraintsTolerance(const double constr_tol)
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->m_constrTol = constr_tol;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     double InverseKinematics::constraintsTolerance() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         return IK_PIMPL(m_pimpl)->m_constrTol;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setVerbosity(const unsigned int verbose)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         IK_PIMPL(m_pimpl)->m_verbosityLevel = verbose;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     std::string InverseKinematics::linearSolverName()
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->m_solverName;
+#else
+        missingIpoptErrorReport();
+        return {};
+#endif
     }
 
     void InverseKinematics::setLinearSolverName(const std::string &solverName)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         IK_PIMPL(m_pimpl)->m_solverName = solverName;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addFrameConstraint(const std::string& frameName)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         iDynTree::Transform w_X_frame = IK_PIMPL(m_pimpl)->dynamics().getWorldTransform(frameName);
         return addFrameConstraint(frameName, w_X_frame);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addFrameConstraint(const std::string& frameName, const iDynTree::Transform& constraintValue)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addFrameConstraint(internal::kinematics::TransformConstraint::fullTransformConstraint(frameName, constraintValue));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addFramePositionConstraint(const std::string& frameName, const iDynTree::Position& constraintValue)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addFrameConstraint(internal::kinematics::TransformConstraint::positionConstraint(frameName, constraintValue));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addFramePositionConstraint(const std::string& frameName, const iDynTree::Transform& constraintValue)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addFrameConstraint(internal::kinematics::TransformConstraint::positionConstraint(frameName, constraintValue.getPosition()));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addFrameRotationConstraint(const std::string& frameName, const iDynTree::Rotation& constraintValue)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addFrameConstraint(internal::kinematics::TransformConstraint::rotationConstraint(frameName, constraintValue));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addFrameRotationConstraint(const std::string& frameName, const iDynTree::Transform& constraintValue)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addFrameConstraint(internal::kinematics::TransformConstraint::rotationConstraint(frameName, constraintValue.getRotation()));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::activateFrameConstraint(const std::string& frameName, const Transform& newConstraintValue)
     {
+#ifdef IDYNTREE_USES_IPOPT
         iDynTree::LinkIndex frameIndex = IK_PIMPL(m_pimpl)->m_dynamics.getFrameIndex(frameName);
         if (frameIndex < 0)
         {
@@ -244,10 +376,14 @@ namespace iDynTree {
         IK_PIMPL(m_pimpl)->m_problemInitialized = false;
 
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::deactivateFrameConstraint(const std::string& frameName)
     {
+#ifdef IDYNTREE_USES_IPOPT
         iDynTree::LinkIndex frameIndex = IK_PIMPL(m_pimpl)->m_dynamics.getFrameIndex(frameName);
         if (frameIndex < 0)
         {
@@ -266,10 +402,14 @@ namespace iDynTree {
         IK_PIMPL(m_pimpl)->m_problemInitialized = false;
 
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool  InverseKinematics::isFrameConstraintActive(const std::string& frameName) const
     {
+#ifdef IDYNTREE_USES_IPOPT
         iDynTree::LinkIndex frameIndex = IK_PIMPL(m_pimpl)->m_dynamics.getFrameIndex(frameName);
         if (frameIndex < 0)
         {
@@ -283,6 +423,9 @@ namespace iDynTree {
         }
 
         return it->second.isActive();
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
 
@@ -292,11 +435,15 @@ namespace iDynTree {
                                                                 const iDynTree::Direction yAxisOfPlaneInWorld,
                                                                 const iDynTree::Position originOfPlaneInWorld)
     {
+#ifdef IDYNTREE_USES_IPOPT
         std::vector<std::string> supportFrames;
         std::vector<Polygon> supportPolygons;
         supportFrames.push_back(firstSupportFrame);
         supportPolygons.push_back(firstSupportPolygon);
         return addCenterOfMassProjectionConstraint(supportFrames,supportPolygons,xAxisOfPlaneInWorld,yAxisOfPlaneInWorld,originOfPlaneInWorld);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addCenterOfMassProjectionConstraint(const std::string &firstSupportFrame,
@@ -307,6 +454,7 @@ namespace iDynTree {
                                                                 const iDynTree::Direction yAxisOfPlaneInWorld,
                                                                 const iDynTree::Position originOfPlaneInWorld)
     {
+#ifdef IDYNTREE_USES_IPOPT
         std::vector<std::string> supportFrames;
         std::vector<Polygon> supportPolygons;
         supportFrames.push_back(firstSupportFrame);
@@ -314,6 +462,9 @@ namespace iDynTree {
         supportPolygons.push_back(firstSupportPolygon);
         supportPolygons.push_back(secondSupportPolygon);
         return addCenterOfMassProjectionConstraint(supportFrames,supportPolygons,xAxisOfPlaneInWorld,yAxisOfPlaneInWorld,originOfPlaneInWorld);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addCenterOfMassProjectionConstraint(const std::vector<std::string> &supportFrames,
@@ -322,6 +473,7 @@ namespace iDynTree {
                                                                 const iDynTree::Direction yAxisOfPlaneInWorld,
                                                                 const iDynTree::Position originOfPlaneInWorld)
     {
+#ifdef IDYNTREE_USES_IPOPT
         if( supportFrames.size() == 0 )
         {
             reportError("InverseKinematics","addCenterOfMassProjectionConstraint","No support frames specified");
@@ -379,10 +531,14 @@ namespace iDynTree {
         IK_PIMPL(m_pimpl)->m_problemInitialized = false;
 
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     double InverseKinematics::getCenterOfMassProjectionMargin()
     {
+#ifdef IDYNTREE_USES_IPOPT
         if (!IK_PIMPL(m_pimpl)->m_problemInitialized) {
             IK_PIMPL(m_pimpl)->computeProblemSizeAndResizeBuffers();
         }
@@ -395,10 +551,14 @@ namespace iDynTree {
 
         iDynTree::Vector2 comProjection = IK_PIMPL(m_pimpl)->m_comHullConstraint.projectAlongDirection(comInAbsoluteConstraintFrame);
         return IK_PIMPL(m_pimpl)->m_comHullConstraint.computeMargin(comProjection);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::getCenterOfMassProjectConstraintConvexHull(Polygon2D& poly)
     {
+#ifdef IDYNTREE_USES_IPOPT
         if (!IK_PIMPL(m_pimpl)->m_comHullConstraint.isActive())
         {
             poly.setNrOfVertices(0);
@@ -411,6 +571,9 @@ namespace iDynTree {
 
         poly = IK_PIMPL(m_pimpl)->m_comHullConstraint.projectedConvexHull;
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addTarget(const std::string& frameName,
@@ -418,35 +581,55 @@ namespace iDynTree {
                                       const double positionWeight,
                                       const double rotationWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addTarget(internal::kinematics::TransformConstraint::fullTransformConstraint(frameName,
                                                                                                                constraintValue,
                                                                                                                positionWeight,
                                                                                                                rotationWeight));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addPositionTarget(const std::string& frameName, const iDynTree::Position& constraintValue, const double positionWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addTarget(internal::kinematics::TransformConstraint::positionConstraint(frameName,  constraintValue, positionWeight));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addPositionTarget(const std::string& frameName, const iDynTree::Transform& constraintValue, const double positionWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addTarget(internal::kinematics::TransformConstraint::positionConstraint(frameName,  constraintValue.getPosition(), positionWeight));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addRotationTarget(const std::string& frameName, const iDynTree::Rotation& constraintValue, const double rotationWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addTarget(internal::kinematics::TransformConstraint::rotationConstraint(frameName,  constraintValue, rotationWeight));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::addRotationTarget(const std::string& frameName, const iDynTree::Transform& constraintValue, const double rotationWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->addTarget(internal::kinematics::TransformConstraint::rotationConstraint(frameName,  constraintValue.getRotation(), rotationWeight));
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::updateTarget(const std::string& frameName,
@@ -454,6 +637,7 @@ namespace iDynTree {
                                          const double positionWeight,
                                          const double rotationWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         internal::kinematics::TransformMap::iterator transConstr = IK_PIMPL(m_pimpl)->getTargetRefIfItExists(frameName);
 
         if( transConstr == IK_PIMPL(m_pimpl)->m_targets.end() )
@@ -467,12 +651,16 @@ namespace iDynTree {
         IK_PIMPL(m_pimpl)->updatePositionTarget(transConstr,targetValue.getPosition(),positionWeight);
         IK_PIMPL(m_pimpl)->updateRotationTarget(transConstr,targetValue.getRotation(),rotationWeight);
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::updatePositionTarget(const std::string& frameName,
                                                  const Position& targetValue,
                                                  const double positionWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         internal::kinematics::TransformMap::iterator transConstr = IK_PIMPL(m_pimpl)->getTargetRefIfItExists(frameName);
 
         if( transConstr == IK_PIMPL(m_pimpl)->m_targets.end() )
@@ -485,12 +673,16 @@ namespace iDynTree {
 
         IK_PIMPL(m_pimpl)->updatePositionTarget(transConstr,targetValue,positionWeight);
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::updateRotationTarget(const std::string& frameName,
                                                  const Rotation& targetValue,
                                                  const double rotationWeight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         internal::kinematics::TransformMap::iterator transConstr = IK_PIMPL(m_pimpl)->getTargetRefIfItExists(frameName);
 
         if( transConstr == IK_PIMPL(m_pimpl)->m_targets.end() )
@@ -503,15 +695,23 @@ namespace iDynTree {
 
         IK_PIMPL(m_pimpl)->updateRotationTarget(transConstr,targetValue,rotationWeight);
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setDesiredJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         return this->setDesiredReducedJointConfiguration(desiredJointConfiguration, weight);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setDesiredFullJointsConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         assert(IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration.size() == desiredJointConfiguration.size());
         IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration = desiredJointConfiguration;
@@ -519,10 +719,14 @@ namespace iDynTree {
             iDynTree::toEigen(IK_PIMPL(m_pimpl)->m_preferredJointsWeight).setConstant(weight);
         }
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setDesiredFullJointsConfiguration(const VectorDynSize &desiredJointConfiguration, const VectorDynSize &weights)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         assert(IK_PIMPL(m_pimpl)->m_preferredJointsConfiguration.size() == desiredJointConfiguration.size());
 
@@ -540,10 +744,14 @@ namespace iDynTree {
             }
         }
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setDesiredReducedJointConfiguration(const iDynTree::VectorDynSize& desiredJointConfiguration, double weight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         assert(IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints.size() == desiredJointConfiguration.size());
         for (size_t i = 0; i < desiredJointConfiguration.size(); ++i) {
@@ -554,10 +762,14 @@ namespace iDynTree {
             iDynTree::toEigen(IK_PIMPL(m_pimpl)->m_preferredJointsWeight).setConstant(weight);
         }
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setDesiredReducedJointConfiguration(const VectorDynSize &desiredJointConfiguration, const VectorDynSize &weights)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         assert(IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints.size() == desiredJointConfiguration.size());
 
@@ -574,16 +786,24 @@ namespace iDynTree {
         }
 
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setInitialCondition(const iDynTree::Transform* baseTransform, const iDynTree::VectorDynSize* initialCondition)
     {
+#ifdef IDYNTREE_USES_IPOPT
         return this->setReducedInitialCondition(baseTransform, initialCondition);
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setFullJointsInitialCondition(const iDynTree::Transform* baseTransform,
                                                           const iDynTree::VectorDynSize* initialCondition)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         if (baseTransform) {
             IK_PIMPL(m_pimpl)->m_baseInitialCondition = *baseTransform;
@@ -595,11 +815,15 @@ namespace iDynTree {
             IK_PIMPL(m_pimpl)->m_areJointsInitialConditionsSet = internal::kinematics::InverseKinematicsData::InverseKinematicsInitialConditionFull;
         }
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::setReducedInitialCondition(const iDynTree::Transform* baseTransform,
                                                        const iDynTree::VectorDynSize* initialCondition)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         if (baseTransform) {
             IK_PIMPL(m_pimpl)->m_baseInitialCondition = *baseTransform;
@@ -614,22 +838,35 @@ namespace iDynTree {
             IK_PIMPL(m_pimpl)->m_areJointsInitialConditionsSet = internal::kinematics::InverseKinematicsData::InverseKinematicsInitialConditionPartial;
         }
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setDefaultTargetResolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraint mode)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         IK_PIMPL(m_pimpl)->setDefaultTargetResolutionMode(mode);
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     enum iDynTree::InverseKinematicsTreatTargetAsConstraint InverseKinematics::defaultTargetResolutionMode()
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->defaultTargetResolutionMode();
+#else
+        missingIpoptErrorReport();
+        return InverseKinematicsTreatTargetAsConstraintNone;
+#endif
     }
     
     bool InverseKinematics::setTargetResolutionMode(const std::string& frameName, InverseKinematicsTreatTargetAsConstraint mode)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         internal::kinematics::TransformMap::iterator transConstr = IK_PIMPL(m_pimpl)->getTargetRefIfItExists(frameName);
         
@@ -643,11 +880,15 @@ namespace iDynTree {
         
         IK_PIMPL(m_pimpl)->setTargetResolutionMode(transConstr, mode);
         return true;
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
 
     enum InverseKinematicsTreatTargetAsConstraint InverseKinematics::targetResolutionMode(const std::string& frameName)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         internal::kinematics::TransformMap::iterator transConstr = IK_PIMPL(m_pimpl)->getTargetRefIfItExists(frameName);
         
@@ -660,33 +901,50 @@ namespace iDynTree {
         }
         
         return IK_PIMPL(m_pimpl)->targetResolutionMode(transConstr);
+#else
+        missingIpoptErrorReport();
+        return InverseKinematicsTreatTargetAsConstraintNone;
+#endif
     }
 
     bool InverseKinematics::solve()
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->solveProblem();
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::getSolution(iDynTree::Transform & baseTransformSolution,
                                         iDynTree::VectorDynSize & shapeSolution)
     {
+#ifdef IDYNTREE_USES_IPOPT
         this->getReducedSolution(baseTransformSolution, shapeSolution);
         return;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::getFullJointsSolution(iDynTree::Transform & baseTransformSolution,
                                                   iDynTree::VectorDynSize & shapeSolution)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         assert(shapeSolution.size() == IK_PIMPL(m_pimpl)->m_dofs);
         baseTransformSolution = IK_PIMPL(m_pimpl)->m_baseResults;
         shapeSolution         = IK_PIMPL(m_pimpl)->m_jointsResults;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::getReducedSolution(iDynTree::Transform & baseTransformSolution,
                                                iDynTree::VectorDynSize & shapeSolution)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         baseTransformSolution = IK_PIMPL(m_pimpl)->m_baseResults;
         assert(shapeSolution.size() == IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints.size());
@@ -694,72 +952,121 @@ namespace iDynTree {
             shapeSolution(i) = IK_PIMPL(m_pimpl)->m_jointsResults(IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.modelJointsToOptimisedJoints[i]);
         }
         return;
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     bool InverseKinematics::getPoseForFrame(const std::string& frameName,
                                             iDynTree::Transform& transform)
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         transform = IK_PIMPL(m_pimpl)->dynamics().getWorldTransform(frameName);
         return true;
-
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     const Model& InverseKinematics::model() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return this->reducedModel();
+#else
+        missingIpoptErrorReport();
+        return this->reducedModel();
+#endif
     }
 
     const Model& InverseKinematics::fullModel() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->m_dynamics.model();
+#else
+        missingIpoptErrorReport();
+        return this->reducedModel();
+#endif
     }
     
     const Model& InverseKinematics::reducedModel() const
     {
+#ifdef IDYNTREE_USES_IPOPT
         assert(m_pimpl);
         return IK_PIMPL(m_pimpl)->m_reducedVariablesInfo.reducedModel;
+#else
+        missingIpoptErrorReport();
+        return this->reducedModel();
+#endif
     }
     
     bool InverseKinematics::isCOMTargetActive()
     {
+#ifdef IDYNTREE_USES_IPOPT
         return IK_PIMPL(m_pimpl)->isCoMTargetActive();
+#else
+        return missingIpoptErrorReport();
+#endif
     }
     
     void InverseKinematics::setCOMAsConstraint(bool asConstraint)
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->setCoMasConstraint(asConstraint);
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     
     bool InverseKinematics::isCOMAConstraint()
     {
+#ifdef IDYNTREE_USES_IPOPT
         return IK_PIMPL(m_pimpl)->isCoMaConstraint();
+#else
+        return missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setCOMTarget(Position& desiredPosition, double weight)
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->setCoMTarget(desiredPosition, weight);
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setCOMAsConstraintTolerance(double tolerance)
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->setCoMasConstraintTolerance(tolerance);
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
 
     void InverseKinematics::deactivateCOMTarget()
     {
+#ifdef IDYNTREE_USES_IPOPT
         IK_PIMPL(m_pimpl)->setCoMTargetInactive();
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
     void InverseKinematics::setCOMConstraintProjectionDirection(iDynTree::Vector3 direction)
     {
+#ifdef IDYNTREE_USES_IPOPT
         // define the projection matrix 'Pdirection' in the class 'ConvexHullProjectionConstraint'
         IK_PIMPL(m_pimpl)->m_comHullConstraint_projDirection = direction;
         IK_PIMPL(m_pimpl)->m_comHullConstraint.setProjectionAlongDirection(direction);
+#else
+        missingIpoptErrorReport();
+#endif
     }
 
 }


### PR DESCRIPTION
With this PR bindings for `inverse-kinematics` are generated.

The commit has been done accordingly to the [guidelines](https://github.com/robotology/idyntree/blob/master/doc/generating-idyntree-matlab-bindings.md).

@traversaro is it ok to target `master` with the updated bindings or should `devel` be targeted instead?