### PR TITLE
Add again deprecated headers

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
 #
 # Licensed under either the GNU Lesser General Public License v3.0 :
 # https://www.gnu.org/licenses/lgpl-3.0.html
@@ -43,7 +43,14 @@ set(IDYNTREE_CORE_EXP_HEADERS include/iDynTree/Core/Axis.h
                               include/iDynTree/Core/Triplets.h
                               include/iDynTree/Core/CubicSpline.h
                               include/iDynTree/Core/Span.h
-                              include/iDynTree/Core/SO3Utils.h)
+                              include/iDynTree/Core/SO3Utils.h
+                              # Deprecated headers
+                              include/iDynTree/Core/AngularForceVector3.h
+                              include/iDynTree/Core/AngularMotionVector3.h
+                              include/iDynTree/Core/ForceVector3.h
+                              include/iDynTree/Core/LinearForceVector3.h
+                              include/iDynTree/Core/LinearMotionVector3.h
+                              include/iDynTree/Core/MotionVector3.h)
 
 
 set(IDYNTREE_CORE_EXP_SOURCES src/Axis.cpp

--- a/src/core/include/iDynTree/Core/AngularForceVector3.h
+++ b/src/core/include/iDynTree/Core/AngularForceVector3.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_ANGULAR_FORCE_VECTOR_3_H
+#define IDYNTREE_ANGULAR_FORCE_VECTOR_3_H
+
+#warning <iDynTree/Core/AngularForceVector3.h> is deprecated. Please use GeomVector3 and <iDynTree/Model/GeomVector3.h>.
+
+#include <iDynTree/Core/GeomVector3.h>
+
+#endif /* IDYNTREE_ANGULAR_FORCE_VECTOR_3_H */

--- a/src/core/include/iDynTree/Core/AngularMotionVector3.h
+++ b/src/core/include/iDynTree/Core/AngularMotionVector3.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_ANGULAR_MOTION_VECTOR_3_H
+#define IDYNTREE_ANGULAR_MOTION_VECTOR_3_H
+
+#warning <iDynTree/Core/AngularMotionVector3.h> is deprecated. Please use GeomVector3 and <iDynTree/Model/GeomVector3.h>.
+
+#include <iDynTree/Core/GeomVector3.h>
+
+#endif /* IDYNTREE_ANGULAR_MOTION_VECTOR_3_H */

--- a/src/core/include/iDynTree/Core/ForceVector3.h
+++ b/src/core/include/iDynTree/Core/ForceVector3.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_FORCE_VECTOR_3_H
+#define IDYNTREE_FORCE_VECTOR_3_H
+
+#warning <iDynTree/Core/ForceVector3.h> is deprecated. Please use GeomVector3 and <iDynTree/Model/GeomVector3.h>.
+
+#include <iDynTree/Core/GeomVector3.h>
+
+#endif /* IDYNTREE_FORCE_VECTOR_3_H */

--- a/src/core/include/iDynTree/Core/LinearForceVector3.h
+++ b/src/core/include/iDynTree/Core/LinearForceVector3.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_LINEAR_FORCE_VECTOR_3_H
+#define IDYNTREE_LINEAR_FORCE_VECTOR_3_H
+
+#warning <iDynTree/Core/LinearForceVector3.h> is deprecated. Please use GeomVector3 and <iDynTree/Model/GeomVector3.h>.
+
+#include <iDynTree/Core/GeomVector3.h>
+
+#endif /* IDYNTREE_LINEAR_FORCE_VECTOR_3_H */

--- a/src/core/include/iDynTree/Core/LinearMotionVector3.h
+++ b/src/core/include/iDynTree/Core/LinearMotionVector3.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_LINEAR_MOTION_VECTOR_3_H
+#define IDYNTREE_LINEAR_MOTION_VECTOR_3_H
+
+#warning <iDynTree/Core/LinearMotionVector3.h> is deprecated. Please use GeomVector3 and <iDynTree/Model/GeomVector3.h>.
+
+#include <iDynTree/Core/GeomVector3.h>
+
+#endif /* IDYNTREE_LINEAR_MOTION_VECTOR_3_H */

--- a/src/core/include/iDynTree/Core/MotionVector3.h
+++ b/src/core/include/iDynTree/Core/MotionVector3.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_MOTION_VECTOR_3_H
+#define IDYNTREE_MOTION_VECTOR_3_H
+
+#warning <iDynTree/Core/MotionVector3.h> is deprecated. Please use GeomVector3 and <iDynTree/Model/GeomVector3.h>.
+
+#include <iDynTree/Core/GeomVector3.h>
+
+#endif /* IDYNTREE_MOTION_VECTOR_3_H */


### PR DESCRIPTION
This headers were removed, but they are still used in some downstream projects and were not clearly deprecated in iDynTree 1 . For this reason we add them back, with clear deprecation notices.

Fix https://github.com/robotology/robotology-superbuild/issues/422 .