### PR TITLE
Use MatrixView and Span in KinDynComputations class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and existing objects can be converted to NumPy arrays (`*.toNumPy`) (https://github.com/robotology/idyntree/pull/726).
 - iDynTree Python bindings can now be installed with `pip3 install git+https://github.com/robotology/idyntree.git` (https://github.com/robotology/idyntree/pull/733).
 - Implement the MatrixView class (https://github.com/robotology/idyntree/pull/734)
+- Add the possibility to use `MatrixView` and `Span` as input/output objects for `KinDynComputations` class (https://github.com/robotology/idyntree/pull/736).
 
 ### Fixed
 - Fixed bug in `yarprobotstatepublisher` that caused segmentation fault each time an unknown joint name was read from the input joint states topic (https://github.com/robotology/idyntree/pull/719)
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Python method `*.fromPyList` is replaced by `*.FromPython` (https://github.com/robotology/idyntree/pull/726).
 - The minimum required CMake version to configure and compile iDynTree is now 3.16 (https://github.com/robotology/idyntree/pull/732).
 - The Python package name of the SWIG bindings changed from `iDynTree` to `idyntree.bindings` (https://github.com/robotology/idyntree/pull/733, https://github.com/robotology/idyntree/pull/735). To continue referring to iDynTree classes as `iDynTree.<ClassName>`, you can change your `import iDynTree` statements to `import idyntree.bindings as iDynTree`. Otherwise, you can use `import idyntree.bindings` to refer them as `idyntree.bindings.<ClassName>`.
+- Improve the use of `const` keyword  in `KinDynComputations`(https://github.com/robotology/idyntree/pull/736).
 
 ### Removed 
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -220,8 +220,10 @@ namespace std {
 %include "iDynTree/Core/Transform.h"
 %include "iDynTree/Core/TransformDerivative.h"
 %include "iDynTree/Core/Span.h"
+%include "iDynTree/Core/MatrixView.h"
 
 %template(DynamicSpan) iDynTree::Span<double, iDynTree::dynamic_extent>;
+%template(DynamicMatrixView) iDynTree::MatrixView<double>;
 
 // Model related data structures
 %include "iDynTree/Model/Indices.h"

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -106,7 +106,7 @@ namespace iDynTree
          * \warning performs dynamic memory allocation operations
          *
          */
-        MatrixDynSize(const iDynTree::MatrixView<const double>& other);
+        MatrixDynSize(iDynTree::MatrixView<const double> other);
 
         /**
          * Assignment operator
@@ -124,7 +124,7 @@ namespace iDynTree
          *
          * @return *this
          */
-        MatrixDynSize& operator=(const iDynTree::MatrixView<const double>& other);
+        MatrixDynSize& operator=(iDynTree::MatrixView<const double> other);
 
         /**
          * Denstructor

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -106,7 +106,7 @@ namespace iDynTree
          * \warning performs dynamic memory allocation operations
          *
          */
-        MatrixDynSize(const MatrixView<const double>& other);
+        MatrixDynSize(const iDynTree::MatrixView<const double>& other);
 
         /**
          * Assignment operator
@@ -124,7 +124,7 @@ namespace iDynTree
          *
          * @return *this
          */
-        MatrixDynSize& operator=(const MatrixView<const double>& other);
+        MatrixDynSize& operator=(const iDynTree::MatrixView<const double>& other);
 
         /**
          * Denstructor

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -98,6 +98,16 @@ namespace iDynTree
          */
         MatrixDynSize(const MatrixDynSize& other);
 
+
+        /**
+         * Constructor from MatrixView object
+         *
+         * @param other MatrixView to copy
+         * \warning performs dynamic memory allocation operations
+         *
+         */
+        MatrixDynSize(const MatrixView<const double>& other);
+
         /**
          * Assignment operator
          *

--- a/src/core/include/iDynTree/Core/MatrixFixSize.h
+++ b/src/core/include/iDynTree/Core/MatrixFixSize.h
@@ -82,7 +82,7 @@ namespace iDynTree
          *
          * \warning this class stores data using the row major order
          */
-        MatrixFixSize(const iDynTree::MatrixView<const double>& other);
+        MatrixFixSize(iDynTree::MatrixView<const double> other);
 
         /**
          * @name Matrix interface methods.
@@ -98,7 +98,7 @@ namespace iDynTree
         unsigned int cols() const;
         ///@}
 
-        MatrixFixSize & operator=(const iDynTree::MatrixView<const double>& mat);
+        MatrixFixSize & operator=(iDynTree::MatrixView<const double> mat);
 
         /**
          * Raw data accessor
@@ -196,7 +196,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    MatrixFixSize<nRows,nCols>::MatrixFixSize(const iDynTree::MatrixView<const double>& other)
+    MatrixFixSize<nRows,nCols>::MatrixFixSize(iDynTree::MatrixView<const double> other)
     {
         if( other.rows() != nRows ||
             other.cols() != nCols )
@@ -253,7 +253,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    MatrixFixSize<nRows,nCols> & MatrixFixSize<nRows,nCols>::operator=(const iDynTree::MatrixView<const double>& mat) {
+    MatrixFixSize<nRows,nCols> & MatrixFixSize<nRows,nCols>::operator=(iDynTree::MatrixView<const double> mat) {
         assert(nCols == mat.cols());
         assert(nRows == mat.rows());
 

--- a/src/core/include/iDynTree/Core/MatrixFixSize.h
+++ b/src/core/include/iDynTree/Core/MatrixFixSize.h
@@ -82,7 +82,7 @@ namespace iDynTree
          *
          * \warning this class stores data using the row major order
          */
-        MatrixFixSize(const MatrixView<const double>& other);
+        MatrixFixSize(const iDynTree::MatrixView<const double>& other);
 
         /**
          * @name Matrix interface methods.
@@ -98,7 +98,7 @@ namespace iDynTree
         unsigned int cols() const;
         ///@}
 
-        MatrixFixSize & operator=(const MatrixView<const double>& vec);
+        MatrixFixSize & operator=(const iDynTree::MatrixView<const double>& mat);
 
         /**
          * Raw data accessor
@@ -196,7 +196,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    MatrixFixSize<nRows,nCols>::MatrixFixSize(const MatrixView<const double>& other)
+    MatrixFixSize<nRows,nCols>::MatrixFixSize(const iDynTree::MatrixView<const double>& other)
     {
         if( other.rows() != nRows ||
             other.cols() != nCols )
@@ -253,7 +253,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    MatrixFixSize<nRows,nCols> & MatrixFixSize<nRows,nCols>::operator=(const MatrixView<const double>& mat) {
+    MatrixFixSize<nRows,nCols> & MatrixFixSize<nRows,nCols>::operator=(const iDynTree::MatrixView<const double>& mat) {
         assert(nCols == mat.cols());
         assert(nRows == mat.rows());
 

--- a/src/core/include/iDynTree/Core/MatrixFixSize.h
+++ b/src/core/include/iDynTree/Core/MatrixFixSize.h
@@ -13,6 +13,7 @@
 
 
 #include <iDynTree/Core/Utils.h>
+#include <iDynTree/Core/MatrixView.h>
 
 #include <cassert>
 #include <cstring>
@@ -77,6 +78,13 @@ namespace iDynTree
         MatrixFixSize(const double * in_data, const unsigned int in_rows, const unsigned int in_cols);
 
         /**
+         * Constructor from a MatrixView
+         *
+         * \warning this class stores data using the row major order
+         */
+        MatrixFixSize(const MatrixView<const double>& other);
+
+        /**
          * @name Matrix interface methods.
          * Methods exposing a matrix-like interface to MatrixFixSize.
          *
@@ -89,6 +97,8 @@ namespace iDynTree
         unsigned int rows() const;
         unsigned int cols() const;
         ///@}
+
+        MatrixFixSize & operator=(const MatrixView<const double>& vec);
 
         /**
          * Raw data accessor
@@ -186,6 +196,27 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
+    MatrixFixSize<nRows,nCols>::MatrixFixSize(const MatrixView<const double>& other)
+    {
+        if( other.rows() != nRows ||
+            other.cols() != nCols )
+        {
+            reportError("MatrixFixSize","constructor","input matrix does not have the right size");
+            this->zero();
+        }
+        else
+        {
+            for(unsigned int row=0; row < nRows; row++ )
+            {
+                for(unsigned int col=0; col < nCols; col++ )
+                {
+                    this->m_data[rawIndexRowMajor(row,col)] = other(row, col);
+                }
+            }
+        }
+    }
+
+    template<unsigned int nRows, unsigned int nCols>
     void MatrixFixSize<nRows,nCols>::zero()
     {
         for(unsigned int row=0; row < this->rows(); row++ )
@@ -219,6 +250,21 @@ namespace iDynTree
     const double* MatrixFixSize<nRows,nCols>::data() const
     {
         return this->m_data;
+    }
+
+    template<unsigned int nRows, unsigned int nCols>
+    MatrixFixSize<nRows,nCols> & MatrixFixSize<nRows,nCols>::operator=(const MatrixView<const double>& mat) {
+        assert(nCols == mat.cols());
+        assert(nRows == mat.rows());
+
+        for(unsigned int i = 0; i < nRows; i++)
+        {
+            for(unsigned int j = 0; j < nCols; j++)
+            {
+                this->m_data[this->rawIndexRowMajor(i,j)] = mat(i, j);
+            }
+        }
+        return *this;
     }
 
     template<unsigned int nRows, unsigned int nCols>

--- a/src/core/include/iDynTree/Core/MatrixView.h
+++ b/src/core/include/iDynTree/Core/MatrixView.h
@@ -31,6 +31,7 @@ namespace iDynTree
 
     namespace MatrixViewInternal
     {
+#ifndef SWIG
         // this is required to be compatible with c++17
         template <typename... Ts> struct make_void { typedef void type; };
         template <typename... Ts> using void_t = typename make_void<Ts...>::type;
@@ -51,6 +52,7 @@ namespace iDynTree
          */
         template <typename T>
         struct has_IsRowMajor<T, void_t<decltype(T::IsRowMajor)>> : std::true_type {};
+#endif
 
     } // namespace MatrixViewIntenal
 
@@ -109,6 +111,7 @@ namespace iDynTree
         {
         }
 
+#ifndef SWIG
         template <
             class OtherElementType,
             class = std::enable_if_t<
@@ -173,6 +176,8 @@ namespace iDynTree
             : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), order)
         {
         }
+
+#endif // SWIG
 
         MatrixView(pointer in_data,
                    index_type in_rows,

--- a/src/core/include/iDynTree/Core/Position.h
+++ b/src/core/include/iDynTree/Core/Position.h
@@ -65,7 +65,7 @@ namespace iDynTree
         /**
          * Create a Position from a span
          */
-        Position(const Span<const double> & other);
+        Position(const iDynTree::Span<const double> & other);
 
         /**
          * Geometric operations

--- a/src/core/include/iDynTree/Core/Position.h
+++ b/src/core/include/iDynTree/Core/Position.h
@@ -63,6 +63,11 @@ namespace iDynTree
         Position(const PositionRaw & other);
 
         /**
+         * Create a Position from a span
+         */
+        Position(const Span<const double> & other);
+
+        /**
          * Geometric operations
          */
         const Position & changePoint(const Position & newPoint);

--- a/src/core/include/iDynTree/Core/Position.h
+++ b/src/core/include/iDynTree/Core/Position.h
@@ -65,7 +65,7 @@ namespace iDynTree
         /**
          * Create a Position from a span
          */
-        Position(const iDynTree::Span<const double> & other);
+        Position(iDynTree::Span<const double> other);
 
         /**
          * Geometric operations

--- a/src/core/include/iDynTree/Core/PositionRaw.h
+++ b/src/core/include/iDynTree/Core/PositionRaw.h
@@ -55,7 +55,7 @@ namespace iDynTree
          * Construct from a span
          * @warning if the Span size is different from 3 an assert is thrown at run-time.
          */
-        PositionRaw(const iDynTree::Span<const double>& other);
+        PositionRaw(iDynTree::Span<const double> other);
 
         /**
          * Geometric operations

--- a/src/core/include/iDynTree/Core/PositionRaw.h
+++ b/src/core/include/iDynTree/Core/PositionRaw.h
@@ -52,6 +52,12 @@ namespace iDynTree
         PositionRaw(const PositionRaw & other);
 
         /**
+         * Construct from a span
+         * @warning if the Span size is different from 3 an assert is thrown at run-time.
+         */
+        PositionRaw(const Span<const double>& other);
+
+        /**
          * Geometric operations
          */
         const PositionRaw & changePoint(const PositionRaw & newPoint);

--- a/src/core/include/iDynTree/Core/PositionRaw.h
+++ b/src/core/include/iDynTree/Core/PositionRaw.h
@@ -55,7 +55,7 @@ namespace iDynTree
          * Construct from a span
          * @warning if the Span size is different from 3 an assert is thrown at run-time.
          */
-        PositionRaw(const Span<const double>& other);
+        PositionRaw(const iDynTree::Span<const double>& other);
 
         /**
          * Geometric operations

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -82,7 +82,7 @@ namespace iDynTree
         /**
          * Create a Rotation from a MatrixView.
          */
-        Rotation(const MatrixView<const double>& other);
+        Rotation(const iDynTree::MatrixView<const double>& other);
 
         /**
          * Geometric operations.

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -80,6 +80,11 @@ namespace iDynTree
         Rotation(const Rotation & other);
 
         /**
+         * Create a Rotation from a MatrixView.
+         */
+        Rotation(const MatrixView<const double>& other);
+
+        /**
          * Geometric operations.
          * For the inverse2() operation, both the forward and the inverse geometric relations have to
          * be expressed in the reference orientation frame!!

--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -82,7 +82,7 @@ namespace iDynTree
         /**
          * Create a Rotation from a MatrixView.
          */
-        Rotation(const iDynTree::MatrixView<const double>& other);
+        Rotation(iDynTree::MatrixView<const double> other);
 
         /**
          * Geometric operations.

--- a/src/core/include/iDynTree/Core/RotationRaw.h
+++ b/src/core/include/iDynTree/Core/RotationRaw.h
@@ -65,7 +65,7 @@ namespace iDynTree
                     const unsigned int in_rows,
                     const unsigned int in_cols);
 
-        RotationRaw(const iDynTree::MatrixView<const double>& other);
+        RotationRaw(iDynTree::MatrixView<const double> other);
 
         /**
          * Copy constructor: create a RotationRaw from another RotationRaw.

--- a/src/core/include/iDynTree/Core/RotationRaw.h
+++ b/src/core/include/iDynTree/Core/RotationRaw.h
@@ -21,6 +21,8 @@ namespace iDynTree
     class SpatialForceVector;
     class ClassicalAcc;
     class RotationalInertiaRaw;
+    template<class>
+    class MatrixView;
 
     /**
      * Class providing the raw coordinates for iDynTree::Rotation class.
@@ -63,7 +65,7 @@ namespace iDynTree
                     const unsigned int in_rows,
                     const unsigned int in_cols);
 
-        RotationRaw(const MatrixView<const double>& other);
+        RotationRaw(const iDynTree::MatrixView<const double>& other);
 
         /**
          * Copy constructor: create a RotationRaw from another RotationRaw.

--- a/src/core/include/iDynTree/Core/RotationRaw.h
+++ b/src/core/include/iDynTree/Core/RotationRaw.h
@@ -63,6 +63,8 @@ namespace iDynTree
                     const unsigned int in_rows,
                     const unsigned int in_cols);
 
+        RotationRaw(const MatrixView<const double>& other);
+
         /**
          * Copy constructor: create a RotationRaw from another RotationRaw.
          */

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -80,6 +80,18 @@ namespace iDynTree
          */
         VectorDynSize(const VectorDynSize& vec);
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+
+        /**
+         * Constructor from an iDynTree::Span
+         *
+         * @param vec span representing a vector
+         *
+         * \warning performs dynamic memory allocation operations
+         */
+        VectorDynSize(const Span<const double> & vec);
+#endif
+
         /**
          * Denstructor
          *

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -89,7 +89,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        VectorDynSize(const Span<const double> & vec);
+        VectorDynSize(const iDynTree::Span<const double> & vec);
 #endif
 
         /**
@@ -120,7 +120,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        VectorDynSize & operator=(const Span<const double>& vec);
+        VectorDynSize & operator=(const iDynTree::Span<const double>& vec);
 #endif
         /**
          * @name Vector interface methods.

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -89,7 +89,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        VectorDynSize(const iDynTree::Span<const double> & vec);
+        VectorDynSize(iDynTree::Span<const double> vec);
 #endif
 
         /**
@@ -120,7 +120,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        VectorDynSize & operator=(const iDynTree::Span<const double>& vec);
+        VectorDynSize & operator=(iDynTree::Span<const double> vec);
 #endif
         /**
          * @name Vector interface methods.

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -54,6 +54,15 @@ namespace iDynTree
          */
         VectorFixSize(const double * in_data, const unsigned int in_size);
 
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+        /**
+         * Constructor from an iDynTree::Span
+         *
+         * Print an error an build a vector full of zeros if in_size is not size().
+         */
+        VectorFixSize(const Span<const double>& vec);
+#endif
+
         /**
          * @name Vector interface methods.
          * Methods exposing a vector-like interface to VectorFixSize.
@@ -208,6 +217,15 @@ namespace iDynTree
             memcpy(this->m_data,in_data,sizeof(double)*VecSize);
         }
     }
+
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+
+    template<unsigned int VecSize>
+    VectorFixSize<VecSize>::VectorFixSize(const Span<const double>& vec)
+        : VectorFixSize<VecSize>::VectorFixSize(vec.data(), vec.size())
+        {}
+
+#endif
 
     template<unsigned int VecSize>
     void VectorFixSize<VecSize>::zero()

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -60,7 +60,7 @@ namespace iDynTree
          *
          * Print an error an build a vector full of zeros if in_size is not size().
          */
-        VectorFixSize(const iDynTree::Span<const double>& vec);
+        VectorFixSize(iDynTree::Span<const double> vec);
 #endif
 
         /**
@@ -133,7 +133,7 @@ namespace iDynTree
          * Checks that dimensions are matching through an assert.
          *
          */
-        VectorFixSize & operator=(const iDynTree::Span<const double>& vec);
+        VectorFixSize & operator=(iDynTree::Span<const double> vec);
 #endif
 
         /**
@@ -221,7 +221,7 @@ namespace iDynTree
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
 
     template<unsigned int VecSize>
-    VectorFixSize<VecSize>::VectorFixSize(const iDynTree::Span<const double>& vec)
+    VectorFixSize<VecSize>::VectorFixSize(iDynTree::Span<const double> vec)
         : VectorFixSize<VecSize>::VectorFixSize(vec.data(), vec.size())
         {}
 
@@ -293,7 +293,7 @@ namespace iDynTree
 
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
     template<unsigned int VecSize>
-    VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const iDynTree::Span<const double>& vec) {
+    VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(iDynTree::Span<const double> vec) {
         assert(VecSize == vec.size());
         std::memcpy(this->m_data, vec.data(), VecSize*sizeof(double));
         return *this;

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -60,7 +60,7 @@ namespace iDynTree
          *
          * Print an error an build a vector full of zeros if in_size is not size().
          */
-        VectorFixSize(const Span<const double>& vec);
+        VectorFixSize(const iDynTree::Span<const double>& vec);
 #endif
 
         /**
@@ -133,7 +133,7 @@ namespace iDynTree
          * Checks that dimensions are matching through an assert.
          *
          */
-        VectorFixSize & operator=(const Span<const double>& vec);
+        VectorFixSize & operator=(const iDynTree::Span<const double>& vec);
 #endif
 
         /**
@@ -221,7 +221,7 @@ namespace iDynTree
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
 
     template<unsigned int VecSize>
-    VectorFixSize<VecSize>::VectorFixSize(const Span<const double>& vec)
+    VectorFixSize<VecSize>::VectorFixSize(const iDynTree::Span<const double>& vec)
         : VectorFixSize<VecSize>::VectorFixSize(vec.data(), vec.size())
         {}
 
@@ -293,7 +293,7 @@ namespace iDynTree
 
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
     template<unsigned int VecSize>
-    VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const Span<const double>& vec) {
+    VectorFixSize<VecSize> & VectorFixSize<VecSize>::operator=(const iDynTree::Span<const double>& vec) {
         assert(VecSize == vec.size());
         std::memcpy(this->m_data, vec.data(), VecSize*sizeof(double));
         return *this;

--- a/src/core/src/MatrixDynSize.cpp
+++ b/src/core/src/MatrixDynSize.cpp
@@ -42,6 +42,29 @@ MatrixDynSize::MatrixDynSize(unsigned int _rows,
     zero();
 }
 
+MatrixDynSize::MatrixDynSize(const MatrixView<const double>& other) : m_rows(other.rows()),
+                                                                      m_cols(other.cols())
+{
+    if( this->m_rows*this->m_cols == 0 )
+    {
+        this->m_capacity = 0;
+        this->m_data = 0;
+    }
+    else
+    {
+        this->m_capacity = this->m_rows*this->m_cols;
+        this->m_data = new double[this->m_capacity];
+
+        // copy the matrix
+        for(unsigned int i = 0; i < m_rows; i++)
+        {
+            for(unsigned int j = 0; j < m_cols; j++)
+            {
+                this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
+            }
+        }
+    }
+}
 
 MatrixDynSize::MatrixDynSize(const double* in_data,
                              const unsigned int in_rows,

--- a/src/core/src/MatrixDynSize.cpp
+++ b/src/core/src/MatrixDynSize.cpp
@@ -42,7 +42,7 @@ MatrixDynSize::MatrixDynSize(unsigned int _rows,
     zero();
 }
 
-MatrixDynSize::MatrixDynSize(const MatrixView<const double>& other) : m_rows(other.rows()),
+MatrixDynSize::MatrixDynSize(MatrixView<const double> other) : m_rows(other.rows()),
                                                                       m_cols(other.cols())
 {
     if( this->m_rows*this->m_cols == 0 )
@@ -130,7 +130,7 @@ MatrixDynSize& MatrixDynSize::operator=(const MatrixDynSize& other)
     return *this;
 }
 
-MatrixDynSize& MatrixDynSize::operator=(const MatrixView<const double>& other)
+MatrixDynSize& MatrixDynSize::operator=(MatrixView<const double> other)
 {
     m_rows = other.rows();
     m_cols = other.cols();

--- a/src/core/src/Position.cpp
+++ b/src/core/src/Position.cpp
@@ -69,7 +69,7 @@ namespace iDynTree
 
     }
 
-    Position::Position(const Span<const double> & other): PositionRaw(other)
+    Position::Position(Span<const double> other): PositionRaw(other)
     {
     }
 

--- a/src/core/src/Position.cpp
+++ b/src/core/src/Position.cpp
@@ -69,6 +69,10 @@ namespace iDynTree
 
     }
 
+    Position::Position(const Span<const double> & other): PositionRaw(other)
+    {
+    }
+
     const Position& Position::changePoint(const Position& newPoint)
     {
         this->PositionRaw::changePoint(newPoint);

--- a/src/core/src/PositionRaw.cpp
+++ b/src/core/src/PositionRaw.cpp
@@ -52,7 +52,7 @@ namespace iDynTree
 
     }
 
-    PositionRaw::PositionRaw(const Span<const double>& other):
+    PositionRaw::PositionRaw(Span<const double> other):
                  VectorFixSize< 3 >(other)
     {
 

--- a/src/core/src/PositionRaw.cpp
+++ b/src/core/src/PositionRaw.cpp
@@ -52,6 +52,12 @@ namespace iDynTree
 
     }
 
+    PositionRaw::PositionRaw(const Span<const double>& other):
+                 VectorFixSize< 3 >(other)
+    {
+
+    }
+
     const PositionRaw& PositionRaw::changePoint(const PositionRaw& newPoint)
     {
         this->m_data[0] += newPoint(0);

--- a/src/core/src/Rotation.cpp
+++ b/src/core/src/Rotation.cpp
@@ -71,6 +71,12 @@ namespace iDynTree
     {
 
     }
+
+    Rotation::Rotation(const MatrixView<const double>& other): RotationRaw(other)
+    {
+
+    }
+
     const Rotation& Rotation::changeOrientFrame(const Rotation& newOrientFrame)
     {
         this->RotationRaw::changeOrientFrame(newOrientFrame);

--- a/src/core/src/Rotation.cpp
+++ b/src/core/src/Rotation.cpp
@@ -72,7 +72,7 @@ namespace iDynTree
 
     }
 
-    Rotation::Rotation(const MatrixView<const double>& other): RotationRaw(other)
+    Rotation::Rotation(MatrixView<const double> other): RotationRaw(other)
     {
 
     }

--- a/src/core/src/RotationRaw.cpp
+++ b/src/core/src/RotationRaw.cpp
@@ -48,6 +48,10 @@ namespace iDynTree
         this->m_data[8] = zz;
     }
 
+    RotationRaw::RotationRaw(const MatrixView<const double>& other):
+                             MatrixFixSize<3, 3>(other)
+    {}
+
     RotationRaw::RotationRaw(const double* in_data, const unsigned int in_rows, const unsigned int in_cols):
                              MatrixFixSize<3, 3>(in_data,in_rows,in_cols)
     {

--- a/src/core/src/RotationRaw.cpp
+++ b/src/core/src/RotationRaw.cpp
@@ -48,7 +48,7 @@ namespace iDynTree
         this->m_data[8] = zz;
     }
 
-    RotationRaw::RotationRaw(const MatrixView<const double>& other):
+    RotationRaw::RotationRaw(MatrixView<const double> other):
                              MatrixFixSize<3, 3>(other)
     {}
 

--- a/src/core/src/VectorDynSize.cpp
+++ b/src/core/src/VectorDynSize.cpp
@@ -75,7 +75,7 @@ VectorDynSize::~VectorDynSize()
     }
 }
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
-VectorDynSize::VectorDynSize(const Span<const double> &vec)
+VectorDynSize::VectorDynSize(Span<const double> vec)
     : VectorDynSize(vec.data(), vec.size())
 {}
 #endif
@@ -101,7 +101,7 @@ VectorDynSize& VectorDynSize::operator=(const VectorDynSize& vec)
 }
 
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
-VectorDynSize &VectorDynSize::operator=(const Span<const double> &vec)
+VectorDynSize &VectorDynSize::operator=(Span<const double> vec)
 {
     // if the size don't match, reallocate the data
     if( this->m_size != vec.size() )

--- a/src/core/src/VectorDynSize.cpp
+++ b/src/core/src/VectorDynSize.cpp
@@ -74,6 +74,11 @@ VectorDynSize::~VectorDynSize()
         this->m_data = 0;
     }
 }
+#if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
+VectorDynSize::VectorDynSize(const Span<const double> &vec)
+    : VectorDynSize(vec.data(), vec.size())
+{}
+#endif
 
 VectorDynSize& VectorDynSize::operator=(const VectorDynSize& vec)
 {

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -357,10 +357,8 @@ public:
     /**
      * Set the state for the robot (floating base) (Span and MatrixView implementation)
      *
-     * @param world_p_base translation part of the homogeneous transformation that transforms position vectors expressed in the base reference frame
-     *                      in position frames expressed in the world reference frame (i.e. pos_world = world_T_base*pos_base .
-     * @param world_R_base rotation part of the homogeneous transformation that transforms position vectors expressed in the base reference frame
-     *                      in position frames expressed in the world reference frame (i.e. pos_world = world_T_base*pos_base .
+     * @param world_T_base the homogeneous transformation that transforms position vectors expressed in the base reference frame
+     *                      in position frames expressed in the world reference frame (i.e. pos_world = world_T_base*pos_base).
      * @param s a vector of getNrOfDegreesOfFreedom() joint positions (in rad)
      * @param base_velocity The twist (linear/angular velocity) of the base, expressed with the convention specified by the used FrameVelocityConvention.
      * @param s_dot a vector of getNrOfDegreesOfFreedom() joint velocities (in rad/sec)
@@ -368,8 +366,7 @@ public:
      * @warning the Span and the MatrixView objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool setRobotState(iDynTree::Span<const double> world_p_base,
-                       iDynTree::MatrixView<const double> world_R_base,
+    bool setRobotState(iDynTree::MatrixView<const double> world_T_base,
                        iDynTree::Span<const double> s,
                        iDynTree::Span<const double> base_velocity,
                        iDynTree::Span<const double> s_dot,
@@ -389,7 +386,7 @@ public:
     /**
      * Set the state for the robot (fixed base)
      * Same as setRobotState, but with:
-     *  world_R_base      = iDynTree::Transform::Identity()
+     *  world_T_base      = iDynTree::Transform::Identity()
      *  base_velocity     = iDynTree::Twist::Zero();
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
@@ -408,8 +405,7 @@ public:
                        iDynTree::VectorDynSize &s_dot,
                        iDynTree::Vector3& world_gravity);
 
-    bool getRobotState(iDynTree::Span<double> world_p_base,
-                       iDynTree::MatrixView<double> world_R_base,
+    bool getRobotState(iDynTree::MatrixView<double> world_T_base,
                        iDynTree::Span<double> s,
                        iDynTree::Span<double> base_velocity,
                        iDynTree::Span<double> s_dot,
@@ -424,8 +420,7 @@ public:
      * Access the robot state.
      */
     iDynTree::Transform getWorldBaseTransform() const;
-    bool getWorldBaseTransform(iDynTree::Span<double> world_p_base,
-                               iDynTree::MatrixView<double> world_R_base) const;
+    bool getWorldBaseTransform(iDynTree::MatrixView<double> world_T_base) const;
 
     iDynTree::Twist getBaseTwist() const;
     bool getBaseTwist(iDynTree::Span<double> base_velocity) const;
@@ -494,15 +489,13 @@ public:
     /**
      * Return the transform where the frame is the frame
      * specified by frameIndex, and the reference frame is the world one
-     * (world_H_frame).
-     * @param world_p_frame contains the position component of world_H_frame.
-     * @param world_R_frame contains the rotation component of world_H_frame.
+     * (world_T_frame).
+     * @param world_T_frame
      * @warning the Span and the MatrixView objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
     bool getWorldTransform(const iDynTree::FrameIndex frameIndex,
-                           iDynTree::Span<double> world_p_frame,
-                           iDynTree::MatrixView<double> world_R_frame);
+                           iDynTree::MatrixView<double> world_T_frame);
 
     /**
      * Version of getWorldTransform where the frame is specified by name.
@@ -520,8 +513,7 @@ public:
      *
      */
     bool getWorldTransform(const std::string & frameName,
-                           iDynTree::Span<double> world_p_frame,
-                           iDynTree::MatrixView<double> world_R_frame);
+                           iDynTree::MatrixView<double> world_T_frame);
 
     /**
      * Return the transforms as a homogeneous matrices where the frame is
@@ -544,15 +536,12 @@ public:
      * Return the transform where the frame is the frame
      * specified by frameIndex, and the reference frame is the one specified
      * by refFrameIndex (refFrame_H_frame).
-     * @param refFrame_p_frame contains the position component of refFrame_H_frame.
-     * @param refFrame_R_frame contains the rotation component of refFrame_H_frame.
      * @warning the Span and the MatrixView objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
     bool getRelativeTransform(const iDynTree::FrameIndex refFrameIndex,
                               const iDynTree::FrameIndex frameIndex,
-                              iDynTree::Span<double> refFrame_p_frame,
-                              iDynTree::MatrixView<double> refFrame_R_frame);
+                              iDynTree::MatrixView<double> refFrame_H_frame);
 
      /**
      * Return the transform between the frame with the origin of the frameOriginIndex
@@ -590,8 +579,7 @@ public:
                                       const iDynTree::FrameIndex refFrameOrientationIndex,
                                       const iDynTree::FrameIndex    frameOriginIndex,
                                       const iDynTree::FrameIndex    frameOrientationIndex,
-                                      iDynTree::Span<double> refFrameOrigin_refFrameOrientation_p_frameOrigin_frameORientation,
-                                      iDynTree::MatrixView<double> refFrameOrigin_refFrameOrientation_R_frameOrigin_frameORientation);
+                                      iDynTree::MatrixView<double> refFrameOrigin_refFrameOrientation_H_frameOrigin_frameORientation);
 
     /**
      * Version of getRelativeTransform where the frames are specified by name.
@@ -610,8 +598,7 @@ public:
      */
     bool getRelativeTransform(const std::string & refFrameName,
                               const std::string & frameName,
-                              iDynTree::Span<double> refFrame_p_frame,
-                              iDynTree::MatrixView<double> refFrame_R_frame);
+                              iDynTree::MatrixView<double> refFrame_H_frame);
     //@}
 
     /**

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright (C) 2016 Fondazione Istituto Italiano di Tecnologia
  *
  * Licensed under either the GNU Lesser General Public License v3.0 :
@@ -274,7 +274,7 @@ public:
      */
     bool getRelativeJacobianSparsityPattern(const iDynTree::FrameIndex refFrameIndex,
                                             const iDynTree::FrameIndex frameIndex,
-                                            const MatrixView<double> & outJacobianPattern) const;
+                                            iDynTree::MatrixView<double> outJacobianPattern) const;
 
 
     /**
@@ -306,7 +306,7 @@ public:
      * @return true on success. False otherwise
      */
     bool getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
-                                                     const MatrixView<double> & outJacobianPattern) const;
+                                                     iDynTree::MatrixView<double> outJacobianPattern) const;
 
 
     //@}
@@ -335,7 +335,7 @@ public:
      * @param[in] s A vector of dimension this->model().getNrOfPosCoords() .
      * @return true if all went well, false otherwise.
      */
-    bool setJointPos(const iDynTree::Span<const double> & s);
+    bool setJointPos(iDynTree::Span<const double> s);
 
     /**
      * Set the state for the robot (floating base)
@@ -368,12 +368,12 @@ public:
      * @warning the Span and the MatrixView objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool setRobotState(const iDynTree::Span<const double>& world_p_base,
-                       const iDynTree::MatrixView<const double>& world_R_base,
-                       const iDynTree::Span<const double>& s,
-                       const iDynTree::Span<const double>& base_velocity,
-                       const iDynTree::Span<const double>& s_dot,
-                       const iDynTree::Span<const double>& world_gravity);
+    bool setRobotState(iDynTree::Span<const double> world_p_base,
+                       iDynTree::MatrixView<const double> world_R_base,
+                       iDynTree::Span<const double> s,
+                       iDynTree::Span<const double> base_velocity,
+                       iDynTree::Span<const double> s_dot,
+                       iDynTree::Span<const double> world_gravity);
 
     /**
      * Set the state for the robot (fixed base)
@@ -394,9 +394,9 @@ public:
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool setRobotState(const iDynTree::Span<const double>& s,
-                       const iDynTree::Span<const double>& s_dot,
-                       const iDynTree::Span<const double>& world_gravity);
+    bool setRobotState(iDynTree::Span<const double> s,
+                       iDynTree::Span<const double> s_dot,
+                       iDynTree::Span<const double> world_gravity);
 
     void getRobotState(iDynTree::Transform &world_T_base,
                        iDynTree::VectorDynSize& s,
@@ -408,27 +408,27 @@ public:
                        iDynTree::VectorDynSize &s_dot,
                        iDynTree::Vector3& world_gravity);
 
-    bool getRobotState(const iDynTree::Span<double>& world_p_base,
-                       const iDynTree::MatrixView<double>& world_R_base,
-                       const iDynTree::Span<double>& s,
-                       const iDynTree::Span<double>& base_velocity,
-                       const iDynTree::Span<double>& s_dot,
-                       const iDynTree::Span<double>& world_gravity);
+    bool getRobotState(iDynTree::Span<double> world_p_base,
+                       iDynTree::MatrixView<double> world_R_base,
+                       iDynTree::Span<double> s,
+                       iDynTree::Span<double> base_velocity,
+                       iDynTree::Span<double> s_dot,
+                       iDynTree::Span<double> world_gravity);
 
-    void getRobotState(const iDynTree::Span<double>& s,
-                       const iDynTree::Span<double>& s_dot,
-                       const iDynTree::Span<double>& world_gravity);
+    void getRobotState(iDynTree::Span<double> s,
+                       iDynTree::Span<double> s_dot,
+                       iDynTree::Span<double> world_gravity);
 
 
     /**
      * Access the robot state.
      */
     iDynTree::Transform getWorldBaseTransform() const;
-    bool getWorldBaseTransform(const iDynTree::Span<double>& world_p_base,
-                               const iDynTree::MatrixView<double>& world_R_base) const;
+    bool getWorldBaseTransform(iDynTree::Span<double> world_p_base,
+                               iDynTree::MatrixView<double> world_R_base) const;
 
     iDynTree::Twist getBaseTwist() const;
-    bool getBaseTwist(const iDynTree::Span<double> & base_velocity) const;
+    bool getBaseTwist(iDynTree::Span<double> base_velocity) const;
 
     bool getJointPos(iDynTree::VectorDynSize &q) const;
 
@@ -437,7 +437,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getJointPos(const iDynTree::Span<double> &q) const;
+    bool getJointPos(iDynTree::Span<double>q) const;
 
     bool getJointVel(iDynTree::VectorDynSize &dq) const;
 
@@ -446,7 +446,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getJointVel(const iDynTree::Span<double> &dq) const;
+    bool getJointVel(iDynTree::Span<double>dq) const;
 
     /**
      * Get the n+6 velocity of the model.
@@ -460,7 +460,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getModelVel(const iDynTree::Span<double> &nu) const;
+    bool getModelVel(iDynTree::Span<double>nu) const;
 
 
     //@}
@@ -501,8 +501,8 @@ public:
      * @return true if all went well, false otherwise.
      */
     bool getWorldTransform(const iDynTree::FrameIndex frameIndex,
-                           const iDynTree::Span<double>& world_p_frame,
-                           const iDynTree::MatrixView<double>& world_R_frame);
+                           iDynTree::Span<double> world_p_frame,
+                           iDynTree::MatrixView<double> world_R_frame);
 
     /**
      * Version of getWorldTransform where the frame is specified by name.
@@ -520,8 +520,8 @@ public:
      *
      */
     bool getWorldTransform(const std::string & frameName,
-                           const iDynTree::Span<double>& world_p_frame,
-                           const iDynTree::MatrixView<double>& world_R_frame);
+                           iDynTree::Span<double> world_p_frame,
+                           iDynTree::MatrixView<double> world_R_frame);
 
     /**
      * Return the transforms as a homogeneous matrices where the frame is
@@ -551,8 +551,8 @@ public:
      */
     bool getRelativeTransform(const iDynTree::FrameIndex refFrameIndex,
                               const iDynTree::FrameIndex frameIndex,
-                              const iDynTree::Span<double>& refFrame_p_frame,
-                              const iDynTree::MatrixView<double>& refFrame_R_frame);
+                              iDynTree::Span<double> refFrame_p_frame,
+                              iDynTree::MatrixView<double> refFrame_R_frame);
 
      /**
      * Return the transform between the frame with the origin of the frameOriginIndex
@@ -590,8 +590,8 @@ public:
                                       const iDynTree::FrameIndex refFrameOrientationIndex,
                                       const iDynTree::FrameIndex    frameOriginIndex,
                                       const iDynTree::FrameIndex    frameOrientationIndex,
-                                      const iDynTree::Span<double>& refFrameOrigin_refFrameOrientation_p_frameOrigin_frameORientation,
-                                      const iDynTree::MatrixView<double>& refFrameOrigin_refFrameOrientation_R_frameOrigin_frameORientation);
+                                      iDynTree::Span<double> refFrameOrigin_refFrameOrientation_p_frameOrigin_frameORientation,
+                                      iDynTree::MatrixView<double> refFrameOrigin_refFrameOrientation_R_frameOrigin_frameORientation);
 
     /**
      * Version of getRelativeTransform where the frames are specified by name.
@@ -610,8 +610,8 @@ public:
      */
     bool getRelativeTransform(const std::string & refFrameName,
                               const std::string & frameName,
-                              const iDynTree::Span<double>& refFrame_p_frame,
-                              const iDynTree::MatrixView<double>& refFrame_R_frame);
+                              iDynTree::Span<double> refFrame_p_frame,
+                              iDynTree::MatrixView<double> refFrame_R_frame);
     //@}
 
     /**
@@ -631,7 +631,7 @@ public:
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getFrameVel(const std::string & frameName, const iDynTree::Span<double> & twist);
+    bool getFrameVel(const std::string & frameName, iDynTree::Span<double> twist);
 
     /**
      * Return the frame velocity, with the convention specified by getFrameVelocityRepresentation .
@@ -645,7 +645,7 @@ public:
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getFrameVel(const FrameIndex frameIdx, const iDynTree::Span<double> & twist);
+    bool getFrameVel(const FrameIndex frameIdx, iDynTree::Span<double> twist);
 
     /**
      * Return the frame acceleration, with the convention specified by getFrameVelocityRepresentation .
@@ -666,9 +666,9 @@ public:
      * @return true if all went well, false otherwise.
      */
     bool getFrameAcc(const std::string & frameName,
-                     const Span<const double>& baseAcc,
-                     const Span<const double>& s_ddot,
-                     const Span<double>& frame_acceleration);
+                     iDynTree::Span<const double> baseAcc,
+                     iDynTree::Span<const double> s_ddot,
+                     iDynTree::Span<double> frame_acceleration);
 
     /**
      * Return the frame acceleration, with the convention specified by getFrameVelocityRepresentation .
@@ -689,9 +689,9 @@ public:
      * @return true if all went well, false otherwise.
      */
     bool getFrameAcc(const FrameIndex frameName,
-                     const Span<const double>& baseAcc,
-                     const Span<const double>& s_ddot,
-                     const Span<double>& frame_acceleration);
+                     iDynTree::Span<const double> baseAcc,
+                     iDynTree::Span<const double> s_ddot,
+                     iDynTree::Span<double> frame_acceleration);
 
     /**
      * Compute the free floating jacobian for a given frame for the given representaiton.
@@ -716,7 +716,7 @@ public:
      * @return true if all went well, false otherwise.
      */
     bool getFrameFreeFloatingJacobian(const std::string & frameName,
-                                      const MatrixView<double> & outJacobian);
+                                      iDynTree::MatrixView<double> outJacobian);
 
     /**
      * Compute the free floating jacobian for a given frame for the given representaiton (MatrixView implementation).
@@ -725,7 +725,7 @@ public:
      * @return true if all went well, false otherwise.
      */
     bool getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
-                                      const MatrixView<double> & outJacobian);
+                                      iDynTree::MatrixView<double> outJacobian);
 
 
 
@@ -757,7 +757,7 @@ public:
      */
     bool getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
                              const iDynTree::FrameIndex frameIndex,
-                             const MatrixView<double> & outJacobian);
+                             iDynTree::MatrixView<double> outJacobian);
 
     /**
      * Return the relative Jacobian between the two frames
@@ -800,7 +800,7 @@ public:
                                      const iDynTree::FrameIndex frameIndex,
                                      const iDynTree::FrameIndex expressedOriginFrameIndex,
                                      const iDynTree::FrameIndex expressedOrientationFrameIndex,
-                                     const MatrixView<double> & outJacobian);
+                                     iDynTree::MatrixView<double> outJacobian);
 
 
     /**
@@ -817,7 +817,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise
      */
-    bool getFrameBiasAcc(const FrameIndex frameIdx, const iDynTree::Span<double> & bias_acc);
+    bool getFrameBiasAcc(const FrameIndex frameIdx, iDynTree::Span<double> bias_acc);
 
     /**
      * Get the bias acceleration (i.e. acceleration not due to robot acceleration) of the frame velocity.
@@ -833,7 +833,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise
      */
-    bool getFrameBiasAcc(const std::string & frameName, const iDynTree::Span<double> & bias_acc);
+    bool getFrameBiasAcc(const std::string & frameName, iDynTree::Span<double> bias_acc);
 
     // Todo getFrameRelativeVel and getFrameRelativeJacobian to match the getRelativeTransform behaviour
 
@@ -863,7 +863,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getCenterOfMassPosition(const iDynTree::Span<double> & pos);
+    bool getCenterOfMassPosition(iDynTree::Span<double> pos);
 
     /**
      * Return the center of mass velocity, with respect to the world/inertial frame.
@@ -881,7 +881,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getCenterOfMassVelocity(const iDynTree::Span<double> & vel);
+    bool getCenterOfMassVelocity(iDynTree::Span<double> vel);
 
     /**
      * Return the center of mass jacobian, i.e. the 3 \times (n+6) matrix such that:
@@ -897,7 +897,7 @@ public:
      * @warning the MatrixView object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getCenterOfMassJacobian(const MatrixView<double> & comJacobian);
+    bool getCenterOfMassJacobian(iDynTree::MatrixView<double> comJacobian);
 
     /**
      * Return the center of mass bias acceleration.
@@ -909,7 +909,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-     bool getCenterOfMassBiasAcc(const iDynTree::Span<double> & acc);
+     bool getCenterOfMassBiasAcc(iDynTree::Span<double> acc);
 
     /**
      * Get the average velocity of the robot.
@@ -929,7 +929,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getAverageVelocity(const iDynTree::Span<double> & acc);
+    bool getAverageVelocity(iDynTree::Span<double> acc);
 
     /**
      * Get the jacobian of the average velocity of the robot.
@@ -951,7 +951,7 @@ public:
      * @warning the MatrixView object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getAverageVelocityJacobian(const MatrixView<double> & avgVelocityJacobian);
+    bool getAverageVelocityJacobian(iDynTree::MatrixView<double> avgVelocityJacobian);
 
     /**
      * Get the centroidal average velocity of the robot.
@@ -979,7 +979,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getCentroidalAverageVelocity(const iDynTree::Span<double> & acc);
+    bool getCentroidalAverageVelocity(iDynTree::Span<double> acc);
 
     /**
      * Get the jacobian of the centroidal average velocity of the robot.
@@ -995,7 +995,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getCentroidalAverageVelocityJacobian(const MatrixView<double> & centroidalAvgVelocityJacobian);
+    bool getCentroidalAverageVelocityJacobian(iDynTree::MatrixView<double> centroidalAvgVelocityJacobian);
 
     /**
      * Get the linear and angular momentum of the robot.
@@ -1014,7 +1014,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getLinearAngularMomentum(const iDynTree::Span<double> & spatialMomentum);
+    bool getLinearAngularMomentum(iDynTree::Span<double> spatialMomentum);
 
     /**
      * Get the linear and angular momentum jacobian of the robot.
@@ -1031,7 +1031,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getLinearAngularMomentumJacobian(const MatrixView<double> & linAngMomentumJacobian);
+    bool getLinearAngularMomentumJacobian(iDynTree::MatrixView<double> linAngMomentumJacobian);
 
     /**
      * Get the centroidal (total) momentum of the robot.
@@ -1047,7 +1047,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
      */
-    bool getCentroidalTotalMomentum(const iDynTree::Span<double>& spatial_momentum);
+    bool getCentroidalTotalMomentum(iDynTree::Span<double> spatial_momentum);
 
     /**
      * @brief Get the total centroidal momentum jacobian of the robot.
@@ -1074,7 +1074,7 @@ public:
      * introduced in https://doi.org/10.1109/IROS.2008.4650772 .
      * @warning the MatrixView object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      */
-    bool getCentroidalTotalMomentumJacobian(const MatrixView<double> & centroidalTotalMomentumJacobian);
+    bool getCentroidalTotalMomentumJacobian(iDynTree::MatrixView<double> centroidalTotalMomentumJacobian);
 
     //@}
 
@@ -1163,7 +1163,7 @@ public:
      * @warning the MatrixView object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getFreeFloatingMassMatrix(const MatrixView<double> & freeFloatingMassMatrix);
+    bool getFreeFloatingMassMatrix(iDynTree::MatrixView<double> freeFloatingMassMatrix);
 
     /**
      * @brief Compute the free floating inverse dynamics.
@@ -1203,8 +1203,8 @@ public:
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool inverseDynamics(const iDynTree::Span<const double>& baseAcc,
-                         const iDynTree::Span<const double>& s_ddot,
+    bool inverseDynamics(iDynTree::Span<const double> baseAcc,
+                         iDynTree::Span<const double> s_ddot,
                          const LinkNetExternalWrenches & linkExtForces,
                                FreeFloatingGeneralizedTorques & baseForceAndJointTorques);
 
@@ -1238,7 +1238,7 @@ public:
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool generalizedBiasForces(const iDynTree::Span<double> & generalizedBiasForces);
+    bool generalizedBiasForces(iDynTree::Span<double> generalizedBiasForces);
 
     /**
      * @brief Compute the getNrOfDOFS()+6 vector of generalized gravity forces.
@@ -1270,7 +1270,7 @@ public:
      * @warning the Span objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool generalizedGravityForces(const iDynTree::Span<double> & generalizedGravityForces);
+    bool generalizedGravityForces(iDynTree::Span<double> generalizedGravityForces);
 
     /**
      * @brief Compute the getNrOfDOFS()+6 vector of generalized external forces.

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -432,7 +432,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getJointPos(iDynTree::Span<double>q) const;
+    bool getJointPos(iDynTree::Span<double> q) const;
 
     bool getJointVel(iDynTree::VectorDynSize &dq) const;
 
@@ -441,7 +441,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getJointVel(iDynTree::Span<double>dq) const;
+    bool getJointVel(iDynTree::Span<double> dq) const;
 
     /**
      * Get the n+6 velocity of the model.

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -16,8 +16,8 @@
 
 #include <iDynTree/Core/VectorFixSize.h>
 #include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/MatrixView.h>
 #include <iDynTree/Core/Utils.h>
-
 
 #include <iDynTree/Model/Indices.h>
 #include <iDynTree/Model/FreeFloatingMatrices.h>
@@ -256,6 +256,10 @@ public:
                                             const iDynTree::FrameIndex frameIndex,
                                             iDynTree::MatrixDynSize & outJacobianPattern) const;
 
+    bool getRelativeJacobianSparsityPattern(const iDynTree::FrameIndex refFrameIndex,
+                                            const iDynTree::FrameIndex frameIndex,
+                                            MatrixView<double> outJacobianPattern) const;
+
 
     /**
      * Returns the sparsity pattern of the free floating Jacobian for the specified frame
@@ -270,6 +274,9 @@ public:
      */
     bool getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
                                                      iDynTree::MatrixDynSize & outJacobianPattern) const;
+
+    bool getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
+                                                     MatrixView<double> outJacobianPattern) const;
 
 
     //@}
@@ -464,6 +471,11 @@ public:
     bool getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
                                       iDynTree::MatrixDynSize & outJacobian);
 
+    bool getFrameFreeFloatingJacobian(const std::string & frameName,
+                                      const MatrixView<double> & outJacobian);
+
+    bool getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
+                                      const MatrixView<double> & outJacobian);
 
 
 
@@ -480,6 +492,10 @@ public:
     bool getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
                              const iDynTree::FrameIndex frameIndex,
                              iDynTree::MatrixDynSize & outJacobian);
+
+    bool getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
+                             const iDynTree::FrameIndex frameIndex,
+                             MatrixView<double> outJacobian);
 
     /**
      * Return the relative Jacobian between the two frames
@@ -501,6 +517,12 @@ public:
                                      const iDynTree::FrameIndex expressedOriginFrameIndex,
                                      const iDynTree::FrameIndex expressedOrientationFrameIndex,
                                      iDynTree::MatrixDynSize & outJacobian);
+
+    bool getRelativeJacobianExplicit(const iDynTree::FrameIndex refFrameIndex,
+                                     const iDynTree::FrameIndex frameIndex,
+                                     const iDynTree::FrameIndex expressedOriginFrameIndex,
+                                     const iDynTree::FrameIndex expressedOrientationFrameIndex,
+                                     MatrixView<double> outJacobian);
 
 
     /**
@@ -555,6 +577,8 @@ public:
      */
     bool getCenterOfMassJacobian(MatrixDynSize & comJacobian);
 
+    bool getCenterOfMassJacobian(MatrixView<double> comJacobian);
+
     /**
      * Return the center of mass bias acceleration.
      */
@@ -580,6 +604,8 @@ public:
      */
     bool getAverageVelocityJacobian(MatrixDynSize & avgVelocityJacobian);
 
+    bool getAverageVelocityJacobian(MatrixView<double> avgVelocityJacobian);
+
     /**
      * Get the centroidal average velocity of the robot.
      *
@@ -600,6 +626,8 @@ public:
      */
     bool getCentroidalAverageVelocityJacobian(MatrixDynSize & centroidalAvgVelocityJacobian);
 
+    bool getCentroidalAverageVelocityJacobian(MatrixView<double> centroidalAvgVelocityJacobian);
+
     /**
      * Get the linear and angular momentum of the robot.
      * The quantity is expressed in (B[A]), (A) or (B) depending on the FrameVelocityConvention used.
@@ -615,6 +643,8 @@ public:
      * \note Implementation incomplete, please refrain to use until this warning has been removed.
      */
     bool getLinearAngularMomentumJacobian(MatrixDynSize & linAngMomentumJacobian);
+
+    bool getLinearAngularMomentumJacobian(MatrixView<double> linAngMomentumJacobian);
 
     /**
      * Get the centroidal (total) momentum of the robot.
@@ -635,6 +665,8 @@ public:
      * introduced in https://doi.org/10.1109/IROS.2008.4650772 .
      */
     bool getCentroidalTotalMomentumJacobian(MatrixDynSize& centroidalTotalMomentumJacobian);
+
+    bool getCentroidalTotalMomentumJacobian(MatrixView<double> centroidalTotalMomentumJacobian);
 
     //@}
 
@@ -704,6 +736,7 @@ public:
      */
     bool getFreeFloatingMassMatrix(MatrixDynSize & freeFloatingMassMatrix);
 
+    bool getFreeFloatingMassMatrix(MatrixView<double> freeFloatingMassMatrix);
 
     /**
      * @brief Compute the free floating inverse dynamics.
@@ -807,4 +840,3 @@ public:
 }
 
 #endif
-

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright (C) 2016 Fondazione Istituto Italiano di Tecnologia
  *
  * Licensed under either the GNU Lesser General Public License v3.0 :
@@ -490,8 +490,9 @@ public:
      * Return the transform where the frame is the frame
      * specified by frameIndex, and the reference frame is the world one
      * (world_T_frame).
-     * @param world_T_frame
-     * @warning the Span and the MatrixView objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
+     * @param world_T_frame a 4x4 matrix representing the homogeneous transformation that transforms position vectors expressed in the 'frame' reference frame
+     *                      in position frames expressed in the world reference frame (i.e. pos_world = world_T_frame * pos_frame).
+     * @warning the MatrixView object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
     bool getWorldTransform(const iDynTree::FrameIndex frameIndex,
@@ -536,6 +537,8 @@ public:
      * Return the transform where the frame is the frame
      * specified by frameIndex, and the reference frame is the one specified
      * by refFrameIndex (refFrame_H_frame).
+     * @param refFrame_H_frame a 4x4 matrix representing the homogeneous transformation that transforms position vectors expressed in the 'frame' reference frame
+     *                      in position frames expressed in the 'refFrame' reference frame (i.e. pos_refFrame = refFrame_T_frame * pos_frame).
      * @warning the Span and the MatrixView objects should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
@@ -645,7 +648,7 @@ public:
 
     /**
      * Return the frame acceleration, with the convention specified by getFrameVelocityRepresentation.
-     * (MatrixView and Span version)
+     * (Span version)
      *
      * @warning As this method recomputes the accelerations of all links for each call, it may be computationally expensive.
      *

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -455,7 +455,7 @@ public:
      * @warning the Span object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true if all went well, false otherwise.
      */
-    bool getModelVel(iDynTree::Span<double>nu) const;
+    bool getModelVel(iDynTree::Span<double> nu) const;
 
 
     //@}

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1744,7 +1744,7 @@ bool KinDynComputations::getRelativeJacobian(const iDynTree::FrameIndex refFrame
 
     outJacobian.resize(6, pimpl->m_robot_model.getNrOfDOFs());
 
-    this->getRelativeJacobian(refFrameIndex, frameIndex, MatrixView<double>(outJacobian));
+    return this->getRelativeJacobian(refFrameIndex, frameIndex, MatrixView<double>(outJacobian));
 }
 
 bool KinDynComputations::getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -121,10 +121,10 @@ public:
     const SpatialInertia & getRobotLockedInertia();
 
     // Process a jacobian that expects a body fixed base velocity depending on the selected FrameVelocityRepresentation
-    void processOnRightSideMatrixExpectingBodyFixedModelVelocity(const MatrixView<double> & mat);
-    void processOnLeftSideBodyFixedBaseMomentumJacobian(const MatrixView<double> & jac);
-    void processOnLeftSideBodyFixedAvgVelocityJacobian(const MatrixView<double> & jac);
-    void processOnLeftSideBodyFixedCentroidalAvgVelocityJacobian(const MatrixView<double> & jac, const FrameVelocityRepresentation & leftSideRepresentation);
+    void processOnRightSideMatrixExpectingBodyFixedModelVelocity(MatrixView<double> mat);
+    void processOnLeftSideBodyFixedBaseMomentumJacobian(MatrixView<double> jac);
+    void processOnLeftSideBodyFixedAvgVelocityJacobian(MatrixView<double> jac);
+    void processOnLeftSideBodyFixedCentroidalAvgVelocityJacobian(MatrixView<double> jac, const FrameVelocityRepresentation & leftSideRepresentation);
 
     // Transform a wrench from and to body fixed and the used representation
     Wrench fromBodyFixedToUsedRepresentation(const Wrench & wrenchInBodyFixed, const Transform & inertial_X_link);
@@ -565,7 +565,7 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
 
 bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::FrameIndex refFrameIndex,
                                                             const iDynTree::FrameIndex frameIndex,
-                                                            const MatrixView<double> & outJacobian) const
+                                                            MatrixView<double> outJacobian) const
     {
         bool ok = (outJacobian.rows() == 6)
             && (outJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs());
@@ -656,7 +656,7 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
     }
 
     bool KinDynComputations::getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
-                                                                         const MatrixView<double> & outJacobianPattern) const
+                                                                         MatrixView<double> outJacobianPattern) const
     {
         if (!pimpl->m_robot_model.isValidFrameIndex(frameIndex))
         {
@@ -761,9 +761,9 @@ bool KinDynComputations::setRobotState(const VectorDynSize& s,
                          world_gravity);
 }
 
-bool KinDynComputations::setRobotState(const iDynTree::Span<const double>& s,
-                                       const iDynTree::Span<const double>& s_dot,
-                                       const iDynTree::Span<const double>& world_gravity)
+bool KinDynComputations::setRobotState(Span<const double> s,
+                                       Span<const double> s_dot,
+                                       Span<const double> world_gravity)
 {
     Transform world_T_base = Transform::Identity();
     Twist base_velocity = Twist::Zero();
@@ -774,12 +774,12 @@ bool KinDynComputations::setRobotState(const iDynTree::Span<const double>& s,
 }
 
 
-bool KinDynComputations::setRobotState(const iDynTree::Span<const double> &world_p_base,
-                                       const iDynTree::MatrixView<const double> &world_R_base,
-                                       const iDynTree::Span<const double>& s,
-                                       const iDynTree::Span<const double>& base_velocity,
-                                       const iDynTree::Span<const double>& s_dot,
-                                       const iDynTree::Span<const double>& world_gravity)
+bool KinDynComputations::setRobotState(Span<const double> world_p_base,
+                                       iDynTree::MatrixView<const double> world_R_base,
+                                       Span<const double> s,
+                                       Span<const double> base_velocity,
+                                       Span<const double> s_dot,
+                                       Span<const double> world_gravity)
 
 {
     bool ok = s.size() == pimpl->m_robot_model.getNrOfPosCoords();
@@ -944,12 +944,12 @@ void KinDynComputations::getRobotState(Transform& world_T_base,
 
 }
 
-bool KinDynComputations::getRobotState(const iDynTree::Span<double>& world_p_base,
-                                       const iDynTree::MatrixView<double>& world_R_base,
-                                       const iDynTree::Span<double>& s,
-                                       const iDynTree::Span<double>& base_velocity,
-                                       const iDynTree::Span<double>& s_dot,
-                                       const iDynTree::Span<double>& world_gravity)
+bool KinDynComputations::getRobotState(iDynTree::Span<double> world_p_base,
+                                       iDynTree::MatrixView<double> world_R_base,
+                                       iDynTree::Span<double> s,
+                                       iDynTree::Span<double> base_velocity,
+                                       iDynTree::Span<double> s_dot,
+                                       iDynTree::Span<double> world_gravity)
 {
     bool ok = s.size() == pimpl->m_robot_model.getNrOfPosCoords();
     if( !ok )
@@ -1024,9 +1024,9 @@ void KinDynComputations::getRobotState(iDynTree::VectorDynSize &s,
     toEigen(s_dot) = toEigen(pimpl->m_vel.jointVel());
 }
 
-void KinDynComputations::getRobotState(const iDynTree::Span<double>& s,
-                                       const iDynTree::Span<double>& s_dot,
-                                       const iDynTree::Span<double>& world_gravity)
+void KinDynComputations::getRobotState(iDynTree::Span<double> s,
+                                       iDynTree::Span<double> s_dot,
+                                       iDynTree::Span<double> world_gravity)
 {
     constexpr int expected_size_gravity = 3;
     assert(s.size() == pimpl->m_robot_model.getNrOfDOFs());
@@ -1039,7 +1039,7 @@ void KinDynComputations::getRobotState(const iDynTree::Span<double>& s,
 }
 
 
-bool KinDynComputations::setJointPos(const iDynTree::Span<const double>& s)
+bool KinDynComputations::setJointPos(Span<const double> s)
 {
     bool ok = (s.size() == pimpl->m_robot_model.getNrOfPosCoords());
     if( !ok )
@@ -1078,8 +1078,8 @@ Transform KinDynComputations::getWorldBaseTransform() const
     return this->pimpl->m_pos.worldBasePos();
 }
 
-bool KinDynComputations::getWorldBaseTransform(const iDynTree::Span<double>& world_p_base,
-                                               const iDynTree::MatrixView<double>& world_R_base) const
+bool KinDynComputations::getWorldBaseTransform(iDynTree::Span<double> world_p_base,
+                                               iDynTree::MatrixView<double> world_R_base) const
 {
     constexpr int expected_position_size = 3;
     bool ok = world_p_base.size() == expected_position_size;
@@ -1126,7 +1126,7 @@ Twist KinDynComputations::getBaseTwist() const
     return Twist::Zero();
 }
 
-bool KinDynComputations::getBaseTwist(const iDynTree::Span<double> & base_velocity) const
+bool KinDynComputations::getBaseTwist(Span<double> base_velocity) const
 {
     constexpr int expected_twist_size = 6;
     bool ok = base_velocity.size() == expected_twist_size;
@@ -1147,7 +1147,7 @@ bool KinDynComputations::getJointPos(VectorDynSize& q) const
     return true;
 }
 
-bool KinDynComputations::getJointPos(const iDynTree::Span<double> &q) const
+bool KinDynComputations::getJointPos(Span<double>q) const
 {
     bool ok = q.size() == pimpl->m_robot_model.getNrOfPosCoords();
     if( !ok )
@@ -1167,7 +1167,7 @@ bool KinDynComputations::getJointVel(VectorDynSize& dq) const
     return true;
 }
 
-bool KinDynComputations::getJointVel(const iDynTree::Span<double> &dq) const
+bool KinDynComputations::getJointVel(Span<double>dq) const
 {
     bool ok = dq.size() == pimpl->m_robot_model.getNrOfPosCoords();
     if( !ok )
@@ -1189,7 +1189,7 @@ bool KinDynComputations::getModelVel(VectorDynSize& nu) const
     return true;
 }
 
-bool KinDynComputations::getModelVel(const iDynTree::Span<double>& nu) const
+bool KinDynComputations::getModelVel(iDynTree::Span<double> nu) const
 {
 
     bool ok = nu.size() == (pimpl->m_robot_model.getNrOfPosCoords() + 6);
@@ -1228,8 +1228,8 @@ Transform KinDynComputations::getRelativeTransform(const std::string& refFrameNa
 
 bool KinDynComputations::getRelativeTransform(const std::string & refFrameName,
                                               const std::string & frameName,
-                                              const iDynTree::Span<double>& refFrame_p_frame,
-                                              const iDynTree::MatrixView<double>& refFrame_R_frame)
+                                              iDynTree::Span<double> refFrame_p_frame,
+                                              iDynTree::MatrixView<double> refFrame_R_frame)
 {
     const int refFrameIndex = getFrameIndex(refFrameName);
     const int frameIndex = getFrameIndex(frameName);
@@ -1278,8 +1278,8 @@ Transform KinDynComputations::getRelativeTransform(const iDynTree::FrameIndex re
 
 bool KinDynComputations::getRelativeTransform(const iDynTree::FrameIndex refFrameIndex,
                                               const iDynTree::FrameIndex frameIndex,
-                                              const iDynTree::Span<double>& refFrame_p_frame,
-                                              const iDynTree::MatrixView<double>& refFrame_R_frame)
+                                              iDynTree::Span<double> refFrame_p_frame,
+                                              iDynTree::MatrixView<double> refFrame_R_frame)
 {
     constexpr int expected_position_size = 3;
     bool ok = refFrame_p_frame.size() == expected_position_size;
@@ -1364,8 +1364,8 @@ bool KinDynComputations::getRelativeTransformExplicit(const iDynTree::FrameIndex
                                                       const iDynTree::FrameIndex refFrameOrientationIndex,
                                                       const iDynTree::FrameIndex    frameOriginIndex,
                                                       const iDynTree::FrameIndex    frameOrientationIndex,
-                                                      const iDynTree::Span<double>& position,
-                                                      const iDynTree::MatrixView<double>& rotation)
+                                                      iDynTree::Span<double> position,
+                                                      iDynTree::MatrixView<double> rotation)
 {
     constexpr int expected_position_size = 3;
     bool ok = position.size() == expected_position_size;
@@ -1451,8 +1451,8 @@ Transform KinDynComputations::getWorldTransform(const FrameIndex frameIndex)
 }
 
 bool KinDynComputations::getWorldTransform(const FrameIndex frameIndex,
-                                           const iDynTree::Span<double>& world_p_frame,
-                                           const iDynTree::MatrixView<double>& world_R_frame)
+                                           iDynTree::Span<double> world_p_frame,
+                                           iDynTree::MatrixView<double> world_R_frame)
 {
     constexpr int expected_position_size = 3;
     bool ok = world_p_frame.size() == expected_position_size;
@@ -1480,8 +1480,8 @@ bool KinDynComputations::getWorldTransform(const FrameIndex frameIndex,
 }
 
 bool KinDynComputations::getWorldTransform(const std::string & frameName,
-                                           const iDynTree::Span<double>& world_p_frame,
-                                           const iDynTree::MatrixView<double>& world_R_frame)
+                                           iDynTree::Span<double> world_p_frame,
+                                           iDynTree::MatrixView<double> world_R_frame)
 {
     int frameIndex = getFrameIndex(frameName);
     if( frameIndex  == iDynTree::FRAME_INVALID_INDEX )
@@ -1526,7 +1526,7 @@ Twist KinDynComputations::getFrameVel(const std::string& frameName)
     return getFrameVel(getFrameIndex(frameName));
 }
 
-bool KinDynComputations::getFrameVel(const std::string & frameName, const iDynTree::Span<double>& twist)
+bool KinDynComputations::getFrameVel(const std::string & frameName, iDynTree::Span<double> twist)
 {
     return this->getFrameVel(getFrameIndex(frameName), twist);
 }
@@ -1569,7 +1569,7 @@ Twist KinDynComputations::getFrameVel(const FrameIndex frameIdx)
 
 }
 
-bool KinDynComputations::getFrameVel(const FrameIndex frameIdx, const iDynTree::Span<double> &twist)
+bool KinDynComputations::getFrameVel(const FrameIndex frameIdx, Span<double>twist)
 {
 
     constexpr int expected_twist_size = 6;
@@ -1594,9 +1594,9 @@ Vector6 KinDynComputations::getFrameAcc(const std::string & frameName,
 }
 
 bool KinDynComputations::getFrameAcc(const std::string & frameName,
-                                     const Span<const double>& baseAcc,
-                                     const Span<const double>& s_ddot,
-                                     const Span<double>& frame_acceleration)
+                                     Span<const double> baseAcc,
+                                     Span<const double> s_ddot,
+                                     Span<double> frame_acceleration)
 {
     return this->getFrameAcc(getFrameIndex(frameName), baseAcc, s_ddot, frame_acceleration);
 }
@@ -1680,9 +1680,9 @@ Vector6 KinDynComputations::getFrameAcc(const FrameIndex frameIdx,
 }
 
 bool KinDynComputations::getFrameAcc(const FrameIndex frame_name,
-                                     const Span<const double>& base_acc,
-                                     const Span<const double>& s_ddot,
-                                     const Span<double>& frame_acceleration)
+                                     Span<const double> base_acc,
+                                     Span<const double> s_ddot,
+                                     Span<double> frame_acceleration)
 {
     bool ok = s_ddot.size() == pimpl->m_robot_model.getNrOfPosCoords();
     if( !ok )
@@ -1724,13 +1724,13 @@ bool KinDynComputations::getFrameFreeFloatingJacobian(const FrameIndex frameInde
 }
 
 bool KinDynComputations::getFrameFreeFloatingJacobian(const std::string& frameName,
-                                                      const MatrixView<double> & outJacobian)
+                                                      MatrixView<double> outJacobian)
 {
     return getFrameFreeFloatingJacobian(getFrameIndex(frameName),outJacobian);
 }
 
 bool KinDynComputations::getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
-                                                      const MatrixView<double> & outJacobian)
+                                                      MatrixView<double> outJacobian)
 {
     if (!pimpl->m_robot_model.isValidFrameIndex(frameIndex))
     {
@@ -1816,7 +1816,7 @@ bool KinDynComputations::getRelativeJacobian(const iDynTree::FrameIndex refFrame
 
 bool KinDynComputations::getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
                                              const iDynTree::FrameIndex frameIndex,
-                                             const MatrixView<double> & outJacobian)
+                                             MatrixView<double> outJacobian)
 {
 
     bool ok = (outJacobian.rows() == 6)
@@ -1869,7 +1869,7 @@ bool KinDynComputations::getRelativeJacobianExplicit(const iDynTree::FrameIndex 
                                                      const iDynTree::FrameIndex frameIndex,
                                                      const iDynTree::FrameIndex expressedOriginFrameIndex,
                                                      const iDynTree::FrameIndex expressedOrientationFrameIndex,
-                                                     const MatrixView<double> & outJacobian)
+                                                     MatrixView<double> outJacobian)
 {
     bool ok = (outJacobian.rows() == 6)
         && (outJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs());
@@ -1972,7 +1972,7 @@ Vector6 KinDynComputations::getFrameBiasAcc(const std::string & frameName)
     return getFrameBiasAcc(getFrameIndex(frameName));
 }
 
-bool KinDynComputations::getFrameBiasAcc(const std::string & frameName, const iDynTree::Span<double> & bias_acc)
+bool KinDynComputations::getFrameBiasAcc(const std::string & frameName, Span<double> bias_acc)
 {
     return getFrameBiasAcc(getFrameIndex(frameName), bias_acc);
 }
@@ -2022,7 +2022,7 @@ Vector6 KinDynComputations::getFrameBiasAcc(const FrameIndex frameIdx)
     }
 }
 
-bool KinDynComputations::getFrameBiasAcc(const FrameIndex frameIndex, const iDynTree::Span<double> & bias_acc)
+bool KinDynComputations::getFrameBiasAcc(const FrameIndex frameIndex, Span<double> bias_acc)
 {
     constexpr int expected_spatial_acceleration_size = 6;
     bool ok = bias_acc.size() == expected_spatial_acceleration_size;
@@ -2048,7 +2048,7 @@ Position KinDynComputations::getCenterOfMassPosition()
     return pimpl->m_pos.worldBasePos()*base_com;
 }
 
-bool KinDynComputations::getCenterOfMassPosition(const iDynTree::Span<double> & pos)
+bool KinDynComputations::getCenterOfMassPosition(Span<double> pos)
 {
     constexpr int expected_position_size = 3;
     bool ok = pos.size() == expected_position_size;
@@ -2082,7 +2082,7 @@ Vector3 KinDynComputations::getCenterOfMassVelocity()
     return com_vel;
 }
 
-bool KinDynComputations::getCenterOfMassVelocity(const iDynTree::Span<double> & vel)
+bool KinDynComputations::getCenterOfMassVelocity(Span<double> vel)
 {
     constexpr int expected_velocity_size = 3;
     bool ok = vel.size() == expected_velocity_size;
@@ -2104,7 +2104,7 @@ bool KinDynComputations::getCenterOfMassJacobian(MatrixDynSize& comJacobian)
     return this->getCenterOfMassJacobian(MatrixView<double>(comJacobian));
 }
 
-bool KinDynComputations::getCenterOfMassJacobian(const MatrixView<double> & comJacobian)
+bool KinDynComputations::getCenterOfMassJacobian(MatrixView<double> comJacobian)
 {
     bool ok = (comJacobian.rows() == 3)
         && (comJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs() + 6);
@@ -2176,7 +2176,7 @@ Vector3 KinDynComputations::getCenterOfMassBiasAcc()
     return comBiasAcc;
 }
 
-bool KinDynComputations::getCenterOfMassBiasAcc(const iDynTree::Span<double> & acc)
+bool KinDynComputations::getCenterOfMassBiasAcc(Span<double> acc)
 {
     constexpr int expected_acceleration_size = 3;
     bool ok = acc.size() == expected_acceleration_size;
@@ -2197,7 +2197,7 @@ const SpatialInertia& KinDynComputations::KinDynComputationsPrivateAttributes::g
 }
 
 void KinDynComputations::KinDynComputationsPrivateAttributes::processOnRightSideMatrixExpectingBodyFixedModelVelocity(
-    const MatrixView<double> & mat)
+    MatrixView<double> mat)
 {
     assert(mat.cols() == m_robot_model.getNrOfDOFs()+6);
 
@@ -2227,7 +2227,7 @@ void KinDynComputations::KinDynComputationsPrivateAttributes::processOnRightSide
 }
 
 void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedAvgVelocityJacobian(
-      const MatrixView<double> & jac)
+      MatrixView<double> jac)
 {
     assert(jac.rows() == 6);
 
@@ -2252,7 +2252,7 @@ void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideB
     toEigen(jac) = toEigen(newOutputFrame_X_oldOutputFrame_)*toEigen(jac);
 }
 
-void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedBaseMomentumJacobian(const MatrixView<double> & jac)
+void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedBaseMomentumJacobian(MatrixView<double> jac)
 {
     Transform newOutputFrame_X_oldOutputFrame;
     if (m_frameVelRepr == BODY_FIXED_REPRESENTATION)
@@ -2302,7 +2302,7 @@ Twist KinDynComputations::getAverageVelocity()
     assert(false);
 }
 
-bool KinDynComputations::getAverageVelocity(const iDynTree::Span<double> & vel)
+bool KinDynComputations::getAverageVelocity(Span<double> vel)
 {
     constexpr int expected_spatial_velocity_size = 6;
     bool ok = vel.size() == expected_spatial_velocity_size;
@@ -2324,7 +2324,7 @@ bool KinDynComputations::getAverageVelocityJacobian(MatrixDynSize& avgVelocityJa
     return this->getAverageVelocityJacobian(MatrixView<double>(avgVelocityJacobian));
 }
 
-bool KinDynComputations::getAverageVelocityJacobian(const MatrixView<double> & avgVelocityJacobian)
+bool KinDynComputations::getAverageVelocityJacobian(MatrixView<double> avgVelocityJacobian)
 {
     bool ok = (avgVelocityJacobian.rows() == 6)
         && (avgVelocityJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs() + 6);
@@ -2353,7 +2353,7 @@ bool KinDynComputations::getAverageVelocityJacobian(const MatrixView<double> & a
 }
 
 void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedCentroidalAvgVelocityJacobian(
-    const MatrixView<double> & jac, const FrameVelocityRepresentation & leftSideRepresentation)
+    MatrixView<double> jac, const FrameVelocityRepresentation & leftSideRepresentation)
 {
     assert(jac.cols() == m_robot_model.getNrOfDOFs()+6);
 
@@ -2415,7 +2415,7 @@ Twist KinDynComputations::getCentroidalAverageVelocity()
     return newOutputFrame_X_oldOutputFrame*base_averageVelocity;
 }
 
-bool KinDynComputations::getCentroidalAverageVelocity(const iDynTree::Span<double> & vel)
+bool KinDynComputations::getCentroidalAverageVelocity(Span<double> vel)
 {
     constexpr int expected_spatial_velocity_size = 6;
     bool ok = vel.size() == expected_spatial_velocity_size;
@@ -2437,7 +2437,7 @@ bool KinDynComputations::getCentroidalAverageVelocityJacobian(MatrixDynSize& cen
     return this->getCentroidalAverageVelocityJacobian(MatrixView<double>(centroidalAvgVelocityJacobian));
 }
 
-bool KinDynComputations::getCentroidalAverageVelocityJacobian(const MatrixView<double> & centroidalAvgVelocityJacobian)
+bool KinDynComputations::getCentroidalAverageVelocityJacobian(MatrixView<double> centroidalAvgVelocityJacobian)
 {
     bool ok = (centroidalAvgVelocityJacobian.rows() == 6)
         && (centroidalAvgVelocityJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs() + 6);
@@ -2487,7 +2487,7 @@ iDynTree::SpatialMomentum KinDynComputations::getLinearAngularMomentum()
     assert(false);
 }
 
-bool KinDynComputations::getLinearAngularMomentum(const iDynTree::Span<double>& spatial_momentum)
+bool KinDynComputations::getLinearAngularMomentum(iDynTree::Span<double> spatial_momentum)
 {
     constexpr int expected_spatial_momentum_size = 6;
     bool ok = spatial_momentum.size() == expected_spatial_momentum_size;
@@ -2509,7 +2509,7 @@ bool KinDynComputations::getLinearAngularMomentumJacobian(MatrixDynSize& linAngM
     return this->getLinearAngularMomentumJacobian(MatrixView<double>(linAngMomentumJacobian));
 }
 
-bool KinDynComputations::getLinearAngularMomentumJacobian(const MatrixView<double> & linAngMomentumJacobian)
+bool KinDynComputations::getLinearAngularMomentumJacobian(MatrixView<double> linAngMomentumJacobian)
 {
     bool ok = (linAngMomentumJacobian.rows() == 6)
         && (linAngMomentumJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs() + 6);
@@ -2562,7 +2562,7 @@ SpatialMomentum KinDynComputations::getCentroidalTotalMomentum()
     return newOutputFrame_X_oldOutputFrame*base_momentum;
 }
 
-bool KinDynComputations::getCentroidalTotalMomentum(const iDynTree::Span<double>& spatial_momentum)
+bool KinDynComputations::getCentroidalTotalMomentum(iDynTree::Span<double> spatial_momentum)
 {
     constexpr int expected_spatial_momentum_size = 6;
     bool ok = spatial_momentum.size() == expected_spatial_momentum_size;
@@ -2584,7 +2584,7 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
     return this->getCentroidalTotalMomentumJacobian(MatrixView<double>(centroidalMomentumJacobian));
 }
 
-bool KinDynComputations::getCentroidalTotalMomentumJacobian(const MatrixView<double> & centroidalMomentumJacobian)
+bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixView<double> centroidalMomentumJacobian)
 {
     bool ok = (centroidalMomentumJacobian.rows() == 6)
         && (centroidalMomentumJacobian.cols() == pimpl->m_robot_model.getNrOfDOFs() + 6);
@@ -2674,7 +2674,7 @@ bool KinDynComputations::getFreeFloatingMassMatrix(MatrixDynSize& freeFloatingMa
     return this->getFreeFloatingMassMatrix(MatrixView<double>(freeFloatingMassMatrix));
 }
 
-bool KinDynComputations::getFreeFloatingMassMatrix(const MatrixView<double> & freeFloatingMassMatrix)
+bool KinDynComputations::getFreeFloatingMassMatrix(MatrixView<double> freeFloatingMassMatrix)
 {
     bool ok = (freeFloatingMassMatrix.cols() == pimpl->m_robot_model.getNrOfDOFs()+6)
         && (freeFloatingMassMatrix.rows() == pimpl->m_robot_model.getNrOfDOFs()+6);
@@ -2818,8 +2818,8 @@ bool KinDynComputations::inverseDynamics(const Vector6& baseAcc,
     return true;
 }
 
-bool KinDynComputations::inverseDynamics(const iDynTree::Span<const double>& baseAcc,
-                                         const iDynTree::Span<const double>& s_ddot,
+bool KinDynComputations::inverseDynamics(Span<const double> baseAcc,
+                                         Span<const double> s_ddot,
                                          const LinkNetExternalWrenches & linkExtForces,
                                                FreeFloatingGeneralizedTorques & baseForceAndJointTorques)
 {
@@ -2904,7 +2904,7 @@ bool KinDynComputations::generalizedBiasForces(FreeFloatingGeneralizedTorques & 
     return true;
 }
 
-bool KinDynComputations::generalizedBiasForces(const iDynTree::Span<double> & generalizedBiasForces)
+bool KinDynComputations::generalizedBiasForces(Span<double> generalizedBiasForces)
 {
     bool ok = generalizedBiasForces.size() == pimpl->m_robot_model.getNrOfDOFs() + 6;
 
@@ -2966,7 +2966,7 @@ bool KinDynComputations::generalizedGravityForces(FreeFloatingGeneralizedTorques
     return true;
 }
 
-bool KinDynComputations::generalizedGravityForces(const iDynTree::Span<double> & generalizedGravityForces)
+bool KinDynComputations::generalizedGravityForces(Span<double> generalizedGravityForces)
 {
     bool ok = generalizedGravityForces.size() == pimpl->m_robot_model.getNrOfDOFs() + 6;
 

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -1117,7 +1117,7 @@ bool KinDynComputations::getJointPos(VectorDynSize& q) const
     return true;
 }
 
-bool KinDynComputations::getJointPos(Span<double>q) const
+bool KinDynComputations::getJointPos(Span<double> q) const
 {
     bool ok = q.size() == pimpl->m_robot_model.getNrOfPosCoords();
     if( !ok )
@@ -1137,7 +1137,7 @@ bool KinDynComputations::getJointVel(VectorDynSize& dq) const
     return true;
 }
 
-bool KinDynComputations::getJointVel(Span<double>dq) const
+bool KinDynComputations::getJointVel(Span<double> dq) const
 {
     bool ok = dq.size() == pimpl->m_robot_model.getNrOfPosCoords();
     if( !ok )

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -117,10 +117,10 @@ public:
     const SpatialInertia & getRobotLockedInertia();
 
     // Process a jacobian that expects a body fixed base velocity depending on the selected FrameVelocityRepresentation
-    void processOnRightSideMatrixExpectingBodyFixedModelVelocity(MatrixDynSize &mat);
-    void processOnLeftSideBodyFixedBaseMomentumJacobian(MatrixDynSize & jac);
-    void processOnLeftSideBodyFixedAvgVelocityJacobian(MatrixDynSize &jac);
-    void processOnLeftSideBodyFixedCentroidalAvgVelocityJacobian(MatrixDynSize &jac, const FrameVelocityRepresentation & leftSideRepresentation);
+    void processOnRightSideMatrixExpectingBodyFixedModelVelocity(MatrixView<double> mat);
+    void processOnLeftSideBodyFixedBaseMomentumJacobian(MatrixView<double> jac);
+    void processOnLeftSideBodyFixedAvgVelocityJacobian(MatrixView<double> jac);
+    void processOnLeftSideBodyFixedCentroidalAvgVelocityJacobian(MatrixView<double> jac, const FrameVelocityRepresentation & leftSideRepresentation);
 
     // Transform a wrench from and to body fixed and the used representation
     Wrench fromBodyFixedToUsedRepresentation(const Wrench & wrenchInBodyFixed, const Transform & inertial_X_link);
@@ -551,6 +551,17 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
                                                             const iDynTree::FrameIndex frameIndex,
                                                             iDynTree::MatrixDynSize & outJacobian) const
     {
+        //I have the two links. Create the jacobian
+        outJacobian.resize(6, pimpl->m_robot_model.getNrOfDOFs());
+
+        this->getRelativeJacobianSparsityPattern(refFrameIndex, frameIndex, MatrixView<double>(outJacobian));
+    }
+
+
+bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::FrameIndex refFrameIndex,
+                                                            const iDynTree::FrameIndex frameIndex,
+                                                            MatrixView<double> outJacobian) const
+    {
         if (!pimpl->m_robot_model.isValidFrameIndex(frameIndex))
         {
             reportError("KinDynComputations","getRelativeJacobian","Frame index out of bounds");
@@ -562,6 +573,9 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
             return false;
         }
 
+        // clear the matrix
+        toEigen(outJacobian).setZero();
+
         // This method computes the sparsity pattern of the relative Jacobian.
         // For details on how to compute the relative Jacobian, see Traversaro's PhD thesis, 3.37
         // or getRelativeJacobianExplicit method.
@@ -570,10 +584,6 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
         // Get the links to which the frames are attached
         LinkIndex jacobianLinkIndex = pimpl->m_robot_model.getFrameLink(frameIndex);
         LinkIndex refJacobianLink = pimpl->m_robot_model.getFrameLink(refFrameIndex);
-
-        //I have the two links. Create the jacobian
-        outJacobian.resize(6, pimpl->m_robot_model.getNrOfDOFs());
-        outJacobian.zero();
 
         iDynTree::Traversal& relativeTraversal = pimpl->m_traversalCache.getTraversalWithLinkAsBase(pimpl->m_robot_model, refJacobianLink);
 
@@ -625,6 +635,15 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
     bool KinDynComputations::getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
                                                                          iDynTree::MatrixDynSize & outJacobianPattern) const
     {
+        outJacobianPattern.resize(6, 6 + getNrOfDegreesOfFreedom());
+
+        return this->getFrameFreeFloatingJacobianSparsityPattern(frameIndex,
+                                                                 MatrixView<double>(outJacobianPattern));
+    }
+
+    bool KinDynComputations::getFrameFreeFloatingJacobianSparsityPattern(const FrameIndex frameIndex,
+                                                                         MatrixView<double> outJacobianPattern) const
+    {
         if (!pimpl->m_robot_model.isValidFrameIndex(frameIndex))
         {
             reportError("KinDynComputations","getFrameJacobian","Frame index out of bounds");
@@ -644,8 +663,7 @@ bool KinDynComputations::getRelativeJacobianSparsityPattern(const iDynTree::Fram
         iDynTree::toEigen(genericAdjointTransform).bottomRightCorner(3, 3).setOnes();
 
         // We zero the jacobian
-        outJacobianPattern.resize(6, 6 + getNrOfDegreesOfFreedom());
-        outJacobianPattern.zero();
+        toEigen(outJacobianPattern).setZero();
 
         // Compute base part
         toEigen(outJacobianPattern).leftCols<6>() = toEigen(genericAdjointTransform);
@@ -1190,15 +1208,26 @@ Vector6 KinDynComputations::getFrameAcc(const FrameIndex frameIdx,
 
 }
 
-
 bool KinDynComputations::getFrameFreeFloatingJacobian(const std::string& frameName,
-                                          MatrixDynSize& outJacobian)
+                                                      MatrixDynSize& outJacobian)
 {
     return getFrameFreeFloatingJacobian(getFrameIndex(frameName),outJacobian);
 }
 
 bool KinDynComputations::getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
                                                       MatrixDynSize& outJacobian)
+{
+    return getFrameFreeFloatingJacobian(frameIndex, MatrixView<double>(outJacobian));
+}
+
+bool KinDynComputations::getFrameFreeFloatingJacobian(const std::string& frameName,
+                                                      const MatrixView<double> & outJacobian)
+{
+    return getFrameFreeFloatingJacobian(getFrameIndex(frameName),outJacobian);
+}
+
+bool KinDynComputations::getFrameFreeFloatingJacobian(const FrameIndex frameIndex,
+                                                      const MatrixView<double> & outJacobian)
 {
     if (!pimpl->m_robot_model.isValidFrameIndex(frameIndex))
     {
@@ -1266,6 +1295,16 @@ bool KinDynComputations::getRelativeJacobian(const iDynTree::FrameIndex refFrame
                                              iDynTree::MatrixDynSize & outJacobian)
 {
 
+    outJacobian.resize(6, pimpl->m_robot_model.getNrOfDOFs());
+
+    this->getRelativeJacobian(refFrameIndex, frameIndex, MatrixView<double>(outJacobian));
+}
+
+bool KinDynComputations::getRelativeJacobian(const iDynTree::FrameIndex refFrameIndex,
+                                             const iDynTree::FrameIndex frameIndex,
+                                             MatrixView<double> outJacobian)
+{
+
     iDynTree::FrameIndex expressedOriginFrame = iDynTree::FRAME_INVALID_INDEX;
     iDynTree::FrameIndex expressedOrientationFrame = iDynTree::FRAME_INVALID_INDEX;
 
@@ -1290,6 +1329,22 @@ bool KinDynComputations::getRelativeJacobianExplicit(const iDynTree::FrameIndex 
                                                      const iDynTree::FrameIndex expressedOriginFrameIndex,
                                                      const iDynTree::FrameIndex expressedOrientationFrameIndex,
                                                      iDynTree::MatrixDynSize & outJacobian)
+{
+
+    outJacobian.resize(6, pimpl->m_robot_model.getNrOfDOFs());
+
+    return this->getRelativeJacobianExplicit(refFrameIndex,
+                                             frameIndex,
+                                             expressedOriginFrameIndex,
+                                             expressedOrientationFrameIndex,
+                                             MatrixView<double>(outJacobian));
+}
+
+bool KinDynComputations::getRelativeJacobianExplicit(const iDynTree::FrameIndex refFrameIndex,
+                                                     const iDynTree::FrameIndex frameIndex,
+                                                     const iDynTree::FrameIndex expressedOriginFrameIndex,
+                                                     const iDynTree::FrameIndex expressedOrientationFrameIndex,
+                                                     MatrixView<double> outJacobian)
 {
     if (!pimpl->m_robot_model.isValidFrameIndex(frameIndex))
     {
@@ -1339,8 +1394,7 @@ bool KinDynComputations::getRelativeJacobianExplicit(const iDynTree::FrameIndex 
     LinkIndex refJacobianLink = pimpl->m_robot_model.getFrameLink(refFrameIndex);
 
     //I have the two links. Create the jacobian
-    outJacobian.resize(6, pimpl->m_robot_model.getNrOfDOFs());
-    outJacobian.zero();
+    toEigen(outJacobian).setZero();
 
     iDynTree::Traversal& relativeTraversal = pimpl->m_traversalCache.getTraversalWithLinkAsBase(pimpl->m_robot_model, refJacobianLink);
 
@@ -1460,9 +1514,14 @@ Vector3 KinDynComputations::getCenterOfMassVelocity()
 
 bool KinDynComputations::getCenterOfMassJacobian(MatrixDynSize& comJacobian)
 {
-    this->computeRawMassMatrixAndTotalMomentum();
-
     comJacobian.resize(3,pimpl->m_robot_model.getNrOfDOFs()+6);
+
+    return this->getCenterOfMassJacobian(MatrixView<double>(comJacobian));
+}
+
+bool KinDynComputations::getCenterOfMassJacobian(MatrixView<double> comJacobian)
+{
+    this->computeRawMassMatrixAndTotalMomentum();
 
     const SpatialInertia & lockedInertia = pimpl->getRobotLockedInertia();
     Matrix6x6 invLockedInertia = lockedInertia.getInverse();
@@ -1527,7 +1586,7 @@ const SpatialInertia& KinDynComputations::KinDynComputationsPrivateAttributes::g
 }
 
 void KinDynComputations::KinDynComputationsPrivateAttributes::processOnRightSideMatrixExpectingBodyFixedModelVelocity(
-        MatrixDynSize &mat)
+    MatrixView<double> mat)
 {
     assert(mat.cols() == m_robot_model.getNrOfDOFs()+6);
 
@@ -1557,7 +1616,7 @@ void KinDynComputations::KinDynComputationsPrivateAttributes::processOnRightSide
 }
 
 void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedAvgVelocityJacobian(
-        MatrixDynSize &jac)
+      MatrixView<double> jac)
 {
     assert(jac.rows() == 6);
 
@@ -1582,7 +1641,7 @@ void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideB
     toEigen(jac) = toEigen(newOutputFrame_X_oldOutputFrame_)*toEigen(jac);
 }
 
-void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedBaseMomentumJacobian(MatrixDynSize& jac)
+void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedBaseMomentumJacobian(MatrixView<double> jac)
 {
     Transform newOutputFrame_X_oldOutputFrame;
     if (m_frameVelRepr == BODY_FIXED_REPRESENTATION)
@@ -1634,9 +1693,15 @@ Twist KinDynComputations::getAverageVelocity()
 
 bool KinDynComputations::getAverageVelocityJacobian(MatrixDynSize& avgVelocityJacobian)
 {
+    avgVelocityJacobian.resize(6,pimpl->m_robot_model.getNrOfDOFs()+6);
+
+    return this->getAverageVelocityJacobian(MatrixView<double>(avgVelocityJacobian));
+}
+
+bool KinDynComputations::getAverageVelocityJacobian(MatrixView<double> avgVelocityJacobian)
+{
     this->computeRawMassMatrixAndTotalMomentum();
 
-    avgVelocityJacobian.resize(6,pimpl->m_robot_model.getNrOfDOFs()+6);
     const SpatialInertia & lockedInertia = pimpl->getRobotLockedInertia();
     Matrix6x6 invLockedInertia = lockedInertia.getInverse();
 
@@ -1651,7 +1716,7 @@ bool KinDynComputations::getAverageVelocityJacobian(MatrixDynSize& avgVelocityJa
 }
 
 void KinDynComputations::KinDynComputationsPrivateAttributes::processOnLeftSideBodyFixedCentroidalAvgVelocityJacobian(
-        MatrixDynSize &jac, const FrameVelocityRepresentation & leftSideRepresentation)
+    MatrixView<double> jac, const FrameVelocityRepresentation & leftSideRepresentation)
 {
     assert(jac.cols() == m_robot_model.getNrOfDOFs()+6);
 
@@ -1713,12 +1778,17 @@ Twist KinDynComputations::getCentroidalAverageVelocity()
     return newOutputFrame_X_oldOutputFrame*base_averageVelocity;
 }
 
-
 bool KinDynComputations::getCentroidalAverageVelocityJacobian(MatrixDynSize& centroidalAvgVelocityJacobian)
+{
+    centroidalAvgVelocityJacobian.resize(6,pimpl->m_robot_model.getNrOfDOFs()+6);
+
+    return this->getCentroidalAverageVelocityJacobian(MatrixView<double>(centroidalAvgVelocityJacobian));
+}
+
+bool KinDynComputations::getCentroidalAverageVelocityJacobian(MatrixView<double> centroidalAvgVelocityJacobian)
 {
     this->computeRawMassMatrixAndTotalMomentum();
 
-    centroidalAvgVelocityJacobian.resize(6,pimpl->m_robot_model.getNrOfDOFs()+6);
     const SpatialInertia & lockedInertia = pimpl->getRobotLockedInertia();
     Matrix6x6 invLockedInertia = lockedInertia.getInverse();
     // The first six rows of the mass matrix are the base-base average velocity jacobian
@@ -1756,9 +1826,14 @@ iDynTree::SpatialMomentum KinDynComputations::getLinearAngularMomentum()
 
 bool KinDynComputations::getLinearAngularMomentumJacobian(MatrixDynSize& linAngMomentumJacobian)
 {
-    this->computeRawMassMatrixAndTotalMomentum();
-
     linAngMomentumJacobian.resize(6,pimpl->m_robot_model.getNrOfDOFs()+6);
+
+    return this->getLinearAngularMomentumJacobian(MatrixView<double>(linAngMomentumJacobian));
+}
+
+bool KinDynComputations::getLinearAngularMomentumJacobian(MatrixView<double> linAngMomentumJacobian)
+{
+    this->computeRawMassMatrixAndTotalMomentum();
 
     toEigen(linAngMomentumJacobian) = toEigen(pimpl->m_rawMassMatrix).block(0,0,6,6+pimpl->m_robot_model.getNrOfDOFs());
 
@@ -1799,6 +1874,13 @@ SpatialMomentum KinDynComputations::getCentroidalTotalMomentum()
 }
 
 bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centroidalMomentumJacobian)
+{
+    centroidalMomentumJacobian.resize(6,pimpl->m_robot_model.getNrOfDOFs()+6);
+
+    return this->getCentroidalTotalMomentumJacobian(MatrixView<double>(centroidalMomentumJacobian));
+}
+
+bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixView<double> centroidalMomentumJacobian)
 {
     if (!getLinearAngularMomentumJacobian(centroidalMomentumJacobian))
     {
@@ -1868,11 +1950,24 @@ bool KinDynComputations::getCentroidalTotalMomentumJacobian(MatrixDynSize& centr
 
 bool KinDynComputations::getFreeFloatingMassMatrix(MatrixDynSize& freeFloatingMassMatrix)
 {
-    // Compute the body-fixed-body-fixed mass matrix, if necessary
-    this->computeRawMassMatrixAndTotalMomentum();
-
     // If the matrix has the right size, this should be inexpensive
     freeFloatingMassMatrix.resize(pimpl->m_robot_model.getNrOfDOFs()+6,pimpl->m_robot_model.getNrOfDOFs()+6);
+
+    this->getFreeFloatingMassMatrix(MatrixView<double>(freeFloatingMassMatrix));
+
+    // Return
+    return this->getFreeFloatingMassMatrix(MatrixView<double>(freeFloatingMassMatrix));
+}
+
+bool KinDynComputations::getFreeFloatingMassMatrix(MatrixView<double> freeFloatingMassMatrix)
+{
+    if(freeFloatingMassMatrix.cols() != pimpl->m_robot_model.getNrOfDOFs()+6 || freeFloatingMassMatrix.rows() != pimpl->m_robot_model.getNrOfDOFs()+6)
+    {
+        return false;
+    }
+
+    // Compute the body-fixed-body-fixed mass matrix, if necessary
+    this->computeRawMassMatrixAndTotalMomentum();
 
     toEigen(freeFloatingMassMatrix) = toEigen(pimpl->m_rawMassMatrix);
 
@@ -2211,4 +2306,3 @@ bool KinDynComputations::inverseDynamicsInertialParametersRegressor(const Vector
 }
 
 }
-

--- a/src/high-level/tests/CMakeLists.txt
+++ b/src/high-level/tests/CMakeLists.txt
@@ -14,3 +14,4 @@ endmacro()
 
 # todo
 add_unit_test_hl(KinDynComputations)
+add_unit_test_hl(KinDynComputationsMatrixViewAndSpan)

--- a/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
@@ -60,8 +60,8 @@ void setRandomState(iDynTree::KinDynComputations & dynComp)
     worldTbase = iDynTree::Transform(Rotation::RPY(random_double(),random_double(),random_double()),
                                      Position(random_double(),random_double(),random_double()));
 
-    Eigen::Matrix3d rot = toEigen(worldTbase.getRotation());
-    Eigen::Vector3d pos = toEigen(worldTbase.getPosition());
+
+    Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
 
     for(int i=0; i < 3; i++)
     {
@@ -83,31 +83,32 @@ void setRandomState(iDynTree::KinDynComputations & dynComp)
         ddqj(dof) = random_double();
     }
 
-    bool ok = dynComp.setRobotState(make_span(pos.data(), pos.size()),
-                                    rot,
+    bool ok = dynComp.setRobotState(transform,
                                     make_span(qj.data(), qj.size()),
                                     make_span(baseVel.data(), baseVel.size()),
                                     make_span(dqj.data(), dqj.size()),
                                     make_span(gravity.data(), gravity.size()));
 
+
+    ASSERT_IS_TRUE(ok);
+
     Eigen::VectorXd qj_read(dofs), dqj_read(dofs);
     Eigen::Vector3d gravity_read;
-    Eigen::Matrix3d rot_read;
-    Eigen::Vector3d pos_read;
+    Eigen::Matrix4d transform_read;
     Eigen::Vector6d baseVel_read;
 
-    dynComp.getRobotState(make_span(pos_read.data(), pos_read.size()),
-                          rot_read,
-                          make_span(qj_read.data(), qj_read.size()),
-                          make_span(baseVel_read.data(), baseVel_read.size()),
-                          make_span(dqj_read.data(), dqj_read.size()),
-                          make_span(gravity_read.data(), gravity_read.size()));
+    ok = dynComp.getRobotState(transform_read,
+                               make_span(qj_read.data(), qj_read.size()),
+                               make_span(baseVel_read.data(), baseVel_read.size()),
+                               make_span(dqj_read.data(), dqj_read.size()),
+                               make_span(gravity_read.data(), gravity_read.size()));
+
+    ASSERT_IS_TRUE(ok);
 
     ASSERT_EQUAL_VECTOR(qj_read, qj);
     ASSERT_EQUAL_VECTOR(dqj_read, dqj);
     ASSERT_EQUAL_VECTOR(gravity_read, gravity);
-    ASSERT_EQUAL_VECTOR(pos_read, pos);
-    ASSERT_EQUAL_MATRIX(rot_read, rot);
+    ASSERT_EQUAL_MATRIX(transform_read, transform);
     ASSERT_EQUAL_VECTOR(baseVel_read, baseVel);
 
     ASSERT_EQUAL_DOUBLE(ok,true);

--- a/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
@@ -1,0 +1,540 @@
+/*
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#include "testModels.h"
+#include <iDynTree/Core/TestUtils.h>
+
+#include <iDynTree/Core/Transform.h>
+#include <iDynTree/Core/Position.h>
+#include <iDynTree/Core/Twist.h>
+#include <iDynTree/Core/SpatialAcc.h>
+#include <iDynTree/Core/SpatialMomentum.h>
+#include <iDynTree/Core/VectorDynSize.h>
+
+#include <iDynTree/Core/EigenHelpers.h>
+
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/JointState.h>
+#include <iDynTree/Model/FreeFloatingState.h>
+
+namespace Eigen
+{
+    using Vector6d = Eigen::Matrix<double, 6, 1>;
+}
+
+using namespace iDynTree;
+
+double random_double()
+{
+    return 1.0*((double)rand()-RAND_MAX/2)/((double)RAND_MAX);
+}
+
+double real_random_double()
+{
+    return 1.0*((double)rand()-RAND_MAX/2)/((double)RAND_MAX);
+}
+
+int real_random_int(int initialValue, int finalValue)
+{
+    int length = finalValue - initialValue;
+    return initialValue + rand() % length;
+}
+
+void setRandomState(iDynTree::KinDynComputations & dynComp)
+{
+    size_t dofs = dynComp.getNrOfDegreesOfFreedom();
+    Transform    worldTbase;
+    Eigen::Vector6d baseVel;
+    Eigen::Vector3d gravity;
+
+    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(Rotation::RPY(random_double(),random_double(),random_double()),
+                                     Position(random_double(),random_double(),random_double()));
+
+    Eigen::Matrix3d rot = toEigen(worldTbase.getRotation());
+    Eigen::Vector3d pos = toEigen(worldTbase.getPosition());
+
+    for(int i=0; i < 3; i++)
+    {
+        gravity(i) = random_double();
+    }
+
+    gravity(2) = 0.0;
+
+    for(int i=0; i < 6; i++)
+    {
+        baseVel(i) = real_random_double();
+    }
+
+    for(size_t dof=0; dof < dofs; dof++)
+
+    {
+        qj(dof) = random_double();
+        dqj(dof) = random_double();
+        ddqj(dof) = random_double();
+    }
+
+    bool ok = dynComp.setRobotState(make_span(pos.data(), pos.size()),
+                                    rot,
+                                    make_span(qj.data(), qj.size()),
+                                    make_span(baseVel.data(), baseVel.size()),
+                                    make_span(dqj.data(), dqj.size()),
+                                    make_span(gravity.data(), gravity.size()));
+
+    Eigen::VectorXd qj_read(dofs), dqj_read(dofs);
+    Eigen::Vector3d gravity_read;
+    Eigen::Matrix3d rot_read;
+    Eigen::Vector3d pos_read;
+    Eigen::Vector6d baseVel_read;
+
+    dynComp.getRobotState(make_span(pos_read.data(), pos_read.size()),
+                          rot_read,
+                          make_span(qj_read.data(), qj_read.size()),
+                          make_span(baseVel_read.data(), baseVel_read.size()),
+                          make_span(dqj_read.data(), dqj_read.size()),
+                          make_span(gravity_read.data(), gravity_read.size()));
+
+    ASSERT_EQUAL_VECTOR(qj_read, qj);
+    ASSERT_EQUAL_VECTOR(dqj_read, dqj);
+    ASSERT_EQUAL_VECTOR(gravity_read, gravity);
+    ASSERT_EQUAL_VECTOR(pos_read, pos);
+    ASSERT_EQUAL_MATRIX(rot_read, rot);
+    ASSERT_EQUAL_VECTOR(baseVel_read, baseVel);
+
+    ASSERT_EQUAL_DOUBLE(ok,true);
+}
+
+void testAverageVelocityAndTotalMomentumJacobian(iDynTree::KinDynComputations & dynComp)
+{
+    Eigen::Vector6d avgVel;
+    Eigen::Vector6d mom, centroidalMom;
+    Eigen::Vector6d avgVelCheck, momCheck, centroidalMomCheck;
+    Eigen::VectorXd nu(dynComp.getNrOfDegreesOfFreedom()+6);
+    ASSERT_IS_TRUE(dynComp.getModelVel(make_span(nu.data(), nu.size())));
+
+    Eigen::MatrixXd momJac(6, dynComp.getNrOfDegreesOfFreedom()+6);
+    Eigen::MatrixXd centroidalMomJac(6, dynComp.getNrOfDegreesOfFreedom()+6);
+    Eigen::MatrixXd avgVelJac(6, dynComp.getNrOfDegreesOfFreedom()+6);
+
+
+    bool ok = dynComp.getAverageVelocity(make_span(avgVel.data(), avgVel.size()));
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getAverageVelocityJacobian(avgVelJac);
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getLinearAngularMomentum(make_span(mom.data(), mom.size()));
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getLinearAngularMomentumJacobian(momJac);
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getCentroidalTotalMomentum(make_span(centroidalMom.data(), centroidalMom.size()));
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getCentroidalTotalMomentumJacobian(centroidalMomJac);
+    ASSERT_IS_TRUE(ok);
+
+    momCheck = momJac * nu;
+    centroidalMomCheck = centroidalMomJac * nu;
+    avgVelCheck = avgVelJac * nu;
+
+    ASSERT_EQUAL_VECTOR(momCheck, mom);
+    ASSERT_EQUAL_VECTOR(centroidalMomCheck, centroidalMom);
+    ASSERT_EQUAL_VECTOR(avgVelCheck, avgVel);
+}
+
+inline Eigen::VectorXd toEigen(const FreeFloatingGeneralizedTorques & genForces)
+{
+    Eigen::VectorXd concat(6+genForces.jointTorques().size());
+    // TODO(traversaro) : We should teach toEigen to handle empty matrices correctly?
+    // relevant: https://forum.kde.org/viewtopic.php?f=74&t=107974
+    if( genForces.jointTorques().size() > 0 )
+    {
+        concat << toEigen(genForces.baseWrench()), toEigen(genForces.jointTorques());
+    }
+    else
+    {
+        concat = toEigen(genForces.baseWrench());
+    }
+    return concat;
+}
+
+// Test different ways of computing inverse dynamics
+void testInverseDynamics(KinDynComputations & dynComp)
+{
+    int dofs = dynComp.getNrOfDegreesOfFreedom();
+    Eigen::Vector6d baseAcc;
+    Eigen::VectorXd shapeAccs(dynComp.getNrOfDegreesOfFreedom());
+
+    iDynTree::LinkNetExternalWrenches netExternalWrenches(dynComp.model());
+    for(unsigned int link=0; link < dynComp.model().getNrOfLinks(); link++ )
+    {
+        netExternalWrenches(link) = getRandomWrench();
+    }
+
+    // Go component for component, for simplifyng debugging
+    for(int i=0; i < 6+dofs; i++)
+    {
+        baseAcc.setZero();
+        shapeAccs.setZero();
+        if( i < 6 )
+        {
+            baseAcc(i) = 1.0;
+        }
+        else
+        {
+            shapeAccs(i-6) = 1.0;
+        }
+
+        FreeFloatingGeneralizedTorques invDynForces(dynComp.model());
+        FreeFloatingGeneralizedTorques massMatrixInvDynForces(dynComp.model());
+
+        // Run classical inverse dynamics
+        bool ok = dynComp.inverseDynamics(make_span(baseAcc.data(), baseAcc.size()),
+                                          make_span(shapeAccs.data(), shapeAccs.size()),
+                                          netExternalWrenches,invDynForces);
+        ASSERT_IS_TRUE(ok);
+
+        // Run inverse dynamics with mass matrix
+        Eigen::MatrixXd massMatrix(dynComp.getNrOfDegreesOfFreedom() + 6, dynComp.getNrOfDegreesOfFreedom() + 6);
+        ok = dynComp.getFreeFloatingMassMatrix(massMatrix);
+        ASSERT_IS_TRUE(ok);
+
+        Eigen::VectorXd invDynBiasForces(dynComp.getNrOfDegreesOfFreedom() + 6);
+        ok = dynComp.generalizedBiasForces(make_span(invDynBiasForces.data(), invDynBiasForces.size()));
+        ASSERT_IS_TRUE(ok);
+
+        FreeFloatingGeneralizedTorques invDynExtForces(dynComp.model());
+        ok = dynComp.generalizedExternalForces(netExternalWrenches, invDynExtForces);
+        ASSERT_IS_TRUE(ok);
+
+        Eigen::VectorXd massMatrixInvDynForcesContinuous(6+dofs);
+        Eigen::VectorXd robotAccs(baseAcc.size() + shapeAccs.size());
+        robotAccs << baseAcc, shapeAccs;
+
+        massMatrixInvDynForcesContinuous = massMatrix * robotAccs + invDynBiasForces + toEigen(invDynExtForces);
+        toEigen(massMatrixInvDynForces.baseWrench().getLinearVec3()) = massMatrixInvDynForcesContinuous.segment<3>(0);
+        toEigen(massMatrixInvDynForces.baseWrench().getAngularVec3()) = massMatrixInvDynForcesContinuous.segment<3>(3);
+        toEigen(massMatrixInvDynForces.jointTorques()) = massMatrixInvDynForcesContinuous.segment(6,dofs);
+
+        ASSERT_EQUAL_SPATIAL_FORCE(massMatrixInvDynForces.baseWrench(), invDynForces.baseWrench());
+        ASSERT_EQUAL_VECTOR(massMatrixInvDynForces.jointTorques(), invDynForces.jointTorques());
+    }
+}
+
+void testRelativeJacobians(KinDynComputations & dynComp)
+{
+    if (dynComp.getNrOfLinks() < 2) return;
+    FrameIndex frame = -1;
+    FrameIndex refFrame = -1;
+
+    if (dynComp.getNrOfLinks() == 2) {
+        frame = 0;
+        refFrame = 1;
+    } else {
+        //Pick two frames at random
+        frame = real_random_int(0, dynComp.getNrOfFrames());
+        //be sure to pick two different frames
+        do {
+            refFrame = real_random_int(0, dynComp.getNrOfFrames());
+        } while (refFrame == frame && frame >= 0);
+    }
+
+    FrameVelocityRepresentation representation = dynComp.getFrameVelocityRepresentation();
+    dynComp.setFrameVelocityRepresentation(MIXED_REPRESENTATION);
+
+    //Compute the relative Jacobian
+    Eigen::MatrixXd relativeJacobian(6, dynComp.getNrOfDegreesOfFreedom());
+    bool ok = dynComp.getRelativeJacobian(refFrame, frame, relativeJacobian);
+    ASSERT_IS_TRUE(ok);
+
+    Eigen::VectorXd qj(dynComp.getNrOfDegreesOfFreedom()), dqj(dynComp.getNrOfDegreesOfFreedom());
+    Eigen::Vector3d gravity;
+    dynComp.getRobotState(make_span(qj.data(), qj.size()),
+                               make_span(dqj.data(), dqj.size()),
+                               make_span(gravity.data(), gravity.size()));
+
+    Eigen::Vector6d relativeVel;
+    relativeVel = relativeJacobian * dqj;
+
+    //this velocity depends on where the Jacobian is expressed
+
+    Eigen::Vector6d frameVel, refFrameVel;
+    ok = dynComp.getFrameVel(frame, make_span(frameVel.data(), frameVel.size()));
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getFrameVel(refFrame, make_span(refFrameVel.data(), refFrameVel.size()));
+    ASSERT_IS_TRUE(ok);
+
+    if (dynComp.getFrameVelocityRepresentation() == INERTIAL_FIXED_REPRESENTATION) {
+        //Inertial = right trivialized.
+        //frameVel is written wrt A
+        //refFrameVel is written wrt A
+        //relativeJacobian is written wrt refFrame
+        relativeVel = toEigen(dynComp.getWorldTransform(refFrame).asAdjointTransform()) * relativeVel;
+    } else if (dynComp.getFrameVelocityRepresentation() == BODY_FIXED_REPRESENTATION) {
+        //BODY = left trivialized.
+        //frameVel is written wrt frame
+        //refFrameVel is written wrt refFrame
+        //relativeJacobian is written wrt frame
+        //convert refFrameVel to frame
+        relativeVel = toEigen(dynComp.getRelativeTransform(frame, refFrame).asAdjointTransform()) * refFrameVel;
+    } else if (dynComp.getFrameVelocityRepresentation() == MIXED_REPRESENTATION) {
+        //MIXED
+        //frameVel is written wrt frame, [A]
+        //refFrameVel is written wrt refFrame, [A]
+        //relativeJacobian is written wrt frame, [refFrame]
+        //convert refFrameVel to frame, [A]
+        Transform frame_A_H_frame(dynComp.getWorldTransform(frame).getRotation(), Position::Zero());
+
+        //refFrameVel = ref_[A]_v_ref, I want frame_[A]_v_ref. As I do not have an explicit A frame I do the following:
+        // frame_[A]_H_frame_[frame] * frame_[frame]_H_ref_[frame] * ref_[frame]_H_ref_[A] * ref_[A]_v_ref
+        Eigen::Vector6d temp = toEigen((frame_A_H_frame * dynComp.getRelativeTransformExplicit(frame, frame, refFrame, frame) * frame_A_H_frame.inverse()).asAdjointTransform()) * refFrameVel;
+        refFrameVel = temp;
+        //and relativeVel to frame [A]
+        temp = toEigen((frame_A_H_frame * dynComp.getRelativeTransformExplicit(frame, frame, frame, refFrame)).asAdjointTransform()) * relativeVel;
+        relativeVel = temp;
+    }
+
+    //now compute the error velocity
+    //now they should be expressed in the same frame
+    Eigen::Vector6d velDifference = frameVel - refFrameVel;
+    ASSERT_EQUAL_VECTOR(velDifference, relativeVel);
+
+    dynComp.setFrameVelocityRepresentation(representation);
+}
+
+// Dummy test: for now it just prints the frameBiasAcc, to check there is no
+// usage of not initialized memory
+void testAbsoluteJacobiansAndFrameBiasAcc(KinDynComputations & dynComp)
+{
+    FrameIndex frame = real_random_int(0, dynComp.getNrOfFrames());
+
+    // Test Jacobian consistency
+
+    // Get robot velocity
+    Eigen::VectorXd nu(6+dynComp.getNrOfDegreesOfFreedom());
+    bool ok = dynComp.getModelVel(make_span(nu.data(), nu.size()));
+    ASSERT_IS_TRUE(ok);
+
+    // Compute frame velocity and jacobian
+    Eigen::Vector6d frameVel;
+
+    ok = dynComp.getFrameVel(frame, make_span(frameVel.data(), frameVel.size()));
+    ASSERT_IS_TRUE(ok);
+
+    Eigen::Vector6d frameVelJac;
+    Eigen::MatrixXd jac(6, dynComp.getNrOfDegreesOfFreedom() + 6);
+    ok = dynComp.getFrameFreeFloatingJacobian(frame, jac);
+    ASSERT_IS_TRUE(ok);
+
+    frameVelJac = jac * nu;
+
+    ASSERT_EQUAL_VECTOR(frameVel, frameVelJac);
+
+    std::cerr << "nu: " << nu.transpose() << std::endl;
+
+    // Compute frame acceleration, and bias acceleration
+    Eigen::Vector6d baseAcc;
+    baseAcc.setZero();
+    baseAcc(0) = 1;
+    baseAcc(1) = 0;
+    baseAcc(2) = 0;
+    baseAcc(3) = 0;
+    baseAcc(4) = 0;
+    baseAcc(5) = 0;
+
+    Eigen::VectorXd sddot(dynComp.model().getNrOfDOFs());
+    for(int i=0; i < sddot.size(); i++)
+    {
+        sddot(i) = i*0.1;
+    }
+
+    Eigen::VectorXd nuDot(6+dynComp.getNrOfDegreesOfFreedom());
+    nuDot.head<6>() = baseAcc;
+    nuDot.tail(dynComp.getNrOfDegreesOfFreedom()) = sddot;
+
+
+    Eigen::Vector6d frameAcc, biasAcc, frameAccJac;
+    ok = dynComp.getFrameAcc(frame,
+                             make_span(baseAcc.data(), baseAcc.size()),
+                             make_span(sddot.data(), sddot.size()),
+                             make_span(frameAcc.data(), frameAcc.size()));
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.getFrameBiasAcc(frame, make_span(biasAcc.data(), biasAcc.size()));
+    ASSERT_IS_TRUE(ok);
+
+    frameAccJac = jac * nuDot + biasAcc;
+
+    ASSERT_EQUAL_VECTOR(frameAcc, frameAccJac);
+}
+
+void testModelConsistency(std::string modelFilePath, const FrameVelocityRepresentation frameVelRepr)
+{
+    iDynTree::KinDynComputations dynComp;
+
+    bool ok = dynComp.loadRobotModelFromFile(modelFilePath);
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.setFrameVelocityRepresentation(frameVelRepr);
+    ASSERT_IS_TRUE(ok);
+
+    for(int i=0; i < 1; i++)
+    {
+        setRandomState(dynComp);
+        testAverageVelocityAndTotalMomentumJacobian(dynComp);
+        testInverseDynamics(dynComp);
+        testRelativeJacobians(dynComp);
+        testAbsoluteJacobiansAndFrameBiasAcc(dynComp);
+    }
+
+}
+
+void testModelConsistencyAllRepresentations(std::string modelName)
+{
+    std::string urdfFileName = getAbsModelPath(modelName);
+    std::cout << "Testing file " << urdfFileName <<  std::endl;
+    std::cout << "Testing MIXED_REPRESENTATION " << urdfFileName <<  std::endl;
+    testModelConsistency(urdfFileName,iDynTree::MIXED_REPRESENTATION);
+    std::cout << "Testing BODY_FIXED_REPRESENTATION " << urdfFileName <<  std::endl;
+    testModelConsistency(urdfFileName,iDynTree::BODY_FIXED_REPRESENTATION);
+    std::cout << "Testing INERTIAL_FIXED_REPRESENTATION " << urdfFileName <<  std::endl;
+    testModelConsistency(urdfFileName,iDynTree::INERTIAL_FIXED_REPRESENTATION);
+}
+
+void testRelativeJacobianSparsity(KinDynComputations & dynComp)
+{
+    // take two frames
+    if (dynComp.getNrOfLinks() < 2) return;
+    FrameIndex frame = -1;
+    FrameIndex refFrame = -1;
+
+    if (dynComp.getNrOfLinks() == 2) {
+        frame = 0;
+        refFrame = 1;
+    } else {
+        //Pick two frames at random
+        frame = real_random_int(0, dynComp.getNrOfFrames());
+        //be sure to pick two different frames
+        do {
+            refFrame = real_random_int(0, dynComp.getNrOfFrames());
+        } while (refFrame == frame && frame >= 0);
+    }
+
+    // get sparsity pattern
+    Eigen::MatrixXd jacobianPattern(6, dynComp.getNrOfDegreesOfFreedom());
+    bool ok = dynComp.getRelativeJacobianSparsityPattern(refFrame, frame, jacobianPattern);
+    ASSERT_IS_TRUE(ok);
+
+    // Now computes the actual jacobian
+    Eigen::MatrixXd jacobian(6, dynComp.getNrOfDegreesOfFreedom());
+    ok = dynComp.getRelativeJacobian(refFrame, frame, jacobian);
+    ASSERT_IS_TRUE(ok);
+
+    ASSERT_IS_TRUE(jacobian.rows() == jacobianPattern.rows() && jacobian.cols() == jacobian.cols());
+
+    for (size_t row = 0; row < jacobian.rows(); ++row) {
+        for (size_t col = 0; col < jacobian.cols(); ++col) {
+            // if jacobian has value != 0, pattern should have 1
+            if (std::abs(jacobian(row, col)) > iDynTree::DEFAULT_TOL) {
+                ASSERT_EQUAL_DOUBLE(jacobianPattern(row, col), 1.0);
+            }
+        }
+    }
+}
+
+void testAbsoluteJacobianSparsity(KinDynComputations & dynComp)
+{
+    // take one frames
+    if (dynComp.getNrOfLinks() < 1) return;
+    FrameIndex frame = -1;
+
+    if (dynComp.getNrOfLinks() == 1) {
+        frame = 0;
+    } else {
+        //Pick one frames at random
+        frame = real_random_int(0, dynComp.getNrOfFrames());
+    }
+
+    // get sparsity pattern
+    Eigen::MatrixXd jacobianPattern(6, 6 + dynComp.getNrOfDegreesOfFreedom());
+    bool ok = dynComp.getFrameFreeFloatingJacobianSparsityPattern(frame, jacobianPattern);
+    ASSERT_IS_TRUE(ok);
+
+    // Now computes the actual jacobian
+    Eigen::MatrixXd jacobian(6, 6 + dynComp.getNrOfDegreesOfFreedom());
+    ok = dynComp.getFrameFreeFloatingJacobian(frame, jacobian);
+    ASSERT_IS_TRUE(ok);
+
+    ASSERT_IS_TRUE(jacobian.rows() == jacobianPattern.rows() && jacobian.cols() == jacobian.cols());
+
+    for (size_t row = 0; row < jacobian.rows(); ++row) {
+        for (size_t col = 0; col < jacobian.cols(); ++col) {
+            // if jacobian has value != 0, pattern should have 1
+            if (std::abs(jacobian(row, col)) > iDynTree::DEFAULT_TOL) {
+                ASSERT_EQUAL_DOUBLE(jacobianPattern(row, col), 1.0);
+            }
+        }
+    }
+}
+
+void testSparsityPattern(std::string modelFilePath, const FrameVelocityRepresentation frameVelRepr)
+{
+    iDynTree::KinDynComputations dynComp;
+
+    bool ok = dynComp.loadRobotModelFromFile(modelFilePath);
+    ASSERT_IS_TRUE(ok);
+
+    ok = dynComp.setFrameVelocityRepresentation(frameVelRepr);
+    ASSERT_IS_TRUE(ok);
+
+    for(int i=0; i < 10; i++)
+    {
+        setRandomState(dynComp);
+        testRelativeJacobianSparsity(dynComp);
+        testAbsoluteJacobianSparsity(dynComp);
+    }
+}
+
+void testSparsityPatternAllRepresentations(std::string modelName)
+{
+    std::string urdfFileName = getAbsModelPath(modelName);
+    std::cout << "Testing file " << urdfFileName <<  std::endl;
+    testSparsityPattern(urdfFileName,iDynTree::MIXED_REPRESENTATION);
+    testSparsityPattern(urdfFileName,iDynTree::BODY_FIXED_REPRESENTATION);
+    testSparsityPattern(urdfFileName,iDynTree::INERTIAL_FIXED_REPRESENTATION);
+}
+
+int main()
+{
+    // Just run the tests on a handful of models to avoid
+    // a long testing time under valgrind
+    testModelConsistencyAllRepresentations("oneLink.urdf");
+    testModelConsistencyAllRepresentations("twoLinks.urdf");
+    testModelConsistencyAllRepresentations("threeLinks.urdf");
+    testModelConsistencyAllRepresentations("bigman.urdf");
+    testModelConsistencyAllRepresentations("icub_skin_frames.urdf");
+    testModelConsistencyAllRepresentations("iCubGenova02.urdf");
+    testModelConsistencyAllRepresentations("icalibrate.urdf");
+
+    testSparsityPatternAllRepresentations("oneLink.urdf");
+    testSparsityPatternAllRepresentations("twoLinks.urdf");
+    testSparsityPatternAllRepresentations("threeLinks.urdf");
+    testSparsityPatternAllRepresentations("bigman.urdf");
+    testSparsityPatternAllRepresentations("icub_skin_frames.urdf");
+
+
+
+    return EXIT_SUCCESS;
+}

--- a/src/model/include/iDynTree/Model/Jacobians.h
+++ b/src/model/include/iDynTree/Model/Jacobians.h
@@ -27,6 +27,9 @@ namespace iDynTree
     class JointPosDoubleArray;
     class MatrixDynSize;
 
+    template<typename>
+    class MatrixView;
+
     /**
      * \ingroup iDynTreeModel
      *
@@ -49,7 +52,7 @@ namespace iDynTree
                                           const LinkIndex linkIndex,
                                           const Transform & jacobFrame_X_world,
                                           const Transform & baseFrame_X_jacobBaseFrame,
-                                                MatrixDynSize & jacobian);
+                                          const MatrixView<double>& jacobian);
 
 
 }

--- a/src/model/src/Jacobians.cpp
+++ b/src/model/src/Jacobians.cpp
@@ -27,10 +27,10 @@ bool FreeFloatingJacobianUsingLinkPos(const Model& model,
                                       const LinkIndex jacobianLinkIndex,
                                       const Transform& jacobFrame_X_world,
                                       const Transform& baseFrame_X_jacobBaseFrame,
-                                            MatrixDynSize& jacobian)
+                                      const MatrixView<double>& jacobian)
 {
     // We zero the jacobian
-    jacobian.zero();
+    toEigen(jacobian).setZero();
 
     // Compute base part
     const Transform & world_H_base = world_H_links(traversal.getBaseLink()->getIndex());


### PR DESCRIPTION
This PR implements several functions to allow using `MatrixView` and `span` object into `KinDynComputations` object.

The original functions remain, however, this PR brakes some ABI because of #687. This would not be a huge problem since the original test passes without any changes (@traversaro correct me if I'm mistaken). 

I've also implemented a new test to check the possibility to call `KinDynComputations` function with `non-iDynTree` objects. 

This PR closes #687 #716 