### PR TITLE
bug-fix: JointIndex validity check

### DIFF
--- a/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
+++ b/src/tools/yarprobotstatepublisher/src/robotstatepublisher.cpp
@@ -230,7 +230,9 @@ void YARPRobotStatePublisherModule::onRead(yarp::rosmsg::sensor_msgs::JointState
     {
         jntIndex = model.getJointIndex(v.name[i]);
 
-        if (!(model.getJoint(jntIndex)->getNrOfDOFs()) || jntIndex == iDynTree::JOINT_INVALID_INDEX)
+        if ( jntIndex == iDynTree::JOINT_INVALID_INDEX)
+            continue;
+        if (!(model.getJoint(jntIndex)->getNrOfDOFs()))
             continue;
 
         m_jointPos(model.getJoint(jntIndex)->getDOFsOffset()) = v.position[i];


### PR DESCRIPTION
The index joint validity  in `YARPRobotStatePublisherModule::onRead` has been placed before the check on the number of DOF in order to avoid segmentation fault