### PR TITLE
Fix the clearing of figure axes when using `gcf` or `name` options in prepareVisualization.m

### DIFF
--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -77,12 +77,12 @@ linkNames=cell(numberOfLinks,1);
 switch options.reuseFigure
     case 'gcf'
         mainHandler=gcf;
-        cla(mainHandler);
+        cla(mainHandler.Children);
     case 'name'
         figHandles = findobj('Type', 'figure', 'Name', options.name);
         if isNameSet && ~isempty(figHandles)
             mainHandler=figHandles(1,1);
-            cla(mainHandler);
+            cla(mainHandler.Children);
         else
             mainHandler=figure;
         end


### PR DESCRIPTION
This fixes https://github.com/robotology/idyntree/issues/712.