### PR TITLE
CI: Bump YCM to v0.11.1 and add macOS portaudio workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         # YCM
         git clone https://github.com/robotology/ycm
         cd ycm
-        git checkout ${YCM_TAG}
+        git checkout a1f5dd33353a1304c73131bdc08036ed5c1d39f4
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.0.3
-  YCM_TAG: v0.11.1
+  YCM_TAG: a1f5dd33353a1304c73131bdc08036ed5c1d39f4
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
   
@@ -90,8 +90,9 @@ jobs:
       shell: bash
       run: |
         # YCM
-        git clone -b ${YCM_TAG} https://github.com/robotology/ycm
+        git clone https://github.com/robotology/ycm
         cd ycm
+        git checkout ${YCM_TAG}
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
 env:
   vcpkg_robotology_TAG: v0.0.3
   YCM_TAG: v0.11.3
-  YARP_TAG: v3.3.2
-  ICUB_TAG: v1.15.0
+  YARP_TAG: v3.4.0
+  ICUB_TAG: v1.16.0
   
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.0.3
-  YCM_TAG: a1f5dd33353a1304c73131bdc08036ed5c1d39f4
+  YCM_TAG: v0.11.1
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
   
@@ -67,7 +67,7 @@ jobs:
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
-        brew install ace assimp boost eigen swig qt5 orocos-kdl octave
+        brew install ace assimp boost eigen swig qt5 orocos-kdl
     
     - name: Dependencies [Ubuntu]
       if: contains(matrix.os, 'ubuntu')
@@ -92,7 +92,7 @@ jobs:
         # YCM
         git clone https://github.com/robotology/ycm
         cd ycm
-        git checkout a1f5dd33353a1304c73131bdc08036ed5c1d39f4
+        git checkout ${YCM_TAG}
         mkdir -p build
         cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
@@ -141,6 +141,12 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
+ 
+ 
+    - name: Dependencies (workaround for portaudio YCM problem) [macOS]
+      if: matrix.os == 'macOS-latest'
+      run: |
+        brew install octave
  
     # ===================
     # CMAKE-BASED PROJECT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.0.3
-  YCM_TAG: v0.11.0
+  YCM_TAG: v0.11.3
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.0.3
-  YCM_TAG: v0.11.3
-  YARP_TAG: v3.4.0
-  ICUB_TAG: v1.16.0
+  YCM_TAG: v0.11.1
+  YARP_TAG: v3.3.0
+  ICUB_TAG: v1.15.0
   
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   vcpkg_robotology_TAG: v0.0.3
   YCM_TAG: v0.11.1
-  YARP_TAG: v3.3.0
+  YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
   
 jobs:


### PR DESCRIPTION
YCM v0.11.0 does not configure anymore due to Eigen3 bitbucket repo being removed. Due to https://github.com/robotology/ycm/issues/353, it is also necessary on macOS to first compile YARP, and only after install octave that depends on portaudio.