### PR TITLE
Implement the MatrixView class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iDynTree now supports build compiled as a shared library also on Windows.
 - When used in Python, new iDynTree objects can be constructed from generic iterable objects and NumPy arrays (`*.FromPython`),
   and existing objects can be converted to NumPy arrays (`*.toNumPy`) (https://github.com/robotology/idyntree/pull/726).
+- Implement the MatrixView class (https://github.com/robotology/idyntree/pull/734)
 
 ### Fixed
 - Fixed bug in `yarprobotstatepublisher` that caused segmentation fault each time an unknown joint name was read from the input joint states topic (https://github.com/robotology/idyntree/pull/719)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,6 +44,7 @@ set(IDYNTREE_CORE_EXP_HEADERS include/iDynTree/Core/Axis.h
                               include/iDynTree/Core/CubicSpline.h
                               include/iDynTree/Core/Span.h
                               include/iDynTree/Core/SO3Utils.h
+                              include/iDynTree/Core/MatrixView.h
                               # Deprecated headers
                               include/iDynTree/Core/AngularForceVector3.h
                               include/iDynTree/Core/AngularMotionVector3.h

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -82,6 +82,37 @@ toEigen(const MatrixView<const double>& mat)
     using MatrixRowMajor = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>;
 
     // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
+    //
+    // Given the following matrix
+    //     _                 _                     _
+    //    / \     _____     |  1   2   3   4    5  |
+    //   / _ \   |_____|    |                      |
+    //  / ___ \  |_____|    |                      |
+    // /_/   \_\            |_ 6   7   8   9   10 _|
+    //
+    // If the matrix is stored as RowMajor matrix there will be a vector v_row in which
+    // the elements are saved
+    // v_row = [1 2 3 4 5 6 7 8 9 10]
+    //
+    // If the matrix is stored as ColMajor matrix there will be a vector v_col in which
+    // the elements are saved
+    // v_col = [1 6 2 7 3 8 4 9 5 10]
+    //
+    // Our goal here is to build a RowMajor Matrix (independently it is RowMajor/ColMajor)
+    // starting from the raw vactor (v_row, v_col)
+    //
+    // From the Eigen documentation https://eigen.tuxfamily.org/dox/classEigen_1_1Stride.html
+    // The inner stride is the pointer increment between two consecutive entries within a given row of a row-major matrix.
+    // The outer stride is the pointer increment between two consecutive rows of a row-major matrix.
+    //
+    // Starting from v_row we can build a RowMajor matrix by choosing the following pair of strides
+    //    - inner_stride = 1
+    //    - outer_stride = 5 = number of columns of A
+    //
+    // Starting from v_col we can build a RowMajor matrix by choosing the following pair of strides
+    //    - inner_stride = 2 = number of rows of A
+    //    - outer_stride = 1
+
     const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
     const int outerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
 
@@ -100,6 +131,37 @@ toEigen(const MatrixView<double>& mat)
     using MatrixRowMajor = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>;
 
     // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
+    //
+    // Given the following matrix
+    //     _                 _                     _
+    //    / \     _____     |  1   2   3   4    5  |
+    //   / _ \   |_____|    |                      |
+    //  / ___ \  |_____|    |                      |
+    // /_/   \_\            |_ 6   7   8   9   10 _|
+    //
+    // If the matrix is stored as RowMajor matrix there will be a vector v_row in which
+    // the elements are saved as
+    // v_row = [1 2 3 4 5 6 7 8 9 10]
+    //
+    // If the matrix is stored as ColMajor matrix there will be a vector v_col in which
+    // the elements are saved as
+    // v_col = [1 6 2 7 3 8 4 9 5 10]
+    //
+    // Our goal here is to build a RowMajor Matrix (independently it is RowMajor/ColMajor)
+    // starting from the raw vactor (v_row, v_col)
+    //
+    // From the Eigen documentation https://eigen.tuxfamily.org/dox/classEigen_1_1Stride.html
+    // The inner stride is the pointer increment between two consecutive entries within a given row of a row-major matrix.
+    // The outer stride is the pointer increment between two consecutive rows of a row-major matrix.
+    //
+    // Starting from v_row we can build a RowMajor matrix by choosing the following pair of strides
+    //    - inner_stride = 1
+    //    - outer_stride = 5 = number of columns of A
+    //
+    // Starting from v_col we can build a RowMajor matrix by choosing the following pair of strides
+    //    - inner_stride = 2 = number of rows of A
+    //    - outer_stride = 1
+
     const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
     const int outerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
 

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -83,7 +83,7 @@ toEigen(const MatrixView<const double>& mat)
 
     // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
     const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
-    const int outerStride = (mat.storageOrder() ==StorageOrder::ColMajor) ? 1 : mat.cols();
+    const int outerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
 
     return Eigen::Map<const MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -83,13 +83,13 @@ toEigen(const MatrixView<const double>& mat)
 
     // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
     const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
-    const int outherStride = (mat.storageOrder() ==StorageOrder::ColMajor) ? 1 : mat.cols();
+    const int outerStride = (mat.storageOrder() ==StorageOrder::ColMajor) ? 1 : mat.cols();
 
     return Eigen::Map<const MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),
         mat.rows(),
         mat.cols(),
-        Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(outherStride, innerStride));
+        Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(outerStride, innerStride));
 }
 
 inline Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>,
@@ -101,13 +101,13 @@ toEigen(const MatrixView<double>& mat)
 
     // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
     const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
-    const int outherStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
+    const int outerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
 
     return Eigen::Map<MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),
         mat.rows(),
         mat.cols(),
-        Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(outherStride, innerStride));
+        Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(outerStride, innerStride));
 }
 
 #endif

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -73,6 +73,43 @@ inline Eigen::Map<Eigen::VectorXd> toEigen(iDynTree::Span<double> vec)
 {
     return Eigen::Map<Eigen::VectorXd>(vec.data(),vec.size());
 }
+
+inline Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>,
+                  0,
+                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>
+toEigen(const MatrixView<const double>& mat)
+{
+    using MatrixRowMajor = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>;
+
+    // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
+    const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
+    const int outherStride = (mat.storageOrder() ==StorageOrder::ColMajor) ? 1 : mat.cols();
+
+    return Eigen::Map<const MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
+        mat.data(),
+        mat.rows(),
+        mat.cols(),
+        Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(outherStride, innerStride));
+}
+
+inline Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>,
+                  0,
+                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>
+toEigen(const MatrixView<double>& mat)
+{
+    using MatrixRowMajor = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>;
+
+    // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
+    const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
+    const int outherStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
+
+    return Eigen::Map<MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
+        mat.data(),
+        mat.rows(),
+        mat.cols(),
+        Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(outherStride, innerStride));
+}
+
 #endif
 
 inline Eigen::Map<const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> > toEigen(const MatrixDynSize & mat)

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -220,6 +220,14 @@ namespace iDynTree
         void fillColMajorBuffer(double * colMajorBuf) const;
 
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+        /** Typedefs to enable make_matrix_view.
+         */
+        ///@{
+        typedef double value_type;
+        ///@}
+#endif
+
         /** @name Output helpers.
          *  Output helpers.
          */

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -14,6 +14,8 @@
 
 #include <string>
 
+#include <iDynTree/Core/MatrixView.h>
+
 namespace iDynTree
 {
     /**
@@ -104,6 +106,15 @@ namespace iDynTree
          * @return *this
          */
         MatrixDynSize& operator=(const MatrixDynSize& other);
+
+        /**
+         * Assignment operator
+         *
+         * @param other the object to copy into self
+         *
+         * @return *this
+         */
+        MatrixDynSize& operator=(const MatrixView<const double>& other);
 
         /**
          * Denstructor

--- a/src/core/include/iDynTree/Core/MatrixFixSize.h
+++ b/src/core/include/iDynTree/Core/MatrixFixSize.h
@@ -141,6 +141,14 @@ namespace iDynTree
          */
         void fillColMajorBuffer(double * colMajorBuf) const;
 
+ #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+        /** Typedefs to enable make_matrix_view.
+         */
+        ///@{
+        typedef double value_type;
+        ///@}
+#endif
+
 
         /** @name Output helpers.
          *  Output helpers.

--- a/src/core/include/iDynTree/Core/MatrixView.h
+++ b/src/core/include/iDynTree/Core/MatrixView.h
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_MATRIX_VIEW_H
+#define IDYNTREE_MATRIX_VIEW_H
+
+#include <cassert>
+
+#include <type_traits>
+
+#include <iDynTree/Core/Span.h>
+#include <iDynTree/Core/Utils.h>
+
+// constexpr workaround for SWIG
+#ifdef SWIG
+#define IDYNTREE_CONSTEXPR
+#else
+#define IDYNTREE_CONSTEXPR constexpr
+#endif
+
+
+namespace iDynTree
+{
+
+    // this is required to be compatible with c++17
+    template <typename... Ts> struct make_void
+    {
+        typedef void type;
+    };
+    template <typename... Ts> using void_t = typename make_void<Ts...>::type;
+
+    /**
+     * has_IsRowMajor is used to build a type-dependent expression that check if an element has
+     * IsRowMajor argument. This specific implementation is used when the the object has not
+     * IsRowMajor.
+     */
+    template <typename T, typename = void> struct has_IsRowMajor : std::false_type
+    {
+    };
+
+    /**
+     * has_IsRowMajor is used to build a type-dependent expression that check if an element has
+     * IsRowMajor argument. This specific implementation is used when the the object has not
+     * IsRowMajor, indeed <code>void_t<\endcode> is used to detect ill-formed types in SFINAE
+     * context.
+     */
+    template <typename T> struct has_IsRowMajor<T, void_t<decltype(T::IsRowMajor)>> : std::true_type
+    {
+    };
+
+    /**
+     * Type of storage ordering
+     */
+    enum class StorageOrder
+    {
+        RowMajor,
+        ColMajor
+    };
+
+    /**
+     * MatrixView implements a view interface of Matrices. Both RowMajor and ColMajor matrices are
+     * supported.
+     * @note The user should define the storage ordering when the MatrixView is created (the default
+     order is RowMajor). However if the MatrixView is generated:
+     *   - from an object having a public member called <code>IsRowMajor</code>, the correct storage
+     order is chosen.
+     *   - from another MatrixView, the correct storage order is chosen.
+     */
+    template <class ElementType> class MatrixView
+    {
+    public:
+        using element_type = ElementType;
+        using value_type = std::remove_cv_t<ElementType>;
+        using pointer = element_type*;
+        using reference = element_type&;
+
+    private:
+        pointer m_storage;
+        unsigned int m_rows;
+        unsigned int m_cols;
+
+        StorageOrder m_storageOrder;
+
+        unsigned int rawIndex(int row, int col) const
+        {
+            if (m_storageOrder == StorageOrder::RowMajor)
+            {
+                return (col + this->m_cols * row);
+            } else
+            {
+                return (this->m_rows * col + row);
+            }
+        }
+
+    public:
+
+        MatrixView()
+            : MatrixView(nullptr, 0, 0, StorageOrder::RowMajor)
+        {}
+        MatrixView(const MatrixView& other)
+            : MatrixView(other.m_storage, other.m_rows, other.m_cols, other.m_storageOrder)
+        {
+        }
+
+        template <
+            class OtherElementType,
+            class = std::enable_if_t<
+                details::is_allowed_element_type_conversion<OtherElementType, element_type>::value>>
+        IDYNTREE_CONSTEXPR MatrixView(const MatrixView<OtherElementType>& other)
+            : MatrixView(other.data(), other.rows(), other.cols(), other.storageOrder())
+        {
+        }
+
+        template <
+            class Container,
+            std::enable_if_t<std::is_const<element_type>::value
+                                 && std::is_convertible<decltype(std::declval<Container>().data()),
+                                                        pointer>::value
+                                 && has_IsRowMajor<Container>::value
+                                 && !std::is_same<Container, MatrixView>::value,
+                             int> = 0>
+        MatrixView(const Container& matrix)
+            : MatrixView(matrix.data(),
+                         matrix.rows(),
+                         matrix.cols(),
+                         Container::IsRowMajor ? StorageOrder::RowMajor
+                                               : StorageOrder::ColMajor)
+        {
+        }
+
+        template <
+            class Container,
+            std::enable_if_t<std::is_const<element_type>::value
+                                 && std::is_convertible<decltype(std::declval<Container>().data()),
+                                                        pointer>::value
+                                 && !has_IsRowMajor<Container>::value
+                                 && !std::is_same<Container, MatrixView>::value,
+                             int> = 0>
+        MatrixView(const Container& matrix, const StorageOrder& order = StorageOrder::RowMajor)
+            : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), order)
+        {
+        }
+
+        template <class Container,
+                  std::enable_if_t<
+                      std::is_convertible<decltype(std::declval<Container>().data()), pointer>::value
+                          && has_IsRowMajor<Container>::value
+                          && !std::is_same<Container, MatrixView>::value,
+                      int> = 0>
+        MatrixView(Container& matrix)
+            : MatrixView(matrix.data(),
+                         matrix.rows(),
+                         matrix.cols(),
+                         Container::IsRowMajor ? StorageOrder::RowMajor
+                                               : StorageOrder::ColMajor)
+        {
+        }
+
+        template <class Container,
+                  std::enable_if_t<
+                      std::is_convertible<decltype(std::declval<Container>().data()), pointer>::value
+                          && !has_IsRowMajor<Container>::value
+                          && !std::is_same<Container, MatrixView>::value,
+                      int> = 0>
+        MatrixView(Container& matrix, const StorageOrder& order = StorageOrder::RowMajor)
+            : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), order)
+        {
+        }
+
+        MatrixView(pointer in_data,
+                   const unsigned int& in_rows,
+                   const unsigned int& in_cols,
+                   const StorageOrder& order = StorageOrder::RowMajor)
+            : m_storage(in_data)
+            , m_rows(in_rows)
+            , m_cols(in_cols)
+            , m_storageOrder(order)
+        {
+        }
+
+        const StorageOrder& storageOrder() const noexcept
+        {
+            return m_storageOrder;
+        }
+
+        pointer data() const noexcept
+        {
+            return m_storage;
+        }
+
+        /**
+         * @name Matrix interface methods.
+         * Methods exposing a matrix-like interface to MatrixView.
+         *
+         */
+        ///@{
+        reference operator()(const unsigned int row, const unsigned int col) const
+        {
+            assert(row < this->rows());
+            assert(col < this->cols());
+            return this->m_storage[rawIndex(row, col)];
+        }
+
+        unsigned int rows() const
+        {
+            return this->m_rows;
+        }
+
+        unsigned int cols() const
+        {
+            return this->m_cols;
+        }
+        ///@}
+    };
+
+    template <class ElementType>
+    IDYNTREE_CONSTEXPR MatrixView<ElementType>
+    make_matrix_view(ElementType* ptr,
+                     const unsigned int& rows,
+                     const unsigned int& cols,
+                     const StorageOrder& order = StorageOrder::RowMajor)
+    {
+        return MatrixView<ElementType>(ptr, rows, cols, order);
+    }
+
+    template <class Container,
+              std::enable_if_t<
+                  has_IsRowMajor<Container>::value
+                      || std::is_same<MatrixView<typename Container::value_type>, Container>::value,
+                  int> = 0>
+    IDYNTREE_CONSTEXPR MatrixView<typename Container::value_type> make_matrix_view(Container& cont)
+    {
+        return MatrixView<typename Container::value_type>(cont);
+    }
+
+    template <class Container,
+              std::enable_if_t<
+                  has_IsRowMajor<Container>::value
+                      || std::is_same<MatrixView<const typename Container::value_type>, Container>::value,
+                  int> = 0>
+    IDYNTREE_CONSTEXPR MatrixView<const typename Container::value_type> make_matrix_view(const Container& cont)
+    {
+        return MatrixView<const typename Container::value_type>(cont);
+    }
+
+    template <class Container,
+              std::enable_if_t<
+                  !has_IsRowMajor<Container>::value
+                      && !std::is_same<MatrixView<typename Container::value_type>, Container>::value,
+                  int> = 0>
+    IDYNTREE_CONSTEXPR MatrixView<typename Container::value_type>
+    make_matrix_view(Container& cont,
+                     const StorageOrder& order = StorageOrder::RowMajor)
+    {
+        return MatrixView<typename Container::value_type>(cont, order);
+    }
+
+    template <class Container,
+              std::enable_if_t<
+                  !has_IsRowMajor<Container>::value
+                      && !std::is_same<MatrixView<typename Container::value_type>, Container>::value,
+                  int> = 0>
+    IDYNTREE_CONSTEXPR MatrixView<const typename Container::value_type>
+    make_matrix_view(const Container& cont,
+                     const StorageOrder& order = StorageOrder::RowMajor)
+    {
+        return MatrixView<const typename Container::value_type>(cont, order);
+    }
+
+} // namespace iDynTree
+
+#endif /* IDYNTREE_MATRIX_MATRIX_VIEW_H */

--- a/src/core/include/iDynTree/Core/MatrixView.h
+++ b/src/core/include/iDynTree/Core/MatrixView.h
@@ -29,31 +29,30 @@
 namespace iDynTree
 {
 
-    // this is required to be compatible with c++17
-    template <typename... Ts> struct make_void
+    namespace MatrixViewInternal
     {
-        typedef void type;
-    };
-    template <typename... Ts> using void_t = typename make_void<Ts...>::type;
+        // this is required to be compatible with c++17
+        template <typename... Ts> struct make_void { typedef void type; };
+        template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
-    /**
-     * has_IsRowMajor is used to build a type-dependent expression that check if an element has
-     * IsRowMajor argument. This specific implementation is used when the the object has not
-     * IsRowMajor.
-     */
-    template <typename T, typename = void> struct has_IsRowMajor : std::false_type
-    {
-    };
+        /**
+         * has_IsRowMajor is used to build a type-dependent expression that check if an
+         * element has IsRowMajor argument. This specific implementation is used when
+         * the the object has not IsRowMajor.
+         */
+        template <typename T, typename = void>
+        struct has_IsRowMajor : std::false_type {};
 
-    /**
-     * has_IsRowMajor is used to build a type-dependent expression that check if an element has
-     * IsRowMajor argument. This specific implementation is used when the the object has not
-     * IsRowMajor, indeed <code>void_t<\endcode> is used to detect ill-formed types in SFINAE
-     * context.
-     */
-    template <typename T> struct has_IsRowMajor<T, void_t<decltype(T::IsRowMajor)>> : std::true_type
-    {
-    };
+        /**
+         * has_IsRowMajor is used to build a type-dependent expression that check if an
+         * element has IsRowMajor argument. This specific implementation is used when
+         * the the object has not IsRowMajor, indeed <code>void_t<\endcode> is used to
+         * detect ill-formed types in SFINAE context.
+         */
+        template <typename T>
+        struct has_IsRowMajor<T, void_t<decltype(T::IsRowMajor)>> : std::true_type {};
+
+    } // namespace MatrixViewIntenal
 
     /**
      * Type of storage ordering
@@ -123,7 +122,7 @@ namespace iDynTree
             std::enable_if_t<std::is_const<element_type>::value
                                  && std::is_convertible<decltype(std::declval<Container>().data()),
                                                         pointer>::value
-                                 && has_IsRowMajor<Container>::value
+                                 && MatrixViewInternal::has_IsRowMajor<Container>::value
                                  && !std::is_same<Container, MatrixView>::value,
                              int> = 0>
         MatrixView(const Container& matrix)
@@ -140,7 +139,7 @@ namespace iDynTree
             std::enable_if_t<std::is_const<element_type>::value
                                  && std::is_convertible<decltype(std::declval<Container>().data()),
                                                         pointer>::value
-                                 && !has_IsRowMajor<Container>::value
+                                 && !MatrixViewInternal::has_IsRowMajor<Container>::value
                                  && !std::is_same<Container, MatrixView>::value,
                              int> = 0>
         MatrixView(const Container& matrix, const StorageOrder& order = StorageOrder::RowMajor)
@@ -151,7 +150,7 @@ namespace iDynTree
         template <class Container,
                   std::enable_if_t<
                       std::is_convertible<decltype(std::declval<Container>().data()), pointer>::value
-                          && has_IsRowMajor<Container>::value
+                          && MatrixViewInternal::has_IsRowMajor<Container>::value
                           && !std::is_same<Container, MatrixView>::value,
                       int> = 0>
         MatrixView(Container& matrix)
@@ -166,7 +165,7 @@ namespace iDynTree
         template <class Container,
                   std::enable_if_t<
                       std::is_convertible<decltype(std::declval<Container>().data()), pointer>::value
-                          && !has_IsRowMajor<Container>::value
+                          && !MatrixViewInternal::has_IsRowMajor<Container>::value
                           && !std::is_same<Container, MatrixView>::value,
                       int> = 0>
         MatrixView(Container& matrix, const StorageOrder& order = StorageOrder::RowMajor)
@@ -232,7 +231,7 @@ namespace iDynTree
 
     template <class Container,
               std::enable_if_t<
-                  has_IsRowMajor<Container>::value
+                  MatrixViewInternal::has_IsRowMajor<Container>::value
                       || std::is_same<MatrixView<typename Container::value_type>, Container>::value,
                   int> = 0>
     IDYNTREE_CONSTEXPR MatrixView<typename Container::value_type> make_matrix_view(Container& cont)
@@ -242,7 +241,7 @@ namespace iDynTree
 
     template <class Container,
               std::enable_if_t<
-                  has_IsRowMajor<Container>::value
+                  MatrixViewInternal::has_IsRowMajor<Container>::value
                       || std::is_same<MatrixView<const typename Container::value_type>, Container>::value,
                   int> = 0>
     IDYNTREE_CONSTEXPR MatrixView<const typename Container::value_type> make_matrix_view(const Container& cont)
@@ -252,7 +251,7 @@ namespace iDynTree
 
     template <class Container,
               std::enable_if_t<
-                  !has_IsRowMajor<Container>::value
+                  !MatrixViewInternal::has_IsRowMajor<Container>::value
                       && !std::is_same<MatrixView<typename Container::value_type>, Container>::value,
                   int> = 0>
     IDYNTREE_CONSTEXPR MatrixView<typename Container::value_type>
@@ -264,7 +263,7 @@ namespace iDynTree
 
     template <class Container,
               std::enable_if_t<
-                  !has_IsRowMajor<Container>::value
+                  !MatrixViewInternal::has_IsRowMajor<Container>::value
                       && !std::is_same<MatrixView<typename Container::value_type>, Container>::value,
                   int> = 0>
     IDYNTREE_CONSTEXPR MatrixView<const typename Container::value_type>

--- a/src/core/include/iDynTree/Core/MatrixView.h
+++ b/src/core/include/iDynTree/Core/MatrixView.h
@@ -77,17 +77,18 @@ namespace iDynTree
     public:
         using element_type = ElementType;
         using value_type = std::remove_cv_t<ElementType>;
+        using index_type = std::ptrdiff_t;
         using pointer = element_type*;
         using reference = element_type&;
 
     private:
         pointer m_storage;
-        unsigned int m_rows;
-        unsigned int m_cols;
+        index_type m_rows;
+        index_type m_cols;
 
         StorageOrder m_storageOrder;
 
-        unsigned int rawIndex(int row, int col) const
+        index_type rawIndex(index_type row, index_type col) const
         {
             if (m_storageOrder == StorageOrder::RowMajor)
             {
@@ -174,8 +175,8 @@ namespace iDynTree
         }
 
         MatrixView(pointer in_data,
-                   const unsigned int& in_rows,
-                   const unsigned int& in_cols,
+                   index_type in_rows,
+                   index_type in_cols,
                    const StorageOrder& order = StorageOrder::RowMajor)
             : m_storage(in_data)
             , m_rows(in_rows)
@@ -200,19 +201,19 @@ namespace iDynTree
          *
          */
         ///@{
-        reference operator()(const unsigned int row, const unsigned int col) const
+        reference operator()(index_type row, const index_type col) const
         {
             assert(row < this->rows());
             assert(col < this->cols());
             return this->m_storage[rawIndex(row, col)];
         }
 
-        unsigned int rows() const
+        index_type rows() const noexcept
         {
             return this->m_rows;
         }
 
-        unsigned int cols() const
+        index_type cols() const noexcept
         {
             return this->m_cols;
         }
@@ -222,8 +223,8 @@ namespace iDynTree
     template <class ElementType>
     IDYNTREE_CONSTEXPR MatrixView<ElementType>
     make_matrix_view(ElementType* ptr,
-                     const unsigned int& rows,
-                     const unsigned int& cols,
+                     typename MatrixView<ElementType>::index_type rows,
+                     typename MatrixView<ElementType>::index_type cols,
                      const StorageOrder& order = StorageOrder::RowMajor)
     {
         return MatrixView<ElementType>(ptr, rows, cols, order);

--- a/src/core/src/MatrixDynSize.cpp
+++ b/src/core/src/MatrixDynSize.cpp
@@ -107,6 +107,41 @@ MatrixDynSize& MatrixDynSize::operator=(const MatrixDynSize& other)
     return *this;
 }
 
+MatrixDynSize& MatrixDynSize::operator=(const MatrixView<const double>& other)
+{
+    m_rows = other.rows();
+    m_cols = other.cols();
+
+    const unsigned requiredCapacity = m_rows * m_cols;
+
+    // if other is empty, return
+    if (requiredCapacity == 0) return  *this;
+
+    // If the copied data fits in the currently allocated buffer,
+    // use that one (if the user want to free the memory can use
+    // the shrink_to_fit method).
+    // Otherwise, allocate a new buffer after deleting the old one)
+    if (m_capacity < requiredCapacity) {
+        // need to allocate new buffer
+        // if old buffer exists, delete it
+        if (m_capacity > 0) {
+            delete [] m_data;
+        }
+        m_data = new double[requiredCapacity];
+        m_capacity = requiredCapacity;
+    }
+
+    for(unsigned int i = 0; i < m_rows; i++)
+    {
+        for(unsigned int j = 0; j < m_cols; j++)
+        {
+            this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
+        }
+    }
+
+    return *this;
+}
+
 MatrixDynSize::~MatrixDynSize()
 {
     if( this->m_capacity > 0 )
@@ -305,6 +340,5 @@ std::string MatrixDynSize::reservedToString() const
 {
     return this->toString();
 }
-
 
 }

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_unit_test(TransformFromMatrix4x4)
 add_unit_test(CubicSpline)
 add_unit_test(Span)
 add_unit_test(SO3Utils)
+add_unit_test(MatrixView)
 
 
 # We have also some usages of the API that we want to make sure that do not compile

--- a/src/core/tests/EigenHelpersUnitTest.cpp
+++ b/src/core/tests/EigenHelpersUnitTest.cpp
@@ -58,6 +58,14 @@ void testMatrixToEigen(const MatrixType& input) {
     ASSERT_EQUAL_MATRIX(input, check);
 }
 
+void checkMatrixViewStorageOrder(const Eigen::MatrixXd& input) {
+    auto matrixView = make_matrix_view(input);
+
+    // The toEigen returns a RowMajor matrix even if the original matrix is ColMajor.
+    // The Eigen::Stride is chosen to have the coherent behaviour.
+    ASSERT_EQUAL_MATRIX(input, toEigen(matrixView));
+}
+
 int main()
 {
     Vector3 vec;
@@ -85,6 +93,8 @@ int main()
     Eigen::MatrixXd mat3(12,31);
     getRandomMatrix(mat3);
     testMatrixToEigen(mat3);
+
+    checkMatrixViewStorageOrder(mat3);
 
     return EXIT_SUCCESS;
 }

--- a/src/core/tests/EigenHelpersUnitTest.cpp
+++ b/src/core/tests/EigenHelpersUnitTest.cpp
@@ -45,6 +45,19 @@ void testSpanToEigen(const Vector3& input) {
     ASSERT_EQUAL_VECTOR(input, check);
 }
 
+template <class MatrixType>
+void testMatrixToEigen(const MatrixType& input) {
+    MatrixDynSize randMat(input.rows(), input.cols()), check(input.rows(), input.cols());
+    getRandomMatrix(randMat);
+    MatrixView<double> matrixViewCheck(check);
+    toEigen(matrixViewCheck) = toEigen(randMat);
+    ASSERT_EQUAL_MATRIX(randMat, check);
+    toEigen(make_matrix_view(check)) = toEigen(randMat);
+    toEigen(randMat) = toEigen(make_matrix_view(check));
+    toEigen(check) = toEigen(make_matrix_view(input));
+    ASSERT_EQUAL_MATRIX(input, check);
+}
+
 int main()
 {
     Vector3 vec;
@@ -59,6 +72,19 @@ int main()
 
     testSpanToEigen(vec);
 
+
+    // test the matrix view
+    Matrix2x3 mat1;
+    getRandomMatrix(mat1);
+    testMatrixToEigen(mat1);
+
+    MatrixDynSize mat2(12,31);
+    getRandomMatrix(mat2);
+    testMatrixToEigen(mat2);
+
+    Eigen::MatrixXd mat3(12,31);
+    getRandomMatrix(mat3);
+    testMatrixToEigen(mat3);
 
     return EXIT_SUCCESS;
 }

--- a/src/core/tests/MatrixDynSizeUnitTest.cpp
+++ b/src/core/tests/MatrixDynSizeUnitTest.cpp
@@ -88,8 +88,19 @@ void checkCopyOperator()
 
 }
 
+void checkMatrixView()
+{
+    MatrixDynSize test1, testToMatrixView;
+    testToMatrixView.resize(15, 12);
+    iDynTree::getRandomMatrix(testToMatrixView);
+
+    test1 = iDynTree::make_matrix_view(testToMatrixView);
+    ASSERT_EQUAL_MATRIX(test1, testToMatrixView);
+}
+
 int main()
 {
     checkCapacity();
     checkCopyOperator();
+    checkMatrixView();
 }

--- a/src/core/tests/MatrixViewUnitTest.cpp
+++ b/src/core/tests/MatrixViewUnitTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/MatrixView.h>
+#include <iDynTree/Core/TestUtils.h>
+#include <iDynTree/Core/EigenHelpers.h>
+
+using namespace iDynTree;
+
+template <class T, class U>
+void areMatricesEqual(const T & mat1, const U & mat2)
+{
+    ASSERT_EQUAL_DOUBLE(mat1.rows(), mat2.rows());
+    ASSERT_EQUAL_DOUBLE(mat1.cols(), mat2.cols());
+
+    ASSERT_EQUAL_MATRIX(mat1, mat2);
+}
+
+int main()
+{
+    // test with iDynTree matrix
+    MatrixDynSize mat1(27, 41);
+    getRandomMatrix(mat1);
+    MatrixView<double> view1(mat1);
+
+    areMatricesEqual(view1, mat1);
+
+    // Test with eigen column major matrix
+    Eigen::MatrixXd mat2(27, 41);
+    mat2.setRandom();
+    MatrixView<double> view2(mat2);
+
+    areMatricesEqual(view2, mat2);
+
+    // Test with eigen row major matrix
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> mat3(27, 41);
+    mat3.setRandom();
+    MatrixView<double> view3(mat3);
+
+    areMatricesEqual(view3, mat3);
+
+    return 0;
+}


### PR DESCRIPTION
This PR has to be the updated version of https://github.com/robotology/idyntree/pull/730. Differently from #730 the `storage ordering` is now a regular attribute of the class, rather than a template parameter. The class now behaves like an `std::span`, i.e. when the copy assignment operator is called the pointer, and not what it's contained, is copied.

I've also implemented `make_matrix_view` to simplify the creation of a `MatrixView`. The usual `toEigen()` functions have been implemented to convert the `MatrixView<>` to an `EigenMap`, in this case, the `StorageOrder` is handled using the `Eigen::Stride` (thanks @S-Dafarra for suggesting this). 

The PR is correlated to UnitTests.

This is the first step to achieve #716

@traversaro @prashanthr05 @S-Dafarra   

This is a  [preliminary working implementation](https://github.com/GiulioRomualdi/idyntree/tree/feature/kindyn_matrix_view)  of `kindyn` with `MatrixView`.