### PR TITLE
Support Ubuntu 20.04 and release 1.0.7 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,11 @@ jobs:
         sudo apt-get install libblas-dev libatlas-base-dev
         sudo apt-get remove libopenblas-base
         
+    - name: Install missing Ubuntu 20.04 dependencies 
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get install libgfortran-10-dev
+        
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@master
@@ -34,7 +34,7 @@ jobs:
     # Remove apt repos that are known to break from time to time 
     # See https://github.com/actions/virtual-environments/issues/323  
     - name: Remove broken apt repos [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+      if: contains(matrix.os, 'ubuntu')
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         
@@ -70,7 +70,7 @@ jobs:
         brew install ace assimp boost eigen swig qt5 orocos-kdl
     
     - name: Dependencies [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+      if: contains(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
@@ -116,7 +116,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         
     - name: Source-based Dependencies [Ubuntu/macOS] 
-      if: steps.cache-source-deps.outputs.cache-hit != 'true' && (matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest')
+      if: steps.cache-source-deps.outputs.cache-hit != 'true' && (contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest')
       shell: bash
       run: |
         # YCM
@@ -159,7 +159,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Configure [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
       shell: bash
       run: |
         mkdir -p build
@@ -169,7 +169,7 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Enable additional Ubuntu options (Valgrind, Octave, Python, legacy KDL) [Ubuntu] 
-      if: matrix.os == 'ubuntu-latest'
+      if: contains(matrix.os, 'ubuntu')
       run: |
         cd build
         # Assimp is disabled on Ubuntu as a workaround for https://github.com/robotology/idyntree/issues/663
@@ -202,7 +202,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         
     - name: Install [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
       shell: bash
       run: |
         cd build
@@ -220,7 +220,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Compile Examples [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
       shell: bash
       run: |
         cd examples
@@ -231,7 +231,7 @@ jobs:
 
         
     - name: Check build if some dependencies are not enabled [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Test
+      # Workaround for https://github.com/robotology/idyntree/issues/694
+      if: matrix.os != 'ubuntu-20.04'
       shell: bash
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         path: ${{ github.workspace }}/install/deps
         # Including ${{ runner.temp }} is a workaround for https://github.com/robotology/whole-body-estimators/issues/60
-        key: source-deps-${{ runner.os }}-${{ runner.temp }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}-github-workspace-${{ env.GITHUB_WORKSPACE }}
+        key: source-deps-${{ matrix.os }}-${{ runner.os }}-${{ runner.temp }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}-github-workspace-${{ env.GITHUB_WORKSPACE }}
     
     - name: Source-based Dependencies [Windows] 
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest-disable-until-issue-569-is-solved'
@@ -178,11 +178,6 @@ jobs:
         # As a workaround, we test against the regular blas instead of openblas
         sudo apt-get install libblas-dev libatlas-base-dev
         sudo apt-get remove libopenblas-base
-        
-    - name: Install missing Ubuntu 20.04 dependencies 
-      if: matrix.os == 'ubuntu-20.04'
-      run: |
-        sudo apt-get install libgfortran-10-dev
         
     - name: Build
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed compilation with assimp installed with apt-get on Ubuntu 20.04 (https://github.com/robotology/idyntree/pull/692, https://github.com/robotology/idyntree/issues/693). 
+
 ## [1.0.6] - 2020-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] - 2020-06-07
+
 ### Fixed
 - Fixed compilation with assimp installed with apt-get on Ubuntu 20.04 (https://github.com/robotology/idyntree/pull/692, https://github.com/robotology/idyntree/issues/693). 
+- Fixed compilation with Octave >= 5 (https://github.com/robotology/idyntree/pull/692, https://github.com/robotology/idyntree/pull/677). 
 
 ## [1.0.6] - 2020-05-06
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(VARS_PREFIX "iDynTree")
 
 set(${VARS_PREFIX}_MAJOR_VERSION 1)
 set(${VARS_PREFIX}_MINOR_VERSION 0)
-set(${VARS_PREFIX}_PATCH_VERSION 6)
+set(${VARS_PREFIX}_PATCH_VERSION 7)
 set(${VARS_PREFIX}_VERSION ${${VARS_PREFIX}_MAJOR_VERSION}.${${VARS_PREFIX}_MINOR_VERSION}.${${VARS_PREFIX}_PATCH_VERSION})
 
 # Pick up our CMake scripts - they are all in the cmake subdirectory.

--- a/cmake/FindOctave.cmake
+++ b/cmake/FindOctave.cmake
@@ -15,7 +15,6 @@
 #  OCTAVE_PATCH_VERSION        - patch version
 #  OCTAVE_OCT_FILE_DIR         - object files that will be dynamically loaded
 #  OCTAVE_OCT_LIB_DIR          - oct libraries
-#  OCTAVE_ROOT_DIR             - octave prefix
 #
 # The macro octave_add_oct allows to create compiled modules.
 # octave_add_oct ( target_name
@@ -24,12 +23,6 @@
 #         [EXTENSION ext]
 # )
 #
-# To install it, you can the use the variable OCTAVE_OCT_FILE_DIR as follow:
-#  file ( RELATIVE_PATH PKG_OCTAVE_OCT_FILE_DIR ${OCTAVE_ROOT_DIR} ${OCTAVE_OCT_FILE_DIR} )
-#  install (
-#    TARGETS target_name
-#    DESTINATION ${PKG_OCTAVE_OCT_FILE_DIR}
-#  )
 #=============================================================================
 # Copyright 2013, Julien Schueller
 # All rights reserved.
@@ -61,9 +54,6 @@ find_program( OCTAVE_CONFIG_EXECUTABLE
               NAMES octave-config
             )
 if ( OCTAVE_CONFIG_EXECUTABLE )
-  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p PREFIX
-                    OUTPUT_VARIABLE OCTAVE_ROOT_DIR
-                    OUTPUT_STRIP_TRAILING_WHITESPACE )
 
   execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p BINDIR
                     OUTPUT_VARIABLE OCTAVE_BIN_PATHS
@@ -158,7 +148,7 @@ endmacro ()
 # handle REQUIRED and QUIET options
 include ( FindPackageHandleStandardArgs )
 
-find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_ROOT_DIR OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
+find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
 
 mark_as_advanced (
   OCTAVE_OCT_FILE_DIR
@@ -169,7 +159,6 @@ mark_as_advanced (
   OCTAVE_LIBRARIES
   OCTAVE_INCLUDE_DIR
   OCTAVE_INCLUDE_DIRS
-  OCTAVE_ROOT_DIR
   OCTAVE_VERSION_STRING
   OCTAVE_MAJOR_VERSION
   OCTAVE_MINOR_VERSION

--- a/cmake/iDynTreeDependencies.cmake
+++ b/cmake/iDynTreeDependencies.cmake
@@ -99,3 +99,21 @@ endif()
 idyntree_handle_dependency(WORHP DO_NOT_SILENTLY_SEARCH)
 # Workaround for https://github.com/robotology/idyntree/issues/599
 idyntree_handle_dependency(assimp DO_NOT_SILENTLY_SEARCH MAIN_TARGET assimp::assimp)
+# Workaround for https://github.com/robotology/idyntree/issues/693
+if(TARGET assimp::assimp)
+  get_property(assimp_INTERFACE_INCLUDE_DIRECTORIES
+               TARGET assimp::assimp
+               PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+  if(assimp_INTERFACE_INCLUDE_DIRECTORIES MATCHES "/usr/lib/include")
+    string(REPLACE "/usr/lib/include" "/usr/include" assimp_INTERFACE_INCLUDE_DIRECTORIES "${assimp_INTERFACE_INCLUDE_DIRECTORIES}")
+    set_property(TARGET assimp::assimp
+                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                 "${assimp_INTERFACE_INCLUDE_DIRECTORIES}")
+    get_property(assimp_LOCATION_RELEASE
+                 TARGET assimp::assimp
+                 PROPERTY LOCATION_RELEASE)
+    set_property(TARGET assimp::assimp
+                 PROPERTY IMPORTED_LOCATION
+                 "${assimp_LOCATION_RELEASE}")
+  endif()
+endif()

--- a/src/legacy/icub-kdl/tests/CMakeLists.txt
+++ b/src/legacy/icub-kdl/tests/CMakeLists.txt
@@ -5,6 +5,13 @@ include_directories(${CMAKE_SOURCE_DIR}/include
                           ${YARP_INCLUDE_DIRS}
                           ${ICUB_INCLUDE_DIRS})
 
+
+if(IDYNTREE_USES_INTERNAL_URDFDOM)
+    set(urdfdom_LIBRARIES iDynTree_priv_urdfdom_model)
+else()
+    find_package(urdfdom REQUIRED)
+endif()
+
 macro(add_icub_test testName)
     set(testsrc ${testName}Test.cpp)
     set(testbinary ${testName}Test)

--- a/src/legacy/icub-kdl/tests/CMakeLists.txt
+++ b/src/legacy/icub-kdl/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(add_icub_test testName)
     set(testname   test_${testName})
     add_executable(${testbinary} ${testsrc})
     target_include_directories(${testbinary} PRIVATE ${EIGEN3_INCLUDE_DIR})
-    target_link_libraries(${testbinary} idyntree-core idyntree-high-level idyntree-yarp-kdl idyntree-icub-kdl idyntree-kdl idyntree-modelio-urdf-kdl idyntree-modelio-urdf YARP::YARP_os YARP::YARP_math ${orocos_kdl_LIBRARIES} idyntree-testmodels)
+    target_link_libraries(${testbinary} idyntree-core idyntree-high-level idyntree-yarp-kdl idyntree-icub-kdl idyntree-kdl idyntree-modelio-urdf-kdl idyntree-modelio-urdf YARP::YARP_os YARP::YARP_math ${orocos_kdl_LIBRARIES} ${urdfdom_LIBRARIES} ${console_bridge_LIBRARIES} idyntree-testmodels)
     add_test(NAME ${testname} COMMAND ${testbinary})
 
     if(IDYNTREE_RUN_VALGRIND_TESTS)

--- a/src/legacy/icub-kdl/tests/CMakeLists.txt
+++ b/src/legacy/icub-kdl/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(add_icub_test testName)
     set(testname   test_${testName})
     add_executable(${testbinary} ${testsrc})
     target_include_directories(${testbinary} PRIVATE ${EIGEN3_INCLUDE_DIR})
-    target_link_libraries(${testbinary} idyntree-core idyntree-high-level idyntree-yarp-kdl idyntree-icub-kdl  YARP::YARP_os YARP::YARP_math ${orocos_kdl_LIBRARIES} idyntree-testmodels)
+    target_link_libraries(${testbinary} idyntree-core idyntree-high-level idyntree-yarp-kdl idyntree-icub-kdl idyntree-kdl idyntree-modelio-urdf-kdl idyntree-modelio-urdf YARP::YARP_os YARP::YARP_math ${orocos_kdl_LIBRARIES} idyntree-testmodels)
     add_test(NAME ${testname} COMMAND ${testbinary})
 
     if(IDYNTREE_RUN_VALGRIND_TESTS)

--- a/src/model_io/urdf-kdl/CMakeLists.txt
+++ b/src/model_io/urdf-kdl/CMakeLists.txt
@@ -56,15 +56,15 @@ if((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR (${CMAKE_CXX_COMPILER_ID} MATCHES
     target_compile_options(${libraryname} PRIVATE "-Wno-deprecated")
 endif()
 
-target_link_libraries(${libraryname} idyntree-core
-                                     idyntree-model
-                                     idyntree-sensors
-                                     idyntree-kdl
-                                     idyntree-modelio-urdf
-                                     ${orocos_kdl_LIBRARIES}
-                                     ${urdfdom_LIBRARIES}
-                                     ${console_bridge_LIBRARIES}
-                                     ${TinyXML_LIBRARIES})
+target_link_libraries(${libraryname} PRIVATE idyntree-core
+                                             idyntree-model
+                                             idyntree-sensors
+                                             idyntree-kdl
+                                             idyntree-modelio-urdf
+                                             ${orocos_kdl_LIBRARIES}
+                                             ${urdfdom_LIBRARIES}
+                                             ${console_bridge_LIBRARIES}
+                                             ${TinyXML_LIBRARIES})
 
 if(NOT CMAKE_VERSION VERSION_LESS 2.8.12)
     target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS})

--- a/src/regressors/CMakeLists.txt
+++ b/src/regressors/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(${libraryname} PRIVATE SYSTEM ${orocos_kdl_INCLUDE_DI
 
 target_link_libraries(${libraryname} idyntree-core idyntree-sensors)
 if (IDYNTREE_USES_KDL)
-  target_link_libraries(${libraryname} idyntree-modelio-urdf-kdl ${orocos_kdl_LIBRARIES} ${TinyXML_LIBRARIES})
+  target_link_libraries(${libraryname} idyntree-kdl idyntree-modelio-urdf-kdl ${orocos_kdl_LIBRARIES} ${TinyXML_LIBRARIES})
 endif ()
 
 if((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))

--- a/src/tests/benchmark/CMakeLists.txt
+++ b/src/tests/benchmark/CMakeLists.txt
@@ -13,7 +13,7 @@ macro(add_benchmark benchmarkName)
     target_include_directories(${testbinary} PRIVATE ${EIGEN3_INCLUDE_DIR})
     FIND_PACKAGE(Boost)
     include_directories(${Boost_INCLUDE_DIR})
-    target_link_libraries(${testbinary} idyntree-modelio-urdf-kdl idyntree-core idyntree-kdl idyntree-model idyntree-testmodels)
+    target_link_libraries(${testbinary} idyntree-modelio-urdf idyntree-modelio-urdf-kdl idyntree-core idyntree-kdl idyntree-model idyntree-testmodels)
 endmacro()
 
 add_benchmark(Dynamics)

--- a/src/tests/kdl_consistency/CMakeLists.txt
+++ b/src/tests/kdl_consistency/CMakeLists.txt
@@ -15,7 +15,7 @@ macro(add_kdl_consistency_test testName)
     set(testname   ConsistencyTest${testName})
     add_executable(${testbinary} ${testsrc})
     target_include_directories(${testbinary} PRIVATE ${EIGEN3_INCLUDE_DIR})
-    target_link_libraries(${testbinary} idyntree-modelio-urdf-kdl idyntree-core idyntree-kdl idyntree-model idyntree-testmodels)
+    target_link_libraries(${testbinary} idyntree-modelio-urdf-kdl idyntree-core idyntree-kdl idyntree-model idyntree-modelio-urdf idyntree-testmodels)
     add_test(NAME ${testname} COMMAND ${testbinary})
 
     if(IDYNTREE_RUN_VALGRIND_TESTS)


### PR DESCRIPTION
This PR fixes some dependencies as installed in Ubuntu 20.04 : 
* Assimp, by adding a workaround for https://github.com/robotology/idyntree/issues/693
* Octave, backporting the fixes from https://github.com/robotology/idyntree/pull/677\

It also add support for Ubuntu 20.04 compilation in GitHub Actions, disabling for now the tests as some tests are failing on Ubuntu 20.04, see https://github.com/robotology/idyntree/issues/694 .
It also bumps the version to 1.0.7, as the idea  is  to do a  last release in the 1.0 series compatible with Ubuntu 20.04, and then do the 1.1 release by merging `devel` in `master`. 