### PR TITLE
[OUTDATED] Implement the MatrixView class

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,6 +44,7 @@ set(IDYNTREE_CORE_EXP_HEADERS include/iDynTree/Core/Axis.h
                               include/iDynTree/Core/CubicSpline.h
                               include/iDynTree/Core/Span.h
                               include/iDynTree/Core/SO3Utils.h
+                              include/iDynTree/Core/MatrixView.h
                               # Deprecated headers
                               include/iDynTree/Core/AngularForceVector3.h
                               include/iDynTree/Core/AngularMotionVector3.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -134,7 +134,7 @@ if(MSVC)
    add_definitions(-D_USE_MATH_DEFINES)
 endif()
 
-target_compile_features(${libraryname} PUBLIC cxx_attribute_deprecated)
+target_compile_features(${libraryname} PUBLIC cxx_attribute_deprecated cxx_std_17)
 
 install(TARGETS ${libraryname}
         EXPORT iDynTree

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -75,6 +75,26 @@ inline Eigen::Map<Eigen::VectorXd> toEigen(iDynTree::Span<double> vec)
 }
 #endif
 
+inline Eigen::Map<const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>> toEigen(MatrixView<const double, true> mat)
+{
+    return Eigen::Map<const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> >(mat.data(), mat.rows(), mat.cols());
+}
+
+inline Eigen::Map< Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>> toEigen(MatrixView< double, true> mat)
+{
+    return Eigen::Map< Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> >(mat.data(), mat.rows(), mat.cols());
+}
+
+inline Eigen::Map<const Eigen::MatrixXd> toEigen(MatrixView<const double, false> mat)
+{
+    return Eigen::Map<const Eigen::MatrixXd >(mat.data(), mat.rows(), mat.cols());
+}
+
+inline Eigen::Map< Eigen::MatrixXd > toEigen(MatrixView< double, false> mat)
+{
+    return Eigen::Map< Eigen::MatrixXd >(mat.data(), mat.rows(), mat.cols());
+}
+
 inline Eigen::Map<const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> > toEigen(const MatrixDynSize & mat)
 {
     return Eigen::Map<const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> >(mat.data(),mat.rows(),mat.cols());

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -114,7 +114,8 @@ namespace iDynTree
          *
          * @return *this
          */
-        MatrixDynSize& operator=(const MatrixView<const double>& other);
+        template <bool IsRowMajor>
+        MatrixDynSize& operator=(const MatrixView<const double, IsRowMajor>& other);
 
         /**
          * Denstructor
@@ -230,6 +231,42 @@ namespace iDynTree
         ///@}
 
     };
+
+    template <bool IsRowMajor>
+    MatrixDynSize& MatrixDynSize::operator=(const MatrixView<const double, IsRowMajor>& other)
+    {
+        m_rows = other.rows();
+        m_cols = other.cols();
+
+        const unsigned requiredCapacity = m_rows * m_cols;
+
+        // if other is empty, return
+        if (requiredCapacity == 0) return  *this;
+
+        // If the copied data fits in the currently allocated buffer,
+        // use that one (if the user want to free the memory can use
+        // the shrink_to_fit method).
+        // Otherwise, allocate a new buffer after deleting the old one)
+        if (m_capacity < requiredCapacity) {
+            // need to allocate new buffer
+            // if old buffer exists, delete it
+            if (m_capacity > 0) {
+                delete [] m_data;
+            }
+            m_data = new double[requiredCapacity];
+            m_capacity = requiredCapacity;
+        }
+
+        for(unsigned int i = 0; i < m_rows; i++)
+        {
+            for(unsigned int j = 0; j < m_cols; j++)
+            {
+                this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
+            }
+        }
+
+        return *this;
+    }
 }
 
 #endif /* IDYNTREE_MATRIX_DYN_SIZE_H */

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -14,6 +14,8 @@
 
 #include <string>
 
+#include <iDynTree/Core/MatrixView.h>
+
 namespace iDynTree
 {
     /**
@@ -104,6 +106,15 @@ namespace iDynTree
          * @return *this
          */
         MatrixDynSize& operator=(const MatrixDynSize& other);
+
+        /**
+         * Assignment operator
+         *
+         * @param other the object to copy into self
+         *
+         * @return *this
+         */
+        MatrixDynSize& operator=(const MatrixView<const double>& other);
 
         /**
          * Denstructor

--- a/src/core/include/iDynTree/Core/MatrixView.h
+++ b/src/core/include/iDynTree/Core/MatrixView.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_MATRIX_VIEW_H
+#define IDYNTREE_MATRIX_VIEW_H
+
+#include <string>
+#include <iostream>
+#include <cassert>
+
+#include <iDynTree/Core/Utils.h>
+#include <iDynTree/Core/Span.h>
+
+
+namespace iDynTree
+{
+    /**
+     * Class providing a simple viewer for matrices.
+     *
+     * \ingroup iDynTreeCore
+     */
+
+    template<class ElementType>
+    class MatrixView
+    {
+    public:
+        using element_type = ElementType;
+        using pointer = element_type*;
+        using reference = element_type&;
+
+    private:
+
+        pointer m_storage;
+        unsigned int m_rows;
+        unsigned int m_cols;
+        bool m_isRowMajor{true};
+
+        unsigned int rawIndex(int row, int col) const
+        {
+            if (m_isRowMajor)
+            {
+                return (row + this->m_rows*col);
+            }
+            else
+            {
+                return (this->m_cols*row + col);
+            }
+        }
+
+    public:
+        template <class Container,
+                  std::enable_if_t<
+                        std::is_const<element_type>::value &&
+                        std::is_convertible<decltype(std::declval<Container>().data()),
+                                            pointer>::value &&
+                        std::is_same<typename Container::IsRowMajor, bool>::value, int> = 0>
+        MatrixView(const Container& matrix)
+            : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), Container::IsRowMajor)
+        {
+        }
+
+        template <class Container,
+                  std::enable_if_t<
+                        std::is_const<element_type>::value &&
+                        std::is_convertible<decltype(std::declval<Container>().data()),
+                                            pointer>::value, int> = 0>
+        MatrixView(const Container& matrix, const bool& isRowMajor = true)
+            : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), isRowMajor)
+        {
+        }
+
+        template <class Container,
+                  std::enable_if_t<
+                        std::is_convertible<decltype(std::declval<Container>().data()),
+                                            pointer>::value &&
+                        std::is_same<typename Container::IsRowMajor, bool>::value, int> = 0>
+        MatrixView(Container& matrix) : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), Container::IsRowMajor)
+        {
+        }
+
+        template <class Container,
+                  std::enable_if_t<
+                        std::is_convertible<decltype(std::declval<Container>().data()),
+                                            pointer>::value, int> = 0>
+        MatrixView(Container& matrix, const bool& isRowMajor = true)
+            : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), isRowMajor)
+        {
+        }
+
+        MatrixView(pointer in_data, const unsigned int in_rows, const unsigned int in_cols, const bool& isRowMajor)
+            : m_storage(in_data), m_rows(in_rows), m_cols(in_cols), m_isRowMajor(isRowMajor)
+        {
+        }
+
+        MatrixView& operator=(const MatrixView& matrix)
+        {
+            if(matrix == *this)
+                return *this;
+
+            assert(m_rows == matrix.rows());
+            assert(m_cols == matrix.cols());
+
+            for (unsigned int i = 0; i < m_rows; i ++)
+            {
+                for (unsigned int j = 0; i < m_cols; i ++)
+                {
+                    m_storage[this->rawIndex(i, j)] = matrix(i, j);
+                }
+            }
+
+            m_storage = matrix.data();
+
+            return *this;
+        }
+
+        pointer data() const noexcept { return m_storage; }
+
+        /**
+         * @name Matrix interface methods.
+         * Methods exposing a matrix-like interface to MatrixView.
+         *
+         */
+        ///@{
+        reference operator()(const unsigned int row, const unsigned int col) const
+        {
+            assert(row < this->rows());
+            assert(col < this->cols());
+            return this->m_storage[rawIndex(row,col)];
+        }
+
+        reference getVal(const unsigned int row, const unsigned int col) const
+        {
+            this->operator()(row, col);
+        }
+
+        unsigned int rows() const
+        {
+            return this->m_rows;
+        }
+
+        unsigned int cols() const
+        {
+            return this->m_cols;
+        }
+        ///@}
+    };
+
+}
+
+#endif /* IDYNTREE_MATRIX_DYN_SIZE_H */

--- a/src/core/src/MatrixDynSize.cpp
+++ b/src/core/src/MatrixDynSize.cpp
@@ -78,33 +78,35 @@ MatrixDynSize::MatrixDynSize(const MatrixDynSize& other)
 
 MatrixDynSize& MatrixDynSize::operator=(const MatrixDynSize& other)
 {
-    if (this == &other) return *this;
+    return this->operator=(other);
 
-    // Copy the new rows and columns
-    m_rows = other.m_rows;
-    m_cols = other.m_cols;
-    unsigned requiredCapacity = m_rows * m_cols;
+    // if (this == &other) return *this;
 
-    // if other is empty, return
-    if (requiredCapacity == 0) return  *this;
+    // // Copy the new rows and columns
+    // m_rows = other.m_rows;
+    // m_cols = other.m_cols;
+    // unsigned requiredCapacity = m_rows * m_cols;
 
-    // If the copied data fits in the currently allocated buffer,
-    // use that one (if the user want to free the memory can use
-    // the shrink_to_fit method).
-    // Otherwise, allocate a new buffer after deleting the old one)
-    if (m_capacity < requiredCapacity) {
-        // need to allocate new buffer
-        // if old buffer exists, delete it
-        if (m_capacity > 0) {
-            delete [] m_data;
-        }
-        m_data = new double[requiredCapacity];
-        m_capacity = requiredCapacity;
-    }
+    // // if other is empty, return
+    // if (requiredCapacity == 0) return  *this;
 
-    // Now we are sure that m_capacity >= m_rows*m_cols
-    std::memcpy(this->m_data, other.m_data, requiredCapacity * sizeof(double));
-    return *this;
+    // // If the copied data fits in the currently allocated buffer,
+    // // use that one (if the user want to free the memory can use
+    // // the shrink_to_fit method).
+    // // Otherwise, allocate a new buffer after deleting the old one)
+    // if (m_capacity < requiredCapacity) {
+    //     // need to allocate new buffer
+    //     // if old buffer exists, delete it
+    //     if (m_capacity > 0) {
+    //         delete [] m_data;
+    //     }
+    //     m_data = new double[requiredCapacity];
+    //     m_capacity = requiredCapacity;
+    // }
+
+    // // Now we are sure that m_capacity >= m_rows*m_cols
+    // std::memcpy(this->m_data, other.m_data, requiredCapacity * sizeof(double));
+    // return *this;
 }
 
 MatrixDynSize::~MatrixDynSize()
@@ -306,38 +308,4 @@ std::string MatrixDynSize::reservedToString() const
     return this->toString();
 }
 
-MatrixDynSize& MatrixDynSize::operator=(const MatrixView<const double>& other)
-{
-    m_rows = other.rows();
-    m_cols = other.cols();
-
-    const unsigned requiredCapacity = m_rows * m_cols;
-
-    // if other is empty, return
-    if (requiredCapacity == 0) return  *this;
-
-    // If the copied data fits in the currently allocated buffer,
-    // use that one (if the user want to free the memory can use
-    // the shrink_to_fit method).
-    // Otherwise, allocate a new buffer after deleting the old one)
-    if (m_capacity < requiredCapacity) {
-        // need to allocate new buffer
-        // if old buffer exists, delete it
-        if (m_capacity > 0) {
-            delete [] m_data;
-        }
-        m_data = new double[requiredCapacity];
-        m_capacity = requiredCapacity;
-    }
-
-    for(unsigned int i = 0; i < m_rows; i++)
-    {
-        for(unsigned int j = 0; j < m_cols; j++)
-        {
-            this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
-        }
-    }
-
-    return *this;
-}
 }

--- a/src/core/src/MatrixDynSize.cpp
+++ b/src/core/src/MatrixDynSize.cpp
@@ -306,5 +306,38 @@ std::string MatrixDynSize::reservedToString() const
     return this->toString();
 }
 
+MatrixDynSize& MatrixDynSize::operator=(const MatrixView<const double>& other)
+{
+    m_rows = other.rows();
+    m_cols = other.cols();
 
+    const unsigned requiredCapacity = m_rows * m_cols;
+
+    // if other is empty, return
+    if (requiredCapacity == 0) return  *this;
+
+    // If the copied data fits in the currently allocated buffer,
+    // use that one (if the user want to free the memory can use
+    // the shrink_to_fit method).
+    // Otherwise, allocate a new buffer after deleting the old one)
+    if (m_capacity < requiredCapacity) {
+        // need to allocate new buffer
+        // if old buffer exists, delete it
+        if (m_capacity > 0) {
+            delete [] m_data;
+        }
+        m_data = new double[requiredCapacity];
+        m_capacity = requiredCapacity;
+    }
+
+    for(unsigned int i = 0; i < m_rows; i++)
+    {
+        for(unsigned int j = 0; j < m_cols; j++)
+        {
+            this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
+        }
+    }
+
+    return *this;
+}
 }

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_unit_test(TransformFromMatrix4x4)
 add_unit_test(CubicSpline)
 add_unit_test(Span)
 add_unit_test(SO3Utils)
+add_unit_test(MatrixView)
 
 
 # We have also some usages of the API that we want to make sure that do not compile

--- a/src/core/tests/MatrixViewUnitTest.cpp
+++ b/src/core/tests/MatrixViewUnitTest.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/MatrixView.h>
+#include <iDynTree/Core/TestUtils.h>
+#include <iDynTree/Core/EigenHelpers.h>
+
+using namespace iDynTree;
+
+void foo(MatrixView<double> m)
+{
+    std::cerr << "m has " << m.rows() << " rows" << std::endl;
+}
+
+int main()
+{
+    MatrixDynSize m_idyntree(5, 3);
+    MatrixDynSize m_idyntree_2(5, 3);
+    toEigen(m_idyntree).setRandom();
+
+    Eigen::MatrixXd m_eigen(5, 3);
+
+    MatrixView<double, false> eigenView(m_eigen);
+
+    std::cerr << "******************" << std::endl;
+    std::cerr << "Here it is not working because the wrong copy assignment operator has been called" << std::endl;
+    eigenView = m_idyntree;
+    std::cerr << "Eigen " << std::endl;
+    std::cerr << m_eigen << std::endl;
+
+    std::cerr << "iDynTree " << std::endl;
+    std::cerr << m_idyntree.toString() << std::endl;
+    std::cerr << "******************" << std::endl;
+
+
+    std::cerr << "******************" << std::endl;
+    std::cerr << "Eigen " << std::endl;
+    eigenView = MatrixView<double, true>(m_idyntree);
+    std::cerr << m_eigen << std::endl;
+
+    std::cerr << "iDynTree " << std::endl;
+    std::cerr << m_idyntree.toString() << std::endl;
+    std::cerr << "******************" << std::endl;
+
+    foo(m_idyntree);
+
+    // This does not compile
+    // foo(m_eigen);
+
+    // This works thanks to the (CTAD)
+    // https://en.cppreference.com/w/cpp/language/class_template_argument_deduction
+    // https://devblogs.microsoft.com/cppblog/how-to-use-class-template-argument-deduction/
+    MatrixView eigenView2(m_eigen);
+
+    // // This is not compiling
+    //  error: could not convert ‘iDynTree::MatrixView<double, false>(m_eigen)’ from ‘iDynTree::MatrixView<double, false>’ to ‘iDynTree::MatrixView<double, true>’
+    // foo(MatrixView(m_eigen));
+
+    return 0;
+}

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -16,8 +16,8 @@
 
 #include <iDynTree/Core/VectorFixSize.h>
 #include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/MatrixView.h>
 #include <iDynTree/Core/Utils.h>
-
 
 #include <iDynTree/Model/Indices.h>
 #include <iDynTree/Model/FreeFloatingMatrices.h>
@@ -256,6 +256,10 @@ public:
                                             const iDynTree::FrameIndex frameIndex,
                                             iDynTree::MatrixDynSize & outJacobianPattern) const;
 
+    bool getRelativeJacobianSparsityPattern(const iDynTree::FrameIndex refFrameIndex,
+                                            const iDynTree::FrameIndex frameIndex,
+                                            MatrixView<double> outJacobianPattern) const;
+
 
     /**
      * Returns the sparsity pattern of the free floating Jacobian for the specified frame
@@ -270,6 +274,9 @@ public:
      */
     bool getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
                                                      iDynTree::MatrixDynSize & outJacobianPattern) const;
+
+    bool getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
+                                                     MatrixView<double> outJacobianPattern) const;
 
 
     //@}
@@ -464,6 +471,11 @@ public:
     bool getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
                                       iDynTree::MatrixDynSize & outJacobian);
 
+    bool getFrameFreeFloatingJacobian(const std::string & frameName,
+                                      const MatrixView<double> & outJacobian);
+
+    bool getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
+                                      const MatrixView<double> & outJacobian);
 
 
 
@@ -480,6 +492,10 @@ public:
     bool getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
                              const iDynTree::FrameIndex frameIndex,
                              iDynTree::MatrixDynSize & outJacobian);
+
+    bool getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
+                             const iDynTree::FrameIndex frameIndex,
+                             MatrixView<double> outJacobian);
 
     /**
      * Return the relative Jacobian between the two frames
@@ -501,6 +517,12 @@ public:
                                      const iDynTree::FrameIndex expressedOriginFrameIndex,
                                      const iDynTree::FrameIndex expressedOrientationFrameIndex,
                                      iDynTree::MatrixDynSize & outJacobian);
+
+    bool getRelativeJacobianExplicit(const iDynTree::FrameIndex refFrameIndex,
+                                     const iDynTree::FrameIndex frameIndex,
+                                     const iDynTree::FrameIndex expressedOriginFrameIndex,
+                                     const iDynTree::FrameIndex expressedOrientationFrameIndex,
+                                     MatrixView<double> outJacobian);
 
 
     /**
@@ -555,6 +577,8 @@ public:
      */
     bool getCenterOfMassJacobian(MatrixDynSize & comJacobian);
 
+    bool getCenterOfMassJacobian(MatrixView<double> comJacobian);
+
     /**
      * Return the center of mass bias acceleration.
      */
@@ -580,6 +604,8 @@ public:
      */
     bool getAverageVelocityJacobian(MatrixDynSize & avgVelocityJacobian);
 
+    bool getAverageVelocityJacobian(MatrixView<double> avgVelocityJacobian);
+
     /**
      * Get the centroidal average velocity of the robot.
      *
@@ -600,6 +626,8 @@ public:
      */
     bool getCentroidalAverageVelocityJacobian(MatrixDynSize & centroidalAvgVelocityJacobian);
 
+    bool getCentroidalAverageVelocityJacobian(MatrixView<double> centroidalAvgVelocityJacobian);
+
     /**
      * Get the linear and angular momentum of the robot.
      * The quantity is expressed in (B[A]), (A) or (B) depending on the FrameVelocityConvention used.
@@ -615,6 +643,8 @@ public:
      * \note Implementation incomplete, please refrain to use until this warning has been removed.
      */
     bool getLinearAngularMomentumJacobian(MatrixDynSize & linAngMomentumJacobian);
+
+    bool getLinearAngularMomentumJacobian(MatrixView<double> linAngMomentumJacobian);
 
     /**
      * Get the centroidal (total) momentum of the robot.
@@ -635,6 +665,8 @@ public:
      * introduced in https://doi.org/10.1109/IROS.2008.4650772 .
      */
     bool getCentroidalTotalMomentumJacobian(MatrixDynSize& centroidalTotalMomentumJacobian);
+
+    bool getCentroidalTotalMomentumJacobian(MatrixView<double> centroidalTotalMomentumJacobian);
 
     //@}
 
@@ -704,6 +736,7 @@ public:
      */
     bool getFreeFloatingMassMatrix(MatrixDynSize & freeFloatingMassMatrix);
 
+    bool getFreeFloatingMassMatrix(MatrixView<double> freeFloatingMassMatrix);
 
     /**
      * @brief Compute the free floating inverse dynamics.
@@ -807,4 +840,3 @@ public:
 }
 
 #endif
-

--- a/src/model/include/iDynTree/Model/Jacobians.h
+++ b/src/model/include/iDynTree/Model/Jacobians.h
@@ -11,6 +11,8 @@
 #ifndef IDYNTREE_JACOBIANS_H
 #define IDYNTREE_JACOBIANS_H
 
+#include <iDynTree/Core/MatrixView.h>
+
 #include <iDynTree/Model/Indices.h>
 
 namespace iDynTree
@@ -49,7 +51,7 @@ namespace iDynTree
                                           const LinkIndex linkIndex,
                                           const Transform & jacobFrame_X_world,
                                           const Transform & baseFrame_X_jacobBaseFrame,
-                                                MatrixDynSize & jacobian);
+                                          const MatrixView<double> & jacobian);
 
 
 }

--- a/src/model/src/Jacobians.cpp
+++ b/src/model/src/Jacobians.cpp
@@ -27,7 +27,7 @@ bool FreeFloatingJacobianUsingLinkPos(const Model& model,
                                       const LinkIndex jacobianLinkIndex,
                                       const Transform& jacobFrame_X_world,
                                       const Transform& baseFrame_X_jacobBaseFrame,
-                                            MatrixDynSize& jacobian)
+                                      const MatrixView<double>& jacobian)
 {
     // We zero the jacobian
     jacobian.zero();


### PR DESCRIPTION
This PR wants to be a draft of the `MatrixView` class proposed by @traversaro in #716.

The code presented here is in `alpha` state, it's not completely working and it can be improved. 

What I would like to have is a `viewer` for matrix objects that can be used with `iDynTree` and other different matrices (at least `Eigen`), the object must be able to handle `RowMajor` and `ColMajor` matrices. 
Thanks to this object we will be able to improve the compatibility of iDynTree with other libraries.  

In details :
1. The PR introduces `C++17` (first limitation) to simplify the usage of the template and to use the [`Class Template Argument Deduction`](https://devblogs.microsoft.com/cppblog/how-to-use-class-template-argument-deduction/)
2. The `RowMajor`, `ColMajor` type is chosen at compile time (This simplify the definition of the `Eigen::Map`) Please check:  https://github.com/robotology/idyntree/blob/8ab43ffd6605bc98f719f3b582e1cf625b7d6bd1/src/core/include/iDynTree/Core/EigenHelpers.h#L78-L96
3. Point 2 is a limitation, this simplifies a lot the conversion between a `MatrixView` storing `RowMajor` matrix to `ColMajor`
    Indeed I would like to have something that allows doing
    ```cpp
     void foo(MatrixView<double> m)
     {
      ....
     }
  
     iDynTree::MatrixDynSize m_iDynTree(3,53);
     foo(m_iDynTree);
     Eigen::MatrixXd m_eigen(12,31);
     foo(m_eigen);
    ```
   In other words, here I would like to have an implicit conversion from an `iDynTree`, `Eigen` object to a `MatrixView`. As regards the storing order, in `iDynTree` all the matrix as stored as `RowMajor` while in `Eigen` we can use `IsRowMajor` to check if an `Eigen::Dense` object is stored as `RowMajor` or not.
4. Another problem I've right now is how the compiler decides to call the copy assignment operator (with this operator I copy the values contained in the matrix, i.e. I'm using a different logic w.r.t. `std::span`)
 https://github.com/robotology/idyntree/blob/8ab43ffd6605bc98f719f3b582e1cf625b7d6bd1/src/core/tests/MatrixViewUnitTest.cpp#L31-L41
5. Note the first line of the code presented in point 4 can be changed into
   ```cpp
    MatrixView eigenView(m_eigen);
   ```
   This is possible thanks to a brand new feature of C++17.   [`Class Template Argument Deduction`](https://devblogs.microsoft.com/cppblog/how-to-use-class-template-argument-deduction/). The following lines define the deduction rule
https://github.com/robotology/idyntree/blob/8ab43ffd6605bc98f719f3b582e1cf625b7d6bd1/src/core/include/iDynTree/Core/MatrixView.h#L207-L213

cc @traversaro @S-Dafarra @prashanthr05 @diegoferigo 