### PR TITLE
Add new features to the MATLAB visualizer: added world frame, optional ground and modification of visual aspects using variable inputs

### DIFF
--- a/bindings/matlab/+iDynTreeWrappers/README.md
+++ b/bindings/matlab/+iDynTreeWrappers/README.md
@@ -88,3 +88,5 @@ Not actual wrappers, they use the iDynTreeWrappers in combination with the MATLA
 - [updateVisualization](updateVisualization.m)
 - [getMeshes](getMeshes.m)
 - [plotMeshInWorld](plotMeshInWorld.m)
+- [modifyLinkVisual](modifyLinkVisual.m)
+- [modifyLinksVisualization](modifyLinksVisualization.m)

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -75,7 +75,7 @@ for links=1:numberOfLinks
         link_H_geom=solidarray{solids}.link_H_geometry.asHomogeneousTransform.toMatlab;
         meshInfo(solids).link_H_geom=link_H_geom;
         meshInfo(solids).mesh_triangles=mesh_triangles;              
-        map(count,:)=[{meshFile},{linkName}];
+        map(count,:)=[{meshInfo(solids).meshFile},{linkName}];
         count=count+1;
     end
     linkMeshInfo(links).meshInfo=meshInfo;

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -31,11 +31,11 @@ iterator=linkSolidShapesV.begin;
 % iterate getting the name of the mesh and the name of the link
 count=1;
 link_with_no_visual=[];
-for links=1:numberOfLinks    
+for links=1:numberOfLinks
     linkName=model.getLinkName(links-1);
     linkMeshInfo(links).linkName=linkName;
     solidarray=iterator.next;
-    solids_number=size(solidarray,2);    
+    solids_number=size(solidarray,2);
     meshInfo=struct('meshFile',{},'mesh_triangles',{},'link_H_geom',{});
     for solids=1:solids_number
         if solidarray{solids}.isExternalMesh
@@ -52,7 +52,7 @@ for links=1:numberOfLinks
             meshInfo(solids).meshFile=meshFile;
             meshInfo(solids).scale=scale';
         else
-            meshInfo(solids).scale=[1,1,1];  
+            meshInfo(solids).scale=[1,1,1];
             if solidarray{solids}.isCylinder
                 meshInfo(solids).meshFile='cylinder';
                 length=solidarray{solids}.asCylinder.length;
@@ -67,14 +67,14 @@ for links=1:numberOfLinks
                 mesh_triangles=calculateMeshFromBox(box_dimensions);
             end
             if solidarray{solids}.isSphere
-                meshInfo(solids).meshFile='sphere';                
+                meshInfo(solids).meshFile='sphere';
                 radius=solidarray{solids}.asSphere.radius;
                 mesh_triangles=calculateMeshFromSphere(radius);
             end
         end
         link_H_geom=solidarray{solids}.link_H_geometry.asHomogeneousTransform.toMatlab;
         meshInfo(solids).link_H_geom=link_H_geom;
-        meshInfo(solids).mesh_triangles=mesh_triangles;              
+        meshInfo(solids).mesh_triangles=mesh_triangles;
         map(count,:)=[{meshInfo(solids).meshFile},{linkName}];
         count=count+1;
     end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
@@ -1,0 +1,119 @@
+function []=modifyLinkVisual(meshHandle,varargin)
+% Modifies a single `meshHandle` with the specified changes.
+%     - Iputs:
+%         - `meshHandle` : Struct containing the patch type of variable ( `modelMesh` field ) and the original information of the mesh in `fullMesh_bckup` field.
+%     - Optional Inputs:
+%         - `color` : Selects the color of the meshes.
+%         - `transparency` : Sets the alpha value of the patch. Is the
+%         level of transparency between 0 fully transparent and 1 solid.
+%         - `wireframe_rendering` : the reduction ratio of faces to
+%         wireframe. Follows convention of reducepatch.
+%         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
+%     - Outputs:
+%         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
+%         - `transform`    : The transform object for the link
+%         - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
+%         - `useDefault`  : Enables the use of the default values instead of ignoring non specified changes.
+%
+% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+% 
+% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+% This software may be modified and distributed under the terms of the
+% GNU Lesser General Public License v2.1 or any later version.
+%% input parser section
+p = inputParser;
+p.StructExpand = false;
+p.KeepUnmatched= true;
+% Default values
+default_color= [0.1843    0.3098    0.3098];
+default_transparency=0.5;
+default_style='fullMesh';
+default_wireframe_rendering=0.08;
+default_material='dull';
+default_useDefault=false;
+% accepted values
+expected_materials={'dull','metal','shiny'};
+expected_styles={'fullMesh','wireframe','invisible'};
+% add parameters and validity funcitons
+addRequired(p,'structInput');
+addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
+addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
+addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
+addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
+addParameter(p,'useDefault',default_useDefault);
+
+% parse inputs
+parse(p,meshHandle,varargin{:});
+options=p.Results;
+for nMeshes=1:length(meshHandle.modelMesh)
+    modelMesh=meshHandle.modelMesh(nMeshes);
+    if ~any(ismember(p.UsingDefaults,'color')) || options.useDefault
+        changeColor(modelMesh,options.color);
+    end
+    if ~any(ismember(p.UsingDefaults,'transparency')) || options.useDefault
+        alpha(modelMesh,options.transparency);
+    end
+    if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
+        material(modelMesh,options.material);
+    end
+    
+    
+    if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
+        [isWF,noColor]=isWireframe(modelMesh);        
+            
+        if strcmpi(options.style,'wireframe') && ~isWF
+            if noColor
+                color=options.color;
+            else
+                color=modelMesh.FaceColor;
+            end
+            reducepatch(modelMesh,options.wireframe_rendering);
+            modelMesh.FaceColor='none';
+            modelMesh.EdgeColor=color;
+        end
+        if strcmpi(options.style,'fullMesh') && isWF % means full mesh
+            if noColor
+                color=options.color;
+            else
+                color=modelMesh.EdgeColor;
+            end
+            modelMesh.Vertices=meshHandle.fullMesh_bckup(nMeshes).vertices;
+            modelMesh.Faces=meshHandle.fullMesh_bckup(nMeshes).faces;
+            modelMesh.FaceColor=color;
+            modelMesh.EdgeColor='none';
+        end
+        if strcmpi(options.style,'invisible')% make invisible
+            modelMesh.Visible='off';
+        else
+            modelMesh.Visible='on';
+        end
+    end
+end
+
+    function []=changeColor(modelMesh,color)
+        if isWireframe(modelMesh)
+            modelMesh.EdgeColor=color;
+        else
+            modelMesh.FaceColor=color;
+        end
+    end
+
+    function [isIt,noColor]=isWireframe(meshHandle)
+        % if there is a numeric value in edges and a char ('none') in faces
+        % then is wireframe
+        noColor=false;
+        if ischar(meshHandle.FaceColor) && ~ischar(meshHandle.EdgeColor)
+            isIt=true;
+        end
+        % As long as there is a color in faces is not wireframe
+        if ~ischar(meshHandle.FaceColor) && ischar(meshHandle.EdgeColor)
+            isIt=false;
+        end
+        % The mesh is invisble and not on purpose. Make it wireframe.
+        if ~exist('isIt','var')
+            isIt=true;
+            noColor=true;
+        end
+    end
+end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
@@ -1,6 +1,6 @@
 function []=modifyLinkVisual(meshHandle,varargin)
 % Modifies a single `meshHandle` with the specified changes.
-%     - Iputs:
+%     - Inputs:
 %         - `meshHandle` : Struct containing the patch type of variable ( `modelMesh` field ) and the original information of the mesh in `fullMesh_bckup` field.
 %     - Optional Inputs:
 %         - `color` : Selects the color of the meshes.

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
@@ -16,7 +16,7 @@ function []=modifyLinkVisual(meshHandle,varargin)
 %         - `useDefault`  : Enables the use of the default values instead of ignoring non specified changes.
 %
 % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-% 
+%
 % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 % This software may be modified and distributed under the terms of the
 % GNU Lesser General Public License v2.1 or any later version.
@@ -57,11 +57,11 @@ for nMeshes=1:length(meshHandle.modelMesh)
     if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
         material(modelMesh,options.material);
     end
-    
-    
+
+
     if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
-        [isWF,noColor]=isWireframe(modelMesh);        
-            
+        [isWF,noColor]=isWireframe(modelMesh);
+
         if strcmpi(options.style,'wireframe') && ~isWF
             if noColor
                 color=options.color;

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
@@ -1,0 +1,55 @@
+function []=modifyLinksVisualization(Visualizer,varargin)
+% Allows the modifications of the meshes of the selected links. By default it will modify all objects in the Visualizer variable
+%   - `modifyLinksVisualization` : Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
+%       - Inputs:
+%             - `Visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables `linkNames`,`transforms` and `NOBJ`.
+%                 - `linkNames`  : variable that contains the link names.
+%                 - `meshHandles` : variable that has the handles of the mesh objects.
+%                 - `NOBJ` : variable that contains the number of visual objects to update.
+%       - Optional Inputs:
+%             - `linksToModify`  : Cell array containing the names of the links to modify
+%             - `linksIndices`   : array containing the indices of the links to modify
+% :exclamation:   Note: all extra variables are sent to `modifyLinkVisual`
+%
+% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+% 
+% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+% This software may be modified and distributed under the terms of the
+% GNU Lesser General Public License v2.1 or any later version.
+%% input parser section
+p = inputParser;
+p.StructExpand = false;
+p.KeepUnmatched= true;
+% Default values
+default_linksToModify={'all'};
+default_linksIndices=-99;
+% add parameters and validity funcitons
+addRequired(p,'structInput');
+addParameter(p,'linksToModify',default_linksToModify,@(x) iscell(x));
+addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) && ~any(x>Visualizer.NOBJ));
+
+% parse inputs
+parse(p,Visualizer,varargin{:});
+options=p.Results;
+
+if ~any(ismember(p.UsingDefaults,'linksToModify'))  || ~any(ismember(p.UsingDefaults,'linksIndices'))
+    % select the indices of the links to modify
+    if ~any(ismember(p.UsingDefaults,'linksIndices'))
+        indices=options.linksIndices;
+    else
+        [~,indices_temp]=ismember(options.linksToModify,Visualizer.linkNames);
+        indices=nonzeros(indices_temp);
+        if length(indices_temp)~=length(indices)
+            notInModel=length(indices_temp)-length(indices);
+            indices_notInModel=find(indices_temp==0);
+            warndlg(sprintf('The list of links to modify contains %d names (positions [ %s ] ) that are not in the list of links of the model',notInModel,num2str(indices_notInModel')));
+        end
+    end
+else
+    % by default modify all links
+    indices=1:Visualizer.NOBJ;
+end
+
+for it=1:length(indices)
+    iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});  
+end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
@@ -12,7 +12,7 @@ function []=modifyLinksVisualization(Visualizer,varargin)
 % :exclamation:   Note: all extra variables are sent to `modifyLinkVisual`
 %
 % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-% 
+%
 % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 % This software may be modified and distributed under the terms of the
 % GNU Lesser General Public License v2.1 or any later version.
@@ -51,5 +51,5 @@ else
 end
 
 for it=1:length(indices)
-    iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});  
+    iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});
 end

--- a/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
+++ b/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
@@ -1,54 +1,88 @@
-function [meshHandles,transform]=plotMeshInWorld(linkMeshInfo,w_H_link)
+function [meshHandles,transform]=plotMeshInWorld(linkMeshInfo,w_H_link,varargin)
 % Gets the mesh information for each link in the model.
 %     - Iputs:
 %         - `linkMeshInfo` : An individual `linkMeshInfo` from the array output variable from `getMeshes` function.
 %         - `w_H_link` : Homogeneous transform from the world to the link
+%     - Optional Inputs:
+%         - `color` : Selects the color of the meshes.
+%         - `transparency` : Sets the alpha value of the patch. Is the
+%         level of transparency between 0 fully transparent and 1 solid.
+%         - `wireframe_rendering` : the reduction ratio of faces to
+%         wireframe. Follows convention of reducepatch.
+%         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
 %     - Outputs:
 %         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
-%         - `transform`            : The transform object for the link
-% 
+%         - `transform`    : The transform object for the link
+%
 % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
 %
 % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 % This software may be modified and distributed under the terms of the
 % GNU Lesser General Public License v2.1 or any later version.
-
-        
+%% input parser section
+p = inputParser;
+p.StructExpand = false;
+p.KeepUnmatched= true;
 % Default values
-meshColor= [0.1843    0.3098    0.3098];
-transparency=0.5;
+default_color= [0.1843    0.3098    0.3098];
+default_transparency=0.5;
+default_style='fullMesh';
+default_wireframe_rendering=0.08;
+% accepted values
+expected_styles={'fullMesh','wireframe'};
+% add parameters and validity funcitons
+addRequired(p,'structInput');
+addRequired(p,'w_H_link',@(x)validateattributes(x,{'numeric'},{'size',[4,4]}));
+addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
+addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
+addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
+% parse inputs
+parse(p,linkMeshInfo,w_H_link,varargin{:});
+options=p.Results;
 
-% create a transform object %
+%% Create a transform object %
 transform = hgtransform('Parent',gca);
 for mesh_number=1:length(linkMeshInfo.meshInfo)
-    
+
     mesh_triangles=linkMeshInfo.meshInfo(mesh_number).mesh_triangles;
     link_H_geom=linkMeshInfo.meshInfo(mesh_number).link_H_geom;
     scale=linkMeshInfo.meshInfo(mesh_number).scale;
-    
+
     % Change scale
-    % Scale the STL mesh    
-    corrected_vertices=mesh_triangles.Points.*scale;    
-    
-    % Applying transform to link frame to stl file  :    
+    % Scale the STL mesh
+    corrected_vertices=mesh_triangles.Points.*scale;
+
+    % Applying transform to link frame to stl file  :
     corrected_vertices=link_H_geom*[corrected_vertices';ones(1,size(corrected_vertices,1))];
     corrected_vertices=corrected_vertices';
     corrected_vertices=corrected_vertices(:,1:3);
-    
+
     % plot in figureusing patch
     modelMesh(mesh_number) = ...
         patch('Faces',mesh_triangles.ConnectivityList,'Vertices',corrected_vertices,...
-        'FaceColor',meshColor , ...
+        'FaceColor',options.color , ...
         'EdgeColor',  'none',        ...
         'FaceLighting',    'gouraud',     ...
         'AmbientStrength', 0.25);
-    
+
+    faces_bckup=modelMesh(mesh_number).Faces;
+    vertices_bckup=modelMesh(mesh_number).Vertices;
+    meshHandles.fullMesh_bckup(mesh_number).faces=faces_bckup;
+    meshHandles.fullMesh_bckup(mesh_number).vertices=vertices_bckup;
+
+    if strcmp(options.style,'wireframe')
+        reducepatch(modelMesh(mesh_number),options.wireframe_rendering);
+        modelMesh(mesh_number).FaceColor='none';
+        modelMesh(mesh_number).EdgeColor=options.color;
+    end
+
     %parent transform as parent to the mesh
     set(modelMesh(mesh_number),'Parent',transform);
-    
+
     % Set the object transparency
-    alpha(modelMesh(mesh_number),transparency);
-    
+    alpha(modelMesh(mesh_number),options.transparency);
+
 end
 set(transform,'Matrix',w_H_link);
 meshHandles.modelMesh=modelMesh;

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -6,7 +6,7 @@ function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,va
 %   `. `meshFilePrefix` should replace package to allow to find the rest of the path.
 % - Optional Inputs:
 %     - `view` : Selects the angle in which the figure is seen.
-%     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';            
+%     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
 %     - `debug` : Enables having extra information for debugging purposes.
 %     - `groundOn` : Enables showing a plane as the ground.
 %     - `groundColor` : Selects the color of the ground.
@@ -18,7 +18,7 @@ function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,va
 %           - `transforms` : Is the transform objects array. There is one transform for each link
 %           - `linkNames`  : The name of the links in the same order of the transforms
 %           - `linkNames_idyn`  : The idyntree string vector equivalent to `linkNames`
-%           - `NOBJ` : Contains the number of visual objects in the visualizer            
+%           - `NOBJ` : Contains the number of visual objects in the visualizer
 %           - `meshHandles` : Has the handles of the mesh objects.
 %           - `parent`     : Contains the axes object of the parent figure.
 %           - `mainHandler`: Is the handle of the overall figure.

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -1,30 +1,64 @@
-function [transforms,linkNames,linkNames_idyn,map,linkMeshInfo,meshHandles,parent,mainHandler]=prepareVisualization(KinDynModel,meshFilePrefix)
+function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,varargin)
 % Creates the figures, loads the meshes, handles some visual effects, and creates the transform objects
 % - Iputs:
 %   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
 %   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
 %   `. `meshFilePrefix` should replace package to allow to find the rest of the path.
-% - Outputs:
-%   - `transforms` : Is the transform objects array. There is one transform for each link
-%   - `linkNames`  : The name of the links in the same order of the transforms
-%   - `linkNames_iDyn`  : The name of the links in the same order of the
-%   transforms in a iDyntree string vector variable
-%   - `map`       : Cell array having both the names of the meshes and the associated link
-%   - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
-%   - `meshHandles` : Has the handles of the mesh objects.
-%   - `parent`     : Contains the axes object of the parent figure.
-%   - `mainHandler`: Is the handle of the overall figure.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+% - Optional Inputs:
+%     - `view` : Selects the angle in which the figure is seen.
+%     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';            
+%     - `debug` : Enables having extra information for debugging purposes.
+%     - `groundOn` : Enables showing a plane as the ground.
+%     - `groundColor` : Selects the color of the ground.
+%     - `groundTransparency` : Selects the transparency of the ground.
+%     - `groundFrame` : Selects the frame in which the ground is attached.
+%     Note: all extra variables are sent to `plotMeshInWorld`
+%   - Outputs:
+%       - `Visualizer` : Struct containing the following fields
+%           - `transforms` : Is the transform objects array. There is one transform for each link
+%           - `linkNames`  : The name of the links in the same order of the transforms
+%           - `linkNames_idyn`  : The idyntree string vector equivalent to `linkNames`
+%           - `NOBJ` : Contains the number of visual objects in the visualizer            
+%           - `meshHandles` : Has the handles of the mesh objects.
+%           - `parent`     : Contains the axes object of the parent figure.
+%           - `mainHandler`: Is the handle of the overall figure.
+%           - `DEBUG` : Flag stating if the debug mode was set or not.
+%           Fields included if debug mode is on:
+%           - `map`       : Cell array having both the names of the meshes and the associated link
+%           - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
 %
 % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 % This software may be modified and distributed under the terms of the
 % GNU Lesser General Public License v2.1 or any later version.
+%% input parser section
+p = inputParser;
+p.StructExpand = false;
+p.KeepUnmatched= true;
+% Default values
+default_view=[128.0181 16.8000];
+default_material='dull';
+default_debug=false;
+default_groundOn=false;
+default_groundColor=[0 0.5 0.5];
+default_groundTransparency=0.8;
+default_groundFrame='none';
+% accepted values
+expected_materials={'dull','metal','shiny'};
+% add parameters and validity funcitons
+addRequired(p,'structInput');
+addRequired(p,'meshFilePrefix',@(x) isstring(x) || ischar(x));
+addParameter(p,'view',default_view,@isnumeric);
+addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
+addParameter(p,'debug',default_debug,@(x) islogical(x));
+addParameter(p,'groundOn',default_groundOn,@(x) islogical(x));
+addParameter(p,'groundColor',default_groundColor,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+addParameter(p,'groundTransparency',default_groundTransparency,@(x) isnumeric(x) && isscalar(x));
+addParameter(p,'groundFrame',default_groundFrame,@(x) isstring(x) || ischar(x));
 
-% Desirable views
-custom_view=[128.0181 16.8000];
-custom_view2=[43.9924 18.0000];
-% Get meshes from the model variable
+% parse inputs
+parse(p,KinDynModel,meshFilePrefix,varargin{:});
+options=p.Results;
+%% Get meshes from the model variable
 model=KinDynModel.kinDynComp.model;
 [linkMeshInfo,map]=iDynTreeWrappers.getMeshes(model,meshFilePrefix);
 numberOfLinks=length(linkMeshInfo);
@@ -36,18 +70,38 @@ linkNames_idyn=iDynTree.StringVector();
 
 for it=1:numberOfLinks
     w_H_link=iDynTreeWrappers.getWorldTransform(KinDynModel,linkMeshInfo(it).linkName);
-    [meshHandles(it,:),transforms(it)]=iDynTreeWrappers.plotMeshInWorld(linkMeshInfo(it),w_H_link);
+    [meshHandles(it,:),transforms(it)]=iDynTreeWrappers.plotMeshInWorld(linkMeshInfo(it),w_H_link,varargin{:});
     linkNames{it}=linkMeshInfo(it).linkName;
     linkNames_idyn.push_back(linkNames{it});
 end
 
 % Add a camera light, and tone down the specular highlighting
 camlight('headlight');
-material('dull');
+material(options.material);
 
 % Make axis pretty and add grid for visual reference
 axis equal;
+axis tight;
 grid on;
+
+% Apply views
+view(parent,options.view);
+
+% Add world reference frame
+hold on;
+currentAxisValues=axis;
+axisRange=currentAxisValues([2,4,6])-currentAxisValues([1,3,5]);
+frameAxisSize = min(axisRange)/4;
+% linewidth value 1 = to 0.35mm. It is better if we increase the linewidth
+% in proportion to the axisSize of the frame.c
+linewidthSize=frameAxisSize*50;
+plot3(parent, [0 frameAxisSize], [0 0], [0 0], 'r', 'linewidth', linewidthSize);
+plot3(parent, [0 0], [0 frameAxisSize], [0 0], 'g', 'linewidth', linewidthSize);
+plot3(parent, [0 0], [0 0], [0 frameAxisSize], 'b', 'linewidth', linewidthSize);
+axisTextDistance = frameAxisSize+frameAxisSize*.2;
+text(parent, axisTextDistance, 0, 0, 'x', 'color', 'r');
+text(parent, 0, axisTextDistance, 0, 'y', 'color', 'g');
+text(parent, 0, 0, axisTextDistance, 'z', 'color', 'b');
 
 % Axis labels
 title('Robot Visualizer ');
@@ -55,5 +109,59 @@ xlabel('{x}');
 ylabel('{y}');
 zlabel('{z}');
 
-% Apply views
-view(parent,custom_view);
+% Draw the ground
+if options.groundOn
+    % Create plane on x y axis
+    normal_vector=[0,0,1];
+    point_on_plane=[0,0,0];
+    d=normal_vector*point_on_plane';
+    x = [1 -1 -1 1]*max(axisRange(1:2)); % Generate data for x vertices
+    y = [1 1 -1 -1]*max(axisRange(1:2)); % Generate data for y vertices
+    z = 1/normal_vector(3)*(normal_vector(1)*x + normal_vector(2)*y + d); % Solve for z vertices data
+    groundHandle=patch('XData',x,'YData',y,'ZData',z,'FaceColor', options.groundColor);
+    alpha(groundHandle,options.groundTransparency);
+    % apply transform
+    groundTransform = hgtransform('Parent',parent);
+    set(groundHandle,'Parent',groundTransform);
+    if any(ismember(p.UsingDefaults,'groundFrame'))
+        w_H_plane=eye(4,4);
+        options.groundFrame=linkNames{1};
+    else
+        w_H_plane_idyn=KinDynModel.kinDynComp.getWorldTransform(options.groundFrame);
+        w_H_plane= w_H_plane_idyn.asHomogeneousTransform.toMatlab();
+        w_H_plane(1:2,4)=0;
+    end
+    set(groundTransform,'Matrix',w_H_plane);
+
+    objectFrames_idyn=iDynTree.StringVector();
+    objectFrames_idyn.push_back(options.groundFrame);
+
+    % Build Object struct
+    Objects.frames_idyn=objectFrames_idyn;
+    Objects.transform=groundTransform;
+    Objects.frames=options.groundFrame;
+    Objects.types={'plane'};
+    Objects.names={'ground'};
+    Objects.handle=groundHandle;
+
+    if options.debug
+        Objects.map=[Objects.names',Objects.frames'];
+    end
+else
+    Objects=[];
+end
+
+% Build Output struct
+Visualizer.transforms=transforms;
+Visualizer.linkNames_idyn=linkNames_idyn;
+Visualizer.linkNames=linkNames;
+Visualizer.NOBJ=length(transforms);
+Visualizer.meshHandles=meshHandles;
+Visualizer.mainHandler=mainHandler;
+Visualizer.parent=parent;
+Visualizer.DEBUG=options.debug;
+
+if options.debug
+    Visualizer.map=map;
+    Visualizer.linkMeshInfo=linkMeshInfo;
+end

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -1,6 +1,6 @@
 function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,varargin)
 % Creates the figures, loads the meshes, handles some visual effects, and creates the transform objects
-% - Iputs:
+% - Inputs:
 %   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
 %   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
 %   `. `meshFilePrefix` should replace package to allow to find the rest of the path.

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
@@ -1,11 +1,13 @@
-function []=updateVisualization(KinDynModel,linkNames,transforms)
+function []=updateVisualization(KinDynModel,Visualizer)
 % We use the transform handlers to update the robot image using the
 % iDyntree kinematics
 % Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
 %     - Inputs:
 %           - `KinDynModel`: iDyntreewrappers main variable. Contains the model.
-%           - `linkNames`  : The `linkNames` variable output from the `prepareVisualization` function that contains the link names.
-%           - `transforms` : The `transforms` variable output from the `prepareVisualization` function.
+%           - `visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables linkNames,transforms and NOBJ
+%               - `linkNames`  : variable that contains the link names.
+%               - `transforms` : variable that contains transform objects that are parent of the meshes.
+%               - `NOBJ` : variable that contains the number of visual objects to update.
 %
 % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
 %
@@ -13,15 +15,8 @@ function []=updateVisualization(KinDynModel,linkNames,transforms)
 % This software may be modified and distributed under the terms of the
 % GNU Lesser General Public License v2.1 or any later version.
 
-if iscellstr(linkNames) % sending an cell array with the link names
-    for it=1:length(linkNames)
-        w_H_link=iDynTreeWrappers.getWorldTransform(KinDynModel,linkNames{it});
-        transforms(it).Matrix=w_H_link;
-    end    
-else % expecting an iDyntree.StringVector. This is more time efficient
-    transforms_idyn=KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(linkNames);
-    w_H_links= transforms_idyn.toMatlab();
-    for it=1:KinDynModel.kinDynComp.getNrOfLinks
-        transforms(it).Matrix=squeeze(w_H_links(it,:,:));
-    end
+transforms_idyn=KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(Visualizer.linkNames_idyn);
+w_H_links= transforms_idyn.toMatlab();
+for it=1:Visualizer.NOBJ
+    Visualizer.transforms(it).Matrix=squeeze(w_H_links(it,:,:));
 end

--- a/doc/matlab_visualization.md
+++ b/doc/matlab_visualization.md
@@ -9,28 +9,55 @@ It uses the [iDynTreeWrappers](../bindings/matlab/%2BiDynTreeWrappers) to handle
 ## functions
 ### Main functions
 - `prepareVisualization` : Creates the figures, loads the meshes, handles some visual effects, and creates the transform objects
-    - Iputs:
+    - Inputs:
         - `KinDynModel` : iDynTreeWrappers main variable. Contains the model.
         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
 `. `meshFilePrefix` should replace package to allow to find the rest of the path.
+        - `varargin`  : Variable that allows to add option configuration parameters. Admitted options are:
+            - `view` : Selects the angle in which the figure is seen.
+            - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';            
+            - `debug` : Enables having extra information for debugging purposes.
+            - `groundOn` : Enables showing a plane as the ground.
+            - `groundColor` : Selects the color of the ground.
+            - `groundTransparency` : Selects the transparency of the ground.
+            - `groundFrame` : Selects the frame in which the ground is attached.
+:exclamation:   Note: all extra variables are sent to `plotMeshInWorld`
     - Outputs:
-        - `transforms` : Is the transform objects array. There is one transform for each link
-        - `linkNames`  : The name of the links in the same order of the transforms
-        - `map`       : Cell array having both the names of the meshes and the associated link
-        - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
-        - `meshHandles` : Has the handles of the mesh objects.
-        - `parent`     : Contains the axes object of the parent figure.
-        - `mainHandler`: Is the handle of the overall figure.
+        - `Visualizer` : Struct containing the following fields
+            - `transforms` : Is the transform objects array. There is one transform for each link
+            - `linkNames`  : The name of the links in the same order of the transforms
+            - `linkNames_idyn`  : The idyntree string vector equivalent to `linkNames`
+            - `NOBJ` : Contains the number of visual objects in the visualizer            
+            - `meshHandles` : Has the handles of the mesh objects.
+            - `parent`     : Contains the axes object of the parent figure.
+            - `mainHandler`: Is the handle of the overall figure.
+            - `DEBUG` : Flag stating if the debug mode was set or not.
+            Fields if debug mode is on:
+            - `map`       : Cell array having both the names of the meshes and the associated link
+            - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
 
 - `updateVisualization` : Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
     - Inputs:
-          - `KinDynModel`: iDynTreeWrappers main variable. Contains the model.
-          - `linkNames`  : The `linkNames` variable output from the `prepareVisualization` function.
-          - `transforms` : The `transforms` variable output from the `prepareVisualization` function.
+          - `KinDynModel`: iDyntreewrappers main variable. Contains the model.
+          - `Visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables `linkNames`,`meshHandles` and `NOBJ`.
+              - `linkNames`  : variable that contains the link names.
+              - `transforms` : variable that contains transform objects that are parent of the meshes.
+              - `NOBJ` : variable that contains the number of visual objects to update.
+
+  - `modifyLinksVisualization` : Allows the modifications of the meshes of the selected links. By default it will modify all objects in the `Visualizer` variable
+      - Inputs:
+            - `Visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables `linkNames`,`transforms` and `NOBJ`.
+                - `linkNames`  : variable that contains the link names.
+                - `meshHandles` : variable that has the handles of the mesh objects.
+                - `NOBJ` : variable that contains the number of visual objects to update.
+      - Optional Inputs:
+            - `linksToModify`  : Cell array containing the names of the links to modify
+            - `linksIndices`   : array containing the indices of the links to modify
+:exclamation:   Note: all extra variables are sent to `modifyLinkVisual`
 
 ### Other functions
 - `getMeshes` : Gets the mesh information for each link in the model.
-    - Iputs:
+    - Inputs:
         - `model` : iDynTree model loaded form a URDF.
         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
 `. `meshFilePrefix` should replace package to allow to find the rest of the path.
@@ -39,9 +66,27 @@ It uses the [iDynTreeWrappers](../bindings/matlab/%2BiDynTreeWrappers) to handle
         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
 
 - `plotMeshInWorld` : Gets the mesh information for each link in the model.
-            - Iputs:
-                - `linkMeshInfo` : An individual `linkMeshInfo` from the array output variable from `getMeshes` function.
-                - `w_H_link` : Homogeneous transform from the world to the link
-            - Outputs:
-                - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
-                - `transform`            : The transform object for the link
+    - Inputs:
+        - `linkMeshInfo` : An individual `linkMeshInfo` from the array output variable from `getMeshes` function.
+        - `w_H_link` : Homogeneous transform from the world to the link
+    - Optional Inputs:
+        - `color` : Selects the color of the meshes.
+        - `transparency` : Sets the alpha value of the patch. Is the
+        level of transparency between 0 fully transparent and 1 solid.
+        - `wireframe_rendering` : the reduction ratio of faces to
+        wireframe. Follows convention of reducepatch.
+        - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
+    - Outputs:
+        - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
+        - `transform`    : The transform object for the link
+
+- `modifyLinkVisual` : Modifies a single `meshHandle` with the specified changes.
+    - Inputs:
+        - `meshHandle` : Struct containing the patch type of variable ( `modelMesh` field ) and the original information of the mesh in `fullMesh_bckup` field.
+    - Optional Inputs:
+        - `color` : Selects the color of the meshes.
+        - `transparency` : Sets the alpha value of the patch. Is the
+        level of transparency between 0 fully transparent and 1 solid.
+        - `wireframe_rendering` : the reduction ratio of faces to
+        wireframe. Follows convention of reducepatch.
+        - `style` : Selects the style of display of meshes, either fullMesh or wireframe.

--- a/examples/iDynTreeWrappers/visualizeRobot.m
+++ b/examples/iDynTreeWrappers/visualizeRobot.m
@@ -2,14 +2,14 @@
 % To use insert the path where the meshes may be found, it replaces what is required
 % to complete the path inside the urdf visual mesh field.
 
-% Example: 
+% Example:
 % If a test model has the following mesh file in the URDF
 % 'package://stl/sim_sea_2-5_root_link_prt-binary.stl'
 % The required path is what it takes to reach the stl folder.
-% meshFilePrefix=<path_to_stl_folder>; 
+% meshFilePrefix=<path_to_stl_folder>;
 % It basically replaces the functionality of find Package by inserting the
 % path manually.
-% The path to the model is also required: 
+% The path to the model is also required:
 % modelPath=<path_to_urdf_folder>;
 
 % REMARK : If you have installed the URDF models by https://github.com/robotology/icub-models
@@ -22,7 +22,7 @@ icubModelsInstallPrefix = getenv('ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX');
 
 
  meshFilePrefix = [icubModelsInstallPrefix '/share'];
-% Select the robot using the folder name 
+% Select the robot using the folder name
 robotName='';
 
 % Example
@@ -73,13 +73,14 @@ KinDynModel = iDynTreeWrappers.loadReducedModel(jointOrder,'root_link',modelPath
 % create vector of positions
 joints_positions=zeros(KinDynModel.NDOF,1);
 
-fakeWorld=[1,0,0,0;0,1,0,0;0,0,1,0.6;0,0,0,1];%eye(4);
-                
+% add a world to base mainly to avoid overlap of coordinate frame and robot
+world_H_base=[1,0,0,0;0,1,0,0;0,0,1,0.6;0,0,0,1];
+
 % Set initial position of the robot
-iDynTreeWrappers.setRobotState(KinDynModel,fakeWorld,joints_positions,zeros(6,1),zeros(size(joints_positions)),[0,0,-9.81]);
+iDynTreeWrappers.setRobotState(KinDynModel,world_H_base,joints_positions,zeros(6,1),zeros(size(joints_positions)),[0,0,-9.81]);
 
 % Prepare figure, handles and variables required for the update, some extra
-% options are commented. 
+% options are commented.
 [visualizer,objects]=iDynTreeWrappers.prepareVisualization(KinDynModel,meshFilePrefix,...
     'color',[0,0,1],'material','metal','transparency',1,'debug',true,'view',[-92.9356   22.4635],...
     'groundOn',true,'groundColor',[0.5 0.5 0.5], 'groundTransparency',0.5,'groundFrame','l_sole');%,... % optional inputs
@@ -93,7 +94,7 @@ joints_positions([16 17 19 23 24 26])=pi/10;
 
 %% Update robot position
 % update kinematics
-iDynTreeWrappers.setRobotState(KinDynModel,fakeWorld,joints_positions,zeros(6,1),zeros(size(joints_positions)),[0,0,-9.81]);
+iDynTreeWrappers.setRobotState(KinDynModel,world_H_base,joints_positions,zeros(6,1),zeros(size(joints_positions)),[0,0,-9.81]);
 
 tic
  iDynTreeWrappers.updateVisualization(KinDynModel,visualizer);
@@ -120,4 +121,3 @@ pause(1);
 iDynTreeWrappers.modifyLinksVisualization(visualizer,'linksToModify',linkstoModify(3),'style','invisible');
 pause(1);
 iDynTreeWrappers.modifyLinksVisualization(visualizer,'linksToModify',linkstoModify(3),'style','fullMesh');
-


### PR DESCRIPTION
In this PR we allow to receive variable inputs for:

-  custom view point
-  change color of the robot
-  change level of transparency
-  have a shinny surface or dull
-  change style of display: full mesh , wireframe or invisible

It can be done from the variable inputs in the prepareVisualization function or using the modifyLinksVisual after the figure creation.

In addition at the preparation stage it can add

-  add something to represent the floor
-  add a frame to indicate the world

The input and outputs of the visualization have been changed to a struct to facilitate the use.
It also fixes a couple of bugs that appear when using pure geometry objects and when some links have no visuals.

Fixes #679 #678 
Closes #660 