### PR TITLE
Add #include <string> in Triplets.h as std::string is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed compilation with Visual Studio 2019 16.6 (https://github.com/robotology/idyntree/pull/672).
 
 ## [1.0.5] - 2020-04-03
 

--- a/src/core/include/iDynTree/Core/Triplets.h
+++ b/src/core/include/iDynTree/Core/Triplets.h
@@ -14,6 +14,7 @@
 #include <iDynTree/Core/Utils.h>
 
 #include <iterator>
+#include <string>
 #include <vector>
 
 


### PR DESCRIPTION
Fix compilation on Visual Studio 2019 16.6, see https://github.com/robotology/idyntree/issues/671 .