### PR TITLE
Update Python SWIG bindings module name

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
         run: pip -v install dist/*.tar.gz
 
       - name: Test import
-        run: python -c 'from idyntree import iDynTree'
+        run: python -c 'import idyntree.bindings'
 
       - name: Remove sdist
         run: |
@@ -56,7 +56,7 @@ jobs:
         run: pip -v install dist/*.whl
 
       - name: Test import
-        run: python -c 'from idyntree import iDynTree'
+        run: python -c 'import idyntree.bindings'
 
       - name: Remove bdist_wheel
         run: pip uninstall -y idyntree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   control if iDynTree is built as a shared or a static library.
 - The Python method `*.fromPyList` is replaced by `*.FromPython` (https://github.com/robotology/idyntree/pull/726).
 - The minimum required CMake version to configure and compile iDynTree is now 3.16 (https://github.com/robotology/idyntree/pull/732).
-- Import the Python SWIG bindings changed from `import iDynTree` to either `from idyntree import iDynTree` or `import idyntree.iDynTree` (https://github.com/robotology/idyntree/pull/733).
+- The Python package name of the SWIG bindings changed from `iDynTree` to `idyntree.bindings` (https://github.com/robotology/idyntree/pull/733, https://github.com/robotology/idyntree/pull/735). To continue referring to iDynTree classes as `iDynTree.<ClassName>`, you can change your `import iDynTree` statements to `import idyntree.bindings as iDynTree`. Otherwise, you can use `import idyntree.bindings` to refer them as `idyntree.bindings.<ClassName>`.
 
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -4,7 +4,9 @@ message(STATUS "Using Python: ${Python3_EXECUTABLE}")
 cmake_policy(SET CMP0078 NEW)
 cmake_policy(SET CMP0086 NEW)
 
-set_source_files_properties(../iDynTree.i PROPERTIES CPLUSPLUS ON)
+set_source_files_properties(../iDynTree.i PROPERTIES
+    CPLUSPLUS ON
+    SWIG_MODULE_NAME "bindings")
 
 set(target_name iDynTree)
 
@@ -32,8 +34,8 @@ set_property(
     TARGET ${target_name}
     PROPERTY SWIG_GENERATED_COMPILE_OPTIONS -Wextra)
 
-# Add a simple __init__.py that loads the bindings and allows using idyntree.iDynTree
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/idyntree/__init__.py "from . import iDynTree")
+# Add a simple __init__.py that loads the bindings and allows using idyntree.bindings
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/idyntree/__init__.py "from . import bindings")
 
 if(IDYNTREE_PACKAGE_FOR_PYPI)
     set(PYTHON_INSTDIR ${CMAKE_INSTALL_PREFIX})
@@ -48,7 +50,7 @@ endif()
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/idyntree/__init__.py
-          ${CMAKE_CURRENT_BINARY_DIR}/idyntree/iDynTree.py
+          ${CMAKE_CURRENT_BINARY_DIR}/idyntree/bindings.py
     DESTINATION ${PYTHON_INSTDIR})
 
 install(TARGETS ${target_name} DESTINATION ${PYTHON_INSTDIR})

--- a/bindings/python/tests/geometry.py
+++ b/bindings/python/tests/geometry.py
@@ -12,7 +12,7 @@ sys.path.append("../../../lib/python/")
 sys.path.append("../../../lib/python/Debug/")
 
 import unittest
-from idyntree import iDynTree
+import idyntree.bindings as iDynTree
 import random
 
 class PositionTest(unittest.TestCase):

--- a/bindings/python/tests/helpers.py
+++ b/bindings/python/tests/helpers.py
@@ -10,7 +10,7 @@ sys.path.append("../../../lib/python/Debug/")
 
 import unittest
 import numpy as np
-from idyntree import iDynTree
+import idyntree.bindings as iDynTree
 import random
 
 class HelpersTest(unittest.TestCase):

--- a/bindings/python/tests/joints.py
+++ b/bindings/python/tests/joints.py
@@ -12,7 +12,7 @@ sys.path.append("../../../lib/python/")
 sys.path.append("../../../lib/python/Debug/")
 
 import unittest
-from idyntree import iDynTree
+import idyntree.bindings as iDynTree
 import random
 
 class JointTest(unittest.TestCase):


### PR DESCRIPTION
After yesterday's #733, I slept on it and gave some though about, and I'm not fully convinced of the way we import the autogenerated swig module: `from idyntree import iDynTree` or `import idyntree.iDynTree as xxx`.

I think we have to take advantage of this task to converge towards an idiomatic pattern, and the evergreen [PEP8](https://www.python.org/dev/peps/pep-0008/#package-and-module-names) discourages the usage of camelcase module names. Changing it to something else would not alter downstream usage more than what already did in #733.

This PR updates the way the swig module is imported as follows:

- `import idyntree.bindings`
- `from idyntree import bindings`
- `import idyntree.bindings as iDynTree`

Particularly, the third option is useful as a single-line update to obtain a soft backward-compatibility, and I mean that beyond the change of the import statement, no further changes are necessary.

I think that this change makes also more clear that the functions that are used come from C++, and it's more intuitive to differentiate them from pure-python functions and classes that we might add in the future.