### PR TITLE
Fix name of assimp::assimp imported target for Assimp >= 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,8 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        # Assimp is disabled as workaround for https://github.com/robotology/idyntree/issues/599
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
-              -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=OFF \
+              -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Enable additional Ubuntu options (Valgrind, Octave, Python, legacy KDL) [Ubuntu] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2020-04-02
+
+### Fixed 
+- Further fix for configuration compilation with Assimp >= 5.0.0 (https://github.com/robotology/idyntree/pull/666). 
+
 ## [1.0.3] - 2020-04-01
 
 ### Fixed 

--- a/src/solid-shapes/CMakeLists.txt
+++ b/src/solid-shapes/CMakeLists.txt
@@ -20,7 +20,7 @@ if (IDYNTREE_USES_ASSIMP)
   # In assimp 5.0, only the imported assimp::assimp target is defined, in earlier 
   # versions (that do no export the version to CMake) the ASSIMP_* variables are defined
   if(assimp_VERSION AND assimp_VERSION VERSION_GREATER_EQUAL 5.0)
-    target_link_libraries(${libraryname} PRIVATE "assimp::assimp")
+    target_link_libraries(${libraryname} PRIVATE assimp::assimp)
   else()
     target_include_directories(${libraryname} PRIVATE "${ASSIMP_INCLUDE_DIRS}")
     link_directories("${ASSIMP_LIBRARY_DIRS}")

--- a/src/solid-shapes/CMakeLists.txt
+++ b/src/solid-shapes/CMakeLists.txt
@@ -20,7 +20,7 @@ if (IDYNTREE_USES_ASSIMP)
   # In assimp 5.0, only the imported assimp::assimp target is defined, in earlier 
   # versions (that do no export the version to CMake) the ASSIMP_* variables are defined
   if(assimp_VERSION AND assimp_VERSION VERSION_GREATER_EQUAL 5.0)
-    target_link_libraries(${libraryname} PRIVATE "${ASSIMP_LIBRARIES}")
+    target_link_libraries(${libraryname} PRIVATE "assimp::assimp")
   else()
     target_include_directories(${libraryname} PRIVATE "${ASSIMP_INCLUDE_DIRS}")
     link_directories("${ASSIMP_LIBRARY_DIRS}")


### PR DESCRIPTION
Despite what was written in the documentation of the CMake changes in https://github.com/robotology/idyntree/pull/661/files, the imported target `assimp::assimp` was not actually linked when Assimp 5.0 was found, but instead still the legacy ${ASSIMP_LIBRARIES} variable. For some reason, this was still working fine with the assimp version from vcpkg 2019.10 . 

Fix https://github.com/robotology/idyntree/issues/665
Fix https://github.com/robotology/idyntree/issues/599
Fix https://github.com/robotology/idyntree/issues/584