### PR TITLE
Fix bug in init() of SimpleLeggedOdometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix bug in init() of SimpleLeggedOdometry that used an incorrect initial world frame location if used with an additional frame of a link (https://github.com/robotology/idyntree/pull/698)
+
 ## [1.1.0] - 2020-06-08
 
 ### Added

--- a/src/estimation/src/SimpleLeggedOdometry.cpp
+++ b/src/estimation/src/SimpleLeggedOdometry.cpp
@@ -68,7 +68,7 @@ bool SimpleLeggedOdometry::init(const FrameIndex initialFixedFrameIndex,
     m_fixedLinkIndex = m_model.getFrameLink(initialFixedFrameIndex);
 
     Transform world_H_initialFixedFrame = initialFixedFrame_H_world.inverse();
-    Transform initalFixedFrame_H_fixedLink =  m_model.getFrameTransform(m_fixedLinkIndex).inverse();
+    Transform initalFixedFrame_H_fixedLink =  m_model.getFrameTransform(initialFixedFrameIndex).inverse();
 
     m_world_H_fixedLink = world_H_initialFixedFrame*initalFixedFrame_H_fixedLink;
 


### PR DESCRIPTION
THis PR fixes the following,

- One of the overloaded instances init() methods in SimpleLeggedOdometry was using `link_H_frame` is computed by passing the link index instead of the frame index.
https://github.com/robotology/idyntree/blob/ba43b00fd84c0753c4fa03cfc4a04ec03c6bce0b/src/estimation/src/SimpleLeggedOdometry.cpp#L71
This was fixed to use the frame index.


## Experiment description for the Identification of the bug

A legged odometry experiment was done in Gazebo simulation using the `iCubGazeboV2_5` URDF model and the results were compared with ground truth measurements coming from Gazebo.
The following steps were followed to set up and run SimpleLeggedOdometry,
- `l_sole` was used as an initial reference frame with the following transformation with world
``` matlab
>> ref_H_w

ref_H_w =

    1.0000   -0.0050    0.0003   -0.0341
    0.0050    0.9999   -0.0118    0.0082
   -0.0002    0.0118    0.9999   -0.0108
         0         0         0    1.0000
```
- Right after the initialization and updating kinematics, calling the getWorldFrameTransform on the `l_sole` resulted in,
``` matlab
>> w_H_lsole

ans =

    1.0000    0.0050   -0.0002    0.0341
   -0.0050    0.9999    0.0118   -0.0090
    0.0003   -0.0118    0.9999   -0.0536
         0         0         0    1.0000
```
while the expected was

``` matlab
>> w_H_lsole

ans =

    1.0000    0.0050   -0.0002    0.0340
   -0.0050    0.9999    0.0118   -0.0082
    0.0003   -0.0118    0.9999    0.0108
         0         0         0    1.0000
```

With some investigation, it was identified that during initialization the `w_H_refframe` was wrongly calculated only up to the link associated with the `refframe` and not upto the `refframe` itself.

## Results
### Before the fix suggested in this PR,
**l_sole position z(m)**
![leftfootposnonflatfloor](https://user-images.githubusercontent.com/6506093/84645494-f4ca9780-af00-11ea-8945-6ca366c5b6ac.jpg)


### After the fix suggested in this PR,

**l_sole position z(m)**
![postfixleftfootposnonflat](https://user-images.githubusercontent.com/6506093/84645525-00b65980-af01-11ea-8276-e9c8ffa6c2ac.jpg)

It can be observed that the initial offset in the estimate has vanished.
**Note the drift in the estimate is not relevant to the issue in hand. So it can be ignored for the scope of this PR.**

