### PR TITLE
Bump minimum required version of CMake to 3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - By default  iDynTree is compiled as a shared library also on Windows. The `BUILD_SHARED_LIBS` CMake variable can be used to
   control if iDynTree is built as a shared or a static library.
 - The Python method `*.fromPyList` is replaced by `*.FromPython` (https://github.com/robotology/idyntree/pull/726).
+- The minimum required CMake version to configure and compile iDynTree is now 3.16 . 
 
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 1.99.0
+project(iDynTree VERSION 1.99.1
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/462 . 
In theory the minimum requirement is 3.14, but as we are not testing it, I think is safer to just enforce what we are testing.