### PR TITLE
idyntree-modelio-xml: Remove non-existing include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the possibility of reusing an already opened figure with the MATLAB iDynTree Visualizer either if the name coincides or by using gcf.
 
 ### Fixed
-- Fix bug in init() of SimpleLeggedOdometry that used an incorrect initial world frame location if used with an additional frame of a link (https://github.com/robotology/idyntree/pull/698)
+- Fixed bug in init() of SimpleLeggedOdometry that used an incorrect initial world frame location if used with an additional frame of a link (https://github.com/robotology/idyntree/pull/698).
+- Fixed bug that prevented to use iDynTree cmake packages directly from the build directory (https://github.com/robotology/idyntree/pull/728).
 
 ## [1.1.0] - 2020-06-08
 

--- a/src/model_io/xml/CMakeLists.txt
+++ b/src/model_io/xml/CMakeLists.txt
@@ -34,7 +34,6 @@ add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 # We want to include the same-library header files directly (in the implementation), but with the full prefix in the .h (as this will be public)
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/iDynTree>"
-                                                 "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/private>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>"
                                           PRIVATE ${EIGEN3_INCLUDE_DIR}
                                                   ${LIBXML2_INCLUDE_DIR})


### PR DESCRIPTION
This creates problem when iDynTree is used from the build directory.
The problem emerged in https://github.com/robotology/idyntree/issues/727 .