### PR TITLE
Fix missing return type in ObserverThread::init() method

### DIFF
--- a/src/tools/idyntree-sole-gui/plugin/ObserverThread.cpp
+++ b/src/tools/idyntree-sole-gui/plugin/ObserverThread.cpp
@@ -230,6 +230,8 @@ bool ObserverThread::init(yarp::os::ResourceFinder& config)
 
         filtIMUGravity = new iCub::ctrl::FirstOrderLowPassFilter(6.0, this->getRate()/1000.0, initIMUFilter);
     }
+
+    return true;
 }
 
 ObserverThread::~ObserverThread()


### PR DESCRIPTION
cc @traversaro @isorrentino 