### PR TITLE
Bump minimum required CMake version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(iDynTree VERSION 1.99.0
                  LANGUAGES C CXX)


### PR DESCRIPTION
This is necessary because we now use the `LibXml2::LibXml2` imported target that is available only for CMake >= 3.12  https://cmake.org/cmake/help/v3.12/module/FindLibXml2.html .

It should not be a problem for the majority of IIT-related uses due to https://github.com/robotology/QA/issues/364 .