### PR TITLE
Remove additional project and cmake_minimum_required calls in nested directories

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_Base CXX)
-
 set(IDYNTREE_CORE_EXP_HEADERS include/iDynTree/Core/Axis.h
                               include/iDynTree/Core/ArticulatedBodyInertia.h
                               include/iDynTree/Core/ClassicalAcc.h

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_Estimation CXX)
-
 set(IDYNTREE_ESTIMATION_HEADERS include/iDynTree/Estimation/BerdyHelper.h
                                 include/iDynTree/Estimation/ExternalWrenchesEstimation.h
                                 include/iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h

--- a/src/high-level/CMakeLists.txt
+++ b/src/high-level/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_HighLevel CXX)
-
 set(IDYNTREE_HIGH_LEVEL_HEADERS include/iDynTree/KinDynComputations.h)
 
 set(IDYNTREE_HIGH_LEVEL_SOURCES src/KinDynComputations.cpp)

--- a/src/icub/CMakeLists.txt
+++ b/src/icub/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_ICUB CXX)
-
 SET(iDynTree_ICUB_source src/iKinConversions.cpp
                          src/skinDynLibConversions.cpp)
 

--- a/src/inverse-kinematics/CMakeLists.txt
+++ b/src/inverse-kinematics/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
-project(iDynTree_InverseKinematics CXX)
-
 set(libraryname idyntree-inverse-kinematics)
 
 set(IDYN_TREE_IK_SOURCES src/ConvexHullHelpers.cpp

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_Model CXX)
-
 set(IDYNTREE_MODEL_HEADERS include/iDynTree/Model/ContactWrench.h
                            include/iDynTree/Model/DenavitHartenberg.h
                            include/iDynTree/Model/FixedJoint.h

--- a/src/model_io/xml/CMakeLists.txt
+++ b/src/model_io/xml/CMakeLists.txt
@@ -6,10 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_ModelIO_XML CXX)
-
-find_package(LibXml2 REQUIRED)
-
 set(IDYNTREE_MODELIO_XML_HEADERS include/iDynTree/XMLParser.h
                                  include/iDynTree/XMLElement.h
                                  include/iDynTree/XMLAttribute.h

--- a/src/optimalcontrol/CMakeLists.txt
+++ b/src/optimalcontrol/CMakeLists.txt
@@ -6,10 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-cmake_minimum_required(VERSION 3.0)
-
-project(idyntree_optimalcontrol)
-
 set(libraryname idyntree-optimalcontrol)
 
 

--- a/src/regressors/CMakeLists.txt
+++ b/src/regressors/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_Regressors CXX)
-
 include_directories(include/kdl_codyco/regressors)
 include_directories(include)
 

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -6,8 +6,6 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_Sensors CXX)
-
 set(IDYNTREE_SENSORS_HEADERS include/iDynTree/Sensors/AllSensorsTypes.h
                              include/iDynTree/Sensors/Sensors.h
                              include/iDynTree/Sensors/SixAxisForceTorqueSensor.h

--- a/src/tools/plotter/CMakeLists.txt
+++ b/src/tools/plotter/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.0)
-
-project(iDynTreePlotter)
-
 find_package(Qt5 COMPONENTS Widgets Charts QUIET)
 if (${Qt5Charts_FOUND})
 
@@ -11,17 +7,17 @@ if (${Qt5Charts_FOUND})
                   HEADERS_VAR THRIFT_HEADERS
                   INCLUDE_DIRS_VAR THRIFT_INCLUDE_DIRS)
 
-  add_library(${PROJECT_NAME}-service STATIC ${THRIFT_SOURCES} ${THRIFT_HEADERS})
-  target_include_directories(${PROJECT_NAME}-service SYSTEM PUBLIC ${THRIFT_INCLUDE_DIRS})
-  target_link_libraries(${PROJECT_NAME}-service YARP::YARP_init YARP::YARP_OS YARP::YARP_sig)
+  add_library(iDynTreePlotter-service STATIC ${THRIFT_SOURCES} ${THRIFT_HEADERS})
+  target_include_directories(iDynTreePlotter-service SYSTEM PUBLIC ${THRIFT_INCLUDE_DIRS})
+  target_link_libraries(iDynTreePlotter-service YARP::YARP_init YARP::YARP_OS YARP::YARP_sig)
   
   
   set(SOURCES src/main.cpp src/ChartsManager.cpp src/ChartsManagerWindow.cpp)
   set(HEADERS include/ChartsManager.h include/ChartsManagerWindow.h)
   
-  add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
-  target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-  target_link_libraries(${PROJECT_NAME} Qt5::Charts Qt5::Widgets
-                                        ${PROJECT_NAME}-service)
+  add_executable(iDynTreePlotter ${SOURCES} ${HEADERS})
+  target_include_directories(iDynTreePlotter PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  target_link_libraries(iDynTreePlotter Qt5::Charts Qt5::Widgets
+                                        iDynTreePlotter-service)
   
 endif()

--- a/src/tools/yarprobotstatepublisher/CMakeLists.txt
+++ b/src/tools/yarprobotstatepublisher/CMakeLists.txt
@@ -2,16 +2,14 @@
 # All Rights Reserved.
 # Authors: Silvio Traversaro <silvio.traversaro@iit.it>
 
-project(yarprobotstatepublisher)
-
-add_executable(${PROJECT_NAME}
+add_executable(yarprobotstatepublisher
     include/robotstatepublisher.h
     src/main.cpp
     src/robotstatepublisher.cpp)
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(yarprobotstatepublisher PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(yarprobotstatepublisher
     YARP::YARP_init
     YARP::YARP_os
     YARP::YARP_dev
@@ -19,4 +17,4 @@ target_link_libraries(${PROJECT_NAME}
     idyntree-high-level
     idyntree-yarp)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+install(TARGETS yarprobotstatepublisher DESTINATION bin)

--- a/src/tools/yarprobotstatepublisher/CMakeLists.txt
+++ b/src/tools/yarprobotstatepublisher/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(yarprobotstatepublisher
     src/main.cpp
     src/robotstatepublisher.cpp)
 
-target_include_directories(yarprobotstatepublisher PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(yarprobotstatepublisher PRIVATE include)
 
 target_link_libraries(yarprobotstatepublisher
     YARP::YARP_init


### PR DESCRIPTION
The definition of a project in CMake is typically used to indicate a self-sufficient project that can be built on its own. This was not the case for most of the use of project. Those calls just created confusion on the values of all the PROJECT_ variables, so they are not really useful and they can be simply removed.