### PR TITLE
Cleanup CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added `bindings` for handling `linkSolidShapes` properly (https://github.com/robotology/idyntree/issues/656)
-- Added `bindings` for `InverseKinematics` (https://github.com/robotology/idyntree/pull/633)
-- Implement `cbegin()` / `cend()` and `begin()` / `end()` methods for `VectorDynSize` and `VectorFixSize` (https://github.com/robotology/idyntree/pull/646)
+- Added `bindings` for handling `linkSolidShapes` properly (https://github.com/robotology/idyntree/issues/656).
+- Added `bindings` for `InverseKinematics` (https://github.com/robotology/idyntree/pull/633).
+- Implement `cbegin()` / `cend()` and `begin()` / `end()` methods for `VectorDynSize` and `VectorFixSize` (https://github.com/robotology/idyntree/pull/646).
 
 ## [1.0.5] - 2020-04-03
 
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed 
 - Further fix for configuration compilation with Assimp >= 5.0.0 (https://github.com/robotology/idyntree/pull/666). 
->>>>>>> master
 
 ## [1.0.3] - 2020-04-01
 


### PR DESCRIPTION
* Remove spurious leftover of conflict in a merge.
* Add missing periods at the end  of the sentences.