### PR TITLE
Add support to compile iDynTree as a shared library on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a new CMake option `IDYNTREE_COMPILES_TOOLS` to disable compilation of iDynTree tools.
 - Added a `KinDynComputations::getCentroidalTotalMomentumJacobian()` method (https://github.com/robotology/idyntree/pull/706)
+- iDynTree now supports build compiled as a shared library also on Windows. 
+
+### Changed
+- By default  iDynTree is compiled as a shared library also on Windows. The `BUILD_SHARED_LIBS` CMake variable can be used to
+  control if iDynTree is built as a shared or a static library.
 
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/cmake/iDynTreeOptions.cmake
+++ b/cmake/iDynTreeOptions.cmake
@@ -1,11 +1,8 @@
 #########################################################################
 # Control whether libraries are shared or static.
-if( MSVC )
-option(IDYNTREE_SHARED_LIBRARY "Compile iDynTree as a shared library" FALSE)
-else()
-option(IDYNTREE_SHARED_LIBRARY "Compile iDynTree as a shared library" TRUE)
-endif()
-option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ${IDYNTREE_SHARED_LIBRARY})
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 #########################################################################
 option(IDYNTREE_ONLY_DOCS "Only produce iDynTree documentation, without compiling" FALSE)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -107,6 +107,12 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(${libraryname} PRIVATE Eigen3::Eigen)
 
+# On Windows correctly export global constants that are not inlined
+include(GenerateExportHeader)
+generate_export_header(${libraryname} EXPORT_FILE_NAME CoreExport.h)
+list(APPEND IDYNTREE_CORE_EXP_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/CoreExport.h)
+target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
+
 set_property(TARGET ${libraryname} PROPERTY PUBLIC_HEADER ${IDYNTREE_CORE_EXP_HEADERS})
 
 target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS})

--- a/src/core/include/iDynTree/Core/Utils.h
+++ b/src/core/include/iDynTree/Core/Utils.h
@@ -32,17 +32,21 @@
 #if defined(SWIG)
 #define IDYNTREE_DEPRECATED
 #define IDYNTREE_DEPRECATED_WITH_MSG(msg)
+// Workaround for SWIG problems with GenerateExportHeader-generated code
+#define IDYNTREE_CORE_EXPORT
 #else
 #define IDYNTREE_DEPRECATED [[deprecated]]
 #define IDYNTREE_DEPRECATED_WITH_MSG(msg) [[deprecated(msg)]]
+#include "CoreExport.h"
 #endif
+
 
 namespace iDynTree
 {
-    extern int UNKNOWN;
+    IDYNTREE_CORE_EXPORT extern int UNKNOWN;
 
     /// Default tolerance for methods with a tolerance, setted to 1e-10
-    extern double DEFAULT_TOL;
+    IDYNTREE_CORE_EXPORT extern double DEFAULT_TOL;
 
     /**
      * Function embedding the semantic checks

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -70,6 +70,13 @@ target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURR
 target_link_libraries(${libraryname} PUBLIC idyntree-core
                                      PRIVATE Eigen3::Eigen)
 
+# On Windows correctly export global constants that are not inlined
+include(GenerateExportHeader)
+generate_export_header(${libraryname} EXPORT_FILE_NAME ModelExport.h)
+list(APPEND IDYNTREE_MODEL_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/ModelExport.h)
+
+target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
+
 set_property(TARGET ${libraryname} PROPERTY PUBLIC_HEADER ${IDYNTREE_MODEL_HEADERS})
 
 install(TARGETS ${libraryname}

--- a/src/model/include/iDynTree/Model/Indices.h
+++ b/src/model/include/iDynTree/Model/Indices.h
@@ -13,27 +13,34 @@
 
 #include <string>
 
+// Workaround for SWIG problems with GenerateExportHeader-generated code
+#if defined(SWIG)
+#define IDYNTREE_MODEL_EXPORT
+#else
+#include "ModelExport.h"
+#endif
+
 namespace iDynTree
 {
     typedef int LinkIndex;
-    extern LinkIndex LINK_INVALID_INDEX;
-    extern std::string LINK_INVALID_NAME;
+    IDYNTREE_MODEL_EXPORT extern LinkIndex LINK_INVALID_INDEX;
+    IDYNTREE_MODEL_EXPORT extern std::string LINK_INVALID_NAME;
 
     typedef int JointIndex;
-    extern int JOINT_INVALID_INDEX;
-    extern std::string JOINT_INVALID_NAME;
+    IDYNTREE_MODEL_EXPORT extern int JOINT_INVALID_INDEX;
+    IDYNTREE_MODEL_EXPORT extern std::string JOINT_INVALID_NAME;
 
     typedef int DOFIndex;
-    extern int DOF_INVALID_INDEX;
-    extern std::string DOF_INVALID_NAME;
+    IDYNTREE_MODEL_EXPORT extern int DOF_INVALID_INDEX;
+    IDYNTREE_MODEL_EXPORT extern std::string DOF_INVALID_NAME;
 
 
     typedef int FrameIndex;
-    extern int FRAME_INVALID_INDEX;
-    extern std::string FRAME_INVALID_NAME;
+    IDYNTREE_MODEL_EXPORT extern int FRAME_INVALID_INDEX;
+    IDYNTREE_MODEL_EXPORT extern std::string FRAME_INVALID_NAME;
 
     typedef int TraversalIndex;
-    extern TraversalIndex TRAVERSAL_INVALID_INDEX;
+    IDYNTREE_MODEL_EXPORT extern TraversalIndex TRAVERSAL_INVALID_INDEX;
 
 }
 


### PR DESCRIPTION
Furthermore:
* Cleanup IDYNTREE_COMPILE_SHARED legacy variable and just use the idiomatic BUILD_SHARED_LIBS CMake variable.
* Build as shared by default on Windows

We use CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to export the majority of symbols on Windows, and GenerateExportHeader for the global variables. Apparently SWIG has some problems with GenerateExportHeader-generated code (see https://github.com/swig/swig/issues/1325), so that has been handled with appropriate preprocessor logic. 
For more info check https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/ .

Fix https://github.com/robotology/idyntree/issues/710 .