### PR TITLE
 Remove spurious inclusion of Eigen headers in public headers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed 
+- Remove spurious inclusion of Eigen headers in ExtendedKalmanFilter.h public header, that could create probles when using that header in a downstream project that does not use Eigen (https://github.com/robotology/idyntree/pull/639).
+
 ## [1.0.1] - 2020-01-14
 
 ### Fixed

--- a/src/estimation/include/iDynTree/Estimation/ExtendedKalmanFilter.h
+++ b/src/estimation/include/iDynTree/Estimation/ExtendedKalmanFilter.h
@@ -14,7 +14,6 @@
 #include <iDynTree/Core/VectorDynSize.h>
 #include <iDynTree/Core/MatrixDynSize.h>
 #include <iDynTree/Core/Utils.h>
-#include <iDynTree/Core/EigenHelpers.h>
 #include <vector>
 
 namespace iDynTree

--- a/src/estimation/src/ExtendedKalmanFilter.cpp
+++ b/src/estimation/src/ExtendedKalmanFilter.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iDynTree/Estimation/ExtendedKalmanFilter.h>
+#include <iDynTree/Core/EigenHelpers.h>
 
 iDynTree::DiscreteExtendedKalmanFilterHelper::DiscreteExtendedKalmanFilterHelper()
 {

--- a/src/estimation/tests/AttitudeEstimatorUnitTest.cpp
+++ b/src/estimation/tests/AttitudeEstimatorUnitTest.cpp
@@ -11,6 +11,8 @@
 #include <iDynTree/Estimation/AttitudeQuaternionEKF.h>
 #include <iDynTree/Estimation/AttitudeMahonyFilter.h>
 #include <iDynTree/Core/TestUtils.h>
+#include <iDynTree/Core/SpatialMotionVector.h>
+#include <iDynTree/Core/SpatialForceVector.h>
 #include <iostream>
 #include <memory>
 


### PR DESCRIPTION
This could created a failure in downstream  projects if the downstream project did not used Eigen. 