### PR TITLE
Add cache GitHub Action to cache dependency compiled from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       shell: bash
       run: |
         cd ${VCPKG_INSTALLATION_ROOT}
+        git fetch --unshallow
         git checkout ${vcpkg_TAG}
         ./bootstrap-vcpkg.sh
         vcpkg.exe update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,11 @@ on:
   # * is a special character in YAML so you have to quote this string
   # Execute a "nightly" build at 2 AM UTC 
   - cron:  '0 2 * * *'
-  
+
+env:
+  YCM_TAG: v0.11.0
+  YARP_TAG: v3.3.2
+  ICUB_TAG: v1.15.0
   
 jobs:
   build:
@@ -56,60 +60,67 @@ jobs:
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5charts5-dev \
                              libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev
         
+    - name: Cache Source-based Dependencies
+      id: cache-source-deps
+      uses: actions/cache@v1
+      with:
+        path: install_deps
+        key: source-deps-${{ runner.os }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
+    
     - name: Source-based Dependencies [Windows] 
-      if: matrix.os == 'windows-latest-disable-until-issue-569-is-solved'
+      if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest-disable-until-issue-569-is-solved'
       shell: bash
       run: |
         # YCM
-        git clone https://github.com/robotology/ycm
+        git clone -b ${YCM_TAG} https://github.com/robotology/ycm
         cd ycm
         mkdir -p build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         # YARP
-        git clone https://github.com/robotology/yarp
+        git clone -b ${YARP_TAG} https://github.com/robotology/yarp
         cd yarp
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         # Workaround for https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports/issues/3
         export IPOPT_DIR=${VCPKG_INSTALLATION_ROOT}/installed/x64-windows
         # ICUB
-        git clone https://github.com/robotology/icub-main
+        git clone -b ${ICUB_TAG} https://github.com/robotology/icub-main
         cd icub-main
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         
     - name: Source-based Dependencies [Ubuntu/macOS] 
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: steps.cache-source-deps.outputs.cache-hit != 'true' && (matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest')
       shell: bash
       run: |
         # YCM
-        git clone https://github.com/robotology/ycm
+        git clone -b ${YCM_TAG} https://github.com/robotology/ycm
         cd ycm
         mkdir -p build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
         # YARP
-        git clone https://github.com/robotology/yarp
+        git clone -b ${YARP_TAG} https://github.com/robotology/yarp
         cd yarp
         mkdir -p build
         cd build
-        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
         # ICUB
-        git clone https://github.com/robotology/icub-main
+        git clone -b ${ICUB_TAG} https://github.com/robotology/icub-main
         cd icub-main
         mkdir -p build
         cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
  
     # ===================
@@ -125,7 +136,7 @@ jobs:
         cd build
         # ipopt disabled until https://github.com/robotology/idyntree/issues/274 is fixed
         # assimp disabled until https://github.com/robotology/idyntree/issues/601 is fixed
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps \
               -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=OFF -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON \
               -DIDYNTREE_USES_PYTHON:BOOL=OFF -DIDYNTREE_USES_OCTAVE:BOOL=OFF -DIDYNTREE_USES_IPOPT:BOOL=OFF -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
@@ -137,7 +148,7 @@ jobs:
         mkdir -p build
         cd build
         # IDYNTREE_USES_ASSIMP set to OFF as a workaround for https://github.com/robotology/idyntree/issues/599
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
               -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
@@ -188,7 +199,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install .. 
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install .. 
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Compile Examples [Ubuntu/macOS]
@@ -198,7 +209,7 @@ jobs:
         cd examples
         mkdir -p build
         cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install .. 
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install .. 
         cmake --build . --config ${{ matrix.build_type }}
 
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   - cron:  '0 2 * * *'
 
 env:
+  vcpkg_TAG: 2020.01 
   YCM_TAG: v0.11.0
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
@@ -43,7 +44,12 @@ jobs:
     
     - name: Dependencies [Windows]
       if: matrix.os == 'windows-latest'
+      shell: bash
       run: |
+        cd ${VCPKG_INSTALLATION_ROOT}
+        git checkout ${vcpkg_TAG}
+        ./bootstrap-vcpkg.sh
+        vcpkg.exe update
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
         vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace assimp libxml2 eigen3 ipopt-binary 
         
@@ -65,7 +71,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: install_deps
-        key: source-deps-${{ runner.os }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
+        key: source-deps-${{ runner.os }}-vcpkg-${{ env.vcpkg_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
     
     - name: Source-based Dependencies [Windows] 
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest-disable-until-issue-569-is-solved'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       id: cache-source-deps
       uses: actions/cache@v1
       with:
-        path: install_deps
+        path: ${{ github.workspace }}/install/deps
         key: source-deps-${{ runner.os }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
     
     - name: Source-based Dependencies [Windows] 
@@ -87,7 +87,7 @@ jobs:
         cd ycm
         mkdir -p build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         # YARP
         git clone -b ${YARP_TAG} https://github.com/robotology/yarp
@@ -95,7 +95,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         # Workaround for https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports/issues/3
         export IPOPT_DIR=${VCPKG_INSTALLATION_ROOT}/installed/x64-windows
@@ -105,7 +105,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
+              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         
     - name: Source-based Dependencies [Ubuntu/macOS] 
@@ -117,21 +117,21 @@ jobs:
         cd ycm
         mkdir -p build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
+        cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
         # YARP
         git clone -b ${YARP_TAG} https://github.com/robotology/yarp
         cd yarp
         mkdir -p build
         cd build
-        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
+        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
         # ICUB
         git clone -b ${ICUB_TAG} https://github.com/robotology/icub-main
         cd icub-main
         mkdir -p build
         cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install_deps ..
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
  
     # ===================
@@ -147,7 +147,7 @@ jobs:
         cd build
         # ipopt disabled until https://github.com/robotology/idyntree/issues/274 is fixed
         # assimp disabled until https://github.com/robotology/idyntree/issues/601 is fixed
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps \
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
               -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=OFF -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON \
               -DIDYNTREE_USES_PYTHON:BOOL=OFF -DIDYNTREE_USES_OCTAVE:BOOL=OFF -DIDYNTREE_USES_IPOPT:BOOL=OFF -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
@@ -159,7 +159,7 @@ jobs:
         mkdir -p build
         cd build
         # IDYNTREE_USES_ASSIMP set to OFF as a workaround for https://github.com/robotology/idyntree/issues/599
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
               -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
@@ -210,7 +210,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install" .. 
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install/deps;${GITHUB_WORKSPACE}/install" .. 
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Compile Examples [Ubuntu/macOS]
@@ -220,7 +220,7 @@ jobs:
         cd examples
         mkdir -p build
         cd build
-        cmake -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install" .. 
+        cmake -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install/deps;${GITHUB_WORKSPACE}/install" .. 
         cmake --build . --config ${{ matrix.build_type }}
 
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-              -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install .. 
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install" .. 
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Compile Examples [Ubuntu/macOS]
@@ -220,7 +220,7 @@ jobs:
         cd examples
         mkdir -p build
         cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install .. 
+        cmake -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install_deps;${GITHUB_WORKSPACE}/install" .. 
         cmake --build . --config ${{ matrix.build_type }}
 
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         cd C:/
         md C:/robotology
         md C:/robotology/vcpkg
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/%vcpkg_robotology_TAG%/vcpkg-robotology.zip
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology.zip
         unzip vcpkg-robotology.zip -d C:/robotology/vcpkg
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
         echo "::set-env name=VCPKG_INSTALLATION_ROOT::C:/robotology/vcpkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  vcpkg_TAG: 97302ca1729eac9917c8a8977667601453795c90
+  vcpkg_robotology_TAG: v0.0.3
   YCM_TAG: v0.11.0
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
@@ -44,15 +44,19 @@ jobs:
     
     - name: Dependencies [Windows]
       if: matrix.os == 'windows-latest'
-      shell: bash
       run: |
-        cd ${VCPKG_INSTALLATION_ROOT}
-        git fetch --unshallow
-        git checkout ${vcpkg_TAG}
-        ./bootstrap-vcpkg.sh
-        vcpkg.exe update
-        git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
-        vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace assimp libxml2 eigen3 ipopt-binary 
+        # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need 
+        choco install -y wget unzip
+        # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/robotology/vcpkg 
+        # that has been used to create the pre-compiled archive
+        cd C:/
+        md C:/robotology
+        md C:/robotology/vcpkg
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/%vcpkg_robotology_TAG%/vcpkg-robotology.zip
+        unzip vcpkg-robotology.zip -d C:/robotology/vcpkg
+        # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
+        echo "::set-env name=VCPKG_INSTALLATION_ROOT::C:/robotology/vcpkg"
+
         
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
@@ -72,7 +76,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: install_deps
-        key: source-deps-${{ runner.os }}-vcpkg-${{ env.vcpkg_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
+        key: source-deps-${{ runner.os }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
     
     - name: Source-based Dependencies [Windows] 
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest-disable-until-issue-569-is-solved'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  vcpkg_TAG: 2020.01 
+  vcpkg_TAG: 97302ca1729eac9917c8a8977667601453795c90
   YCM_TAG: v0.11.0
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0

--- a/src/icub/CMakeLists.txt
+++ b/src/icub/CMakeLists.txt
@@ -35,9 +35,7 @@ target_link_libraries(${libraryname} LINK_PUBLIC iKin skinDynLib idyntree-core i
 
 target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS})
 
-target_include_directories(${libraryname} INTERFACE ${skinDynLib_INCLUDE_DIRS})
 target_include_directories(${libraryname} PRIVATE SYSTEM ${skinDynLib_INCLUDE_DIRS})
-target_include_directories(${libraryname} INTERFACE ${iKin_INCLUDE_DIRS})
 target_include_directories(${libraryname} PRIVATE SYSTEM ${iKin_INCLUDE_DIRS})
 
 


### PR DESCRIPTION
This  PR adds support for use GitHub Actions cache (see https://github.com/actions/cache) for storing the dependency build from source (YCM, YARP and ICUB).
Furthermore:
* Switch to use releases for vcpkg, YCM, YARP and ICUB used for testing
* Switch to use pre-compiled vcpkg archive (to workaround the issue https://github.com/dic-iit/bipedal-locomotion-controllers/issues/30)
* Cleanup some old wrong include directories in idyntree-icub that were interacting in a weird way with the fact that the install directory of the source-based dependencies is  inside the source directory