### PR TITLE
Introduce Eigen::Vector to describe the iDynTree::VectorFixSize

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -102,7 +102,7 @@ if(MSVC)
    add_definitions(-D_USE_MATH_DEFINES)
 endif()
 
-target_compile_features(${libraryname} PUBLIC cxx_attribute_deprecated)
+target_compile_features(${libraryname} PUBLIC cxx_attribute_deprecated cxx_std_17)
 
 install(TARGETS ${libraryname}
         EXPORT iDynTree

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -92,13 +92,13 @@ add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 if (DEFINED CMAKE_COMPILER_IS_GNUCXX)
   if(${CMAKE_COMPILER_IS_GNUCXX} AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5)
-    target_compile_options(idyntree-core INTERFACE ${CXX11_FLAGS})
+    target_compile_options(idyntree-core INTERFACE ${CXX17_FLAGS})
   endif()
 endif()
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(${libraryname} PRIVATE Eigen3::Eigen)
+target_link_libraries(${libraryname} PUBLIC Eigen3::Eigen)
 
 set_property(TARGET ${libraryname} PROPERTY PUBLIC_HEADER ${IDYNTREE_CORE_EXP_HEADERS})
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -90,12 +90,6 @@ set(libraryname idyntree-core)
 add_library(${libraryname} ${IDYNTREE_CORE_EXP_SOURCES} ${IDYNTREE_CORE_EXP_HEADERS})
 add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
-if (DEFINED CMAKE_COMPILER_IS_GNUCXX)
-  if(${CMAKE_COMPILER_IS_GNUCXX} AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5)
-    target_compile_options(idyntree-core INTERFACE ${CXX17_FLAGS})
-  endif()
-endif()
-
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(${libraryname} PUBLIC Eigen3::Eigen)

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -201,7 +201,7 @@ namespace iDynTree
         else
         {
             Eigen::Map<const Eigen::Matrix<double, VecSize, 1>> map(in_data, in_size);
-            this->operator=(map);
+            *this = map;
         }
     }
 

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -49,6 +49,13 @@ namespace iDynTree
         VectorFixSize(const double * in_data, const unsigned int in_size);
 
         /**
+         * Constructor from an Eigen::MatrixBase
+         *
+         */
+        template<class Derived>
+        VectorFixSize(const Eigen::MatrixBase<Derived>& vector);
+
+        /**
          * @name Vector interface methods.
          * Methods exposing a vector-like interface to VectorFixSize.
          */
@@ -114,6 +121,13 @@ namespace iDynTree
 #endif
 
         /**
+         * Copy assignment operator for Eigen::MatrixBase.
+         *
+         */
+        template <class Derived>
+        VectorFixSize & operator=(const Eigen::MatrixBase<Derived>& vector);
+
+        /**
          * Assign all element of the vector to 0.
          */
         void zero();
@@ -166,6 +180,13 @@ namespace iDynTree
 
     }
 
+    template<unsigned int VecSize>
+    template<class Derived>
+    VectorFixSize<VecSize>::VectorFixSize(const Eigen::MatrixBase<Derived>& vector)
+        : Eigen::Matrix<double, VecSize, 1>(vector)
+    {
+
+    }
 
     template<unsigned int VecSize>
     VectorFixSize<VecSize>::VectorFixSize(const double* in_data,
@@ -243,6 +264,13 @@ namespace iDynTree
     }
 #endif
 
+    template<unsigned int VecSize>
+    template<class Derived>
+    VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const Eigen::MatrixBase<Derived>& vector)
+    {
+        Eigen::Matrix<double, VecSize, 1>::operator=(vector);
+        return *this;
+    }
 
     template<unsigned int VecSize>
     double VectorFixSize<VecSize>::getVal(const unsigned int index) const

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -20,6 +20,8 @@
 #include <cassert>
 #include <cstring>
 
+#include <Eigen/Dense>
+
 namespace iDynTree
 {
     /**
@@ -29,16 +31,8 @@ namespace iDynTree
      *
      * \ingroup iDynTreeCore
      */
-    template<unsigned int VecSize> class VectorFixSize
+    template<unsigned int VecSize> class VectorFixSize : public Eigen::Matrix<double, VecSize, 1>
     {
-    protected:
-        /**
-         * Storage for the VectorDynSize
-         *
-         * Array of VecSize doubles.
-         */
-        double m_data[VecSize];
-
     public:
         /**
          * Default constructor.
@@ -59,14 +53,6 @@ namespace iDynTree
          * Methods exposing a vector-like interface to VectorFixSize.
          */
         ///@{
-        double operator()(const unsigned int index) const;
-
-        double& operator()(const unsigned int index);
-
-        double operator[](const unsigned int index) const;
-
-        double& operator[](const unsigned int index);
-
         double getVal(const unsigned int index) const;
 
         bool setVal(const unsigned int index, const double new_el);
@@ -128,20 +114,6 @@ namespace iDynTree
 #endif
 
         /**
-         * Raw data accessor
-         *
-         * @return a const pointer to a vector of size() doubles
-         */
-        const double * data() const;
-
-        /**
-         * Raw data accessor
-         *
-         * @return a pointer to a vector of size() doubles
-         */
-        double * data();
-
-        /**
          * Assign all element of the vector to 0.
          */
         void zero();
@@ -189,6 +161,7 @@ namespace iDynTree
     //Implementation
     template<unsigned int VecSize>
     VectorFixSize<VecSize>::VectorFixSize()
+        : Eigen::Matrix<double, VecSize, 1>()
     {
 
     }
@@ -197,6 +170,7 @@ namespace iDynTree
     template<unsigned int VecSize>
     VectorFixSize<VecSize>::VectorFixSize(const double* in_data,
                                  const unsigned int in_size)
+        : Eigen::Matrix<double, VecSize, 1>()
     {
         if( in_size != VecSize )
         {
@@ -205,7 +179,7 @@ namespace iDynTree
         }
         else
         {
-            memcpy(this->m_data,in_data,sizeof(double)*VecSize);
+            std::memcpy(this->data(), in_data, sizeof(double) * VecSize);
         }
     }
 
@@ -214,57 +188,44 @@ namespace iDynTree
     {
         for(unsigned int i=0; i < VecSize; i++ )
         {
-            this->m_data[i] = 0.0;
+            this->operator[](i) = 0.0;
         }
-    }
-
-
-    template<unsigned int VecSize>
-    double* VectorFixSize<VecSize>::data()
-    {
-        return this->m_data;
-    }
-
-    template<unsigned int VecSize>
-    const double* VectorFixSize<VecSize>::data() const
-    {
-        return this->m_data;
     }
 
     template<unsigned int VecSize>
     const double* VectorFixSize<VecSize>::begin() const noexcept
     {
-        return this->m_data;
+        return this->data();
     }
 
     template<unsigned int VecSize>
     const double* VectorFixSize<VecSize>::end() const noexcept
     {
-        return this->m_data + VecSize;
+        return this->data() + VecSize;
     }
 
     template<unsigned int VecSize>
     const double* VectorFixSize<VecSize>::cbegin() const noexcept
     {
-        return this->m_data;
+        return this->data();
     }
 
     template<unsigned int VecSize>
     const double* VectorFixSize<VecSize>::cend() const noexcept
     {
-        return this->m_data + VecSize;
+        return this->data() + VecSize;
     }
 
     template <unsigned int VecSize>
     double *VectorFixSize<VecSize>::begin() noexcept
     {
-        return this->m_data;
+        return this->data();
     }
 
     template<unsigned int VecSize>
     double* VectorFixSize<VecSize>::end() noexcept
     {
-        return this->m_data + VecSize;
+        return this->data() + VecSize;
     }
 
     template<unsigned int VecSize>
@@ -277,38 +238,11 @@ namespace iDynTree
     template<unsigned int VecSize>
     VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const Span<const double>& vec) {
         assert(VecSize == vec.size());
-        std::memcpy(this->m_data, vec.data(), VecSize*sizeof(double));
+        std::memcpy(this->data(), vec.data(), VecSize * sizeof(double));
         return *this;
     }
 #endif
 
-    template<unsigned int VecSize>
-    double VectorFixSize<VecSize>::operator()(const unsigned int index) const
-    {
-        assert(index < VecSize);
-        return this->m_data[index];
-    }
-
-    template<unsigned int VecSize>
-    double & VectorFixSize<VecSize>::operator()(const unsigned int index)
-    {
-        assert(index < VecSize);
-        return this->m_data[index];
-    }
-
-    template<unsigned int VecSize>
-    double VectorFixSize<VecSize>::operator[](const unsigned int index) const
-    {
-        assert(index < VecSize);
-        return this->m_data[index];
-    }
-
-    template<unsigned int VecSize>
-    double & VectorFixSize<VecSize>::operator[](const unsigned int index)
-    {
-        assert(index < VecSize);
-        return this->m_data[index];
-    }
 
     template<unsigned int VecSize>
     double VectorFixSize<VecSize>::getVal(const unsigned int index) const
@@ -319,7 +253,7 @@ namespace iDynTree
             return 0.0;
         }
 
-        return this->m_data[index];
+        return this->operator[](index);
     }
 
     template<unsigned int VecSize>
@@ -331,7 +265,7 @@ namespace iDynTree
             return false;
         }
 
-        this->m_data[index] = new_el;
+        this->operator[](index) = new_el;
 
         return true;
     }
@@ -341,7 +275,7 @@ namespace iDynTree
     {
         for(unsigned int i=0; i < this->size(); i++ )
         {
-            buf[i] = this->m_data[i];
+            buf[i] = this->operator[](i);
         }
     }
 
@@ -352,7 +286,7 @@ namespace iDynTree
 
         for(unsigned int i=0; i < this->size(); i++ )
         {
-            ss << this->m_data[i] << " ";
+            ss << this->operator[](i) << " ";
         }
 
         return ss.str();
@@ -365,7 +299,7 @@ namespace iDynTree
 
         for(unsigned int i=0; i < this->size(); i++ )
         {
-            ss << this->m_data[i] << " ";
+            ss << this->operator[](i) << " ";
         }
 
         return ss.str();

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -200,17 +200,15 @@ namespace iDynTree
         }
         else
         {
-            std::memcpy(this->data(), in_data, sizeof(double) * VecSize);
+            Eigen::Map<const Eigen::Matrix<double, VecSize, 1>> map(in_data, in_size);
+            this->operator=(map);
         }
     }
 
     template<unsigned int VecSize>
     void VectorFixSize<VecSize>::zero()
     {
-        for(unsigned int i=0; i < VecSize; i++ )
-        {
-            this->operator[](i) = 0.0;
-        }
+        this->setZero();
     }
 
     template<unsigned int VecSize>
@@ -259,7 +257,9 @@ namespace iDynTree
     template<unsigned int VecSize>
     VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const Span<const double>& vec) {
         assert(VecSize == vec.size());
-        std::memcpy(this->data(), vec.data(), VecSize * sizeof(double));
+
+        Eigen::Map<const Eigen::Matrix<double, VecSize, 1>> map(vec.data(), vec.size());
+        this->operator=(map);
         return *this;
     }
 #endif

--- a/src/core/src/Direction.cpp
+++ b/src/core/src/Direction.cpp
@@ -21,9 +21,9 @@ namespace iDynTree
 {
     Direction::Direction(double x, double y, double z)
     {
-        this->m_data[0] = x;
-        this->m_data[1] = y;
-        this->m_data[2] = z;
+        this->data()[0] = x;
+        this->data()[1] = y;
+        this->data()[2] = z;
 
         this->Normalize();
     }
@@ -36,22 +36,22 @@ namespace iDynTree
 
     Direction::Direction(const Direction& other):VectorFixSize< int(3) >(other)
     {
-        this->m_data[0] = other.m_data[0];
-        this->m_data[1] = other.m_data[1];
-        this->m_data[2] = other.m_data[2];
+        this->data()[0] = other.data()[0];
+        this->data()[1] = other.data()[1];
+        this->data()[2] = other.data()[2];
     }
 
 
     void Direction::setToDefault()
     {
-        this->m_data[0] = 1.0;
-        this->m_data[1] = 0.0;
-        this->m_data[2] = 0.0;
+        this->data()[0] = 1.0;
+        this->data()[1] = 0.0;
+        this->data()[2] = 0.0;
     }
 
     void Direction::Normalize(double tol)
     {
-        Eigen::Map<Eigen::Vector3d> vec(this->m_data);
+        Eigen::Map<Eigen::Vector3d> vec(this->data());
         double nrm = vec.norm();
         if( nrm < tol )
         {
@@ -105,18 +105,18 @@ namespace iDynTree
 
     Direction Direction::reverse() const
     {
-        return Direction(-this->m_data[0],
-                         -this->m_data[1],
-                         -this->m_data[2]);
+        return Direction(-this->data()[0],
+                         -this->data()[1],
+                         -this->data()[2]);
     }
 
     std::string Direction::toString() const
     {
         std::stringstream ss;
 
-        ss << " x " << this->m_data[0]
-        << " y " << this->m_data[1]
-        << " z " << this->m_data[2];
+        ss << " x " << this->data()[0]
+        << " y " << this->data()[1]
+        << " z " << this->data()[2];
 
         return ss.str();
     }

--- a/src/core/src/GeomVector3.cpp
+++ b/src/core/src/GeomVector3.cpp
@@ -31,16 +31,16 @@ namespace iDynTree
 
     GeomVector3::GeomVector3(const double x, const double y, const double z)
     {
-        this->m_data[0] = x;
-        this->m_data[1] = y;
-        this->m_data[2] = z;
+        this->data()[0] = x;
+        this->data()[1] = y;
+        this->data()[2] = z;
     }
 
     GeomVector3::GeomVector3(const Vector3 other)
     {
-        this->m_data[0] = other(0);
-        this->m_data[1] = other(1);
-        this->m_data[2] = other(2);
+        this->data()[0] = other(0);
+        this->data()[1] = other(1);
+        this->data()[2] = other(2);
     }
 
     // Geometric operations

--- a/src/core/src/PositionRaw.cpp
+++ b/src/core/src/PositionRaw.cpp
@@ -33,9 +33,9 @@ namespace iDynTree
 
     PositionRaw::PositionRaw(double x, double y, double z)
     {
-        this->m_data[0] = x;
-        this->m_data[1] = y;
-        this->m_data[2] = z;
+        this->data()[0] = x;
+        this->data()[1] = y;
+        this->data()[2] = z;
     }
 
     PositionRaw::PositionRaw(const double* in_data, const unsigned int in_size):
@@ -46,26 +46,26 @@ namespace iDynTree
 
     PositionRaw::PositionRaw(const PositionRaw& other):VectorFixSize< int(3) >(other)
     {
-        this->m_data[0] = other.m_data[0];
-        this->m_data[1] = other.m_data[1];
-        this->m_data[2] = other.m_data[2];
+        this->data()[0] = other.data()[0];
+        this->data()[1] = other.data()[1];
+        this->data()[2] = other.data()[2];
 
     }
 
     const PositionRaw& PositionRaw::changePoint(const PositionRaw& newPoint)
     {
-        this->m_data[0] += newPoint(0);
-        this->m_data[1] += newPoint(1);
-        this->m_data[2] += newPoint(2);
+        this->data()[0] += newPoint(0);
+        this->data()[1] += newPoint(1);
+        this->data()[2] += newPoint(2);
 
         return *this;
     }
 
     const PositionRaw& PositionRaw::changeRefPoint(const PositionRaw& newRefPoint)
     {
-        this->m_data[0] += newRefPoint(0);
-        this->m_data[1] += newRefPoint(1);
-        this->m_data[2] += newRefPoint(2);
+        this->data()[0] += newRefPoint(0);
+        this->data()[1] += newRefPoint(1);
+        this->data()[2] += newRefPoint(2);
 
         return *this;
     }
@@ -82,9 +82,9 @@ namespace iDynTree
     PositionRaw PositionRaw::inverse(const PositionRaw& op)
     {
         PositionRaw result;
-        result(0) = -op.m_data[0];
-        result(1) = -op.m_data[1];
-        result(2) = -op.m_data[2];
+        result(0) = -op.data()[0];
+        result(1) = -op.data()[1];
+        result(2) = -op.data()[2];
         return result;
     }
 
@@ -123,7 +123,7 @@ namespace iDynTree
     std::string PositionRaw::toString() const
     {
         std::stringstream ss;
-        ss << this->m_data[0] << " " << this->m_data[1] << " " << this->m_data[2];
+        ss << this->data()[0] << " " << this->data()[1] << " " << this->data()[2];
         return ss.str();
     }
 

--- a/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
+++ b/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <algorithm>
+#include <random>
 
 using namespace iDynTree;
 
@@ -205,7 +206,8 @@ void checkLoadReducedModelOrderIsKept(std::string urdfFileName)
         }
     }
 
-    std::random_shuffle(dofsName.begin(), dofsName.end());
+    std::mt19937 g{42};
+    std::shuffle(dofsName.begin(), dofsName.end(), g);
 
     //now load the new model and check they are the same
     ASSERT_IS_TRUE(loader.loadReducedModelFromFullModel(loadedModel, dofsName) && loader.isValid());


### PR DESCRIPTION
This PR is in view of #707.

In details the with this PR `DynTree::VectorFixSize` will inherit from  `Eigen::Matrix<double, VecSize, 1>`, consequentially, the methods already implemented in `Eigen` (e.g. `data()`) have been removed. 