### PR TITLE
Model solid shape and exporter cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the possibility of reusing an already opened figure with the MATLAB iDynTree Visualizer either if the name coincides or by using gcf.
 
+
+### Changed
+- `SolidShapes.h` public API **changes**. API changes are back compatible, but as the **ABI has changed**, this means a re-compilation of the dependent projects is needed. In details:
+    - Added getters and setters to all classes in `SolidShapes.h` (`idyntree-model`). Public attributes are still available for compatibility but are now **deprecated** and will be removed in the next major release of iDynTree (2.x).
+    - Added `Material` class in `SolidShapes.h` (`idyntree-model`). The `material` attribute in `SolidShape` is now deprecated. Please use the `color` property in the new `Material` class to maintain the previous behaviour. Note that the old and new properties are completely orthogonal. Ensure the code is consistent with their uses.
+
 ### Fixed
-- Fixed bug in init() of SimpleLeggedOdometry that used an incorrect initial world frame location if used with an additional frame of a link (https://github.com/robotology/idyntree/pull/698).
+- Fixed bug in init() of `SimpleLeggedOdometry` that used an incorrect initial world frame location if used with an additional frame of a link (https://github.com/robotology/idyntree/pull/698).
 - Fixed bug that prevented to use iDynTree cmake packages directly from the build directory (https://github.com/robotology/idyntree/pull/728).
 
 ## [1.1.0] - 2020-06-08

--- a/src/model/include/iDynTree/Model/SolidShapes.h
+++ b/src/model/include/iDynTree/Model/SolidShapes.h
@@ -15,9 +15,38 @@
 #include <string>
 #include <vector>
 #include <iDynTree/Core/Transform.h>
+#include <iDynTree/Model/Indices.h>
 
+// TODO: Deprecation of public attributes.
+// - Ensure everybody migrated to use getters and setters.
+// - Move public attributes into private section and rename them with member
+//   convention (i.e. m_xxx).
+// - Bonus: change all the getters from `getXXX()` to `xxx()` (this can't be
+//   done now as you can't have a function with the same name as the variable).
 namespace iDynTree
 {
+    class Material {
+    public:
+        explicit Material();
+        explicit Material(const std::string& name);
+
+        std::string name() const;
+
+        bool hasColor() const;
+        Vector4 color() const;
+        void setColor(const Vector4& color);
+
+        bool hasTexture() const;
+        std::string texture() const;
+        void setTexture(const std::string& texture);
+
+    private:
+        Vector4 m_color;
+        bool m_isColorSet;
+        std::string m_texture;
+        std::string m_name;
+    };
+
     class Sphere;
     class Box;
     class Cylinder;
@@ -27,27 +56,57 @@ namespace iDynTree
     class SolidShape
     {
     public:
+        explicit SolidShape();
+
         virtual ~SolidShape()=0;
         virtual SolidShape* clone()=0;
-        std::string name;
-        /**
-         * True if the name is valid, false otherwise.
-         */
-        bool nameIsValid{false};
-        Transform link_H_geometry;
 
         /**
-         * Material of the geometry, encoded as a rgba vector.
+         * Returns the name of the shape.
          */
-        Vector4 material;
+        const std::string& getName() const;
 
-        // To correctly wrap this objects in SWIG, we cannot rely on dynamic_cast .
+        /**
+         * Sets the specified name.
+         */
+        void setName(const std::string& name);
+
+        /**
+         * Returns if the name is valid.
+         */
+        bool isNameValid() const;
+
+        /**
+         * Returns the homogeneus transformation of the geometry w.r.t. the attached link.
+         */
+        const Transform& getLink_H_geometry() const;
+
+        /**
+         * Sets the homogeneus transformation of the geometry w.r.t. the attached link.
+         */
+        void setLink_H_geometry(const Transform& newTransform);
+
+        /**
+         * Returns if the material is valid, i.e. you can call getMaterial().
+         */
+        bool isMaterialSet() const;
+
+        /**
+         * Returns the current material.
+         */
+        const Material& getMaterial() const;
+
+        /**
+         * Sets the material. isMaterialSet will return true after this call.
+         */
+        void setMaterial(const Material& material);
 
         bool isSphere() const;
         bool isBox() const;
         bool isCylinder() const;
         bool isExternalMesh() const;
 
+        // Utility methods to traverse the SolidShape class hierachy.
         Sphere* asSphere();
         Box *asBox();
         Cylinder* asCylinder();
@@ -57,13 +116,47 @@ namespace iDynTree
         const Box* asBox() const;
         const Cylinder* asCylinder() const;
         const ExternalMesh* asExternalMesh() const;
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
+        std::string name;
+        /**
+         * True if the name is valid, false otherwise.
+         */
+        IDYNTREE_DEPRECATED_WITH_MSG("Use isNameValid().")
+        bool nameIsValid;
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
+        Transform link_H_geometry;
+
+        /**
+         * Material of the geometry, encoded as a rgba vector.
+         */
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters and the Material class.")
+        Vector4 material;
+
+    private:
+        bool m_isMaterialSet;
+        Material m_material;
     };
 
     class Sphere: public SolidShape
     {
     public:
         virtual ~Sphere();
+
         virtual SolidShape* clone();
+
+        /**
+         * Returns the current radius.
+         */
+        double getRadius() const;
+
+        /**
+         * Sets the new radius.
+         */
+        void setRadius(double radius);
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         double radius;
     };
 
@@ -80,8 +173,42 @@ namespace iDynTree
     public:
         virtual ~Box();
         virtual SolidShape* clone();
+
+        /**
+         * Returns the current x side length.
+         */
+        double getX() const;
+
+        /**
+         * Sets the x side length.
+         */
+        void setX(double x);
+
+        /**
+         * Returns the current y side length.
+         */
+        double getY() const;
+
+        /**
+         * Sets the y side length.
+         */
+        void setY(double y);
+    
+        /**
+         * Returns the current z side length.
+         */
+        double getZ() const;
+
+        /**
+         * Sets the z side length.
+         */
+        void setZ(double z);
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         double x;
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         double y;
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         double z;
     };
 
@@ -90,7 +217,31 @@ namespace iDynTree
     public:
         virtual ~Cylinder();
         virtual SolidShape* clone();
+
+        /**
+         * Returns the current cylinder length.
+         */
+        double getLength() const;
+
+        /**
+         * Sets the cylinder length.
+         */
+        void setLength(double length);
+
+        /**
+         * Returns the current cylinder radius.
+         */
+        double getRadius() const;
+
+        /**
+         * Sets the cylinder radius.
+         */
+        void setRadius(double radius);
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         double length;
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         double radius;
     };
 
@@ -99,7 +250,31 @@ namespace iDynTree
     public:
         virtual ~ExternalMesh();
         virtual SolidShape* clone();
+
+        /**
+         * Returns the current filename.
+         */
+        const std::string& getFilename() const;
+
+        /**
+         * Sets the filename.
+         */
+        void setFilename(const std::string& filename);
+
+        /**
+         * Returns the current scale.
+         */
+        const iDynTree::Vector3& getScale() const;
+
+        /**
+         * Sets the scale.
+         */
+        void setScale(const iDynTree::Vector3& scale);
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         std::string filename;
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use the setter and getters.")
         iDynTree::Vector3 scale;
     };
 
@@ -110,14 +285,21 @@ namespace iDynTree
 
     public:
         ModelSolidShapes();
+        ~ModelSolidShapes();
+
         ModelSolidShapes(const ModelSolidShapes& other);
         ModelSolidShapes& operator=(const ModelSolidShapes& other);
+
         void clear();
-        ~ModelSolidShapes();
         void resize(size_t nrOfLinks);
         void resize(const Model& model);
         bool isConsistent(const Model & model) const;
 
+        std::vector<std::vector<SolidShape *> >& getLinkSolidShapes();
+
+        const std::vector<std::vector<SolidShape *> >& getLinkSolidShapes() const;
+
+        IDYNTREE_DEPRECATED_WITH_MSG("Please use getLinkSolidShapes().")
         /**
          * Storage ot ModelSolidShapes.
          */

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -901,11 +901,6 @@ const ModelSolidShapes& Model::collisionSolidShapes() const
     return m_collisionSolidShapes;
 }
 
-
-
-
-
-
 std::string Model::toString() const
 {
     std::stringstream ss;
@@ -935,9 +930,4 @@ std::string Model::toString() const
 
     return ss.str();
 }
-
-
-
-
-
 }

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -273,10 +273,10 @@ LinkIndex Model::addLink(const std::string& name, const Link& link)
     }
 
     // Add an empty vector of collision shapes
-    m_collisionSolidShapes.linkSolidShapes.push_back(std::vector<SolidShape*>(0));
+    m_collisionSolidShapes.getLinkSolidShapes().push_back(std::vector<SolidShape*>(0));
 
     // Add an empty vector of visual shapes
-    m_visualSolidShapes.linkSolidShapes.push_back(std::vector<SolidShape*>(0));
+    m_visualSolidShapes.getLinkSolidShapes().push_back(std::vector<SolidShape*>(0));
 
 
     return newLinkIndex;

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -297,34 +297,36 @@ void reducedModelAddSolidShapes(const Model& fullModel,
         Transform subModelBase_H_visitedLink     = subModelBase_X_link(visitedLinkIndex);
 
         // Add visual shapes to the new lumped link, i.e. the subModelBase
-        for(int shapeIdx=0; shapeIdx < fullModel.visualSolidShapes().linkSolidShapes[visitedLinkIndex].size(); shapeIdx++)
+        auto& visualSolidShapes = fullModel.visualSolidShapes().getLinkSolidShapes();
+        for(int shapeIdx=0; shapeIdx < visualSolidShapes[visitedLinkIndex].size(); shapeIdx++)
         {
             // Clone the shape
-            SolidShape * copiedShape = fullModel.visualSolidShapes().linkSolidShapes[visitedLinkIndex][shapeIdx]->clone();
+            SolidShape * copiedShape = visualSolidShapes[visitedLinkIndex][shapeIdx]->clone();
 
             // Update shape transform from the old link to the new link
-            Transform visitedLink_H_shape = fullModel.visualSolidShapes().linkSolidShapes[visitedLinkIndex][shapeIdx]->link_H_geometry;
-            copiedShape->link_H_geometry = subModelBase_H_visitedLink*visitedLink_H_shape;
+            Transform visitedLink_H_shape = visualSolidShapes[visitedLinkIndex][shapeIdx]->getLink_H_geometry();
+            copiedShape->setLink_H_geometry(subModelBase_H_visitedLink * visitedLink_H_shape);
 
             // Ownership of the new pointer is transfered to the ModelSolidShapes class
             // (it will be eventually deleted by the close() method
-            reducedModel.visualSolidShapes().linkSolidShapes[subModelBaseIndexInReducedModel].push_back(copiedShape);
+            reducedModel.visualSolidShapes().getLinkSolidShapes()[subModelBaseIndexInReducedModel].push_back(copiedShape);
         }
 
         // Add collision shapes to the new lumped link, i.e. the subModelBase
-        for(int shapeIdx=0; shapeIdx < fullModel.collisionSolidShapes().linkSolidShapes[visitedLinkIndex].size(); shapeIdx++)
+        auto& collisionSolidShapes = fullModel.collisionSolidShapes().getLinkSolidShapes();
+        for(int shapeIdx=0; shapeIdx < collisionSolidShapes[visitedLinkIndex].size(); shapeIdx++)
         {
             // Clone the shape : ownership of the new pointer is transfered to the ModelSolidShapes class
             // (it will be eventually deleted by the close() method
-            SolidShape * copiedShape = fullModel.collisionSolidShapes().linkSolidShapes[visitedLinkIndex][shapeIdx]->clone();
+            SolidShape * copiedShape = collisionSolidShapes[visitedLinkIndex][shapeIdx]->clone();
 
             // Update shape transform from the old link to the new link
-            Transform visitedLink_H_shape = fullModel.collisionSolidShapes().linkSolidShapes[visitedLinkIndex][shapeIdx]->link_H_geometry;
-            copiedShape->link_H_geometry = subModelBase_H_visitedLink*visitedLink_H_shape;
+            Transform visitedLink_H_shape = collisionSolidShapes[visitedLinkIndex][shapeIdx]->getLink_H_geometry();
+            copiedShape->setLink_H_geometry(subModelBase_H_visitedLink*visitedLink_H_shape);
 
             // Ownership of the new pointer is transfered to the ModelSolidShapes class
             // (it will be eventually deleted by the close() method
-            reducedModel.collisionSolidShapes().linkSolidShapes[subModelBaseIndexInReducedModel].push_back(copiedShape);
+            reducedModel.collisionSolidShapes().getLinkSolidShapes()[subModelBaseIndexInReducedModel].push_back(copiedShape);
         }
     }
 

--- a/src/model/src/SolidShapes.cpp
+++ b/src/model/src/SolidShapes.cpp
@@ -11,10 +11,65 @@
 #include <iDynTree/Model/SolidShapes.h>
 #include <iDynTree/Model/Model.h>
 
+#include <string>
+
 namespace iDynTree
 {
+    Material::Material(): Material("") {}
+
+    Material::Material(const std::string& name): m_isColorSet(false),
+    m_name(name) {}
+
+    std::string Material::name() const { return m_name; }
+
+    bool Material::hasColor() const { return m_isColorSet;}
+
+    Vector4 Material::color() const {return m_color;}
+
+    void Material::setColor(const Vector4& color) {
+        m_color = color;
+        m_isColorSet = true;
+    }
+
+    bool Material::hasTexture() const { return !m_texture.empty(); }
+
+    std::string Material::texture() const { return m_texture; }
+
+    void Material::setTexture(const std::string& texture) {
+        m_texture = texture;
+    }
+
+    SolidShape::SolidShape(): nameIsValid(false), m_isMaterialSet(false) {}
+
     SolidShape::~SolidShape()
     {
+    }
+
+    const std::string& SolidShape::getName() const { return name; }
+
+    void SolidShape::setName(const std::string &name) {
+        this->name = name;
+        nameIsValid = !name.empty();
+    }
+
+    bool SolidShape::isNameValid() const { return nameIsValid; }
+
+    const Transform& SolidShape::getLink_H_geometry() const {
+        return link_H_geometry;
+        
+    }
+
+    void SolidShape::setLink_H_geometry(const Transform& newTransform) {
+        this->link_H_geometry = newTransform;
+    }
+
+    bool SolidShape::isMaterialSet() const { return m_isMaterialSet; }
+
+    const Material& SolidShape::getMaterial() const {return m_material; }
+    
+    void SolidShape::setMaterial(const Material& material) {
+        m_material = material;
+        m_isMaterialSet = true;
     }
 
     bool SolidShape::isSphere() const
@@ -77,7 +132,6 @@ namespace iDynTree
         return dynamic_cast<const ExternalMesh*>(this);
     }
 
-
     Sphere::~Sphere()
     {
     }
@@ -86,6 +140,10 @@ namespace iDynTree
     {
         return new Sphere(*this);
     }
+
+    double Sphere::getRadius() const { return radius; }
+
+    void Sphere::setRadius(double radius) { this->radius = radius; }
 
     Box::~Box()
     {
@@ -96,6 +154,18 @@ namespace iDynTree
         return new Box(*this);
     }
 
+    double Box::getX() const { return x; }
+
+    void Box::setX(double x) { this->x = x; }
+
+    double Box::getY() const { return y; }
+
+    void Box::setY(double y) { this->y = y; }
+
+    double Box::getZ() const { return z; }
+
+    void Box::setZ(double z) { this->z = z; }
+
     Cylinder::~Cylinder()
     {
     }
@@ -105,6 +175,14 @@ namespace iDynTree
         return new Cylinder(*this);
     }
 
+    double Cylinder::getLength() const { return length; }
+
+    void Cylinder::setLength(double length) { this->length = length; }
+
+    double Cylinder::getRadius() const { return radius; }
+
+    void Cylinder::setRadius(double radius) { this->radius = radius; }
+
     ExternalMesh::~ExternalMesh()
     {
     }
@@ -112,6 +190,18 @@ namespace iDynTree
     SolidShape* ExternalMesh::clone()
     {
         return new ExternalMesh(*this);
+    }
+
+    const std::string& ExternalMesh::getFilename() const { return filename; }
+
+    void ExternalMesh::setFilename(const std::string& filename) {
+        this->filename = filename;
+    }
+
+    const iDynTree::Vector3& ExternalMesh::getScale() const { return scale; }
+
+    void ExternalMesh::setScale(const iDynTree::Vector3& scale) {
+        this->scale = scale;
     }
 
     void ModelSolidShapes::clear()
@@ -177,5 +267,13 @@ namespace iDynTree
     bool ModelSolidShapes::isConsistent(const Model& model) const
     {
         return (this->linkSolidShapes.size() == model.getNrOfLinks());
+    }
+
+    std::vector<std::vector<SolidShape *>>& ModelSolidShapes::getLinkSolidShapes() {
+        return linkSolidShapes;
+    }
+
+    const std::vector<std::vector<SolidShape *>>& ModelSolidShapes::getLinkSolidShapes() const {
+        return linkSolidShapes;
     }
 }

--- a/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h
@@ -53,7 +53,15 @@ public:
      * Default value: true.
      * Supported formats: urdf.
      */
-    bool exportFirstBaseLinkAdditionalFrameAsFakeURDFBase{true};
+    bool exportFirstBaseLinkAdditionalFrameAsFakeURDFBase;
+
+    /**
+     * Specify the robot name.
+     *
+     * Default: "iDynTreeURDFModelExportModelName".
+     * Supported formats: urdf.
+     */
+    std::string robotExportedName;
 
     /**
      * Constructor.

--- a/src/model_io/urdf/src/GeometryElement.cpp
+++ b/src/model_io/urdf/src/GeometryElement.cpp
@@ -42,9 +42,9 @@ namespace iDynTree{
                 }
                 Box *box = new Box();
 
-                box->x = boxDimensionn(0);
-                box->y = boxDimensionn(1);
-                box->z = boxDimensionn(2);
+                box->setX(boxDimensionn(0));
+                box->setY(boxDimensionn(1));
+                box->setZ(boxDimensionn(2));
 
                 m_shape = std::shared_ptr<SolidShape>(box);
                 return true;
@@ -73,8 +73,8 @@ namespace iDynTree{
                     return false;
                 }
                 Cylinder * cylinder = new Cylinder();
-                cylinder->radius = radius;
-                cylinder->length = length;
+                cylinder->setRadius(radius);
+                cylinder->setLength(length);
 
                 m_shape = std::shared_ptr<Cylinder>(cylinder);
                 return true;
@@ -94,7 +94,7 @@ namespace iDynTree{
                 }
 
                 Sphere * sphere = new Sphere();
-                sphere->radius = radius;
+                sphere->setRadius(radius);
 
                 m_shape = std::shared_ptr<Sphere>(sphere);
                 return true;
@@ -110,15 +110,16 @@ namespace iDynTree{
                     // For now we just support urdf with local meshes, see as an example
                     // https://github.com/bulletphysics/bullet3/tree/master/data
                     ExternalMesh * externalMesh = new ExternalMesh();
-                    externalMesh->filename = found->second->value();
+                    externalMesh->setFilename(found->second->value());
                     //                    pExternalMesh->filename = getURDFMeshAbsolutePathFilename(urdf_filename,localName);
-
-                    externalMesh->scale(0) = externalMesh->scale(1) = externalMesh->scale(2) = 1.0;
+                    iDynTree::Vector3 scale;
+                    scale(0) = scale(1) = scale(2) = 1.0;
 
                     found = attributes.find("scale");
                     if (found != attributes.end()) {
-                        vector3FromString(found->second->value(), externalMesh->scale);
+                        vector3FromString(found->second->value(), scale);
                     }
+                    externalMesh->setScale(scale);
                     m_shape = std::shared_ptr<ExternalMesh>(externalMesh);
                 }
                 return true;

--- a/src/model_io/urdf/src/ModelExporter.cpp
+++ b/src/model_io/urdf/src/ModelExporter.cpp
@@ -19,7 +19,9 @@ namespace iDynTree
 {
 
 ModelExporterOptions::ModelExporterOptions()
-: baseLink("") {}
+: baseLink(""),
+    exportFirstBaseLinkAdditionalFrameAsFakeURDFBase(true),
+    robotExportedName("iDynTreeURDFModelExportModelName") {}
 
 
 class ModelExporter::Pimpl {

--- a/src/model_io/urdf/src/URDFDocument.cpp
+++ b/src/model_io/urdf/src/URDFDocument.cpp
@@ -354,9 +354,10 @@ namespace iDynTree {
                 // Retrieving the geometry
                 std::shared_ptr<SolidShape> shape = visual.m_solidShape;
                 if (visual.m_material) {
+                    Material material;
                     // Now check material (if exists) if it has all the information
                     if (visual.m_material->m_rgba) {
-                        shape->material = *visual.m_material->m_rgba;
+                        material.setColor(*visual.m_material->m_rgba);
                     } else {
                         // Look in the DB for the material with the specified name
                         auto found = materialDatabase.find(visual.m_material->m_name);
@@ -365,18 +366,20 @@ namespace iDynTree {
                             reportError("URDFDocument", "addVisualPropertiesToModel", message.c_str());
                             return false;
                         }
-                        shape->material = *found->second.m_rgba;
+                        material.setColor(*found->second.m_rgba);
                     }
+                    shape->setMaterial(material);
                 }
 
-                shape->name = visual.m_name;
-                shape->nameIsValid = visual.m_nameAttributeFound;
-                shape->link_H_geometry = link_H_geometry;
+                if (visual.m_nameAttributeFound) {
+                    shape->setName(visual.m_name);
+                }
+                shape->setLink_H_geometry(link_H_geometry);
 
                 LinkIndex idyntreeLinkIndex = model.getLinkIndex(linkName);
                 // ModelSolidShapes contains plain pointers, but they own the memory.
                 SolidShape *solidShape = shape->clone();
-                modelGeometries.linkSolidShapes[idyntreeLinkIndex].push_back(solidShape);
+                modelGeometries.getLinkSolidShapes()[idyntreeLinkIndex].push_back(solidShape);
             }
         }
         return true;

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -162,7 +162,7 @@ bool exportSolidShape(const SolidShape* solidShape, exportSolidShapePropertyType
         xmlNodePtr box_xml = xmlNewChild(geometry_xml, NULL, BAD_CAST "box", NULL);
 
         // Export size attribute
-        double size_data[3] = {box->x, box->y, box->z};
+        double size_data[3] = {box->getX(), box->getY(), box->getZ()};
         std::string size_str;
         ok = ok && vectorToString(Vector3(size_data, 3) , size_str);
         xmlNewProp(box_xml, BAD_CAST "size", BAD_CAST size_str.c_str());
@@ -175,12 +175,12 @@ bool exportSolidShape(const SolidShape* solidShape, exportSolidShapePropertyType
 
         // Export radius attribute
         std::string radius_str;
-        ok = ok && doubleToStringWithClassicLocale(cylinder->radius, radius_str);
+        ok = ok && doubleToStringWithClassicLocale(cylinder->getRadius(), radius_str);
         xmlNewProp(cylinder_xml, BAD_CAST "radius", BAD_CAST radius_str.c_str());
 
         // Export length attribute
         std::string length_str;
-        ok = ok && doubleToStringWithClassicLocale(cylinder->length, length_str);
+        ok = ok && doubleToStringWithClassicLocale(cylinder->getLength(), length_str);
         xmlNewProp(cylinder_xml, BAD_CAST "length", BAD_CAST length_str.c_str());
 
     } else if (solidShape->isSphere()) {
@@ -191,7 +191,7 @@ bool exportSolidShape(const SolidShape* solidShape, exportSolidShapePropertyType
 
         // Export radius attribute
         std::string radius_str;
-        ok = ok && doubleToStringWithClassicLocale(sphere->radius, radius_str);
+        ok = ok && doubleToStringWithClassicLocale(sphere->getRadius(), radius_str);
         xmlNewProp(sphere_xml, BAD_CAST "radius", BAD_CAST radius_str.c_str());
 
     } else if (solidShape->isExternalMesh()) {
@@ -201,11 +201,11 @@ bool exportSolidShape(const SolidShape* solidShape, exportSolidShapePropertyType
         xmlNodePtr mesh_xml = xmlNewChild(geometry_xml, NULL, BAD_CAST "mesh", NULL);
 
         // Export filename attribute
-        xmlNewProp(mesh_xml, BAD_CAST "filename", BAD_CAST mesh->filename.c_str());
+        xmlNewProp(mesh_xml, BAD_CAST "filename", BAD_CAST mesh->getFilename().c_str());
 
         // Export scale attribute
         std::string scale_str;
-        ok = ok && vectorToString(mesh->scale, scale_str);
+        ok = ok && vectorToString(mesh->getScale(), scale_str);
         xmlNewProp(mesh_xml, BAD_CAST "scale", BAD_CAST scale_str.c_str());
 
     } else {
@@ -263,15 +263,15 @@ bool exportLink(const Link &link, const std::string linkName, const Model& model
     LinkIndex linkIndex = model.getLinkIndex(linkName);
 
     // Export visual shapes
-    for(unsigned int shapeIdx=0; shapeIdx < model.visualSolidShapes().linkSolidShapes[linkIndex].size(); shapeIdx++) {
-        SolidShape * exportedShape = model.visualSolidShapes().linkSolidShapes[linkIndex][shapeIdx];
+    for(unsigned int shapeIdx=0; shapeIdx < model.visualSolidShapes().getLinkSolidShapes()[linkIndex].size(); shapeIdx++) {
+        SolidShape * exportedShape = model.visualSolidShapes().getLinkSolidShapes()[linkIndex][shapeIdx];
         exportSolidShape(exportedShape, VISUAL, link_xml);
     }
 
     // Export collision shapes
-    for(unsigned int shapeIdx=0; shapeIdx < model.collisionSolidShapes().linkSolidShapes[linkIndex].size(); shapeIdx++) {
+    for(unsigned int shapeIdx=0; shapeIdx < model.collisionSolidShapes().getLinkSolidShapes()[linkIndex].size(); shapeIdx++) {
         // Clone the shape
-        SolidShape * exportedShape = model.collisionSolidShapes().linkSolidShapes[linkIndex][shapeIdx];
+        SolidShape * exportedShape = model.collisionSolidShapes().getLinkSolidShapes()[linkIndex][shapeIdx];
         exportSolidShape(exportedShape, COLLISION, link_xml);
     }
 

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -461,7 +461,7 @@ bool URDFStringFromModel(const iDynTree::Model & model,
     xmlDocPtr urdf_xml = xmlNewDoc(BAD_CAST "1.0");
     xmlNodePtr robot = xmlNewNode(NULL, BAD_CAST "robot");
     // TODO(traversaro) properly export this :)
-    xmlNewProp(robot, BAD_CAST "name", BAD_CAST "iDynTreeURDFModelExportModelName");
+    xmlNewProp(robot, BAD_CAST "name", BAD_CAST options.robotExportedName.c_str());
     xmlDocSetRootElement(urdf_xml, robot);
 
     // TODO(traversaro) : We are assuming that the model has no loops,

--- a/src/model_io/urdf/tests/ModelExporterUnitTest.cpp
+++ b/src/model_io/urdf/tests/ModelExporterUnitTest.cpp
@@ -27,7 +27,7 @@ unsigned int getNrOfVisuals(const iDynTree::Model& model)
 {
     unsigned int nrOfVisuals = 0;
     for (LinkIndex index = 0; index < model.getNrOfLinks(); ++index) {
-        nrOfVisuals += model.visualSolidShapes().linkSolidShapes[index].size();
+        nrOfVisuals += model.visualSolidShapes().getLinkSolidShapes()[index].size();
     }
     return nrOfVisuals;
 }
@@ -36,7 +36,7 @@ unsigned int getNrOfCollisions(const iDynTree::Model& model)
 {
     unsigned int nrOfCollisions = 0;
     for (LinkIndex index = 0; index < model.getNrOfLinks(); ++index) {
-        nrOfCollisions += model.collisionSolidShapes().linkSolidShapes[index].size();
+        nrOfCollisions += model.collisionSolidShapes().getLinkSolidShapes()[index].size();
     }
     return nrOfCollisions;
 }
@@ -48,34 +48,34 @@ void checkSolidAreEqual(SolidShape* solid, SolidShape* solidCheck)
     ASSERT_IS_TRUE(solid->isSphere() == solidCheck->isSphere());
     ASSERT_IS_TRUE(solid->isExternalMesh() == solidCheck->isExternalMesh());
 
-    ASSERT_IS_TRUE(solid->name == solidCheck->name);
-    ASSERT_IS_TRUE(solid->nameIsValid == solidCheck->nameIsValid);
+    ASSERT_IS_TRUE(solid->getName() == solidCheck->getName());
+    ASSERT_IS_TRUE(solid->isNameValid() == solidCheck->isNameValid());
 
-    ASSERT_EQUAL_TRANSFORM(solid->link_H_geometry, solidCheck->link_H_geometry);
+    ASSERT_EQUAL_TRANSFORM(solid->getLink_H_geometry(), solidCheck->getLink_H_geometry());
 
     if (solid->isBox()) {
         const Box* box = solid->asBox();
         const Box* boxCheck = solidCheck->asBox();
-        ASSERT_EQUAL_DOUBLE(box->x, boxCheck->x);
-        ASSERT_EQUAL_DOUBLE(box->y, boxCheck->y);
-        ASSERT_EQUAL_DOUBLE(box->z, boxCheck->z);
+        ASSERT_EQUAL_DOUBLE(box->getX(), boxCheck->getX());
+        ASSERT_EQUAL_DOUBLE(box->getY(), boxCheck->getY());
+        ASSERT_EQUAL_DOUBLE(box->getZ(), boxCheck->getZ());
 
     } else if (solid->isCylinder()) {
         const Cylinder* cylinder = solid->asCylinder();
         const Cylinder* cylinderCheck = solidCheck->asCylinder();
-        ASSERT_EQUAL_DOUBLE(cylinder->radius, cylinderCheck->radius);
-        ASSERT_EQUAL_DOUBLE(cylinder->length, cylinderCheck->length);
+        ASSERT_EQUAL_DOUBLE(cylinder->getRadius(), cylinderCheck->getRadius());
+        ASSERT_EQUAL_DOUBLE(cylinder->getLength(), cylinderCheck->getLength());
 
     } else if (solid->isSphere()) {
         const Sphere* sphere = solid->asSphere();
         const Sphere* sphereCheck = solidCheck->asSphere();
-        ASSERT_EQUAL_DOUBLE(sphere->radius, sphereCheck->radius);
+        ASSERT_EQUAL_DOUBLE(sphere->getRadius(), sphereCheck->getRadius());
 
     } else if (solid->isExternalMesh()) {
         const ExternalMesh* mesh = solid->asExternalMesh();
         const ExternalMesh* meshCheck = solidCheck->asExternalMesh();
-        ASSERT_EQUAL_VECTOR(mesh->scale, meshCheck->scale);
-        ASSERT_IS_TRUE(mesh->filename == meshCheck->filename);
+        ASSERT_EQUAL_VECTOR(mesh->getScale(), meshCheck->getScale());
+        ASSERT_IS_TRUE(mesh->getFilename() == meshCheck->getFilename());
     } else {
         ASSERT_IS_TRUE(false);
     }
@@ -127,26 +127,26 @@ void checkImportExportURDF(std::string fileName)
         // For each link, verify that the visual and collision shape correspond
 
         // First verify that the number of visual elements are the same
-        ASSERT_EQUAL_DOUBLE(model.visualSolidShapes().linkSolidShapes[lnkIndex].size(),
-                            modelReloaded.visualSolidShapes().linkSolidShapes[lnkIndexInReloaded].size());
+        ASSERT_EQUAL_DOUBLE(model.visualSolidShapes().getLinkSolidShapes()[lnkIndex].size(),
+                            modelReloaded.visualSolidShapes().getLinkSolidShapes()[lnkIndexInReloaded].size());
 
         // Then, if there is only one element, verify that it matches
-        if (model.visualSolidShapes().linkSolidShapes[lnkIndex].size() == 1) {
-            SolidShape* solidInModel = model.visualSolidShapes().linkSolidShapes[lnkIndex][0];
-            SolidShape* solidInModelReloaded = modelReloaded.visualSolidShapes().linkSolidShapes[lnkIndexInReloaded][0];
-            std::cerr << "original: " << solidInModel->link_H_geometry.toString() << std::endl
-                      << "reloaded: " << solidInModelReloaded->link_H_geometry.toString() << std::endl;
+        if (model.visualSolidShapes().getLinkSolidShapes()[lnkIndex].size() == 1) {
+            SolidShape* solidInModel = model.visualSolidShapes().getLinkSolidShapes()[lnkIndex][0];
+            SolidShape* solidInModelReloaded = modelReloaded.visualSolidShapes().getLinkSolidShapes()[lnkIndexInReloaded][0];
+            std::cerr << "original: " << solidInModel->getLink_H_geometry().toString() << std::endl
+                      << "reloaded: " << solidInModelReloaded->getLink_H_geometry().toString() << std::endl;
             checkSolidAreEqual(solidInModel, solidInModelReloaded);
         }
 
         // First verify that the number of visual elements are the same
-        ASSERT_EQUAL_DOUBLE(model.collisionSolidShapes().linkSolidShapes[lnkIndex].size(),
-                            modelReloaded.collisionSolidShapes().linkSolidShapes[lnkIndexInReloaded].size());
+        ASSERT_EQUAL_DOUBLE(model.collisionSolidShapes().getLinkSolidShapes()[lnkIndex].size(),
+                            modelReloaded.collisionSolidShapes().getLinkSolidShapes()[lnkIndexInReloaded].size());
 
         // Then, if there is only one element, verify that it matches
-        if (model.collisionSolidShapes().linkSolidShapes[lnkIndex].size() == 1) {
-            SolidShape* solidInModel = model.collisionSolidShapes().linkSolidShapes[lnkIndex][0];
-            SolidShape* solidInModelReloaded = modelReloaded.collisionSolidShapes().linkSolidShapes[lnkIndexInReloaded][0];
+        if (model.collisionSolidShapes().getLinkSolidShapes()[lnkIndex].size() == 1) {
+            SolidShape* solidInModel = model.collisionSolidShapes().getLinkSolidShapes()[lnkIndex][0];
+            SolidShape* solidInModelReloaded = modelReloaded.collisionSolidShapes().getLinkSolidShapes()[lnkIndexInReloaded][0];
             checkSolidAreEqual(solidInModel, solidInModelReloaded);
         }
     }

--- a/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
+++ b/src/model_io/urdf/tests/URDFModelImportUnitTest.cpp
@@ -38,7 +38,7 @@ unsigned int getNrOfVisuals(const iDynTree::Model& model)
 {
     unsigned int nrOfVisuals = 0;
     for (LinkIndex index = 0; index < model.getNrOfLinks(); ++index) {
-        nrOfVisuals += model.visualSolidShapes().linkSolidShapes[index].size();
+        nrOfVisuals += model.visualSolidShapes().getLinkSolidShapes()[index].size();
     }
     return nrOfVisuals;
 }
@@ -47,7 +47,7 @@ unsigned int getNrOfCollisions(const iDynTree::Model& model)
 {
     unsigned int nrOfCollisions = 0;
     for (LinkIndex index = 0; index < model.getNrOfLinks(); ++index) {
-        nrOfCollisions += model.collisionSolidShapes().linkSolidShapes[index].size();
+        nrOfCollisions += model.collisionSolidShapes().getLinkSolidShapes()[index].size();
     }
     return nrOfCollisions;
 }

--- a/src/solid-shapes/src/InertialParametersSolidShapesHelpers.cpp
+++ b/src/solid-shapes/src/InertialParametersSolidShapesHelpers.cpp
@@ -31,7 +31,7 @@ namespace iDynTree
 SpatialInertia boxGet6DInertiaInLinkFrameFromDensity(const Box& box,
                                                      double density)
 {
-    double boxVolume = box.x*box.y*box.z;
+    double boxVolume = box.getX() * box.getY() * box.getZ();
     double boxMass   = density*boxVolume;
     // Assuming uniform density, the center of mass is coincident with the box center
     PositionRaw comInGeomFrame;
@@ -39,21 +39,21 @@ SpatialInertia boxGet6DInertiaInLinkFrameFromDensity(const Box& box,
     // From http://scienceworld.wolfram.com/physics/MomentofInertiaRectangularParallelepiped.html
     RotationalInertiaRaw rotInertiaInGeomFrame;
     rotInertiaInGeomFrame.zero();
-    double x2 = box.x*box.x;
-    double y2 = box.y*box.y;
-    double z2 = box.z*box.z;
+    double x2 = box.getX() * box.getX();
+    double y2 = box.getY() * box.getY();
+    double z2 = box.getZ() * box.getZ();
     rotInertiaInGeomFrame(0, 0) = (boxMass/12.0)*(y2+z2);
     rotInertiaInGeomFrame(1, 1) = (boxMass/12.0)*(x2+z2);
     rotInertiaInGeomFrame(2, 2) = (boxMass/12.0)*(x2+y2);
 
     SpatialInertia inertiaInGeometryFrame = SpatialInertia(boxMass, comInGeomFrame, rotInertiaInGeomFrame);
 
-    return box.link_H_geometry*inertiaInGeometryFrame;
+    return box.getLink_H_geometry() * inertiaInGeometryFrame;
 }
 
 double boxGetVolume(const Box& box)
 {
-    return box.x*box.y*box.z;
+    return box.getX() * box.getY() * box.getX();
 }
 
 #ifdef IDYNTREE_USES_ASSIMP


### PR DESCRIPTION
This PR provides a couple of changes to the classes in `SolidShapes` model file.

Currently all the attributes are public. While this is totally ok for plain data structures, some of these classes have methods that depend on the state of the object e.g. `isNameValid`, or others needs to understand if an attribute has been set or not (as the default value is not enough).
For consistency, this PR adds setter and getters to all attributes.
To avoid being a breaking change, all attributes are kept public, but marked as deprecated.
Unfortunately, to avoid data inconsistency, the setters and getters will use the deprecated attributes, thus generating lots of noise (if needed we can suppress the warnings locally (@traversaro let me know)).

In addition, I created a `Material` class, and the old `material` property is now represented by the `color` attribute of the new class.

This PR adds also the possibility to specify a robot name while exporting the URDF.