### PR TITLE
GitHub Actions: add check of successful compilation if some dependencies are disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,3 +193,17 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install .. 
         cmake --build . --config ${{ matrix.build_type }}
+
+        
+    - name: Check build if some dependencies are not enabled [Ubuntu]
+      shell: bash
+      run: |
+        cd build
+        for missing_dep in Qt5 IPOPT ASSIMP; do
+            echo "Testing ${missing_dep} as missing dependency."
+            # Deselect missing dependency and build
+            cmake -DIDYNTREE_USES_${missing_dep}:BOOL=OFF .
+            cmake --build . --config ${{ matrix.build_type }}
+            # Enable again dependency 
+            cmake -DIDYNTREE_USES_${missing_dep}:BOOL=ON .
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,11 @@ jobs:
 
         
     - name: Check build if some dependencies are not enabled [Ubuntu]
+      if: matrix.os == 'ubuntu-latest'
       shell: bash
       run: |
         cd build
-        for missing_dep in Qt5 IPOPT ASSIMP; do
+        for missing_dep in ASSIMP Qt5 IPOPT; do
             echo "Testing ${missing_dep} as missing dependency."
             # Deselect missing dependency and build
             cmake -DIDYNTREE_USES_${missing_dep}:BOOL=OFF .


### PR DESCRIPTION
We just run in on Ubuntu as that should  catch most of the regression w.r.t. to this kind of problem. This step is the final step  of the CI, and for this reason the actual files to be compiled should be minimal for each one of this builds, as all this options will just remove some files to compile.

This will be useful to detect regressions  such as the one described in https://github.com/robotology/idyntree/pull/633#issuecomment-575176428 .