### PR TITLE
Removed unnecessary warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .
 - Remove the semantics related classes. They were deprecated in iDynTree 1.0 .
-- Remove unnecessary warning messages from [ModelSensorsTransformers.cpp](https://github.com/robotology/idyntree/blob/master/src/sensors/src/ModelSensorsTransformers.cpp) and [URDFDocument.cpp](https://github.com/robotology/idyntree/blob/master/src/model_io/urdf/src/URDFDocument.cpp)
+- Remove unnecessary warning messages from [ModelSensorsTransformers.cpp](https://github.com/robotology/idyntree/blob/master/src/sensors/src/ModelSensorsTransformers.cpp) and [URDFDocument.cpp](https://github.com/robotology/idyntree/blob/master/src/model_io/urdf/src/URDFDocument.cpp) (see https://github.com/robotology/idyntree/pull/718)
 
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .
 - Remove the semantics related classes. They were deprecated in iDynTree 1.0 .
+- Remove unnecessary warning messages from [ModelSensorsTransformers.cpp](https://github.com/robotology/idyntree/blob/master/src/sensors/src/ModelSensorsTransformers.cpp) and [URDFDocument.cpp](https://github.com/robotology/idyntree/blob/master/src/model_io/urdf/src/URDFDocument.cpp)
 
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .
 - Remove the semantics related classes. They were deprecated in iDynTree 1.0 .
-- Remove unnecessary warning messages from [ModelSensorsTransformers.cpp](https://github.com/robotology/idyntree/blob/master/src/sensors/src/ModelSensorsTransformers.cpp) and [URDFDocument.cpp](https://github.com/robotology/idyntree/blob/master/src/model_io/urdf/src/URDFDocument.cpp) (see https://github.com/robotology/idyntree/pull/718)
+- Remove unnecessary warning messages from [ModelSensorsTransformers.cpp](https://github.com/robotology/idyntree/blob/master/src/sensors/src/ModelSensorsTransformers.cpp) and [URDFDocument.cpp](https://github.com/robotology/idyntree/blob/master/src/model_io/urdf/src/URDFDocument.cpp) (see [PR 718](https://github.com/robotology/idyntree/pull/718))
 
 
 ## [Unreleased]

--- a/src/model_io/urdf/src/URDFDocument.cpp
+++ b/src/model_io/urdf/src/URDFDocument.cpp
@@ -260,12 +260,7 @@ namespace iDynTree {
                     LinkIndex linkToWhichTheSensorIsAttached = linkSensor->getParentLinkIndex();
                     std::string linkToWhichTheSensorIsAttachedName = model.getLinkName(linkToWhichTheSensorIsAttached);
 
-                    if (model.isFrameNameUsed(linkSensor->getName()))
-                    {
-                        std::string err = "addSensorFramesAsAdditionalFrames is specified as an option, but it is impossible to add the frame of sensor " + linkSensor->getName() + " as there is already a frame with that name";
-                        reportWarning("", "addSensorFramesAsAdditionalFramesToModel", err.c_str());
-                    }
-                    else
+                    if (!model.isFrameNameUsed(linkSensor->getName()))
                     {
                         // std::cerr << "Adding sensor " << linkSensor->getName() << " to link " << linkToWhichTheSensorIsAttachedName << " as additional frame"<< std::endl;
                         bool ok = model.addAdditionalFrameToLink(linkToWhichTheSensorIsAttachedName,linkSensor->getName(),linkSensor->getLinkSensorTransform());
@@ -291,12 +286,7 @@ namespace iDynTree {
 
                     std::string linkToWhichTheSensorIsAttachedName = ftSensor->getSecondLinkName();
 
-                    if (model.isFrameNameUsed(ftSensor->getName()))
-                    {
-                        std::string err = "addSensorFramesAsAdditionalFrames is specified as an option, but it is impossible to add the frame of sensor " + ftSensor->getName() + " as there is already a frame with that name";
-                        reportWarning("", "addSensorFramesAsAdditionalFramesToModel", err.c_str());
-                    }
-                    else
+                    if (!model.isFrameNameUsed(ftSensor->getName()))
                     {
                         Transform link_H_sensor;
                         bool ok = ftSensor->getLinkSensorTransform(ftSensor->getSecondLinkIndex(),link_H_sensor);

--- a/src/sensors/src/ModelSensorsTransformers.cpp
+++ b/src/sensors/src/ModelSensorsTransformers.cpp
@@ -154,14 +154,6 @@ bool createReducedModelAndSensors(const Model& fullModel,
 
                 delete sensorCopy;
             }
-            // If the joint to which is attached the sensor has been lumped, notify that the joint
-            // sensor will not be present in the reduced model
-            else {
-                std::stringstream ss;
-                ss << "The joint " << parentJointName << " is not in the reduced model, the associated joint sensor won't be present" << std::endl;
-                reportWarning("", "createReducedModelAndSensors", ss.str().c_str());
-
-            }
         }
         else {
             std::stringstream ss;


### PR DESCRIPTION
Following https://github.com/robotology/idyntree/issues/408, I removed two unnecessary warning messages.

I changed the condition of the `if` statement to avoid to have empty `else` statements in the logic. I compiled it on Ubuntu 18.04 and tested and it seems ok to me.

I targeted `devel` branch for the PR. If there is any `changelog` to update, I will update it.