### PR TITLE
Bump minimum required version of CMake to 3.16 and update CMake SWIG policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - By default  iDynTree is compiled as a shared library also on Windows. The `BUILD_SHARED_LIBS` CMake variable can be used to
   control if iDynTree is built as a shared or a static library.
 - The Python method `*.fromPyList` is replaced by `*.FromPython` (https://github.com/robotology/idyntree/pull/726).
+- The minimum required CMake version to configure and compile iDynTree is now 3.16 (https://github.com/robotology/idyntree/pull/732).
 
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 1.99.0
+project(iDynTree VERSION 1.99.1
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,26 +1,34 @@
-set(CMAKE_SWIG_FLAGS "-Wextra;-module;iDynTree;-threads")
-
 find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
 message(STATUS "Using Python: ${Python3_EXECUTABLE}")
 
+cmake_policy(SET CMP0078 NEW)
+cmake_policy(SET CMP0086 NEW)
+
 set_source_files_properties(../iDynTree.i PROPERTIES CPLUSPLUS ON)
 
-swig_add_library(iDynTree_python
+set(target_name iDynTree)
+
+swig_add_library(${target_name}
     TYPE SHARED
     LANGUAGE python
     SOURCES ../iDynTree.i)
 
-set(target_name ${SWIG_MODULE_iDynTree_python_REAL_NAME})
-
 target_link_libraries(${target_name} PUBLIC Python3::Python Python3::NumPy)
+
 set_target_properties(${target_name} PROPERTIES
-    OUTPUT_NAME "_iDynTree"
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/python)
 
 set_property(
     TARGET ${target_name}
-    PROPERTY SWIG_DEPENDS
-    python.i numpy.i)
+    PROPERTY SWIG_DEPENDS python.i numpy.i)
+
+set_property(
+    TARGET ${target_name}
+    PROPERTY SWIG_COMPILE_OPTIONS -Wextra -threads)
+
+set_property(
+    TARGET ${target_name}
+    PROPERTY SWIG_GENERATED_COMPILE_OPTIONS -Wextra)
 
 # installation path is determined reliably on most platforms using distutils
 execute_process(COMMAND ${Python3_EXECUTABLE}


### PR DESCRIPTION
This PR fixes the error due to a bump of the minimum requirement of CMake that is being proposed in #731. 

The problem is that recent CMake releases set by default the NEW version of policy [`CMP0078`](https://cmake.org/cmake/help/v3.14/policy/CMP0078.html#policy:CMP0078) that affects the naming of the target and the resulting library. This change breaks the old CMake structure.

In addition to this fix, I also applied the NEW version of policy [`CMP0086`](https://cmake.org/cmake/help/v3.14/policy/CMP0086.html#policy:CMP0086) that allows removing the generic `CMAKE_SWIG_FLAGS` replacing it with `set_property` calls.

---

P.S. I never used SWIG bindings in a multi-thread application and I'm not sure what's the best way to handle the SWIG flags. It seems that the `-threads` option that was already enabled is enough to disable the GIL, however as discussed in https://github.com/swig/swig/issues/927 maybe it is not enough and other options should be added in the `.i` file. Let's keep things as they were before but also keep it in mind in case of multi-threading problems.