### PR TITLE
enable IDYNTREE_USES_OCTAVE in MacOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,12 @@ jobs:
               -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
               -DIDYNTREE_USES_OCTAVE:BOOL=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
-    - name: Enable additional Ubuntu options (Valgrind, Octave, Python, legacy KDL) [Ubuntu] 
+    - name: Enable additional Ubuntu options (Valgrind, Python, legacy KDL) [Ubuntu] 
       if: matrix.os == 'ubuntu-latest'
       run: |
         cd build
         # Assimp is disabled on Ubuntu as a workaround for https://github.com/robotology/idyntree/issues/663
-        cmake -DIDYNTREE_USES_OCTAVE:BOOL=ON -DIDYNTREE_USES_PYTHON:BOOL=ON -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON -DIDYNTREE_USES_KDL:BOOL=ON  -DIDYNTREE_USES_ASSIMP:BOOL=OFF  .
+        cmake -DIDYNTREE_USES_PYTHON:BOOL=ON -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON -DIDYNTREE_USES_KDL:BOOL=ON  -DIDYNTREE_USES_ASSIMP:BOOL=OFF  .
         # For some reason, Ubuntu 18.04 image in GitHub Actions contain OpenBLAS 0.3.5, that is affected by https://github.com/xianyi/OpenBLAS/issues/2003
         # As a workaround, we test against the regular blas instead of openblas
         sudo apt-get install libblas-dev libatlas-base-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
-        brew install ace assimp boost eigen swig qt5 orocos-kdl
+        brew install ace assimp boost eigen swig qt5 orocos-kdl octave
     
     - name: Dependencies [Ubuntu]
       if: matrix.os == 'ubuntu-latest'
@@ -166,7 +166,7 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
               -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
-              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+              -DIDYNTREE_USES_OCTAVE:BOOL=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Enable additional Ubuntu options (Valgrind, Octave, Python, legacy KDL) [Ubuntu] 
       if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `bindings` for handling `linkSolidShapes` properly (https://github.com/robotology/idyntree/issues/656).
 - Added `bindings` for `InverseKinematics` (https://github.com/robotology/idyntree/pull/633).
 - Implement `cbegin()` / `cend()` and `begin()` / `end()` methods for `VectorDynSize` and `VectorFixSize` (https://github.com/robotology/idyntree/pull/646).
+- Added CI for MacOS with `IDYNTREE_USES_OCTAVE` `ON`
 
 ## [1.0.5] - 2020-04-03
 

--- a/cmake/FindOctave.cmake
+++ b/cmake/FindOctave.cmake
@@ -15,7 +15,6 @@
 #  OCTAVE_PATCH_VERSION        - patch version
 #  OCTAVE_OCT_FILE_DIR         - object files that will be dynamically loaded
 #  OCTAVE_OCT_LIB_DIR          - oct libraries
-#  OCTAVE_ROOT_DIR             - octave prefix
 #
 # The macro octave_add_oct allows to create compiled modules.
 # octave_add_oct ( target_name
@@ -24,12 +23,6 @@
 #         [EXTENSION ext]
 # )
 #
-# To install it, you can the use the variable OCTAVE_OCT_FILE_DIR as follow:
-#  file ( RELATIVE_PATH PKG_OCTAVE_OCT_FILE_DIR ${OCTAVE_ROOT_DIR} ${OCTAVE_OCT_FILE_DIR} )
-#  install (
-#    TARGETS target_name
-#    DESTINATION ${PKG_OCTAVE_OCT_FILE_DIR}
-#  )
 #=============================================================================
 # Copyright 2013, Julien Schueller
 # All rights reserved.
@@ -61,9 +54,6 @@ find_program( OCTAVE_CONFIG_EXECUTABLE
               NAMES octave-config
             )
 if ( OCTAVE_CONFIG_EXECUTABLE )
-  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p PREFIX
-                    OUTPUT_VARIABLE OCTAVE_ROOT_DIR
-                    OUTPUT_STRIP_TRAILING_WHITESPACE )
 
   execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p BINDIR
                     OUTPUT_VARIABLE OCTAVE_BIN_PATHS
@@ -158,7 +148,7 @@ endmacro ()
 # handle REQUIRED and QUIET options
 include ( FindPackageHandleStandardArgs )
 
-find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_ROOT_DIR OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
+find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
 
 mark_as_advanced (
   OCTAVE_OCT_FILE_DIR
@@ -169,7 +159,6 @@ mark_as_advanced (
   OCTAVE_LIBRARIES
   OCTAVE_INCLUDE_DIR
   OCTAVE_INCLUDE_DIRS
-  OCTAVE_ROOT_DIR
   OCTAVE_VERSION_STRING
   OCTAVE_MAJOR_VERSION
   OCTAVE_MINOR_VERSION


### PR DESCRIPTION
Enabling `IDYNTREE_USES_OCTAVE` in MacOS CI will avoid regression such as https://github.com/robotology/idyntree/issues/675