### PR TITLE
Add begin/end member functions for iDynTree vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `bindings` for `InverseKinematics` (https://github.com/robotology/idyntree/pull/633)
+- Implement `cbegin()` / `cend()` and `begin()` / `end()` methods for `VectorDynSize` and `VectorFixSize` (https://github.com/robotology/idyntree/pull/646)
 
-### Fixed 
+### Fixed
 - Remove spurious inclusion of Eigen headers in ExtendedKalmanFilter.h public header, that could create probles when using that header in a downstream project that does not use Eigen (https://github.com/robotology/idyntree/pull/639).
 - Added find_dependency(OsqpEigen) and find_dependency(LibXml2) when iDynTree is compiled as a static library, fixing the use of iDynTree on Windows (https://github.com/robotology/idyntree/pull/642).
 

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -127,6 +127,48 @@ namespace iDynTree
 
         bool setVal(const unsigned int index, const double new_el);
 
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* begin() const noexcept;
+
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* end() const noexcept;
+
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* cbegin() const noexcept;
+
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* cend() const noexcept;
+
+        /**
+         * Returns a iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        double* begin() noexcept;
+
+        /**
+         * Returns a iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        double* end() noexcept;
+
         unsigned int size() const;
 
         ///@}

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -71,6 +71,48 @@ namespace iDynTree
 
         bool setVal(const unsigned int index, const double new_el);
 
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* begin() const noexcept;
+
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* end() const noexcept;
+
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* cbegin() const noexcept;
+
+        /**
+         * Returns a const iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        const double* cend() const noexcept;
+
+        /**
+         * Returns a iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        double* begin() noexcept;
+
+        /**
+         * Returns a iterator to the beginning of the vector
+         * @note At the moment iterator is implemented as a pointer, it may change in the future.
+         * For this reason it should not be used as a pointer to the data, use data() instead.
+         */
+        double* end() noexcept;
+
         unsigned int size() const;
 
         ///@}
@@ -187,6 +229,42 @@ namespace iDynTree
     const double* VectorFixSize<VecSize>::data() const
     {
         return this->m_data;
+    }
+
+    template<unsigned int VecSize>
+    const double* VectorFixSize<VecSize>::begin() const noexcept
+    {
+        return this->m_data;
+    }
+
+    template<unsigned int VecSize>
+    const double* VectorFixSize<VecSize>::end() const noexcept
+    {
+        return this->m_data + VecSize;
+    }
+
+    template<unsigned int VecSize>
+    const double* VectorFixSize<VecSize>::cbegin() const noexcept
+    {
+        return this->m_data;
+    }
+
+    template<unsigned int VecSize>
+    const double* VectorFixSize<VecSize>::cend() const noexcept
+    {
+        return this->m_data + VecSize;
+    }
+
+    template <unsigned int VecSize>
+    double *VectorFixSize<VecSize>::begin() noexcept
+    {
+        return this->m_data;
+    }
+
+    template<unsigned int VecSize>
+    double* VectorFixSize<VecSize>::end() noexcept
+    {
+        return this->m_data + VecSize;
     }
 
     template<unsigned int VecSize>

--- a/src/core/src/VectorDynSize.cpp
+++ b/src/core/src/VectorDynSize.cpp
@@ -189,6 +189,36 @@ bool VectorDynSize::setVal(const unsigned int index, const double new_el)
     return true;
 }
 
+const double* VectorDynSize::begin() const noexcept
+{
+    return this->m_data;
+}
+
+const double* VectorDynSize::end() const noexcept
+{
+    return this->m_data + this->m_size;
+}
+
+const double* VectorDynSize::cbegin() const noexcept
+{
+    return this->m_data;
+}
+
+const double* VectorDynSize::cend() const noexcept
+{
+    return this->m_data + this->m_size;
+}
+
+double* VectorDynSize::begin() noexcept
+{
+    return this->m_data;
+}
+
+double* VectorDynSize::end() noexcept
+{
+    return this->m_data + this->m_size;
+}
+
 void VectorDynSize::changeCapacityAndCopyData(const unsigned int _newCapacity)
 {
     //Corner case: zero capacity


### PR DESCRIPTION
This PR:
- Implement `begin()/end()` and `cbegin()/cend()` methods for `VectorFixSize`
- Implement `begin()/end()` and `cbegin()/cend()` methods for `VectorDynSize`
- Update the `CHANGELOG.md`

The implementation of these members will allow the user to use [range-based for loop](https://en.cppreference.com/w/cpp/language/range-for).

Related issue #645 