### PR TITLE
Set CMAKE_POSITION_INDEPENDENT_CODE to TRUE as a CMake option

### DIFF
--- a/cmake/iDynTreeOptions.cmake
+++ b/cmake/iDynTreeOptions.cmake
@@ -13,7 +13,7 @@ mark_as_advanced(IDYNTREE_ONLY_DOCS)
 
 #########################################################################
 # Use position indipendent code
-set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+option(CMAKE_POSITION_INDEPENDENT_CODE "When compiling static libraries generate position independent code" TRUE)
 
 #########################################################################
 # Turn on testing.


### PR DESCRIPTION
Setting CMAKE_POSITION_INDEPENDENT_CODE to true via an option  simplify changing the value CMAKE_POSITION_INDEPENDENT_CODE for an external user, for example if  it is cross-compiling iDynTree as static library for  a target that does not support position independent code.