### PR TITLE
Fix configuration and compilation against assimp 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         
     - name: Additional vcpkg Dependencies [Windows]
       if: matrix.os == 'windows-latest'
+      shell: bash
       run: |
         # Install dependencies that are not included in the robotology-superbuild-dependencies-vcpkg archive
         ${VCPKG_INSTALLATION_ROOT}/vcpkg.exe --install assimp:x64-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,9 @@ jobs:
       run: |
         mkdir -p build
         cd build
+        # Assimp is disabled as workaround for https://github.com/robotology/idyntree/issues/599
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
-              -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
+              -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Enable additional Ubuntu options (Valgrind, Octave, Python, legacy KDL) [Ubuntu] 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: bash
       run: |
-        # Install dependencies that are not included in the robotology-superbuild-dependencies-vcpkg archive
+        # Install dependencies that are not included in the robotology-superbuild-dependencies-vcpkg archive (for now)
         ${VCPKG_INSTALLATION_ROOT}/vcpkg.exe install assimp:x64-windows
 
     - name: Dependencies [macOS]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       shell: bash
       run: |
         # Install dependencies that are not included in the robotology-superbuild-dependencies-vcpkg archive
-        ${VCPKG_INSTALLATION_ROOT}/vcpkg.exe --install assimp:x64-windows
+        ${VCPKG_INSTALLATION_ROOT}/vcpkg.exe install assimp:x64-windows
 
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,13 @@ jobs:
         unzip vcpkg-robotology.zip -d C:/robotology/vcpkg
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
         echo "::set-env name=VCPKG_INSTALLATION_ROOT::C:/robotology/vcpkg"
-
         
+    - name: Additional vcpkg Dependencies [Windows]
+      if: matrix.os == 'windows-latest'
+      run: |
+        # Install dependencies that are not included in the robotology-superbuild-dependencies-vcpkg archive
+        ${VCPKG_INSTALLATION_ROOT}/vcpkg.exe --install assimp:x64-windows
+
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
@@ -148,7 +153,7 @@ jobs:
         # ipopt disabled until https://github.com/robotology/idyntree/issues/274 is fixed
         # assimp disabled until https://github.com/robotology/idyntree/issues/601 is fixed
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
-              -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=OFF -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON \
+              -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_ASSIMP:BOOL=ON  -DIDYNTREE_USES_YARP:BOOL=OFF -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON \
               -DIDYNTREE_USES_PYTHON:BOOL=OFF -DIDYNTREE_USES_OCTAVE:BOOL=OFF -DIDYNTREE_USES_IPOPT:BOOL=OFF -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
@@ -158,9 +163,8 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        # IDYNTREE_USES_ASSIMP set to OFF as a workaround for https://github.com/robotology/idyntree/issues/599
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
-              -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
+              -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Enable additional Ubuntu options (Valgrind, Octave, Python, legacy KDL) [Ubuntu] 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
         mkdir -p build
         cd build
         # ipopt disabled until https://github.com/robotology/idyntree/issues/274 is fixed
-        # assimp disabled until https://github.com/robotology/idyntree/issues/601 is fixed
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
               -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_ASSIMP:BOOL=ON  -DIDYNTREE_USES_YARP:BOOL=OFF -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON \
               -DIDYNTREE_USES_PYTHON:BOOL=OFF -DIDYNTREE_USES_OCTAVE:BOOL=OFF -DIDYNTREE_USES_IPOPT:BOOL=OFF -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
@@ -172,7 +171,8 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         cd build
-        cmake -DIDYNTREE_USES_OCTAVE:BOOL=ON -DIDYNTREE_USES_PYTHON:BOOL=ON -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON -DIDYNTREE_USES_KDL:BOOL=ON .
+        # Assimp is disabled on Ubuntu as a workaround for https://github.com/robotology/idyntree/issues/663
+        cmake -DIDYNTREE_USES_OCTAVE:BOOL=ON -DIDYNTREE_USES_PYTHON:BOOL=ON -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON -DIDYNTREE_USES_KDL:BOOL=ON  -DIDYNTREE_USES_ASSIMP:BOOL=OFF  .
         # For some reason, Ubuntu 18.04 image in GitHub Actions contain OpenBLAS 0.3.5, that is affected by https://github.com/xianyi/OpenBLAS/issues/2003
         # As a workaround, we test against the regular blas instead of openblas
         sudo apt-get install libblas-dev libatlas-base-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2020-04-01
+
+### Fixed 
+- Fixed configuration and compilation with Assimp >= 5.0.0 . 
+
 ## [1.0.2] - 2020-02-21
 
 ### Fixed 

--- a/cmake/iDynTreeDependencies.cmake
+++ b/cmake/iDynTreeDependencies.cmake
@@ -98,4 +98,4 @@ if(IDYNTREE_USES_ALGLIB AND ALGLIB_FOUND)
 endif()
 idyntree_handle_dependency(WORHP DO_NOT_SILENTLY_SEARCH)
 # Workaround for https://github.com/robotology/idyntree/issues/599
-idyntree_handle_dependency(ASSIMP DO_NOT_SILENTLY_SEARCH MAIN_TARGET assimp::assimp)
+idyntree_handle_dependency(assimp DO_NOT_SILENTLY_SEARCH MAIN_TARGET assimp::assimp)

--- a/src/solid-shapes/CMakeLists.txt
+++ b/src/solid-shapes/CMakeLists.txt
@@ -16,9 +16,16 @@ target_include_directories(${libraryname} PRIVATE ${EIGEN3_INCLUDE_DIR})
 
 if (IDYNTREE_USES_ASSIMP)
   target_compile_definitions(${libraryname} PRIVATE IDYNTREE_USES_ASSIMP)
-  target_include_directories(${libraryname} PRIVATE "${ASSIMP_INCLUDE_DIRS}")
-  link_directories("${ASSIMP_LIBRARY_DIRS}")
-  target_link_libraries(${libraryname} PRIVATE "${ASSIMP_LIBRARIES}")
+  # Depending on the assimp version, the way of consuming assimp changes
+  # In assimp 5.0, only the imported assimp::assimp target is defined, in earlier 
+  # versions (that do no export the version to CMake) the ASSIMP_* variables are defined
+  if(assimp_VERSION AND assimp_VERSION VERSION_GREATER_EQUAL 5.0)
+    target_link_libraries(${libraryname} PRIVATE "${ASSIMP_LIBRARIES}")
+  else()
+    target_include_directories(${libraryname} PRIVATE "${ASSIMP_INCLUDE_DIRS}")
+    link_directories("${ASSIMP_LIBRARY_DIRS}")
+    target_link_libraries(${libraryname} PRIVATE "${ASSIMP_LIBRARIES}")
+  endif()
 endif()
 
 set_property(TARGET ${libraryname} PROPERTY PUBLIC_HEADER ${IDYNTREE_SOLID_SHAPES_HEADERS})


### PR DESCRIPTION
assimp 5 does not export the same CMake variables as assimp 4, so it is necessary to change the CMake commands to link with assimp depending on the assimp version used.

For reference, this are the CMake config for assimp 5 and 4: 
* https://github.com/assimp/assimp/blob/v5.0.1/assimpTargets.cmake.in
* https://github.com/assimp/assimp/blob/v4.1.0/assimp-config.cmake.in

This  PR also: 
* Fixes the cmake package name of assimp, that is not `ASSIMP` , but always `assimp` . 
* Enables testing against assimp in macOS and Windows in GitHub Actions 
* Release v1.0.3 that contains the hot fix of compatibility with Assimp 5.

Fix https://github.com/robotology/idyntree/issues/601