### PR TITLE
Implement KinDynComputations::getCentroidalTotalMomentumJacobian() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a new CMake option `IDYNTREE_COMPILES_TOOLS` to disable compilation of iDynTree tools.
+- Added a `KinDynComputations::getCentroidalTotalMomentumJacobian()` method (https://github.com/robotology/idyntree/pull/706)
 
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -623,6 +623,19 @@ public:
      */
     iDynTree::SpatialMomentum getCentroidalTotalMomentum();
 
+    /**
+     * @brief Get the total centroidal momentum jacobian of the robot.
+     * If G is the center of mass, this quantity is expressed in (G[A]), (G[A]) or (G[B]) depending
+     * on the FrameVelocityConvention used.
+     * @param[out] centroidalTotalMomentumJacobian the (6) times (6+getNrOfDOFs()) output centroidal
+     * total momentum jacobian.
+     * @return true if all went well, false otherwise.
+     * @note If the chosen FrameVelocityRepresentation is MIXED_REPRESENTATION or
+     * INERTIAL_FIXED_REPRESENTATION, the function computes the Centroidal Momentum Matrix (CMM)
+     * introduced in https://doi.org/10.1109/IROS.2008.4650772 .
+     */
+    bool getCentroidalTotalMomentumJacobian(MatrixDynSize& centroidalTotalMomentumJacobian);
+
     //@}
 
 

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1817,10 +1817,10 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
         // J_G[B] = G[B]_X_B * J_B
         // where is G[B]_X_B is the adjoint wrench transformation
 
-
         Transform com_T_base_in_base(Rotation::Identity(), A_R_B.inverse() * (basePosition - com));
 
-        toEigen(centroidalMomentumJacobian) = toEigen(com_T_base_in_base.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian);
+        // The eval() solves the Eigen aliasing problem
+        toEigen(centroidalMomentumJacobian) = (toEigen(com_T_base_in_base.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian)).eval();
 
         return true;
     }
@@ -1833,7 +1833,8 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
 
         Transform com_T_base_in_inertial(Rotation::Identity(), basePosition - com);
 
-        toEigen(centroidalMomentumJacobian) = toEigen(com_T_base_in_inertial.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian);
+        // The eval() solves the Eigen aliasing problem
+        toEigen(centroidalMomentumJacobian) = (toEigen(com_T_base_in_inertial.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian)).eval();
 
         return true;
     }
@@ -1847,7 +1848,8 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
 
         iDynTree::Transform com_T_inertial(Rotation::Identity(),  -com);
 
-        toEigen(centroidalMomentumJacobian) = toEigen(com_T_inertial.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian);
+        // The eval() solves the Eigen aliasing problem
+        toEigen(centroidalMomentumJacobian) = (toEigen(com_T_inertial.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian)).eval();
 
         return true;
     }

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1810,7 +1810,9 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
     const Position& basePosition = pimpl->m_pos.worldBasePos().getPosition();
     const Rotation& A_R_B = pimpl->m_pos.worldBasePos().getRotation();
 
-    if (pimpl->m_frameVelRepr == BODY_FIXED_REPRESENTATION)
+    switch (pimpl->m_frameVelRepr)
+    {
+    case BODY_FIXED_REPRESENTATION:
     {
         // The getLinearAngularMomentumJacobian returns a quantity expressed in (B). Here we want to
         // express the quantity in (G[B]).
@@ -1822,9 +1824,10 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
         // The eval() solves the Eigen aliasing problem
         toEigen(centroidalMomentumJacobian) = (toEigen(com_T_base_in_base.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian)).eval();
 
-        return true;
+        break;
     }
-    else if(pimpl->m_frameVelRepr == MIXED_REPRESENTATION)
+
+    case MIXED_REPRESENTATION:
     {
         // The getLinearAngularMomentumJacobian returns a quantity expressed in (B[A]). Here we want
         // to express the quantity in (G[A]).
@@ -1836,9 +1839,10 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
         // The eval() solves the Eigen aliasing problem
         toEigen(centroidalMomentumJacobian) = (toEigen(com_T_base_in_inertial.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian)).eval();
 
-        return true;
+        break;
     }
-    else
+
+    case INERTIAL_FIXED_REPRESENTATION:
     {
         // The getLinearAngularMomentumJacobian returns a quantity expressed in (A). Here we want
         // to express the quantity in (G[A]).
@@ -1851,12 +1855,15 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
         // The eval() solves the Eigen aliasing problem
         toEigen(centroidalMomentumJacobian) = (toEigen(com_T_inertial.asAdjointTransformWrench()) * toEigen(centroidalMomentumJacobian)).eval();
 
-        return true;
+        break;
     }
 
-    assert(false);
+    default:
+        assert(false);
+        return false;
+    }
 
-    return false;
+    return true;
 }
 
 bool KinDynComputations::getFreeFloatingMassMatrix(MatrixDynSize& freeFloatingMassMatrix)

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1801,7 +1801,9 @@ SpatialMomentum KinDynComputations::getCentroidalTotalMomentum()
 bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centroidalMomentumJacobian)
 {
     if (!getLinearAngularMomentumJacobian(centroidalMomentumJacobian))
+    {
         return false;
+    }
 
     // get CoM and base pose
     Position com = getCenterOfMassPosition();

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1803,12 +1803,10 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
     if (!getLinearAngularMomentumJacobian(centroidalMomentumJacobian))
         return false;
 
-    // Get the base link index
-    LinkIndex baseLink = this->pimpl->m_traversal.getBaseLink()->getIndex();
-
+    // get CoM and base pose
     Position com = getCenterOfMassPosition();
-    const Position& basePosition = getWorldTransform(baseLink).getPosition();
-    const Rotation& A_R_B = getWorldTransform(baseLink).getRotation();
+    const Position& basePosition = pimpl->m_pos.worldBasePos().getPosition();
+    const Rotation& A_R_B = pimpl->m_pos.worldBasePos().getRotation();
 
     if (pimpl->m_frameVelRepr == BODY_FIXED_REPRESENTATION)
     {

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -118,12 +118,13 @@ void testRelativeTransform(iDynTree::KinDynComputations & dynComp)
 void testAverageVelocityAndTotalMomentumJacobian(iDynTree::KinDynComputations & dynComp)
 {
     iDynTree::Twist avgVel;
-    iDynTree::SpatialMomentum mom;
-    iDynTree::Vector6 avgVelCheck, momCheck;
+    iDynTree::SpatialMomentum mom, centroidalMom;
+    iDynTree::Vector6 avgVelCheck, momCheck, centroidalMomCheck;
     iDynTree::VectorDynSize nu(dynComp.getNrOfDegreesOfFreedom()+6);
     dynComp.getModelVel(nu);
 
     MomentumFreeFloatingJacobian momJac(dynComp.getRobotModel());
+    MomentumFreeFloatingJacobian centroidalMomJac(dynComp.getRobotModel());
     FrameFreeFloatingJacobian    avgVelJac(dynComp.getRobotModel());
 
     avgVel = dynComp.getAverageVelocity();
@@ -136,10 +137,16 @@ void testAverageVelocityAndTotalMomentumJacobian(iDynTree::KinDynComputations & 
 
     ASSERT_IS_TRUE(ok);
 
+    centroidalMom = dynComp.getCentroidalTotalMomentum();
+    ok = dynComp.getCentroidalTotalMomentumJacobian(centroidalMomJac);
+    ASSERT_IS_TRUE(ok);
+
     toEigen(momCheck) = toEigen(momJac)*toEigen(nu);
+    toEigen(centroidalMomCheck) = toEigen(centroidalMomJac)*toEigen(nu);
     toEigen(avgVelCheck) = toEigen(avgVelJac)*toEigen(nu);
 
     ASSERT_EQUAL_VECTOR(momCheck,mom.asVector());
+    ASSERT_EQUAL_VECTOR(centroidalMomCheck,centroidalMom.asVector());
     ASSERT_EQUAL_VECTOR(avgVelCheck,avgVel.asVector());
 }
 


### PR DESCRIPTION
This PR introduces the `getCentroidalTotalMomentumJacobian()` function in `KinDynComputations` class. 
I also wrote a simple test to spot some bugs in the method

Associated issue https://github.com/robotology/wb-toolbox/issues/20

cc @traversaro @robotology/iit-dynamic-interaction-control 