### PR TITLE
Feature/properly handle link solid shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `bindings` for handling `linkSolidShapes` properly (https://github.com/robotology/idyntree/issues/656)
 - Added `bindings` for `InverseKinematics` (https://github.com/robotology/idyntree/pull/633)
 - Implement `cbegin()` / `cend()` and `begin()` / `end()` methods for `VectorDynSize` and `VectorFixSize` (https://github.com/robotology/idyntree/pull/646)
 
 ## [1.0.2] - 2020-02-21
 
-### Fixed 
+### Fixed
 - Remove spurious inclusion of Eigen headers in ExtendedKalmanFilter.h public header, that could create probles when using that header in a downstream project that does not use Eigen (https://github.com/robotology/idyntree/pull/639).
 - Added find_dependency(OsqpEigen) and find_dependency(LibXml2) when iDynTree is compiled as a static library, fixing the use of iDynTree on Windows (https://github.com/robotology/idyntree/pull/642).
 

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -302,6 +302,11 @@ TEMPLATE_WRAP_MOTION_FORCE(ForceVector3, WRAP_FORCE, SET_NAME_FOR_WRAPPER,,)
 
 %include "joints.i"
 
+%template(SolidshapesVector) std::vector<iDynTree::SolidShape*>;
+//%template(linksSolidshapesVector) std::vector<SolidshapesVector>;
+%template(linksSolidshapesVector) std::vector< std::vector<iDynTree::SolidShape *>>;
+
+
 // Kinematics & Dynamics related functions
 %include "iDynTree/Model/ForwardKinematics.h"
 %include "iDynTree/Model/Dynamics.h"

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -303,7 +303,6 @@ TEMPLATE_WRAP_MOTION_FORCE(ForceVector3, WRAP_FORCE, SET_NAME_FOR_WRAPPER,,)
 %include "joints.i"
 
 %template(SolidshapesVector) std::vector<iDynTree::SolidShape*>;
-//%template(linksSolidshapesVector) std::vector<SolidshapesVector>;
 %template(linksSolidshapesVector) std::vector< std::vector<iDynTree::SolidShape *>>;
 
 

--- a/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
@@ -7,58 +7,58 @@ classdef AccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1383, varargin{:});
+        tmp = iDynTreeMEX(1457, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1384, self);
+        iDynTreeMEX(1458, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1385, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1459, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1386, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1460, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1387, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1461, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1388, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1462, self, varargin{:});
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1389, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1463, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1390, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1464, self, varargin{:});
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1391, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1465, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1392, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1466, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1393, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1467, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1394, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1468, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1395, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1469, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1396, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1470, self, varargin{:});
     end
     function varargout = updateIndeces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1397, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1471, self, varargin{:});
     end
     function varargout = predictMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1398, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1472, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3.m
@@ -7,17 +7,17 @@ classdef AngularForceVector3 < iDynTree.ForceVector3__AngularForceVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(525, varargin{:});
+        tmp = iDynTreeMEX(549, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(526, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(550, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(527, self);
+        iDynTreeMEX(551, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef AngularForceVector3Semantics < iDynTree.ForceVector3Semantics__AngularF
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(521, varargin{:});
+        tmp = iDynTreeMEX(545, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(522, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(546, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(524, self);
+        iDynTreeMEX(548, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(523, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(547, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3.m
@@ -7,17 +7,17 @@ classdef AngularMotionVector3 < iDynTree.MotionVector3__AngularMotionVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(514, varargin{:});
+        tmp = iDynTreeMEX(538, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = exp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(515, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(539, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(516, self);
+        iDynTreeMEX(540, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AngularMotionVector3Semantics.m
@@ -7,14 +7,14 @@ classdef AngularMotionVector3Semantics < iDynTree.GeomVector3Semantics__AngularM
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(512, varargin{:});
+        tmp = iDynTreeMEX(536, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(513, self);
+        iDynTreeMEX(537, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = ArticulatedBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1298, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1372, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
@@ -9,110 +9,110 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1276, varargin{:});
+        tmp = iDynTreeMEX(1350, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1277, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1278, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
     end
     function varargout = S(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1279, self);
+        varargout{1} = iDynTreeMEX(1353, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1280, self, varargin{1});
+        iDynTreeMEX(1354, self, varargin{1});
       end
     end
     function varargout = U(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1281, self);
+        varargout{1} = iDynTreeMEX(1355, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1282, self, varargin{1});
+        iDynTreeMEX(1356, self, varargin{1});
       end
     end
     function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1283, self);
+        varargout{1} = iDynTreeMEX(1357, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1284, self, varargin{1});
+        iDynTreeMEX(1358, self, varargin{1});
       end
     end
     function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1285, self);
+        varargout{1} = iDynTreeMEX(1359, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1286, self, varargin{1});
+        iDynTreeMEX(1360, self, varargin{1});
       end
     end
     function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1287, self);
+        varargout{1} = iDynTreeMEX(1361, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1288, self, varargin{1});
+        iDynTreeMEX(1362, self, varargin{1});
       end
     end
     function varargout = linksBiasAcceleration(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1289, self);
+        varargout{1} = iDynTreeMEX(1363, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1290, self, varargin{1});
+        iDynTreeMEX(1364, self, varargin{1});
       end
     end
     function varargout = linksAccelerations(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1291, self);
+        varargout{1} = iDynTreeMEX(1365, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1292, self, varargin{1});
+        iDynTreeMEX(1366, self, varargin{1});
       end
     end
     function varargout = linkABIs(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1293, self);
+        varargout{1} = iDynTreeMEX(1367, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1294, self, varargin{1});
+        iDynTreeMEX(1368, self, varargin{1});
       end
     end
     function varargout = linksBiasWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1295, self);
+        varargout{1} = iDynTreeMEX(1369, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1296, self, varargin{1});
+        iDynTreeMEX(1370, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1297, self);
+        iDynTreeMEX(1371, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyInertia.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyInertia.m
@@ -9,57 +9,57 @@ classdef ArticulatedBodyInertia < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(684, varargin{:});
+        tmp = iDynTreeMEX(708, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearLinearSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(685, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(709, self, varargin{:});
     end
     function varargout = getLinearAngularSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(686, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(710, self, varargin{:});
     end
     function varargout = getAngularAngularSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(687, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(711, self, varargin{:});
     end
     function varargout = applyInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(689, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(713, self, varargin{:});
     end
     function varargout = asMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(690, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(714, self, varargin{:});
     end
     function varargout = getInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(691, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(715, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(692, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(716, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(693, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(717, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(694, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(718, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(695, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(719, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(698, self);
+        iDynTreeMEX(722, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(688, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(712, varargin{:});
     end
     function varargout = ABADyadHelper(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(696, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(720, varargin{:});
     end
     function varargout = ABADyadHelperLin(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(697, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(721, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
@@ -7,30 +7,30 @@ classdef AttitudeEstimatorState < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1668, self);
+        varargout{1} = iDynTreeMEX(1742, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1669, self, varargin{1});
+        iDynTreeMEX(1743, self, varargin{1});
       end
     end
     function varargout = m_angular_velocity(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1670, self);
+        varargout{1} = iDynTreeMEX(1744, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1671, self, varargin{1});
+        iDynTreeMEX(1745, self, varargin{1});
       end
     end
     function varargout = m_gyroscope_bias(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1672, self);
+        varargout{1} = iDynTreeMEX(1746, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1673, self, varargin{1});
+        iDynTreeMEX(1747, self, varargin{1});
       end
     end
     function self = AttitudeEstimatorState(varargin)
@@ -39,14 +39,14 @@ classdef AttitudeEstimatorState < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1674, varargin{:});
+        tmp = iDynTreeMEX(1748, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1675, self);
+        iDynTreeMEX(1749, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
@@ -7,68 +7,68 @@ classdef AttitudeMahonyFilter < iDynTree.IAttitudeEstimator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1699, varargin{:});
+        tmp = iDynTreeMEX(1773, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = useMagnetoMeterMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
     end
     function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
     end
     function varargout = setGainkp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
     end
     function varargout = setGainki(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
     end
     function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
     end
     function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
     end
     function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1707, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1708, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1709, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1710, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1711, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1712, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1713, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1714, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1715, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1716, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1717, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1718, self);
+        iDynTreeMEX(1792, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
@@ -7,50 +7,50 @@ classdef AttitudeMahonyFilterParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1687, self);
+        varargout{1} = iDynTreeMEX(1761, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1688, self, varargin{1});
+        iDynTreeMEX(1762, self, varargin{1});
       end
     end
     function varargout = kp(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1689, self);
+        varargout{1} = iDynTreeMEX(1763, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1690, self, varargin{1});
+        iDynTreeMEX(1764, self, varargin{1});
       end
     end
     function varargout = ki(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1691, self);
+        varargout{1} = iDynTreeMEX(1765, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1692, self, varargin{1});
+        iDynTreeMEX(1766, self, varargin{1});
       end
     end
     function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1693, self);
+        varargout{1} = iDynTreeMEX(1767, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1694, self, varargin{1});
+        iDynTreeMEX(1768, self, varargin{1});
       end
     end
     function varargout = confidence_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1695, self);
+        varargout{1} = iDynTreeMEX(1769, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1696, self, varargin{1});
+        iDynTreeMEX(1770, self, varargin{1});
       end
     end
     function self = AttitudeMahonyFilterParameters(varargin)
@@ -59,14 +59,14 @@ classdef AttitudeMahonyFilterParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1697, varargin{:});
+        tmp = iDynTreeMEX(1771, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1698, self);
+        iDynTreeMEX(1772, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
@@ -11,74 +11,74 @@ classdef AttitudeQuaternionEKF < iDynTree.IAttitudeEstimator & iDynTree.Discrete
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1764, varargin{:});
+        tmp = iDynTreeMEX(1838, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
     end
     function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
     function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
     end
     function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
     function varargout = setBiasCorrelationTimeFactor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
     end
     function varargout = useMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
     end
     function varargout = setMeasurementNoiseVariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
     end
     function varargout = setSystemNoiseVariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
     end
     function varargout = setInitialStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
     end
     function varargout = initializeFilter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1855, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1856, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1857, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1858, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1785, self);
+        iDynTreeMEX(1859, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
@@ -7,100 +7,100 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1742, self);
+        varargout{1} = iDynTreeMEX(1816, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1743, self, varargin{1});
+        iDynTreeMEX(1817, self, varargin{1});
       end
     end
     function varargout = bias_correlation_time_factor(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1744, self);
+        varargout{1} = iDynTreeMEX(1818, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1745, self, varargin{1});
+        iDynTreeMEX(1819, self, varargin{1});
       end
     end
     function varargout = accelerometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1746, self);
+        varargout{1} = iDynTreeMEX(1820, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1747, self, varargin{1});
+        iDynTreeMEX(1821, self, varargin{1});
       end
     end
     function varargout = magnetometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1748, self);
+        varargout{1} = iDynTreeMEX(1822, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1749, self, varargin{1});
+        iDynTreeMEX(1823, self, varargin{1});
       end
     end
     function varargout = gyroscope_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1750, self);
+        varargout{1} = iDynTreeMEX(1824, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1751, self, varargin{1});
+        iDynTreeMEX(1825, self, varargin{1});
       end
     end
     function varargout = gyro_bias_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1752, self);
+        varargout{1} = iDynTreeMEX(1826, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1753, self, varargin{1});
+        iDynTreeMEX(1827, self, varargin{1});
       end
     end
     function varargout = initial_orientation_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1754, self);
+        varargout{1} = iDynTreeMEX(1828, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1755, self, varargin{1});
+        iDynTreeMEX(1829, self, varargin{1});
       end
     end
     function varargout = initial_ang_vel_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1756, self);
+        varargout{1} = iDynTreeMEX(1830, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1757, self, varargin{1});
+        iDynTreeMEX(1831, self, varargin{1});
       end
     end
     function varargout = initial_gyro_bias_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1758, self);
+        varargout{1} = iDynTreeMEX(1832, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1759, self, varargin{1});
+        iDynTreeMEX(1833, self, varargin{1});
       end
     end
     function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1760, self);
+        varargout{1} = iDynTreeMEX(1834, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1761, self, varargin{1});
+        iDynTreeMEX(1835, self, varargin{1});
       end
     end
     function self = AttitudeQuaternionEKFParameters(varargin)
@@ -109,14 +109,14 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1762, varargin{:});
+        tmp = iDynTreeMEX(1836, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1763, self);
+        iDynTreeMEX(1837, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Axis.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Axis.m
@@ -9,62 +9,62 @@ classdef Axis < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(636, varargin{:});
+        tmp = iDynTreeMEX(660, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(637, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(661, self, varargin{:});
     end
     function varargout = getOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(638, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(662, self, varargin{:});
     end
     function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(639, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(663, self, varargin{:});
     end
     function varargout = setOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(640, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
     end
     function varargout = getRotationTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(641, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(665, self, varargin{:});
     end
     function varargout = getRotationTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(642, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(666, self, varargin{:});
     end
     function varargout = getRotationTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(643, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(667, self, varargin{:});
     end
     function varargout = getRotationSpatialAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(644, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(668, self, varargin{:});
     end
     function varargout = getTranslationTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(645, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(669, self, varargin{:});
     end
     function varargout = getTranslationTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(646, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(670, self, varargin{:});
     end
     function varargout = getTranslationTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(647, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(671, self, varargin{:});
     end
     function varargout = getTranslationSpatialAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(648, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(672, self, varargin{:});
     end
     function varargout = isParallel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(649, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(673, self, varargin{:});
     end
     function varargout = reverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(650, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(674, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(651, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(675, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(652, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(676, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(653, self);
+        iDynTreeMEX(677, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
@@ -7,37 +7,37 @@ classdef BerdyDynamicVariable < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1610, self);
+        varargout{1} = iDynTreeMEX(1684, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1611, self, varargin{1});
+        iDynTreeMEX(1685, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1612, self);
+        varargout{1} = iDynTreeMEX(1686, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1613, self, varargin{1});
+        iDynTreeMEX(1687, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1614, self);
+        varargout{1} = iDynTreeMEX(1688, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1615, self, varargin{1});
+        iDynTreeMEX(1689, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1690, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1691, self, varargin{:});
     end
     function self = BerdyDynamicVariable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdyDynamicVariable < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1618, varargin{:});
+        tmp = iDynTreeMEX(1692, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1619, self);
+        iDynTreeMEX(1693, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
@@ -9,104 +9,104 @@ classdef BerdyHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1620, varargin{:});
+        tmp = iDynTreeMEX(1694, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
     end
     function varargout = getOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
     end
     function varargout = getNrOfDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
     end
     function varargout = getNrOfDynamicEquations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
     end
     function varargout = getNrOfSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
     end
     function varargout = resizeAndZeroBerdyMatrices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
     end
     function varargout = getBerdyMatrices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
     end
     function varargout = getSensorsOrdering(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
     end
     function varargout = getRangeSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1707, self, varargin{:});
     end
     function varargout = getRangeDOFSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1708, self, varargin{:});
     end
     function varargout = getRangeJointSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1709, self, varargin{:});
     end
     function varargout = getRangeLinkSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1710, self, varargin{:});
     end
     function varargout = getRangeLinkVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1637, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1711, self, varargin{:});
     end
     function varargout = getRangeJointVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1638, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1712, self, varargin{:});
     end
     function varargout = getRangeDOFVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1639, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1713, self, varargin{:});
     end
     function varargout = getDynamicVariablesOrdering(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1640, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1714, self, varargin{:});
     end
     function varargout = serializeDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1641, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1715, self, varargin{:});
     end
     function varargout = serializeSensorVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1642, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1716, self, varargin{:});
     end
     function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1643, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1717, self, varargin{:});
     end
     function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1718, self, varargin{:});
     end
     function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1719, self, varargin{:});
     end
     function varargout = updateKinematicsFromFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1720, self, varargin{:});
     end
     function varargout = updateKinematicsFromFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1721, self, varargin{:});
     end
     function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1722, self, varargin{:});
     end
     function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1723, self, varargin{:});
     end
     function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1724, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1651, self);
+        iDynTreeMEX(1725, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
@@ -9,7 +9,7 @@ classdef BerdyOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1581, varargin{:});
+        tmp = iDynTreeMEX(1655, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,88 +18,88 @@ classdef BerdyOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1582, self);
+        varargout{1} = iDynTreeMEX(1656, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1583, self, varargin{1});
+        iDynTreeMEX(1657, self, varargin{1});
       end
     end
     function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1584, self);
+        varargout{1} = iDynTreeMEX(1658, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1585, self, varargin{1});
+        iDynTreeMEX(1659, self, varargin{1});
       end
     end
     function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1586, self);
+        varargout{1} = iDynTreeMEX(1660, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1587, self, varargin{1});
+        iDynTreeMEX(1661, self, varargin{1});
       end
     end
     function varargout = includeAllJointTorquesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1588, self);
+        varargout{1} = iDynTreeMEX(1662, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1589, self, varargin{1});
+        iDynTreeMEX(1663, self, varargin{1});
       end
     end
     function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1590, self);
+        varargout{1} = iDynTreeMEX(1664, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1591, self, varargin{1});
+        iDynTreeMEX(1665, self, varargin{1});
       end
     end
     function varargout = includeFixedBaseExternalWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1592, self);
+        varargout{1} = iDynTreeMEX(1666, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1593, self, varargin{1});
+        iDynTreeMEX(1667, self, varargin{1});
       end
     end
     function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1594, self);
+        varargout{1} = iDynTreeMEX(1668, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1595, self, varargin{1});
+        iDynTreeMEX(1669, self, varargin{1});
       end
     end
     function varargout = baseLink(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1596, self);
+        varargout{1} = iDynTreeMEX(1670, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1597, self, varargin{1});
+        iDynTreeMEX(1671, self, varargin{1});
       end
     end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1672, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1599, self);
+        iDynTreeMEX(1673, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
@@ -7,37 +7,37 @@ classdef BerdySensor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1600, self);
+        varargout{1} = iDynTreeMEX(1674, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1601, self, varargin{1});
+        iDynTreeMEX(1675, self, varargin{1});
       end
     end
     function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1602, self);
+        varargout{1} = iDynTreeMEX(1676, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1603, self, varargin{1});
+        iDynTreeMEX(1677, self, varargin{1});
       end
     end
     function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1604, self);
+        varargout{1} = iDynTreeMEX(1678, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1605, self, varargin{1});
+        iDynTreeMEX(1679, self, varargin{1});
       end
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdySensor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1608, varargin{:});
+        tmp = iDynTreeMEX(1682, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1609, self);
+        iDynTreeMEX(1683, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
@@ -9,58 +9,58 @@ classdef BerdySparseMAPSolver < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1652, varargin{:});
+        tmp = iDynTreeMEX(1726, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1653, self);
+        iDynTreeMEX(1727, self);
         self.SwigClear();
       end
     end
     function varargout = setDynamicsConstraintsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1654, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1728, self, varargin{:});
     end
     function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1655, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1729, self, varargin{:});
     end
     function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1656, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1730, self, varargin{:});
     end
     function varargout = setMeasurementsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1657, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1731, self, varargin{:});
     end
     function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1658, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
     end
     function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1659, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
     end
     function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1660, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
     end
     function varargout = measurementsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1661, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1662, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
     end
     function varargout = initialize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1663, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
     end
     function varargout = updateEstimateInformationFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1664, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1738, self, varargin{:});
     end
     function varargout = updateEstimateInformationFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1665, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1739, self, varargin{:});
     end
     function varargout = doEstimate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1666, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1740, self, varargin{:});
     end
     function varargout = getLastEstimate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1667, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1741, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Box.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Box.m
@@ -2,41 +2,41 @@ classdef Box < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1122, self);
+        iDynTreeMEX(1146, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1123, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1147, self, varargin{:});
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1124, self);
+        varargout{1} = iDynTreeMEX(1148, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1125, self, varargin{1});
+        iDynTreeMEX(1149, self, varargin{1});
       end
     end
     function varargout = y(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1126, self);
+        varargout{1} = iDynTreeMEX(1150, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1127, self, varargin{1});
+        iDynTreeMEX(1151, self, varargin{1});
       end
     end
     function varargout = z(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1128, self);
+        varargout{1} = iDynTreeMEX(1152, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1129, self, varargin{1});
+        iDynTreeMEX(1153, self, varargin{1});
       end
     end
     function self = Box(varargin)
@@ -46,7 +46,7 @@ classdef Box < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1130, varargin{:});
+        tmp = iDynTreeMEX(1154, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/ClassicalAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ClassicalAcc.m
@@ -7,30 +7,30 @@ classdef ClassicalAcc < iDynTree.Vector6
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(621, varargin{:});
+        tmp = iDynTreeMEX(645, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(622, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(646, self, varargin{:});
     end
     function varargout = fromSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(624, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(648, self, varargin{:});
     end
     function varargout = toSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(625, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(649, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(626, self);
+        iDynTreeMEX(650, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(623, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(647, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,40 +7,40 @@ classdef ColorViz < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1896, self);
+        varargout{1} = iDynTreeMEX(1970, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1897, self, varargin{1});
+        iDynTreeMEX(1971, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1898, self);
+        varargout{1} = iDynTreeMEX(1972, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1899, self, varargin{1});
+        iDynTreeMEX(1973, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1900, self);
+        varargout{1} = iDynTreeMEX(1974, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1901, self, varargin{1});
+        iDynTreeMEX(1975, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1902, self);
+        varargout{1} = iDynTreeMEX(1976, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1903, self, varargin{1});
+        iDynTreeMEX(1977, self, varargin{1});
       end
     end
     function self = ColorViz(varargin)
@@ -49,14 +49,14 @@ classdef ColorViz < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1904, varargin{:});
+        tmp = iDynTreeMEX(1978, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1905, self);
+        iDynTreeMEX(1979, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = CompositeRigidBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1275, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1349, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentum(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1272, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1346, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentumDerivativeBias(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1273, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1347, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
@@ -4,13 +4,13 @@ classdef ContactWrench < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = contactId(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1276, self, varargin{:});
     end
     function varargout = contactPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1277, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1278, self, varargin{:});
     end
     function self = ContactWrench(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -18,14 +18,14 @@ classdef ContactWrench < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1255, varargin{:});
+        tmp = iDynTreeMEX(1279, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1256, self);
+        iDynTreeMEX(1280, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
@@ -4,118 +4,118 @@ classdef ConvexHullProjectionConstraint < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = setActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2004, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2078, self, varargin{:});
     end
     function varargout = isActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2079, self, varargin{:});
     end
     function varargout = getNrOfConstraints(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2080, self, varargin{:});
     end
     function varargout = projectedConvexHull(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2007, self);
+        varargout{1} = iDynTreeMEX(2081, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2008, self, varargin{1});
+        iDynTreeMEX(2082, self, varargin{1});
       end
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2009, self);
+        varargout{1} = iDynTreeMEX(2083, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2010, self, varargin{1});
+        iDynTreeMEX(2084, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2011, self);
+        varargout{1} = iDynTreeMEX(2085, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2012, self, varargin{1});
+        iDynTreeMEX(2086, self, varargin{1});
       end
     end
     function varargout = P(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2013, self);
+        varargout{1} = iDynTreeMEX(2087, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2014, self, varargin{1});
+        iDynTreeMEX(2088, self, varargin{1});
       end
     end
     function varargout = Pdirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2015, self);
+        varargout{1} = iDynTreeMEX(2089, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2016, self, varargin{1});
+        iDynTreeMEX(2090, self, varargin{1});
       end
     end
     function varargout = AtimesP(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2017, self);
+        varargout{1} = iDynTreeMEX(2091, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2018, self, varargin{1});
+        iDynTreeMEX(2092, self, varargin{1});
       end
     end
     function varargout = o(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2019, self);
+        varargout{1} = iDynTreeMEX(2093, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2020, self, varargin{1});
+        iDynTreeMEX(2094, self, varargin{1});
       end
     end
     function varargout = buildConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2021, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2095, self, varargin{:});
     end
     function varargout = supportFrameIndices(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2022, self);
+        varargout{1} = iDynTreeMEX(2096, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2023, self, varargin{1});
+        iDynTreeMEX(2097, self, varargin{1});
       end
     end
     function varargout = absoluteFrame_X_supportFrame(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2024, self);
+        varargout{1} = iDynTreeMEX(2098, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2025, self, varargin{1});
+        iDynTreeMEX(2099, self, varargin{1});
       end
     end
     function varargout = project(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2026, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2100, self, varargin{:});
     end
     function varargout = computeMargin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2027, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2101, self, varargin{:});
     end
     function varargout = setProjectionAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2028, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2102, self, varargin{:});
     end
     function varargout = projectAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2029, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2103, self, varargin{:});
     end
     function self = ConvexHullProjectionConstraint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -123,14 +123,14 @@ classdef ConvexHullProjectionConstraint < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2030, varargin{:});
+        tmp = iDynTreeMEX(2104, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2031, self);
+        iDynTreeMEX(2105, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
@@ -2,31 +2,31 @@ classdef Cylinder < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1131, self);
+        iDynTreeMEX(1155, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1132, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
     end
     function varargout = length(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1133, self);
+        varargout{1} = iDynTreeMEX(1157, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1134, self, varargin{1});
+        iDynTreeMEX(1158, self, varargin{1});
       end
     end
     function varargout = radius(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1135, self);
+        varargout{1} = iDynTreeMEX(1159, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1136, self, varargin{1});
+        iDynTreeMEX(1160, self, varargin{1});
       end
     end
     function self = Cylinder(varargin)
@@ -36,7 +36,7 @@ classdef Cylinder < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1137, varargin{:});
+        tmp = iDynTreeMEX(1161, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialForceArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1207, varargin{:});
+        tmp = iDynTreeMEX(1231, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1232, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1233, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1210, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1234, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1211, self);
+        iDynTreeMEX(1235, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialMotionArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1212, varargin{:});
+        tmp = iDynTreeMEX(1236, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1237, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1214, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1215, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1239, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1216, self);
+        iDynTreeMEX(1240, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(857);
+    varargout{1} = iDynTreeMEX(881);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(858,varargin{1});
+    iDynTreeMEX(882,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(859);
+    varargout{1} = iDynTreeMEX(883);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(860,varargin{1});
+    iDynTreeMEX(884,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Direction.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Direction.m
@@ -7,39 +7,39 @@ classdef Direction < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(627, varargin{:});
+        tmp = iDynTreeMEX(651, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = Normalize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(628, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(652, self, varargin{:});
     end
     function varargout = isParallel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(629, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(653, self, varargin{:});
     end
     function varargout = isPerpendicular(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(630, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(654, self, varargin{:});
     end
     function varargout = reverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(631, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(655, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(632, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(656, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(633, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(657, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(635, self);
+        iDynTreeMEX(659, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Default(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(634, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(658, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
@@ -4,65 +4,65 @@ classdef DiscreteExtendedKalmanFilterHelper < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = ekf_f(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1719, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
     end
     function varargout = ekf_h(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1720, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
     end
     function varargout = ekfComputeJacobianF(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1721, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
     end
     function varargout = ekfComputeJacobianH(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1722, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
     end
     function varargout = ekfPredict(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1723, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
     end
     function varargout = ekfUpdate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1724, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
     end
     function varargout = ekfInit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1725, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
     end
     function varargout = ekfReset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1726, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
     end
     function varargout = ekfSetMeasurementVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1727, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
     end
     function varargout = ekfSetInputVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1728, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
     end
     function varargout = ekfSetInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1729, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
     end
     function varargout = ekfSetStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1730, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
     end
     function varargout = ekfSetSystemNoiseCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1731, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
     end
     function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
     end
     function varargout = ekfSetStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
     end
     function varargout = ekfSetInputSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
     end
     function varargout = ekfSetOutputSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
     end
     function varargout = ekfGetStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
     end
     function varargout = ekfGetStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1738, self);
+        iDynTreeMEX(1812, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Dummy.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Dummy.m
@@ -9,14 +9,14 @@ classdef Dummy < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(588, varargin{:});
+        tmp = iDynTreeMEX(612, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(589, self);
+        iDynTreeMEX(613, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
@@ -9,78 +9,78 @@ classdef DynamicSpan < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(828, varargin{:});
+        tmp = iDynTreeMEX(852, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(829, self);
+        iDynTreeMEX(853, self);
         self.SwigClear();
       end
     end
     function varargout = first(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(830, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(854, self, varargin{:});
     end
     function varargout = last(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(831, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(855, self, varargin{:});
     end
     function varargout = subspan(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(832, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(856, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(833, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(857, self, varargin{:});
     end
     function varargout = size_bytes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(834, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(858, self, varargin{:});
     end
     function varargout = empty(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(835, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(859, self, varargin{:});
     end
     function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(836, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(860, self, varargin{:});
     end
     function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(837, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(861, self, varargin{:});
     end
     function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(838, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
     end
     function varargout = at(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(839, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(840, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(864, self, varargin{:});
     end
     function varargout = begin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(841, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
     end
     function varargout = end(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(842, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
     end
     function varargout = cbegin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(843, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(867, self, varargin{:});
     end
     function varargout = cend(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(844, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(845, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
     end
     function varargout = rend(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(846, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
     end
     function varargout = crbegin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(847, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
     end
     function varargout = crend(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(848, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
     end
   end
   methods(Static)
     function v = extent()
-      v = iDynTreeMEX(827);
+      v = iDynTreeMEX(851);
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsComputations.m
@@ -9,118 +9,118 @@ classdef DynamicsComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2097, varargin{:});
+        tmp = iDynTreeMEX(2171, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2098, self);
+        iDynTreeMEX(2172, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2099, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2173, self, varargin{:});
     end
     function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2100, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2174, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2101, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2175, self, varargin{:});
     end
     function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2102, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2176, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2103, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2177, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2104, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2178, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2105, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2179, self, varargin{:});
     end
     function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2106, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2180, self, varargin{:});
     end
     function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2107, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2181, self, varargin{:});
     end
     function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2108, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2182, self, varargin{:});
     end
     function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2109, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2183, self, varargin{:});
     end
     function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2110, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2184, self, varargin{:});
     end
     function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2111, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2185, self, varargin{:});
     end
     function varargout = getJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2112, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2186, self, varargin{:});
     end
     function varargout = getJointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2113, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2187, self, varargin{:});
     end
     function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2114, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2188, self, varargin{:});
     end
     function varargout = getFrameName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2115, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2189, self, varargin{:});
     end
     function varargout = getWorldTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2116, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2190, self, varargin{:});
     end
     function varargout = getRelativeTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2117, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2191, self, varargin{:});
     end
     function varargout = getFrameTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2118, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2192, self, varargin{:});
     end
     function varargout = getFrameTwistInWorldOrient(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2119, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2193, self, varargin{:});
     end
     function varargout = getFrameProperSpatialAcceleration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2120, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2194, self, varargin{:});
     end
     function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2121, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2195, self, varargin{:});
     end
     function varargout = getLinkInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2122, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2196, self, varargin{:});
     end
     function varargout = getJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2123, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2197, self, varargin{:});
     end
     function varargout = getJointName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2124, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2198, self, varargin{:});
     end
     function varargout = getJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2125, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2199, self, varargin{:});
     end
     function varargout = inverseDynamics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2126, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2200, self, varargin{:});
     end
     function varargout = getFreeFloatingMassMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2127, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2201, self, varargin{:});
     end
     function varargout = getFrameJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2128, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2202, self, varargin{:});
     end
     function varargout = getDynamicsRegressor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2129, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2203, self, varargin{:});
     end
     function varargout = getModelDynamicsParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2130, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2204, self, varargin{:});
     end
     function varargout = getCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2131, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2205, self, varargin{:});
     end
     function varargout = getCenterOfMassJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2132, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2206, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorGenerator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorGenerator.m
@@ -9,100 +9,100 @@ classdef DynamicsRegressorGenerator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1807, varargin{:});
+        tmp = iDynTreeMEX(1881, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1808, self);
+        iDynTreeMEX(1882, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotAndSensorsModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
     end
     function varargout = loadRobotAndSensorsModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
     end
     function varargout = loadRegressorStructureFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
     end
     function varargout = loadRegressorStructureFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
     end
     function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
     end
     function varargout = getNrOfOutputs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
     end
     function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
     end
     function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
     end
     function varargout = getDescriptionOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
     end
     function varargout = getDescriptionOfOutput(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
     end
     function varargout = getDescriptionOfOutputs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1896, self, varargin{:});
     end
     function varargout = getDescriptionOfLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
     end
     function varargout = getDescriptionOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
     end
     function varargout = getNrOfFakeLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1900, self, varargin{:});
     end
     function varargout = getBaseLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
     end
     function varargout = getSensorsModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
     end
     function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1903, self, varargin{:});
     end
     function varargout = getSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
     end
     function varargout = setTorqueSensorMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
     end
     function varargout = computeRegressor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
     end
     function varargout = getModelParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
     end
     function varargout = computeFloatingBaseIdentifiableSubspace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
     end
     function varargout = computeFixedBaseIdentifiableSubspace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
     end
     function varargout = generate_random_regressors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParameter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParameter.m
@@ -7,40 +7,40 @@ classdef DynamicsRegressorParameter < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1787, self);
+        varargout{1} = iDynTreeMEX(1861, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1788, self, varargin{1});
+        iDynTreeMEX(1862, self, varargin{1});
       end
     end
     function varargout = elemIndex(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1789, self);
+        varargout{1} = iDynTreeMEX(1863, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1790, self, varargin{1});
+        iDynTreeMEX(1864, self, varargin{1});
       end
     end
     function varargout = type(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1791, self);
+        varargout{1} = iDynTreeMEX(1865, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1792, self, varargin{1});
+        iDynTreeMEX(1866, self, varargin{1});
       end
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
     end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
     end
     function varargout = ne(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
     end
     function self = DynamicsRegressorParameter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -48,14 +48,14 @@ classdef DynamicsRegressorParameter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1796, varargin{:});
+        tmp = iDynTreeMEX(1870, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1797, self);
+        iDynTreeMEX(1871, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParametersList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicsRegressorParametersList.m
@@ -7,26 +7,26 @@ classdef DynamicsRegressorParametersList < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1798, self);
+        varargout{1} = iDynTreeMEX(1872, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1799, self, varargin{1});
+        iDynTreeMEX(1873, self, varargin{1});
       end
     end
     function varargout = getDescriptionOfParameter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
     end
     function varargout = addParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
     end
     function varargout = addList(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
     function varargout = findParam(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
     end
     function varargout = getNrOfParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
     end
     function self = DynamicsRegressorParametersList(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -34,14 +34,14 @@ classdef DynamicsRegressorParametersList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1805, varargin{:});
+        tmp = iDynTreeMEX(1879, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1806, self);
+        iDynTreeMEX(1880, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
@@ -9,52 +9,52 @@ classdef ExtWrenchesAndJointTorquesEstimator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1552, varargin{:});
+        tmp = iDynTreeMEX(1626, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1553, self);
+        iDynTreeMEX(1627, self);
         self.SwigClear();
       end
     end
     function varargout = setModelAndSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1554, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
     end
     function varargout = loadModelAndSensorsFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1555, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
     end
     function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1556, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1557, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1558, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
     end
     function varargout = submodels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1559, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
     end
     function varargout = updateKinematicsFromFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1560, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
     end
     function varargout = updateKinematicsFromFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1561, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
     end
     function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1562, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
     end
     function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1563, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1637, self, varargin{:});
     end
     function varargout = checkThatTheModelIsStill(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1638, self, varargin{:});
     end
     function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1565, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1639, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
@@ -2,31 +2,31 @@ classdef ExternalMesh < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1138, self);
+        iDynTreeMEX(1162, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
     end
     function varargout = filename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1140, self);
+        varargout{1} = iDynTreeMEX(1164, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1141, self, varargin{1});
+        iDynTreeMEX(1165, self, varargin{1});
       end
     end
     function varargout = scale(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1142, self);
+        varargout{1} = iDynTreeMEX(1166, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1143, self, varargin{1});
+        iDynTreeMEX(1167, self, varargin{1});
       end
     end
     function self = ExternalMesh(varargin)
@@ -36,7 +36,7 @@ classdef ExternalMesh < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1144, varargin{:});
+        tmp = iDynTreeMEX(1168, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(861);
+    varargout{1} = iDynTreeMEX(885);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(862,varargin{1});
+    iDynTreeMEX(886,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(863);
+    varargout{1} = iDynTreeMEX(887);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(864,varargin{1});
+    iDynTreeMEX(888,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
@@ -7,103 +7,103 @@ classdef FixedJoint < iDynTree.IJoint
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(947, varargin{:});
+        tmp = iDynTreeMEX(971, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(948, self);
+        iDynTreeMEX(972, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(949, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(950, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(951, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(952, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(953, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(954, self, varargin{:});
-    end
-    function varargout = getSecondAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(955, self, varargin{:});
-    end
-    function varargout = getRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(956, self, varargin{:});
-    end
-    function varargout = getTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
-    end
-    function varargout = getTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
-    end
-    function varargout = getMotionSubspaceVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
-    end
-    function varargout = computeChildPosVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
-    end
-    function varargout = computeChildVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
-    end
-    function varargout = computeChildVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
-    end
-    function varargout = computeChildAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
-    end
-    function varargout = computeChildBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(964, self, varargin{:});
-    end
-    function varargout = computeJointTorque(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(966, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
-    end
-    function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
-    end
-    function varargout = hasPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
-    end
-    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
+    end
+    function varargout = getFirstAttachedLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(978, self, varargin{:});
+    end
+    function varargout = getSecondAttachedLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
+    end
+    function varargout = getRestTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
+    end
+    function varargout = getTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
+    end
+    function varargout = getTransformDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
+    end
+    function varargout = getMotionSubspaceVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
+    end
+    function varargout = computeChildPosVelAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
+    end
+    function varargout = computeChildVelAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(985, self, varargin{:});
+    end
+    function varargout = computeChildVel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
+    end
+    function varargout = computeChildAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
+    end
+    function varargout = computeChildBiasAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
+    end
+    function varargout = computeJointTorque(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
+    end
+    function varargout = hasPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(996, self, varargin{:});
+    end
+    function varargout = enablePosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__AngularForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__AngularForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef ForceVector3Semantics__AngularForceVector3Semantics < iDynTree.GeomVect
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(491, varargin{:});
+        tmp = iDynTreeMEX(515, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(494, self);
+        iDynTreeMEX(518, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(492, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(516, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(493, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(517, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__LinearForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3Semantics__LinearForceVector3Semantics.m
@@ -7,24 +7,24 @@ classdef ForceVector3Semantics__LinearForceVector3Semantics < iDynTree.GeomVecto
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(487, varargin{:});
+        tmp = iDynTreeMEX(511, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(490, self);
+        iDynTreeMEX(514, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(488, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(512, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(489, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(513, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3__AngularForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3__AngularForceVector3.m
@@ -7,14 +7,14 @@ classdef ForceVector3__AngularForceVector3 < iDynTree.GeomVector3__AngularForceV
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(503, varargin{:});
+        tmp = iDynTreeMEX(527, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(504, self);
+        iDynTreeMEX(528, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ForceVector3__LinearForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForceVector3__LinearForceVector3.m
@@ -7,14 +7,14 @@ classdef ForceVector3__LinearForceVector3 < iDynTree.GeomVector3__LinearForceVec
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(501, varargin{:});
+        tmp = iDynTreeMEX(525, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(502, self);
+        iDynTreeMEX(526, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1270, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1344, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardBiasAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1271, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1345, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1268, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1342, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1269, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1343, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPositionKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1266, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1340, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1267, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1341, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef FrameFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1217, varargin{:});
+        tmp = iDynTreeMEX(1241, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1218, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1219, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1220, self);
+        iDynTreeMEX(1244, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
@@ -9,26 +9,26 @@ classdef FreeFloatingAcc < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1246, varargin{:});
+        tmp = iDynTreeMEX(1270, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1271, self, varargin{:});
     end
     function varargout = baseAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1272, self, varargin{:});
     end
     function varargout = jointAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1249, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1273, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1274, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1251, self);
+        iDynTreeMEX(1275, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
@@ -9,26 +9,26 @@ classdef FreeFloatingGeneralizedTorques < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1234, varargin{:});
+        tmp = iDynTreeMEX(1258, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1235, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1259, self, varargin{:});
     end
     function varargout = baseWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1236, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1260, self, varargin{:});
     end
     function varargout = jointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1237, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1261, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1262, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1239, self);
+        iDynTreeMEX(1263, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
@@ -7,17 +7,17 @@ classdef FreeFloatingMassMatrix < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1225, varargin{:});
+        tmp = iDynTreeMEX(1249, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1226, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1227, self);
+        iDynTreeMEX(1251, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
@@ -9,26 +9,26 @@ classdef FreeFloatingPos < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1228, varargin{:});
+        tmp = iDynTreeMEX(1252, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1229, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
     end
     function varargout = worldBasePos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1230, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
     end
     function varargout = jointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1231, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1255, self, varargin{:});
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1232, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1256, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1233, self);
+        iDynTreeMEX(1257, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
@@ -9,26 +9,26 @@ classdef FreeFloatingVel < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1240, varargin{:});
+        tmp = iDynTreeMEX(1264, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1241, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1265, self, varargin{:});
     end
     function varargout = baseVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1266, self, varargin{:});
     end
     function varargout = jointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1267, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1268, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1245, self);
+        iDynTreeMEX(1269, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularForceVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__AngularForceVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(428, varargin{:});
+        tmp = iDynTreeMEX(452, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(429, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(453, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(430, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(454, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(431, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(455, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(432, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(456, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(433, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(457, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(434, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(458, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(437, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(438, self);
+        iDynTreeMEX(462, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(435, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(459, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(436, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(460, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__AngularMotionVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__AngularMotionVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(406, varargin{:});
+        tmp = iDynTreeMEX(430, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(407, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(431, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(408, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(432, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(409, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(433, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(410, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(434, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(411, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(435, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(412, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(436, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(415, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(439, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(416, self);
+        iDynTreeMEX(440, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(413, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(437, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(414, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(438, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearForceVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__LinearForceVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(417, varargin{:});
+        tmp = iDynTreeMEX(441, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(418, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(442, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(419, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(443, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(420, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(444, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(421, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(445, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(422, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(446, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(423, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(447, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(426, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(450, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(427, self);
+        iDynTreeMEX(451, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(424, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(448, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(425, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(449, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3Semantics__LinearMotionVector3Semantics.m
@@ -9,45 +9,45 @@ classdef GeomVector3Semantics__LinearMotionVector3Semantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(395, varargin{:});
+        tmp = iDynTreeMEX(419, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(396, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(420, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(397, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(421, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(398, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(422, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(399, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(423, self, varargin{:});
     end
     function varargout = isUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(400, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(424, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(425, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(404, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(428, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(405, self);
+        iDynTreeMEX(429, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(402, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(426, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(403, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(427, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularForceVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__AngularForceVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(475, self);
+        varargout{1} = iDynTreeMEX(499, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(476, self, varargin{1});
+        iDynTreeMEX(500, self, varargin{1});
       end
     end
     function self = GeomVector3__AngularForceVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__AngularForceVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(477, varargin{:});
+        tmp = iDynTreeMEX(501, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(478, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(502, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(479, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(503, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(482, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(506, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(483, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(507, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(484, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(508, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(485, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(509, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(486, self);
+        iDynTreeMEX(510, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(480, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(504, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(481, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(505, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__AngularMotionVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__AngularMotionVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(451, self);
+        varargout{1} = iDynTreeMEX(475, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(452, self, varargin{1});
+        iDynTreeMEX(476, self, varargin{1});
       end
     end
     function self = GeomVector3__AngularMotionVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__AngularMotionVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(453, varargin{:});
+        tmp = iDynTreeMEX(477, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(454, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(478, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(455, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(479, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(458, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(482, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(459, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(483, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(460, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(484, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(485, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(462, self);
+        iDynTreeMEX(486, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(456, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(480, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(457, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(481, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearForceVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__LinearForceVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(463, self);
+        varargout{1} = iDynTreeMEX(487, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(464, self, varargin{1});
+        iDynTreeMEX(488, self, varargin{1});
       end
     end
     function self = GeomVector3__LinearForceVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__LinearForceVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(465, varargin{:});
+        tmp = iDynTreeMEX(489, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(466, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(490, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(467, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(491, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(470, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(494, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(471, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(495, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(472, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(496, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(473, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(497, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(474, self);
+        iDynTreeMEX(498, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(468, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(492, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(469, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(493, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3__LinearMotionVector3.m
@@ -4,10 +4,10 @@ classdef GeomVector3__LinearMotionVector3 < iDynTree.Vector3
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(439, self);
+        varargout{1} = iDynTreeMEX(463, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(440, self, varargin{1});
+        iDynTreeMEX(464, self, varargin{1});
       end
     end
     function self = GeomVector3__LinearMotionVector3(varargin)
@@ -17,42 +17,42 @@ classdef GeomVector3__LinearMotionVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(441, varargin{:});
+        tmp = iDynTreeMEX(465, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(442, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(466, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(443, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(467, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(446, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(470, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(447, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(471, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(448, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(472, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(449, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(473, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(450, self);
+        iDynTreeMEX(474, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(444, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(468, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(445, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(469, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
@@ -7,58 +7,58 @@ classdef GyroscopeSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1399, varargin{:});
+        tmp = iDynTreeMEX(1473, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1400, self);
+        iDynTreeMEX(1474, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1401, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1475, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1402, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1476, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1403, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1477, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1404, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1478, self, varargin{:});
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1405, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1479, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1406, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1480, self, varargin{:});
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1407, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1481, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1408, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1482, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1409, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1483, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1410, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1484, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1411, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1485, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1412, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1486, self, varargin{:});
     end
     function varargout = updateIndeces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1413, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1487, self, varargin{:});
     end
     function varargout = predictMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1414, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1488, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
@@ -5,39 +5,39 @@ classdef IAttitudeEstimator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1676, self);
+        iDynTreeMEX(1750, self);
         self.SwigClear();
       end
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1677, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1751, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1678, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1752, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1679, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1753, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1754, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1755, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1756, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1757, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1758, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
     end
     function self = IAttitudeEstimator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,18 +5,18 @@ classdef ICamera < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1892, self);
+        iDynTreeMEX(1966, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
     end
     function varargout = setTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
     end
     function varargout = setUpVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,33 +5,33 @@ classdef IEnvironment < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1920, self);
+        iDynTreeMEX(1994, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1995, self, varargin{:});
     end
     function varargout = setElementVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1996, self, varargin{:});
     end
     function varargout = setBackgroundColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1997, self, varargin{:});
     end
     function varargout = setAmbientLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
     end
     function varargout = getLights(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
     end
     function varargout = addLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
     end
     function varargout = lightViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
     end
     function varargout = removeLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1929, self);
+        iDynTreeMEX(2003, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2004, self, varargin{:});
     end
     function varargout = getNrOfJets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
     end
     function varargout = getJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
     end
     function varargout = setJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2007, self, varargin{:});
     end
     function varargout = setJetColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
     end
     function varargout = setJetsDimensions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2009, self, varargin{:});
     end
     function varargout = setJetsIntensity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2010, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJoint.m
@@ -5,108 +5,108 @@ classdef IJoint < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(913, self);
+        iDynTreeMEX(937, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(915, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(916, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
-    end
-    function varargout = getSecondAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
-    end
-    function varargout = getRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(921, self, varargin{:});
-    end
-    function varargout = getTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(922, self, varargin{:});
-    end
-    function varargout = getTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
-    end
-    function varargout = getMotionSubspaceVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
-    end
-    function varargout = computeChildPosVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(925, self, varargin{:});
-    end
-    function varargout = computeChildVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
-    end
-    function varargout = computeChildVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
-    end
-    function varargout = computeChildAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(928, self, varargin{:});
-    end
-    function varargout = computeChildBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(929, self, varargin{:});
-    end
-    function varargout = computeJointTorque(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(930, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(931, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
-    end
-    function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(934, self, varargin{:});
-    end
-    function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(935, self, varargin{:});
-    end
-    function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(936, self, varargin{:});
-    end
-    function varargout = hasPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(937, self, varargin{:});
-    end
-    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(938, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(939, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(940, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(941, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(942, self, varargin{:});
     end
-    function varargout = isRevoluteJoint(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(943, self, varargin{:});
     end
-    function varargout = isFixedJoint(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(944, self, varargin{:});
     end
-    function varargout = asRevoluteJoint(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(945, self, varargin{:});
     end
-    function varargout = asFixedJoint(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(946, self, varargin{:});
+    end
+    function varargout = getTransformDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(947, self, varargin{:});
+    end
+    function varargout = getMotionSubspaceVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(948, self, varargin{:});
+    end
+    function varargout = computeChildPosVelAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(949, self, varargin{:});
+    end
+    function varargout = computeChildVelAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(950, self, varargin{:});
+    end
+    function varargout = computeChildVel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(951, self, varargin{:});
+    end
+    function varargout = computeChildAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(952, self, varargin{:});
+    end
+    function varargout = computeChildBiasAcc(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(953, self, varargin{:});
+    end
+    function varargout = computeJointTorque(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(954, self, varargin{:});
+    end
+    function varargout = setIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(955, self, varargin{:});
+    end
+    function varargout = getIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(956, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
+    end
+    function varargout = hasPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
+    end
+    function varargout = enablePosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(964, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(966, self, varargin{:});
+    end
+    function varargout = isRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
+    end
+    function varargout = isFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
+    end
+    function varargout = asRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
+    end
+    function varargout = asFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
     end
     function self = IJoint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1906, self);
+        iDynTreeMEX(1980, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
     end
     function varargout = setType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
     end
     function varargout = getType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
     end
     function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
     end
     function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
     end
     function varargout = setAmbientColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
     end
     function varargout = getAmbientColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
     end
     function varargout = setSpecularColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
     end
     function varargout = getSpecularColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
     end
     function varargout = setDiffuseColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
     end
     function varargout = getDiffuseColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,57 +5,57 @@ classdef IModelVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1944, self);
+        iDynTreeMEX(2018, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2019, self, varargin{:});
     end
     function varargout = setLinkPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2020, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2021, self, varargin{:});
     end
     function varargout = getInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2022, self, varargin{:});
     end
     function varargout = setModelVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2023, self, varargin{:});
     end
     function varargout = setModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2024, self, varargin{:});
     end
     function varargout = resetModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2025, self, varargin{:});
     end
     function varargout = setLinkColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2026, self, varargin{:});
     end
     function varargout = resetLinkColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2027, self, varargin{:});
     end
     function varargout = getLinkNames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2028, self, varargin{:});
     end
     function varargout = setLinkVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2029, self, varargin{:});
     end
     function varargout = getFeatures(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2030, self, varargin{:});
     end
     function varargout = setFeatureVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2031, self, varargin{:});
     end
     function varargout = jets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1958, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2032, self, varargin{:});
     end
     function varargout = getWorldModelTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1959, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2033, self, varargin{:});
     end
     function varargout = getWorldLinkTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2034, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,27 +5,27 @@ classdef IVectorsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1937, self);
+        iDynTreeMEX(2011, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2012, self, varargin{:});
     end
     function varargout = getNrOfVectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2013, self, varargin{:});
     end
     function varargout = getVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2014, self, varargin{:});
     end
     function varargout = updateVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2015, self, varargin{:});
     end
     function varargout = setVectorColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2016, self, varargin{:});
     end
     function varargout = setVectorsAspect(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2017, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
@@ -1,3 +1,3 @@
 function varargout = InverseDynamicsInertialParametersRegressor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1299, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1373, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
@@ -9,202 +9,202 @@ classdef InverseKinematics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2033, varargin{:});
+        tmp = iDynTreeMEX(2107, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2034, self);
+        iDynTreeMEX(2108, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2035, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2109, self, varargin{:});
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2036, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2110, self, varargin{:});
     end
     function varargout = setJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2037, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2111, self, varargin{:});
     end
     function varargout = getJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2038, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2112, self, varargin{:});
     end
     function varargout = clearProblem(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2039, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2113, self, varargin{:});
     end
     function varargout = setFloatingBaseOnFrameNamed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2040, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2114, self, varargin{:});
     end
     function varargout = setRobotConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2041, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2115, self, varargin{:});
     end
     function varargout = setCurrentRobotConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2042, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2116, self, varargin{:});
     end
     function varargout = setJointConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2043, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2117, self, varargin{:});
     end
     function varargout = setRotationParametrization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2044, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2118, self, varargin{:});
     end
     function varargout = rotationParametrization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2045, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2119, self, varargin{:});
     end
     function varargout = setMaxIterations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2046, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2120, self, varargin{:});
     end
     function varargout = maxIterations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2047, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2121, self, varargin{:});
     end
     function varargout = setMaxCPUTime(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2048, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2122, self, varargin{:});
     end
     function varargout = maxCPUTime(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2049, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2123, self, varargin{:});
     end
     function varargout = setCostTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2050, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2124, self, varargin{:});
     end
     function varargout = costTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2051, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2125, self, varargin{:});
     end
     function varargout = setConstraintsTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2052, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2126, self, varargin{:});
     end
     function varargout = constraintsTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2053, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2127, self, varargin{:});
     end
     function varargout = setVerbosity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2054, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2128, self, varargin{:});
     end
     function varargout = linearSolverName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2055, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2129, self, varargin{:});
     end
     function varargout = setLinearSolverName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2056, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2130, self, varargin{:});
     end
     function varargout = addFrameConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2057, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2131, self, varargin{:});
     end
     function varargout = addFramePositionConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2058, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2132, self, varargin{:});
     end
     function varargout = addFrameRotationConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2059, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2133, self, varargin{:});
     end
     function varargout = activateFrameConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2060, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2134, self, varargin{:});
     end
     function varargout = deactivateFrameConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2061, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2135, self, varargin{:});
     end
     function varargout = isFrameConstraintActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2062, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2136, self, varargin{:});
     end
     function varargout = addCenterOfMassProjectionConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2063, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2137, self, varargin{:});
     end
     function varargout = getCenterOfMassProjectionMargin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2064, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2138, self, varargin{:});
     end
     function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2065, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2139, self, varargin{:});
     end
     function varargout = addTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2066, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2140, self, varargin{:});
     end
     function varargout = addPositionTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2067, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2141, self, varargin{:});
     end
     function varargout = addRotationTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2068, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2142, self, varargin{:});
     end
     function varargout = updateTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2069, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2143, self, varargin{:});
     end
     function varargout = updatePositionTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2070, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2144, self, varargin{:});
     end
     function varargout = updateRotationTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2071, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2145, self, varargin{:});
     end
     function varargout = setDefaultTargetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2072, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2146, self, varargin{:});
     end
     function varargout = defaultTargetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2073, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2147, self, varargin{:});
     end
     function varargout = setTargetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2074, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2148, self, varargin{:});
     end
     function varargout = targetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2075, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2149, self, varargin{:});
     end
     function varargout = setDesiredJointConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2076, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2150, self, varargin{:});
     end
     function varargout = setDesiredFullJointsConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2077, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2151, self, varargin{:});
     end
     function varargout = setDesiredReducedJointConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2078, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2152, self, varargin{:});
     end
     function varargout = setInitialCondition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2079, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2153, self, varargin{:});
     end
     function varargout = setFullJointsInitialCondition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2080, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2154, self, varargin{:});
     end
     function varargout = setReducedInitialCondition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2081, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2155, self, varargin{:});
     end
     function varargout = solve(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2082, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2156, self, varargin{:});
     end
     function varargout = getSolution(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2083, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2157, self, varargin{:});
     end
     function varargout = getFullJointsSolution(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2084, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2158, self, varargin{:});
     end
     function varargout = getReducedSolution(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2085, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2159, self, varargin{:});
     end
     function varargout = getPoseForFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2086, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2160, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2087, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2161, self, varargin{:});
     end
     function varargout = fullModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2088, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2162, self, varargin{:});
     end
     function varargout = reducedModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2089, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2163, self, varargin{:});
     end
     function varargout = setCOMTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2090, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2164, self, varargin{:});
     end
     function varargout = setCOMAsConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2091, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2165, self, varargin{:});
     end
     function varargout = setCOMAsConstraintTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2092, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2166, self, varargin{:});
     end
     function varargout = isCOMAConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2093, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2167, self, varargin{:});
     end
     function varargout = isCOMTargetActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2094, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2168, self, varargin{:});
     end
     function varargout = deactivateCOMTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2095, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2169, self, varargin{:});
     end
     function varargout = setCOMConstraintProjectionDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2096, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2170, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(853);
+    varargout{1} = iDynTreeMEX(877);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(854,varargin{1});
+    iDynTreeMEX(878,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(855);
+    varargout{1} = iDynTreeMEX(879);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(856,varargin{1});
+    iDynTreeMEX(880,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointDOFsDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1203, varargin{:});
+        tmp = iDynTreeMEX(1227, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1228, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1205, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1229, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1206, self);
+        iDynTreeMEX(1230, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointPosDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1199, varargin{:});
+        tmp = iDynTreeMEX(1223, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1200, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1224, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1201, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1225, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1202, self);
+        iDynTreeMEX(1226, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
@@ -2,24 +2,24 @@ classdef JointSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1313, self);
+        iDynTreeMEX(1387, self);
         self.SwigClear();
       end
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1388, self, varargin{:});
     end
     function varargout = getParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1389, self, varargin{:});
     end
     function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1390, self, varargin{:});
     end
     function varargout = setParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1391, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1392, self, varargin{:});
     end
     function self = JointSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -9,175 +9,175 @@ classdef KinDynComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1837, varargin{:});
+        tmp = iDynTreeMEX(1911, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1838, self);
+        iDynTreeMEX(1912, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
     end
     function varargout = loadRobotModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
     end
     function varargout = loadRobotModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
     end
     function varargout = setFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
     end
     function varargout = getFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
     end
     function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
     end
     function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
     end
     function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
     end
     function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
     end
     function varargout = getRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
     end
     function varargout = getRelativeJacobianSparsityPattern(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
     end
     function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1855, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
     end
     function varargout = setJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1856, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
     end
     function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1857, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
     end
     function varargout = getRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1858, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
     end
     function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1859, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
     function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1860, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
     end
     function varargout = getJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1861, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
     end
     function varargout = getJointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1862, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
     end
     function varargout = getModelVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1863, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
     end
     function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1864, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
     end
     function varargout = getFrameName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1865, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
     function varargout = getWorldTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1866, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
     function varargout = getRelativeTransformExplicit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
     end
     function varargout = getRelativeTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
     function varargout = getFrameVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
     end
     function varargout = getFrameAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
     end
     function varargout = getFrameFreeFloatingJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
     end
     function varargout = getRelativeJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
     end
     function varargout = getRelativeJacobianExplicit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
     end
     function varargout = getFrameBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
     end
     function varargout = getCenterOfMassPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
     end
     function varargout = getCenterOfMassVelocity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
     end
     function varargout = getCenterOfMassJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
     end
     function varargout = getCenterOfMassBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
     end
     function varargout = getAverageVelocity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
     end
     function varargout = getAverageVelocityJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
     end
     function varargout = getCentroidalAverageVelocity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
     end
     function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
     end
     function varargout = getLinearAngularMomentum(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
     end
     function varargout = getLinearAngularMomentumJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1958, self, varargin{:});
     end
     function varargout = getCentroidalTotalMomentum(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1959, self, varargin{:});
     end
     function varargout = getFreeFloatingMassMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
     end
     function varargout = inverseDynamics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1961, self, varargin{:});
     end
     function varargout = generalizedBiasForces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1962, self, varargin{:});
     end
     function varargout = generalizedGravityForces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1963, self, varargin{:});
     end
     function varargout = generalizedExternalForces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1964, self, varargin{:});
     end
     function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1965, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(849);
+    varargout{1} = iDynTreeMEX(873);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(850,varargin{1});
+    iDynTreeMEX(874,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(851);
+    varargout{1} = iDynTreeMEX(875);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(852,varargin{1});
+    iDynTreeMEX(876,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3.m
@@ -7,14 +7,14 @@ classdef LinearForceVector3 < iDynTree.ForceVector3__LinearForceVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(519, varargin{:});
+        tmp = iDynTreeMEX(543, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(520, self);
+        iDynTreeMEX(544, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearForceVector3Semantics.m
@@ -7,14 +7,14 @@ classdef LinearForceVector3Semantics < iDynTree.ForceVector3Semantics__LinearFor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(517, varargin{:});
+        tmp = iDynTreeMEX(541, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(518, self);
+        iDynTreeMEX(542, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3.m
@@ -7,17 +7,17 @@ classdef LinearMotionVector3 < iDynTree.MotionVector3__LinearMotionVector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(509, varargin{:});
+        tmp = iDynTreeMEX(533, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(510, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(511, self);
+        iDynTreeMEX(535, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3Semantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinearMotionVector3Semantics.m
@@ -7,24 +7,24 @@ classdef LinearMotionVector3Semantics < iDynTree.GeomVector3Semantics__LinearMot
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(505, varargin{:});
+        tmp = iDynTreeMEX(529, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(506, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(530, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(508, self);
+        iDynTreeMEX(532, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(507, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(531, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Link.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Link.m
@@ -9,29 +9,29 @@ classdef Link < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(906, varargin{:});
+        tmp = iDynTreeMEX(930, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = inertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(931, self, varargin{:});
     end
     function varargout = setInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
     end
     function varargout = getInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(934, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(935, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(912, self);
+        iDynTreeMEX(936, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
@@ -9,29 +9,29 @@ classdef LinkAccArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(899, varargin{:});
+        tmp = iDynTreeMEX(923, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(925, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(928, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(905, self);
+        iDynTreeMEX(929, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
@@ -9,23 +9,23 @@ classdef LinkArticulatedBodyInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(887, varargin{:});
+        tmp = iDynTreeMEX(911, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(891, self);
+        iDynTreeMEX(915, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
@@ -9,35 +9,35 @@ classdef LinkContactWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1257, varargin{:});
+        tmp = iDynTreeMEX(1281, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1258, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1282, self, varargin{:});
     end
     function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1259, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1283, self, varargin{:});
     end
     function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1260, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1284, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1261, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1285, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1262, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1286, self, varargin{:});
     end
     function varargout = computeNetWrenches(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1263, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1287, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1264, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1288, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1265, self);
+        iDynTreeMEX(1289, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
@@ -9,23 +9,23 @@ classdef LinkInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(882, varargin{:});
+        tmp = iDynTreeMEX(906, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(885, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(886, self);
+        iDynTreeMEX(910, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
@@ -9,29 +9,29 @@ classdef LinkPositions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(867, varargin{:});
+        tmp = iDynTreeMEX(891, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(892, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(873, self);
+        iDynTreeMEX(897, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
@@ -2,30 +2,30 @@ classdef LinkSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1319, self);
+        iDynTreeMEX(1393, self);
         self.SwigClear();
       end
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1394, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1321, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1395, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1322, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1396, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1397, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1398, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1399, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1400, self, varargin{:});
     end
     function self = LinkSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
@@ -9,41 +9,41 @@ classdef LinkUnknownWrenchContacts < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1517, varargin{:});
+        tmp = iDynTreeMEX(1591, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1518, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1519, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1593, self, varargin{:});
     end
     function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1520, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1594, self, varargin{:});
     end
     function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1521, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1595, self, varargin{:});
     end
     function varargout = addNewContactForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1522, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1596, self, varargin{:});
     end
     function varargout = addNewContactInFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1523, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1597, self, varargin{:});
     end
     function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1524, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1525, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1599, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1526, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1527, self);
+        iDynTreeMEX(1601, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
@@ -9,29 +9,29 @@ classdef LinkVelArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(892, varargin{:});
+        tmp = iDynTreeMEX(916, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(921, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(898, self);
+        iDynTreeMEX(922, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
@@ -9,32 +9,32 @@ classdef LinkWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(874, varargin{:});
+        tmp = iDynTreeMEX(898, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(875, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(899, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(876, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(880, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(881, self);
+        iDynTreeMEX(905, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix10x16.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix10x16.m
@@ -9,53 +9,53 @@ classdef Matrix10x16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(266, varargin{:});
+        tmp = iDynTreeMEX(270, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(268, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(269, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(270, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(271, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(272, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(273, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(274, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(275, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(276, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(277, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(278, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(279, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(280, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(281, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(282, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(283, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(280, self);
+        iDynTreeMEX(284, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix1x6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix1x6.m
@@ -9,53 +9,53 @@ classdef Matrix1x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(176, varargin{:});
+        tmp = iDynTreeMEX(180, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(177, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(178, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(179, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(180, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(181, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(182, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(183, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(184, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(185, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(186, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(187, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(188, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(189, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(190, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(191, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(192, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(193, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(190, self);
+        iDynTreeMEX(194, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix2x3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix2x3.m
@@ -9,53 +9,53 @@ classdef Matrix2x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(191, varargin{:});
+        tmp = iDynTreeMEX(195, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(192, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(193, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(194, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(195, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(196, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(197, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(198, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(199, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(200, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(201, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(202, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(203, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(204, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(205, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(206, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(207, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(208, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(205, self);
+        iDynTreeMEX(209, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix3x3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix3x3.m
@@ -9,53 +9,53 @@ classdef Matrix3x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(206, varargin{:});
+        tmp = iDynTreeMEX(210, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(207, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(208, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(209, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(210, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(211, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(212, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(213, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(214, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(215, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(216, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(217, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(218, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(219, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(220, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(221, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(222, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(223, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(220, self);
+        iDynTreeMEX(224, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4.m
@@ -9,53 +9,53 @@ classdef Matrix4x4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(221, varargin{:});
+        tmp = iDynTreeMEX(225, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(222, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(223, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(224, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(225, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(226, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(227, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(228, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(229, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(230, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(231, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(232, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(233, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(234, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(235, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(236, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(237, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(238, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(235, self);
+        iDynTreeMEX(239, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix6x10.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix6x10.m
@@ -9,53 +9,53 @@ classdef Matrix6x10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(251, varargin{:});
+        tmp = iDynTreeMEX(255, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(252, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(253, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(254, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(255, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(256, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(257, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(258, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(259, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(260, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(261, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(262, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(263, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(264, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(265, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(266, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(268, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(265, self);
+        iDynTreeMEX(269, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix6x6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix6x6.m
@@ -9,53 +9,53 @@ classdef Matrix6x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(236, varargin{:});
+        tmp = iDynTreeMEX(240, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(237, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(238, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(239, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(240, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(241, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(242, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(243, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(244, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(245, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(246, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(247, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(248, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(249, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(250, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(251, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(252, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(253, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(250, self);
+        iDynTreeMEX(254, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Model.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Model.m
@@ -9,133 +9,133 @@ classdef Model < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1158, varargin{:});
+        tmp = iDynTreeMEX(1182, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = copy(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1160, self);
+        iDynTreeMEX(1184, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1161, self, varargin{:});
-    end
-    function varargout = getLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1162, self, varargin{:});
-    end
-    function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
-    end
-    function varargout = isValidLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1165, self, varargin{:});
-    end
-    function varargout = addLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1166, self, varargin{:});
-    end
-    function varargout = getNrOfJoints(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1167, self, varargin{:});
-    end
-    function varargout = getJointName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1168, self, varargin{:});
-    end
-    function varargout = getTotalMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1169, self, varargin{:});
-    end
-    function varargout = getJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1170, self, varargin{:});
-    end
-    function varargout = getJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1171, self, varargin{:});
-    end
-    function varargout = isValidJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
-    end
-    function varargout = isLinkNameUsed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
-    end
-    function varargout = isJointNameUsed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1174, self, varargin{:});
-    end
-    function varargout = isFrameNameUsed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1175, self, varargin{:});
-    end
-    function varargout = addJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1176, self, varargin{:});
-    end
-    function varargout = addJointAndLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1177, self, varargin{:});
-    end
-    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
-    end
-    function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
-    end
-    function varargout = addAdditionalFrameToLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
-    end
-    function varargout = getFrameName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
-    end
-    function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
-    end
-    function varargout = isValidFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = getLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
     end
-    function varargout = getFrameLink(self,varargin)
+    function varargout = getLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
     end
-    function varargout = getLinkAdditionalFrames(self,varargin)
+    function varargout = isValidLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
     end
-    function varargout = getNrOfNeighbors(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
     end
-    function varargout = getNeighbor(self,varargin)
+    function varargout = addLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
     end
-    function varargout = setDefaultBaseLink(self,varargin)
+    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1191, self, varargin{:});
     end
-    function varargout = getDefaultBaseLink(self,varargin)
+    function varargout = getJointName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1192, self, varargin{:});
     end
-    function varargout = computeFullTreeTraversal(self,varargin)
+    function varargout = getTotalMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1193, self, varargin{:});
     end
-    function varargout = getInertialParameters(self,varargin)
+    function varargout = getJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
     end
-    function varargout = updateInertialParameters(self,varargin)
+    function varargout = getJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
     end
-    function varargout = visualSolidShapes(self,varargin)
+    function varargout = isValidJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1196, self, varargin{:});
     end
-    function varargout = collisionSolidShapes(self,varargin)
+    function varargout = isLinkNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1197, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = isJointNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
+    end
+    function varargout = isFrameNameUsed(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
+    end
+    function varargout = addJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1200, self, varargin{:});
+    end
+    function varargout = addJointAndLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1201, self, varargin{:});
+    end
+    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1202, self, varargin{:});
+    end
+    function varargout = getNrOfPosCoords(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1203, self, varargin{:});
+    end
+    function varargout = getNrOfDOFs(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1204, self, varargin{:});
+    end
+    function varargout = getNrOfFrames(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1205, self, varargin{:});
+    end
+    function varargout = addAdditionalFrameToLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1206, self, varargin{:});
+    end
+    function varargout = getFrameName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1207, self, varargin{:});
+    end
+    function varargout = getFrameIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
+    end
+    function varargout = isValidFrameIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
+    end
+    function varargout = getFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1210, self, varargin{:});
+    end
+    function varargout = getFrameLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1211, self, varargin{:});
+    end
+    function varargout = getLinkAdditionalFrames(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1212, self, varargin{:});
+    end
+    function varargout = getNrOfNeighbors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
+    end
+    function varargout = getNeighbor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1214, self, varargin{:});
+    end
+    function varargout = setDefaultBaseLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1215, self, varargin{:});
+    end
+    function varargout = getDefaultBaseLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1216, self, varargin{:});
+    end
+    function varargout = computeFullTreeTraversal(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1217, self, varargin{:});
+    end
+    function varargout = getInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1218, self, varargin{:});
+    end
+    function varargout = updateInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1219, self, varargin{:});
+    end
+    function varargout = visualSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1220, self, varargin{:});
+    end
+    function varargout = collisionSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1221, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1222, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelCalibrationHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelCalibrationHelper.m
@@ -9,37 +9,37 @@ classdef ModelCalibrationHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1496, varargin{:});
+        tmp = iDynTreeMEX(1570, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1497, self);
+        iDynTreeMEX(1571, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1498, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1572, self, varargin{:});
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1499, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1573, self, varargin{:});
     end
     function varargout = updateModelInertialParametersToString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1500, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1574, self, varargin{:});
     end
     function varargout = updateModelInertialParametersToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1501, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1575, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1502, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1576, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1503, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1577, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1504, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1578, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
@@ -9,40 +9,40 @@ classdef ModelExporter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1486, varargin{:});
+        tmp = iDynTreeMEX(1560, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1487, self);
+        iDynTreeMEX(1561, self);
         self.SwigClear();
       end
     end
     function varargout = exportingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1488, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1562, self, varargin{:});
     end
     function varargout = setExportingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1489, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1563, self, varargin{:});
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1490, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1491, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1565, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1492, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1566, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1493, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1567, self, varargin{:});
     end
     function varargout = exportModelToString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1494, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1568, self, varargin{:});
     end
     function varargout = exportModelToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1495, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1569, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
@@ -7,20 +7,20 @@ classdef ModelExporterOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1480, self);
+        varargout{1} = iDynTreeMEX(1554, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1481, self, varargin{1});
+        iDynTreeMEX(1555, self, varargin{1});
       end
     end
     function varargout = exportFirstBaseLinkAdditionalFrameAsFakeURDFBase(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1482, self);
+        varargout{1} = iDynTreeMEX(1556, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1483, self, varargin{1});
+        iDynTreeMEX(1557, self, varargin{1});
       end
     end
     function self = ModelExporterOptions(varargin)
@@ -29,14 +29,14 @@ classdef ModelExporterOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1484, varargin{:});
+        tmp = iDynTreeMEX(1558, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1485, self);
+        iDynTreeMEX(1559, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
@@ -9,46 +9,46 @@ classdef ModelLoader < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1468, varargin{:});
+        tmp = iDynTreeMEX(1542, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1469, self);
+        iDynTreeMEX(1543, self);
         self.SwigClear();
       end
     end
     function varargout = parsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1470, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1544, self, varargin{:});
     end
     function varargout = setParsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1471, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1545, self, varargin{:});
     end
     function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1472, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1546, self, varargin{:});
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1473, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1547, self, varargin{:});
     end
     function varargout = loadReducedModelFromFullModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1474, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1548, self, varargin{:});
     end
     function varargout = loadReducedModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1475, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1549, self, varargin{:});
     end
     function varargout = loadReducedModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1476, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1550, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1477, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1551, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1478, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1552, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1479, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1553, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
@@ -7,20 +7,20 @@ classdef ModelParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1462, self);
+        varargout{1} = iDynTreeMEX(1536, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1463, self, varargin{1});
+        iDynTreeMEX(1537, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1464, self);
+        varargout{1} = iDynTreeMEX(1538, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1465, self, varargin{1});
+        iDynTreeMEX(1539, self, varargin{1});
       end
     end
     function self = ModelParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef ModelParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1466, varargin{:});
+        tmp = iDynTreeMEX(1540, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1467, self);
+        iDynTreeMEX(1541, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
@@ -9,34 +9,34 @@ classdef ModelSolidShapes < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1145, varargin{:});
+        tmp = iDynTreeMEX(1169, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1146, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1170, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1147, self);
+        iDynTreeMEX(1171, self);
         self.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1148, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1149, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
     end
     function varargout = linkSolidShapes(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1150, self);
+        varargout{1} = iDynTreeMEX(1174, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1151, self, varargin{1});
+        iDynTreeMEX(1175, self, varargin{1});
       end
     end
   end

--- a/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef MomentumFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1221, varargin{:});
+        tmp = iDynTreeMEX(1245, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1222, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1223, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1224, self);
+        iDynTreeMEX(1248, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MotionVector3__AngularMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MotionVector3__AngularMotionVector3.m
@@ -7,17 +7,17 @@ classdef MotionVector3__AngularMotionVector3 < iDynTree.GeomVector3__AngularMoti
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(498, varargin{:});
+        tmp = iDynTreeMEX(522, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(499, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(523, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(500, self);
+        iDynTreeMEX(524, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MotionVector3__LinearMotionVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MotionVector3__LinearMotionVector3.m
@@ -7,17 +7,17 @@ classdef MotionVector3__LinearMotionVector3 < iDynTree.GeomVector3__LinearMotion
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(495, varargin{:});
+        tmp = iDynTreeMEX(519, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(496, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(520, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(497, self);
+        iDynTreeMEX(521, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl1 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(978, self);
+        iDynTreeMEX(1002, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1003, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
     end
     function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
     end
     function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1008, self, varargin{:});
     end
     function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(985, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
     end
     function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
     end
     function self = MovableJointImpl1(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl2 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(987, self);
+        iDynTreeMEX(1011, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
     end
     function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
     end
     function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
     end
     function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
     end
     function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
     end
     function self = MovableJointImpl2(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl3 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(996, self);
+        iDynTreeMEX(1020, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
     end
     function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
     end
     function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
     end
     function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1003, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
     end
     function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
     end
     function self = MovableJointImpl3(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl4 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1005, self);
+        iDynTreeMEX(1029, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1008, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1032, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1033, self, varargin{:});
     end
     function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
     end
     function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
     end
     function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
     end
     function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
     end
     function self = MovableJointImpl4(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl5 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1014, self);
+        iDynTreeMEX(1038, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1041, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
     end
     function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
     end
     function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
     end
     function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
     end
     function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
     end
     function self = MovableJointImpl5(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl6 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1023, self);
+        iDynTreeMEX(1047, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
     end
     function varargout = setPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
     end
     function varargout = getPosCoordsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
     end
     function varargout = setDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
     end
     function varargout = getDOFsOffset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
     end
     function self = MovableJointImpl6(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
@@ -1,3 +1,3 @@
 function v = NR_OF_SENSOR_TYPES()
-  v = iDynTreeMEX(1300);
+  v = iDynTreeMEX(1374);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
@@ -7,20 +7,20 @@ classdef Neighbor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1152, self);
+        varargout{1} = iDynTreeMEX(1176, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1153, self, varargin{1});
+        iDynTreeMEX(1177, self, varargin{1});
       end
     end
     function varargout = neighborJoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1154, self);
+        varargout{1} = iDynTreeMEX(1178, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1155, self, varargin{1});
+        iDynTreeMEX(1179, self, varargin{1});
       end
     end
     function self = Neighbor(varargin)
@@ -29,14 +29,14 @@ classdef Neighbor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1156, varargin{:});
+        tmp = iDynTreeMEX(1180, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1157, self);
+        iDynTreeMEX(1181, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon.m
@@ -7,10 +7,10 @@ classdef Polygon < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1986, self);
+        varargout{1} = iDynTreeMEX(2060, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1987, self, varargin{1});
+        iDynTreeMEX(2061, self, varargin{1});
       end
     end
     function self = Polygon(varargin)
@@ -19,36 +19,36 @@ classdef Polygon < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1988, varargin{:});
+        tmp = iDynTreeMEX(2062, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2063, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2064, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2065, self, varargin{:});
     end
     function varargout = applyTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2066, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2067, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1995, self);
+        iDynTreeMEX(2069, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = XYRectangleFromOffsets(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(1994, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(2068, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
@@ -7,10 +7,10 @@ classdef Polygon2D < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1996, self);
+        varargout{1} = iDynTreeMEX(2070, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1997, self, varargin{1});
+        iDynTreeMEX(2071, self, varargin{1});
       end
     end
     function self = Polygon2D(varargin)
@@ -19,26 +19,26 @@ classdef Polygon2D < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1998, varargin{:});
+        tmp = iDynTreeMEX(2072, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2073, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2074, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2075, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2076, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2003, self);
+        iDynTreeMEX(2077, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Position.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Position.m
@@ -7,60 +7,60 @@ classdef Position < iDynTree.PositionRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(379, varargin{:});
+        tmp = iDynTreeMEX(403, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(380, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(404, self, varargin{:});
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(381, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(405, self, varargin{:});
     end
     function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(382, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(406, self, varargin{:});
     end
     function varargout = changeCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(383, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(407, self, varargin{:});
     end
     function varargout = changePointOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(386, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(410, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(387, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(411, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(388, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(412, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(389, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(413, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(390, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(414, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(391, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(415, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(392, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(416, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(394, self);
+        iDynTreeMEX(418, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(384, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(408, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(385, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(409, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(393, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(417, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PositionRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PositionRaw.m
@@ -7,39 +7,39 @@ classdef PositionRaw < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(351, varargin{:});
+        tmp = iDynTreeMEX(375, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(352, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(376, self, varargin{:});
     end
     function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(353, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(377, self, varargin{:});
     end
     function varargout = changePointOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(356, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(380, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(357, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(381, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(358, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(382, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(359, self);
+        iDynTreeMEX(383, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(354, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(378, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(355, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(379, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PositionSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PositionSemantics.m
@@ -9,69 +9,69 @@ classdef PositionSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(360, varargin{:});
+        tmp = iDynTreeMEX(384, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(361, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(385, self, varargin{:});
     end
     function varargout = getPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(362, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(386, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(363, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(387, self, varargin{:});
     end
     function varargout = getReferencePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(364, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(388, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(365, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(389, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(366, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(390, self, varargin{:});
     end
     function varargout = setPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(367, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(391, self, varargin{:});
     end
     function varargout = setBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(368, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(392, self, varargin{:});
     end
     function varargout = setReferencePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(369, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(393, self, varargin{:});
     end
     function varargout = setRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(370, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(394, self, varargin{:});
     end
     function varargout = setCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(371, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(395, self, varargin{:});
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(372, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(396, self, varargin{:});
     end
     function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(373, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(397, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(376, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(400, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(377, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(378, self);
+        iDynTreeMEX(402, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(374, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(398, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(375, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(399, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
@@ -7,85 +7,85 @@ classdef PrismaticJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1057, varargin{:});
+        tmp = iDynTreeMEX(1081, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1058, self);
+        iDynTreeMEX(1082, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1083, self, varargin{:});
     end
     function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1060, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1084, self, varargin{:});
     end
     function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1061, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
     end
     function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1062, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
     end
     function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1063, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1087, self, varargin{:});
     end
     function varargout = getSecondAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1064, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1088, self, varargin{:});
     end
     function varargout = getAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
     end
     function varargout = getRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
     end
     function varargout = getTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1091, self, varargin{:});
     end
     function varargout = getTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1092, self, varargin{:});
     end
     function varargout = getMotionSubspaceVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1093, self, varargin{:});
     end
     function varargout = computeChildPosVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
     end
     function varargout = computeChildVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1095, self, varargin{:});
     end
     function varargout = computeChildVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1096, self, varargin{:});
     end
     function varargout = computeChildAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1073, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1097, self, varargin{:});
     end
     function varargout = computeChildBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
     end
     function varargout = computeJointTorque(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1099, self, varargin{:});
     end
     function varargout = hasPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
     end
     function varargout = enablePosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1101, self, varargin{:});
     end
     function varargout = getPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1102, self, varargin{:});
     end
     function varargout = getMinPosLimit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
     end
     function varargout = getMaxPosLimit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
     end
     function varargout = setPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1105, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
@@ -1,3 +1,3 @@
 function varargout = RNEADynamicPhase(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1274, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1348, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
@@ -7,85 +7,85 @@ classdef RevoluteJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1032, varargin{:});
+        tmp = iDynTreeMEX(1056, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1033, self);
+        iDynTreeMEX(1057, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1058, self, varargin{:});
     end
     function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
     end
     function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1060, self, varargin{:});
     end
     function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1037, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1061, self, varargin{:});
     end
     function varargout = getFirstAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1038, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1062, self, varargin{:});
     end
     function varargout = getSecondAttachedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1039, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1063, self, varargin{:});
     end
     function varargout = getAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1064, self, varargin{:});
     end
     function varargout = getRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1041, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
     end
     function varargout = getTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
     end
     function varargout = getTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
     end
     function varargout = getMotionSubspaceVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
     end
     function varargout = computeChildPosVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
     end
     function varargout = computeChildVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
     end
     function varargout = computeChildVelAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1047, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
     end
     function varargout = computeChildAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
     end
     function varargout = computeChildBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1073, self, varargin{:});
     end
     function varargout = computeJointTorque(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
     end
     function varargout = hasPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
     end
     function varargout = enablePosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
     end
     function varargout = getPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
     end
     function varargout = getMinPosLimit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
     end
     function varargout = getMaxPosLimit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
     end
     function varargout = setPosLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RigidBodyInertiaNonLinearParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RigidBodyInertiaNonLinearParametrization.m
@@ -7,65 +7,65 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(699, self);
+        varargout{1} = iDynTreeMEX(723, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(700, self, varargin{1});
+        iDynTreeMEX(724, self, varargin{1});
       end
     end
     function varargout = com(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(701, self);
+        varargout{1} = iDynTreeMEX(725, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(702, self, varargin{1});
+        iDynTreeMEX(726, self, varargin{1});
       end
     end
     function varargout = link_R_centroidal(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(703, self);
+        varargout{1} = iDynTreeMEX(727, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(704, self, varargin{1});
+        iDynTreeMEX(728, self, varargin{1});
       end
     end
     function varargout = centralSecondMomentOfMass(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(705, self);
+        varargout{1} = iDynTreeMEX(729, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(706, self, varargin{1});
+        iDynTreeMEX(730, self, varargin{1});
       end
     end
     function varargout = getLinkCentroidalTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(707, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(731, self, varargin{:});
     end
     function varargout = fromRigidBodyInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(708, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(732, self, varargin{:});
     end
     function varargout = fromInertialParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(709, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(733, self, varargin{:});
     end
     function varargout = toRigidBodyInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(710, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(734, self, varargin{:});
     end
     function varargout = isPhysicallyConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(711, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(735, self, varargin{:});
     end
     function varargout = asVectorWithRotationAsVec(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(712, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(736, self, varargin{:});
     end
     function varargout = fromVectorWithRotationAsVec(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(713, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(737, self, varargin{:});
     end
     function varargout = getGradientWithRotationAsVec(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(714, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(738, self, varargin{:});
     end
     function self = RigidBodyInertiaNonLinearParametrization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -73,14 +73,14 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(715, varargin{:});
+        tmp = iDynTreeMEX(739, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(716, self);
+        iDynTreeMEX(740, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Rotation.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Rotation.m
@@ -7,117 +7,117 @@ classdef Rotation < iDynTree.RotationRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(751, varargin{:});
+        tmp = iDynTreeMEX(775, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(752, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(776, self, varargin{:});
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(753, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
     end
     function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(754, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(778, self, varargin{:});
     end
     function varargout = changeCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(755, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(779, self, varargin{:});
     end
     function varargout = changeCoordFrameOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(758, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(782, self, varargin{:});
     end
     function varargout = inverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(759, self, varargin{:});
-    end
-    function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(760, self, varargin{:});
-    end
-    function varargout = log(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(761, self, varargin{:});
-    end
-    function varargout = fromQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(762, self, varargin{:});
-    end
-    function varargout = getRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(763, self, varargin{:});
-    end
-    function varargout = asRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(764, self, varargin{:});
-    end
-    function varargout = getQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(765, self, varargin{:});
-    end
-    function varargout = asQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(766, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(783, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
+    end
+    function varargout = log(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(785, self, varargin{:});
+    end
+    function varargout = fromQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(786, self, varargin{:});
+    end
+    function varargout = getRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
+    end
+    function varargout = asRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
+    end
+    function varargout = getQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
+    end
+    function varargout = asQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(807, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(808, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(785, self);
+        iDynTreeMEX(809, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(756, varargin{:});
-    end
-    function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(757, varargin{:});
-    end
-    function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(767, varargin{:});
-    end
-    function varargout = RotY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(768, varargin{:});
-    end
-    function varargout = RotZ(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(769, varargin{:});
-    end
-    function varargout = RotAxis(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(770, varargin{:});
-    end
-    function varargout = RotAxisDerivative(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(771, varargin{:});
-    end
-    function varargout = RPY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(772, varargin{:});
-    end
-    function varargout = RPYRightTrivializedDerivative(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(773, varargin{:});
-    end
-    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(774, varargin{:});
-    end
-    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(775, varargin{:});
-    end
-    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(776, varargin{:});
-    end
-    function varargout = QuaternionRightTrivializedDerivative(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(777, varargin{:});
-    end
-    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(778, varargin{:});
-    end
-    function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(779, varargin{:});
-    end
-    function varargout = RotationFromQuaternion(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(780, varargin{:});
     end
-    function varargout = leftJacobian(varargin)
+    function varargout = inverse2(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(781, varargin{:});
     end
+    function varargout = RotX(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(791, varargin{:});
+    end
+    function varargout = RotY(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(792, varargin{:});
+    end
+    function varargout = RotZ(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(793, varargin{:});
+    end
+    function varargout = RotAxis(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(794, varargin{:});
+    end
+    function varargout = RotAxisDerivative(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(795, varargin{:});
+    end
+    function varargout = RPY(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(796, varargin{:});
+    end
+    function varargout = RPYRightTrivializedDerivative(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(797, varargin{:});
+    end
+    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(798, varargin{:});
+    end
+    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(799, varargin{:});
+    end
+    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(800, varargin{:});
+    end
+    function varargout = QuaternionRightTrivializedDerivative(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(801, varargin{:});
+    end
+    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(802, varargin{:});
+    end
+    function varargout = Identity(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(803, varargin{:});
+    end
+    function varargout = RotationFromQuaternion(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(804, varargin{:});
+    end
+    function varargout = leftJacobian(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(805, varargin{:});
+    end
     function varargout = leftJacobianInverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(782, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(806, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationRaw.m
@@ -7,54 +7,54 @@ classdef RotationRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(717, varargin{:});
+        tmp = iDynTreeMEX(741, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(718, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(742, self, varargin{:});
     end
     function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(719, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(743, self, varargin{:});
     end
     function varargout = changeCoordFrameOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(722, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(746, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(728, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(752, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(729, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(753, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(730, self);
+        iDynTreeMEX(754, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(720, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(744, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(721, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(745, varargin{:});
     end
     function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(723, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(747, varargin{:});
     end
     function varargout = RotY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(724, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(748, varargin{:});
     end
     function varargout = RotZ(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(725, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(749, varargin{:});
     end
     function varargout = RPY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(726, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(750, varargin{:});
     end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(727, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(751, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationSemantics.m
@@ -9,72 +9,72 @@ classdef RotationSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(731, varargin{:});
+        tmp = iDynTreeMEX(755, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setToUnknown(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(732, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(756, self, varargin{:});
     end
     function varargout = getOrientationFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(733, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(757, self, varargin{:});
     end
     function varargout = getBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(734, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(758, self, varargin{:});
     end
     function varargout = getReferenceOrientationFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(735, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(759, self, varargin{:});
     end
     function varargout = getRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(736, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(760, self, varargin{:});
     end
     function varargout = getCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(737, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(761, self, varargin{:});
     end
     function varargout = setOrientationFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(738, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(762, self, varargin{:});
     end
     function varargout = setBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(739, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(763, self, varargin{:});
     end
     function varargout = setReferenceOrientationFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(740, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(764, self, varargin{:});
     end
     function varargout = setRefBody(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(741, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(765, self, varargin{:});
     end
     function varargout = setCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(742, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(766, self, varargin{:});
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(743, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(767, self, varargin{:});
     end
     function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(744, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(768, self, varargin{:});
     end
     function varargout = changeCoordFrameOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(745, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(769, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(748, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(772, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(749, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(773, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(750, self);
+        iDynTreeMEX(774, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(746, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(770, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(747, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(771, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationalInertiaRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationalInertiaRaw.m
@@ -7,21 +7,21 @@ classdef RotationalInertiaRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(654, varargin{:});
+        tmp = iDynTreeMEX(678, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(656, self);
+        iDynTreeMEX(680, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(655, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(679, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Sensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sensor.m
@@ -5,33 +5,33 @@ classdef Sensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1304, self);
+        iDynTreeMEX(1378, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1305, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1379, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1380, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1307, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1381, self, varargin{:});
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1382, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1383, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1384, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1385, self, varargin{:});
     end
     function varargout = updateIndeces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1386, self, varargin{:});
     end
     function self = Sensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
@@ -9,61 +9,61 @@ classdef SensorsList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1327, varargin{:});
+        tmp = iDynTreeMEX(1401, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1328, self);
+        iDynTreeMEX(1402, self);
         self.SwigClear();
       end
     end
     function varargout = addSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1403, self, varargin{:});
     end
     function varargout = setSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1330, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1404, self, varargin{:});
     end
     function varargout = getSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1331, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1405, self, varargin{:});
     end
     function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1406, self, varargin{:});
     end
     function varargout = getSensorIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1407, self, varargin{:});
     end
     function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1408, self, varargin{:});
     end
     function varargout = getSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1409, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1410, self, varargin{:});
     end
     function varargout = removeSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1411, self, varargin{:});
     end
     function varargout = removeAllSensorsOfType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1338, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1412, self, varargin{:});
     end
     function varargout = getSixAxisForceTorqueSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1339, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1413, self, varargin{:});
     end
     function varargout = getAccelerometerSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1340, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1414, self, varargin{:});
     end
     function varargout = getGyroscopeSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1415, self, varargin{:});
     end
     function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1416, self, varargin{:});
     end
     function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1417, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
@@ -9,37 +9,37 @@ classdef SensorsMeasurements < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1344, varargin{:});
+        tmp = iDynTreeMEX(1418, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1345, self);
+        iDynTreeMEX(1419, self);
         self.SwigClear();
       end
     end
     function varargout = setNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1420, self, varargin{:});
     end
     function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1347, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1421, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1348, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1422, self, varargin{:});
     end
     function varargout = toVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1349, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1423, self, varargin{:});
     end
     function varargout = setMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1350, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1424, self, varargin{:});
     end
     function varargout = getMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1425, self, varargin{:});
     end
     function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1426, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
@@ -9,46 +9,46 @@ classdef SimpleLeggedOdometry < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1566, varargin{:});
+        tmp = iDynTreeMEX(1640, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1567, self);
+        iDynTreeMEX(1641, self);
         self.SwigClear();
       end
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1568, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1642, self, varargin{:});
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1569, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1643, self, varargin{:});
     end
     function varargout = loadModelFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1570, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1571, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
     end
     function varargout = updateKinematics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1572, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1573, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
     end
     function varargout = changeFixedFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1574, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
     end
     function varargout = getCurrentFixedLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1575, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
     end
     function varargout = getWorldLinkTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1576, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
     end
     function varargout = getWorldFrameTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1577, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
@@ -7,100 +7,100 @@ classdef SixAxisForceTorqueSensor < iDynTree.JointSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1353, varargin{:});
+        tmp = iDynTreeMEX(1427, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1354, self);
+        iDynTreeMEX(1428, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1355, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1429, self, varargin{:});
     end
     function varargout = setFirstLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1356, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1430, self, varargin{:});
     end
     function varargout = setSecondLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1357, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1431, self, varargin{:});
     end
     function varargout = getFirstLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1358, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1432, self, varargin{:});
     end
     function varargout = getSecondLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1359, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1433, self, varargin{:});
     end
     function varargout = setFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1360, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1434, self, varargin{:});
     end
     function varargout = setSecondLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1361, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1435, self, varargin{:});
     end
     function varargout = getFirstLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1362, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1436, self, varargin{:});
     end
     function varargout = getSecondLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1363, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1437, self, varargin{:});
     end
     function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1364, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1438, self, varargin{:});
     end
     function varargout = setParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1365, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1439, self, varargin{:});
     end
     function varargout = setAppliedWrenchLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1366, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1440, self, varargin{:});
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1367, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1441, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1368, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1442, self, varargin{:});
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1369, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1443, self, varargin{:});
     end
     function varargout = getParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1370, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1444, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1371, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1445, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1372, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1446, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1373, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1447, self, varargin{:});
     end
     function varargout = updateIndeces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1374, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1448, self, varargin{:});
     end
     function varargout = getAppliedWrenchLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1375, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1449, self, varargin{:});
     end
     function varargout = isLinkAttachedToSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1376, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1450, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1377, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1451, self, varargin{:});
     end
     function varargout = getWrenchAppliedOnLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1378, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1452, self, varargin{:});
     end
     function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1379, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1453, self, varargin{:});
     end
     function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1380, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1454, self, varargin{:});
     end
     function varargout = predictMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1381, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1455, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1382, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1456, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
@@ -5,76 +5,76 @@ classdef SolidShape < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1099, self);
+        iDynTreeMEX(1123, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1124, self, varargin{:});
     end
     function varargout = name(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1101, self);
+        varargout{1} = iDynTreeMEX(1125, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1102, self, varargin{1});
+        iDynTreeMEX(1126, self, varargin{1});
       end
     end
     function varargout = nameIsValid(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1103, self);
+        varargout{1} = iDynTreeMEX(1127, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1104, self, varargin{1});
+        iDynTreeMEX(1128, self, varargin{1});
       end
     end
     function varargout = link_H_geometry(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1105, self);
+        varargout{1} = iDynTreeMEX(1129, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1106, self, varargin{1});
+        iDynTreeMEX(1130, self, varargin{1});
       end
     end
     function varargout = material(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1107, self);
+        varargout{1} = iDynTreeMEX(1131, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1108, self, varargin{1});
+        iDynTreeMEX(1132, self, varargin{1});
       end
     end
     function varargout = isSphere(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1109, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1133, self, varargin{:});
     end
     function varargout = isBox(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1110, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1134, self, varargin{:});
     end
     function varargout = isCylinder(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1135, self, varargin{:});
     end
     function varargout = isExternalMesh(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1136, self, varargin{:});
     end
     function varargout = asSphere(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1113, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1137, self, varargin{:});
     end
     function varargout = asBox(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1114, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1138, self, varargin{:});
     end
     function varargout = asCylinder(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1115, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
     end
     function varargout = asExternalMesh(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1140, self, varargin{:});
     end
     function self = SolidShape(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SolidshapesVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SolidshapesVector.m
@@ -1,0 +1,95 @@
+classdef SolidshapesVector < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = pop(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1290, self, varargin{:});
+    end
+    function varargout = brace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1291, self, varargin{:});
+    end
+    function varargout = setbrace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1292, self, varargin{:});
+    end
+    function varargout = append(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1293, self, varargin{:});
+    end
+    function varargout = empty(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1294, self, varargin{:});
+    end
+    function varargout = size(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1295, self, varargin{:});
+    end
+    function varargout = swap(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1296, self, varargin{:});
+    end
+    function varargout = begin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1297, self, varargin{:});
+    end
+    function varargout = end(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1298, self, varargin{:});
+    end
+    function varargout = rbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1299, self, varargin{:});
+    end
+    function varargout = rend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1300, self, varargin{:});
+    end
+    function varargout = clear(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1301, self, varargin{:});
+    end
+    function varargout = get_allocator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1302, self, varargin{:});
+    end
+    function varargout = pop_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1303, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1304, self, varargin{:});
+    end
+    function self = SolidshapesVector(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(1305, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function varargout = push_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
+    end
+    function varargout = front(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1307, self, varargin{:});
+    end
+    function varargout = back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
+    end
+    function varargout = assign(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
+    end
+    function varargout = resize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
+    end
+    function varargout = insert(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
+    end
+    function varargout = reserve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
+    end
+    function varargout = capacity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1313, self, varargin{:});
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(1314, self);
+        self.SwigClear();
+      end
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialAcc.m
@@ -7,23 +7,23 @@ classdef SpatialAcc < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(616, varargin{:});
+        tmp = iDynTreeMEX(640, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(617, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(641, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(618, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(642, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(619, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(643, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(620, self);
+        iDynTreeMEX(644, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVector.m
@@ -7,19 +7,19 @@ classdef SpatialForceVector < iDynTree.SpatialForceVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(597, varargin{:});
+        tmp = iDynTreeMEX(621, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(598, self);
+        iDynTreeMEX(622, self);
         self.SwigClear();
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(599, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(623, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialForceVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(563, varargin{:});
+        tmp = iDynTreeMEX(587, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(564, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(588, self, varargin{:});
     end
     function varargout = getAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(565, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(589, self, varargin{:});
     end
     function varargout = setLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(566, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(590, self, varargin{:});
     end
     function varargout = setAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(567, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(591, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(568, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(592, self, varargin{:});
     end
     function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(569, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(593, self, varargin{:});
     end
     function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(570, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(594, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(571, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(595, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(572, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(596, self, varargin{:});
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(573, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(597, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(574, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(598, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(577, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(601, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(578, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(602, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(579, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(603, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(580, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(604, self, varargin{:});
     end
     function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(582, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(606, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(583, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(607, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(584, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(608, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(585, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(609, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(586, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(610, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(587, self);
+        iDynTreeMEX(611, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(575, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(599, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(576, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(600, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(581, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(605, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorSemanticsBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorSemanticsBase.m
@@ -9,23 +9,23 @@ classdef SpatialForceVectorSemanticsBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(533, varargin{:});
+        tmp = iDynTreeMEX(557, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = check_linear2angularConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(558, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(535, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(559, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(536, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(560, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(537, self);
+        iDynTreeMEX(561, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialInertia.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialInertia.m
@@ -7,63 +7,63 @@ classdef SpatialInertia < iDynTree.SpatialInertiaRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(667, varargin{:});
+        tmp = iDynTreeMEX(691, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = asMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(669, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(693, self, varargin{:});
     end
     function varargout = applyInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(670, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(694, self, varargin{:});
     end
     function varargout = getInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(671, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(695, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(672, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(696, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(673, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(697, self, varargin{:});
     end
     function varargout = biasWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(674, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(698, self, varargin{:});
     end
     function varargout = biasWrenchDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(675, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(699, self, varargin{:});
     end
     function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(677, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(701, self, varargin{:});
     end
     function varargout = fromVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(678, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(702, self, varargin{:});
     end
     function varargout = isPhysicallyConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(679, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(703, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(683, self);
+        iDynTreeMEX(707, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(668, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(692, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(676, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(700, varargin{:});
     end
     function varargout = momentumRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(680, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(704, varargin{:});
     end
     function varargout = momentumDerivativeRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(681, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(705, varargin{:});
     end
     function varargout = momentumDerivativeSlotineLiRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(682, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(706, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialInertiaRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialInertiaRaw.m
@@ -9,42 +9,42 @@ classdef SpatialInertiaRaw < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(657, varargin{:});
+        tmp = iDynTreeMEX(681, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromRotationalInertiaWrtCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(658, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(682, self, varargin{:});
     end
     function varargout = getMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(659, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(683, self, varargin{:});
     end
     function varargout = getCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(660, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(684, self, varargin{:});
     end
     function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(661, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(685, self, varargin{:});
     end
     function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(662, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(686, self, varargin{:});
     end
     function varargout = multiply(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(688, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(665, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(689, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(666, self);
+        iDynTreeMEX(690, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(663, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(687, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMomentum.m
@@ -7,23 +7,23 @@ classdef SpatialMomentum < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(611, varargin{:});
+        tmp = iDynTreeMEX(635, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(612, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(636, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(613, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(637, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(614, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(638, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(615, self);
+        iDynTreeMEX(639, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVector.m
@@ -7,29 +7,29 @@ classdef SpatialMotionVector < iDynTree.SpatialMotionVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(590, varargin{:});
+        tmp = iDynTreeMEX(614, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(591, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(615, self, varargin{:});
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(592, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(616, self, varargin{:});
     end
     function varargout = asCrossProductMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(593, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(617, self, varargin{:});
     end
     function varargout = asCrossProductMatrixWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(594, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(618, self, varargin{:});
     end
     function varargout = exp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(595, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(619, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(596, self);
+        iDynTreeMEX(620, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialMotionVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(538, varargin{:});
+        tmp = iDynTreeMEX(562, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(539, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(563, self, varargin{:});
     end
     function varargout = getAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(540, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(564, self, varargin{:});
     end
     function varargout = setLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(541, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(565, self, varargin{:});
     end
     function varargout = setAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(542, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(566, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(543, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(567, self, varargin{:});
     end
     function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(544, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(568, self, varargin{:});
     end
     function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(545, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(569, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(546, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(570, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(547, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(571, self, varargin{:});
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(548, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(572, self, varargin{:});
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(549, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(573, self, varargin{:});
     end
     function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(552, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(576, self, varargin{:});
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(553, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(577, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(554, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(578, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(555, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(579, self, varargin{:});
     end
     function varargout = asVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(557, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(581, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(558, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(582, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(559, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(583, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(560, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(584, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(561, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(585, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(562, self);
+        iDynTreeMEX(586, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(550, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(574, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(551, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(575, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(556, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(580, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorSemanticsBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorSemanticsBase.m
@@ -9,23 +9,23 @@ classdef SpatialMotionVectorSemanticsBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(528, varargin{:});
+        tmp = iDynTreeMEX(552, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = check_linear2angularConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(529, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(553, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(530, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(554, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(531, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(555, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(532, self);
+        iDynTreeMEX(556, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Sphere.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sphere.m
@@ -2,21 +2,21 @@ classdef Sphere < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1117, self);
+        iDynTreeMEX(1141, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1118, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1142, self, varargin{:});
     end
     function varargout = radius(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1119, self);
+        varargout{1} = iDynTreeMEX(1143, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1120, self, varargin{1});
+        iDynTreeMEX(1144, self, varargin{1});
       end
     end
     function self = Sphere(varargin)
@@ -26,7 +26,7 @@ classdef Sphere < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1121, varargin{:});
+        tmp = iDynTreeMEX(1145, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = TRAVERSAL_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(865);
+    varargout{1} = iDynTreeMEX(889);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(866,varargin{1});
+    iDynTreeMEX(890,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef ThreeAxisAngularAccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1415, varargin{:});
+        tmp = iDynTreeMEX(1489, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1416, self);
+        iDynTreeMEX(1490, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1417, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1491, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1418, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1492, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1419, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1493, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1420, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1494, self, varargin{:});
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1421, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1495, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1422, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1496, self, varargin{:});
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1423, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1497, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1424, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1498, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1425, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1499, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1426, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1500, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1427, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1501, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1428, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1502, self, varargin{:});
     end
     function varargout = predictMeasurement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1429, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1503, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
@@ -7,64 +7,64 @@ classdef ThreeAxisForceTorqueContactSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1430, varargin{:});
+        tmp = iDynTreeMEX(1504, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1431, self);
+        iDynTreeMEX(1505, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1432, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1506, self, varargin{:});
     end
     function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1433, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1507, self, varargin{:});
     end
     function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1434, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1508, self, varargin{:});
     end
     function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1435, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1509, self, varargin{:});
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1436, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1510, self, varargin{:});
     end
     function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1437, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1511, self, varargin{:});
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1438, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1512, self, varargin{:});
     end
     function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1439, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1513, self, varargin{:});
     end
     function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1440, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1514, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1441, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1515, self, varargin{:});
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1442, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1516, self, varargin{:});
     end
     function varargout = updateIndices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1443, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1517, self, varargin{:});
     end
     function varargout = setLoadCellLocations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1444, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1518, self, varargin{:});
     end
     function varargout = getLoadCellLocations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1445, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1519, self, varargin{:});
     end
     function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1446, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1520, self, varargin{:});
     end
     function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1447, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1521, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Transform.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Transform.m
@@ -9,69 +9,69 @@ classdef Transform < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(794, varargin{:});
+        tmp = iDynTreeMEX(818, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(795, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(819, self, varargin{:});
     end
     function varargout = getSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(796, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(820, self, varargin{:});
     end
     function varargout = getRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(797, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(821, self, varargin{:});
     end
     function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(798, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
     end
     function varargout = setRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(799, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(800, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
     end
     function varargout = inverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(803, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(827, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(804, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(828, self, varargin{:});
     end
     function varargout = asHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(806, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(830, self, varargin{:});
     end
     function varargout = asAdjointTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(807, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(831, self, varargin{:});
     end
     function varargout = asAdjointTransformWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(808, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(832, self, varargin{:});
     end
     function varargout = log(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(809, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(833, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(810, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(834, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(835, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(812, self);
+        iDynTreeMEX(836, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(801, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(825, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(802, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(826, varargin{:});
     end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(805, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(829, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
@@ -9,51 +9,51 @@ classdef TransformDerivative < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(813, varargin{:});
+        tmp = iDynTreeMEX(837, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(814, self);
+        iDynTreeMEX(838, self);
         self.SwigClear();
       end
     end
     function varargout = getRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(815, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(839, self, varargin{:});
     end
     function varargout = getPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(816, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(840, self, varargin{:});
     end
     function varargout = setRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(817, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(841, self, varargin{:});
     end
     function varargout = setPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(818, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(842, self, varargin{:});
     end
     function varargout = asHomogeneousTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(820, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(844, self, varargin{:});
     end
     function varargout = asAdjointTransformDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(821, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(845, self, varargin{:});
     end
     function varargout = asAdjointTransformWrenchDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(846, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(847, self, varargin{:});
     end
     function varargout = derivativeOfInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(848, self, varargin{:});
     end
     function varargout = transform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(825, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(849, self, varargin{:});
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(819, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(843, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformSemantics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformSemantics.m
@@ -9,32 +9,32 @@ classdef TransformSemantics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(786, varargin{:});
+        tmp = iDynTreeMEX(810, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
     end
     function varargout = getPositionSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(812, self, varargin{:});
     end
     function varargout = setRotationSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(813, self, varargin{:});
     end
     function varargout = setPositionSemantics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(814, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(791, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(815, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(792, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(816, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(793, self);
+        iDynTreeMEX(817, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Traversal.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Traversal.m
@@ -9,61 +9,61 @@ classdef Traversal < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1082, varargin{:});
+        tmp = iDynTreeMEX(1106, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1083, self);
+        iDynTreeMEX(1107, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfVisitedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1084, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1108, self, varargin{:});
     end
     function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1109, self, varargin{:});
     end
     function varargout = getBaseLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1110, self, varargin{:});
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1087, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1088, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
     end
     function varargout = getParentLinkFromLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1113, self, varargin{:});
     end
     function varargout = getParentJointFromLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1114, self, varargin{:});
     end
     function varargout = getTraversalIndexFromLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1091, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1115, self, varargin{:});
     end
     function varargout = reset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1092, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
     end
     function varargout = addTraversalBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1093, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1117, self, varargin{:});
     end
     function varargout = addTraversalElement(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1118, self, varargin{:});
     end
     function varargout = isParentOf(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1095, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1119, self, varargin{:});
     end
     function varargout = getChildLinkIndexFromJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1096, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1120, self, varargin{:});
     end
     function varargout = getParentLinkIndexFromJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1097, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1121, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1122, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Twist.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Twist.m
@@ -7,26 +7,26 @@ classdef Twist < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(600, varargin{:});
+        tmp = iDynTreeMEX(624, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(601, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(625, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(602, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(626, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(603, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(627, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(604, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(628, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(605, self);
+        iDynTreeMEX(629, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/URDFParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/URDFParserOptions.m
@@ -7,20 +7,20 @@ classdef URDFParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1450, self);
+        varargout{1} = iDynTreeMEX(1524, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1451, self, varargin{1});
+        iDynTreeMEX(1525, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1452, self);
+        varargout{1} = iDynTreeMEX(1526, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1453, self, varargin{1});
+        iDynTreeMEX(1527, self, varargin{1});
       end
     end
     function self = URDFParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef URDFParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1454, varargin{:});
+        tmp = iDynTreeMEX(1528, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1455, self);
+        iDynTreeMEX(1529, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
+++ b/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
@@ -9,7 +9,7 @@ classdef UnknownWrenchContact < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1505, varargin{:});
+        tmp = iDynTreeMEX(1579, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,55 +18,55 @@ classdef UnknownWrenchContact < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1506, self);
+        varargout{1} = iDynTreeMEX(1580, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1507, self, varargin{1});
+        iDynTreeMEX(1581, self, varargin{1});
       end
     end
     function varargout = contactPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1508, self);
+        varargout{1} = iDynTreeMEX(1582, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1509, self, varargin{1});
+        iDynTreeMEX(1583, self, varargin{1});
       end
     end
     function varargout = forceDirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1510, self);
+        varargout{1} = iDynTreeMEX(1584, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1511, self, varargin{1});
+        iDynTreeMEX(1585, self, varargin{1});
       end
     end
     function varargout = knownWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1512, self);
+        varargout{1} = iDynTreeMEX(1586, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1513, self, varargin{1});
+        iDynTreeMEX(1587, self, varargin{1});
       end
     end
     function varargout = contactId(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1514, self);
+        varargout{1} = iDynTreeMEX(1588, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1515, self, varargin{1});
+        iDynTreeMEX(1589, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1516, self);
+        iDynTreeMEX(1590, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector10.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector10.m
@@ -9,50 +9,62 @@ classdef Vector10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(323, varargin{:});
+        tmp = iDynTreeMEX(339, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(324, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(340, self, varargin{:});
     end
     function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(325, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(341, self, varargin{:});
     end
     function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(326, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(342, self, varargin{:});
     end
     function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(327, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(343, self, varargin{:});
+    end
+    function varargout = cbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(344, self, varargin{:});
+    end
+    function varargout = cend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(345, self, varargin{:});
+    end
+    function varargout = begin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(346, self, varargin{:});
+    end
+    function varargout = end(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(347, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(328, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(348, self, varargin{:});
     end
     function varargout = data(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(329, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(349, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(330, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(350, self, varargin{:});
     end
     function varargout = fillBuffer(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(331, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(351, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(332, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(352, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(333, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(353, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(334, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(354, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(335, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(355, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(336, self);
+        iDynTreeMEX(356, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector16.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector16.m
@@ -9,50 +9,62 @@ classdef Vector16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(337, varargin{:});
+        tmp = iDynTreeMEX(357, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(338, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(358, self, varargin{:});
     end
     function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(339, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(359, self, varargin{:});
     end
     function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(340, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(360, self, varargin{:});
     end
     function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(341, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(361, self, varargin{:});
+    end
+    function varargout = cbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(362, self, varargin{:});
+    end
+    function varargout = cend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(363, self, varargin{:});
+    end
+    function varargout = begin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(364, self, varargin{:});
+    end
+    function varargout = end(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(365, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(342, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(366, self, varargin{:});
     end
     function varargout = data(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(343, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(367, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(344, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(368, self, varargin{:});
     end
     function varargout = fillBuffer(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(345, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(369, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(346, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(370, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(347, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(371, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(348, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(372, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(349, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(373, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(350, self);
+        iDynTreeMEX(374, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector3.m
@@ -9,50 +9,62 @@ classdef Vector3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(281, varargin{:});
+        tmp = iDynTreeMEX(285, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(282, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(283, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(284, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(285, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(286, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(287, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(288, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(289, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(290, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(291, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(292, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(293, self, varargin{:});
+    end
+    function varargout = size(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(294, self, varargin{:});
+    end
+    function varargout = data(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(295, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(296, self, varargin{:});
+    end
+    function varargout = fillBuffer(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(297, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(298, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(299, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(300, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(301, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(294, self);
+        iDynTreeMEX(302, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector4.m
@@ -9,50 +9,62 @@ classdef Vector4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(295, varargin{:});
+        tmp = iDynTreeMEX(303, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(296, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(297, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(298, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(299, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(300, self, varargin{:});
-    end
-    function varargout = data(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(301, self, varargin{:});
-    end
-    function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(302, self, varargin{:});
-    end
-    function varargout = fillBuffer(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(303, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(304, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(305, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(306, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(307, self, varargin{:});
+    end
+    function varargout = cbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(308, self, varargin{:});
+    end
+    function varargout = cend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(309, self, varargin{:});
+    end
+    function varargout = begin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(310, self, varargin{:});
+    end
+    function varargout = end(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(311, self, varargin{:});
+    end
+    function varargout = size(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(312, self, varargin{:});
+    end
+    function varargout = data(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(313, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(314, self, varargin{:});
+    end
+    function varargout = fillBuffer(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(315, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(316, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(317, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(318, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(319, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(308, self);
+        iDynTreeMEX(320, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector6.m
@@ -9,50 +9,62 @@ classdef Vector6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(309, varargin{:});
+        tmp = iDynTreeMEX(321, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(310, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(322, self, varargin{:});
     end
     function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(311, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(323, self, varargin{:});
     end
     function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(312, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(324, self, varargin{:});
     end
     function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(313, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(325, self, varargin{:});
+    end
+    function varargout = cbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(326, self, varargin{:});
+    end
+    function varargout = cend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(327, self, varargin{:});
+    end
+    function varargout = begin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(328, self, varargin{:});
+    end
+    function varargout = end(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(329, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(314, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(330, self, varargin{:});
     end
     function varargout = data(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(315, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(331, self, varargin{:});
     end
     function varargout = zero(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(316, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(332, self, varargin{:});
     end
     function varargout = fillBuffer(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(317, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(333, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(318, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(334, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(319, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(335, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(320, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(336, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(321, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(337, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(322, self);
+        iDynTreeMEX(338, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/VectorDynSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VectorDynSize.m
@@ -32,41 +32,53 @@ classdef VectorDynSize < SwigRef
     function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(163, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(164, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(165, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(166, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(167, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(168, self, varargin{:});
     end
-    function varargout = shrink_to_fit(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(169, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(170, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(171, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(172, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = shrink_to_fit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(173, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = capacity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(174, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(175, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(176, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(177, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(178, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(179, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,55 +9,55 @@ classdef Visualizer < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1971, varargin{:});
+        tmp = iDynTreeMEX(2045, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1972, self);
+        iDynTreeMEX(2046, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2047, self, varargin{:});
     end
     function varargout = getNrOfVisualizedModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2048, self, varargin{:});
     end
     function varargout = getModelInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2049, self, varargin{:});
     end
     function varargout = getModelInstanceIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2050, self, varargin{:});
     end
     function varargout = addModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2051, self, varargin{:});
     end
     function varargout = modelViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2052, self, varargin{:});
     end
     function varargout = camera(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2053, self, varargin{:});
     end
     function varargout = enviroment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2054, self, varargin{:});
     end
     function varargout = vectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2055, self, varargin{:});
     end
     function varargout = run(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2056, self, varargin{:});
     end
     function varargout = draw(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2057, self, varargin{:});
     end
     function varargout = drawToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2058, self, varargin{:});
     end
     function varargout = close(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2059, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,40 +7,40 @@ classdef VisualizerOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1961, self);
+        varargout{1} = iDynTreeMEX(2035, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1962, self, varargin{1});
+        iDynTreeMEX(2036, self, varargin{1});
       end
     end
     function varargout = winWidth(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1963, self);
+        varargout{1} = iDynTreeMEX(2037, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1964, self, varargin{1});
+        iDynTreeMEX(2038, self, varargin{1});
       end
     end
     function varargout = winHeight(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1965, self);
+        varargout{1} = iDynTreeMEX(2039, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1966, self, varargin{1});
+        iDynTreeMEX(2040, self, varargin{1});
       end
     end
     function varargout = rootFrameArrowsDimension(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1967, self);
+        varargout{1} = iDynTreeMEX(2041, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1968, self, varargin{1});
+        iDynTreeMEX(2042, self, varargin{1});
       end
     end
     function self = VisualizerOptions(varargin)
@@ -49,14 +49,14 @@ classdef VisualizerOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1969, varargin{:});
+        tmp = iDynTreeMEX(2043, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1970, self);
+        iDynTreeMEX(2044, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Wrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Wrench.m
@@ -7,23 +7,23 @@ classdef Wrench < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(606, varargin{:});
+        tmp = iDynTreeMEX(630, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(607, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(631, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(608, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(632, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(609, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(633, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(610, self);
+        iDynTreeMEX(634, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
@@ -1,3 +1,3 @@
 function varargout = computeLinkNetWrenchesWithoutGravity(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1550, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1624, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1458, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1532, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1459, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1533, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
@@ -1,3 +1,3 @@
 function v = dynamic_extent()
-  v = iDynTreeMEX(826);
+  v = iDynTreeMEX(850);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1548, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1622, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1549, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1623, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1547, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1621, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
@@ -9,86 +9,86 @@ classdef estimateExternalWrenchesBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1528, varargin{:});
+        tmp = iDynTreeMEX(1602, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1529, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1603, self, varargin{:});
     end
     function varargout = getNrOfSubModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1530, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1604, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1531, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1605, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1532, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1533, self);
+        varargout{1} = iDynTreeMEX(1607, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1534, self, varargin{1});
+        iDynTreeMEX(1608, self, varargin{1});
       end
     end
     function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1535, self);
+        varargout{1} = iDynTreeMEX(1609, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1536, self, varargin{1});
+        iDynTreeMEX(1610, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1537, self);
+        varargout{1} = iDynTreeMEX(1611, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1538, self, varargin{1});
+        iDynTreeMEX(1612, self, varargin{1});
       end
     end
     function varargout = pinvA(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1539, self);
+        varargout{1} = iDynTreeMEX(1613, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1540, self, varargin{1});
+        iDynTreeMEX(1614, self, varargin{1});
       end
     end
     function varargout = b_contacts_subtree(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1541, self);
+        varargout{1} = iDynTreeMEX(1615, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1542, self, varargin{1});
+        iDynTreeMEX(1616, self, varargin{1});
       end
     end
     function varargout = subModelBase_H_link(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1543, self);
+        varargout{1} = iDynTreeMEX(1617, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1544, self, varargin{1});
+        iDynTreeMEX(1618, self, varargin{1});
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1545, self);
+        iDynTreeMEX(1619, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenchesWithoutInternalFT(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1546, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1620, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
@@ -1,3 +1,3 @@
 function varargout = estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1786, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1860, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateLinkContactWrenchesFromLinkNetExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1551, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1625, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
@@ -1,3 +1,3 @@
 function varargout = getSensorTypeSize(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1303, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1377, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
@@ -1,3 +1,3 @@
 function v = input_dimensions()
-  v = iDynTreeMEX(1741);
+  v = iDynTreeMEX(1815);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isDOFBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1580, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1654, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isJointBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1579, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1653, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
@@ -1,3 +1,3 @@
 function varargout = isJointSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1302, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1376, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isLinkBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1578, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1652, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
@@ -1,3 +1,3 @@
 function varargout = isLinkSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1301, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1375, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/linksSolidshapesVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/linksSolidshapesVector.m
@@ -1,0 +1,95 @@
+classdef linksSolidshapesVector < SwigRef
+  methods
+    function this = swig_this(self)
+      this = iDynTreeMEX(3, self);
+    end
+    function varargout = pop(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
+    end
+    function varargout = brace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
+    end
+    function varargout = setbrace(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
+    end
+    function varargout = append(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
+    end
+    function varargout = empty(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1319, self, varargin{:});
+    end
+    function varargout = size(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
+    end
+    function varargout = swap(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1321, self, varargin{:});
+    end
+    function varargout = begin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1322, self, varargin{:});
+    end
+    function varargout = end(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
+    end
+    function varargout = rbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
+    end
+    function varargout = rend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
+    end
+    function varargout = clear(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
+    end
+    function varargout = get_allocator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1327, self, varargin{:});
+    end
+    function varargout = pop_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1328, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
+    end
+    function self = linksSolidshapesVector(varargin)
+      if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
+        if ~isnull(varargin{1})
+          self.swigPtr = varargin{1}.swigPtr;
+        end
+      else
+        tmp = iDynTreeMEX(1330, varargin{:});
+        self.swigPtr = tmp.swigPtr;
+        tmp.SwigClear();
+      end
+    end
+    function varargout = push_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1331, self, varargin{:});
+    end
+    function varargout = front(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
+    end
+    function varargout = back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
+    end
+    function varargout = assign(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
+    end
+    function varargout = resize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
+    end
+    function varargout = insert(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
+    end
+    function varargout = reserve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
+    end
+    function varargout = capacity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1338, self, varargin{:});
+    end
+    function delete(self)
+      if self.swigPtr
+        iDynTreeMEX(1339, self);
+        self.SwigClear();
+      end
+    end
+  end
+  methods(Static)
+  end
+end

--- a/bindings/matlab/autogenerated/+iDynTree/modelFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/modelFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1456, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1530, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/modelFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/modelFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = modelFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1457, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1531, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_with_magnetometer()
-  v = iDynTreeMEX(1739);
+  v = iDynTreeMEX(1813);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_without_magnetometer()
-  v = iDynTreeMEX(1740);
+  v = iDynTreeMEX(1814);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurements(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1448, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1522, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurementsFromRawBuffers(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1449, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1523, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1460, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1534, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sensorsFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = sensorsFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1461, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1535, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
@@ -1,3 +1,3 @@
 function varargout = sizeOfRotationParametrization(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(2032, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(2106, varargin{:});
 end


### PR DESCRIPTION
Added templates to correctly handle the modelSolidShapes type of variable obtained with the method 
model.visualSolidShapes.linkSolidShapes
 
The reference issue is https://github.com/robotology/idyntree/issues/656