### PR TITLE
[MatrixView] Use an already existing enum to describe the Storage Ordering

### DIFF
--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -81,7 +81,7 @@ toEigen(const MatrixView<const double>& mat)
 {
     using MatrixRowMajor = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>;
 
-    // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
+    // This is a trick required to see a ColumnMajor matrix as a RowMajor matrix.
     //
     // Given the following matrix
     //     _                 _                     _
@@ -94,11 +94,11 @@ toEigen(const MatrixView<const double>& mat)
     // the elements are saved
     // v_row = [1 2 3 4 5 6 7 8 9 10]
     //
-    // If the matrix is stored as ColMajor matrix there will be a vector v_col in which
+    // If the matrix is stored as ColumnMajor matrix there will be a vector v_col in which
     // the elements are saved
     // v_col = [1 6 2 7 3 8 4 9 5 10]
     //
-    // Our goal here is to build a RowMajor Matrix (independently it is RowMajor/ColMajor)
+    // Our goal here is to build a RowMajor Matrix (independently it is RowMajor/ColumnMajor)
     // starting from the raw vactor (v_row, v_col)
     //
     // From the Eigen documentation https://eigen.tuxfamily.org/dox/classEigen_1_1Stride.html
@@ -113,8 +113,8 @@ toEigen(const MatrixView<const double>& mat)
     //    - inner_stride = 2 = number of rows of A
     //    - outer_stride = 1
 
-    const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
-    const int outerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
+    const int innerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? mat.rows() : 1;
+    const int outerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? 1 : mat.cols();
 
     return Eigen::Map<const MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),
@@ -130,7 +130,7 @@ toEigen(const MatrixView<double>& mat)
 {
     using MatrixRowMajor = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>;
 
-    // This is a trick required to see a ColMajor matrix as a RowMajor matrix.
+    // This is a trick required to see a ColumnMajor matrix as a RowMajor matrix.
     //
     // Given the following matrix
     //     _                 _                     _
@@ -143,11 +143,11 @@ toEigen(const MatrixView<double>& mat)
     // the elements are saved as
     // v_row = [1 2 3 4 5 6 7 8 9 10]
     //
-    // If the matrix is stored as ColMajor matrix there will be a vector v_col in which
+    // If the matrix is stored as ColumnMajor matrix there will be a vector v_col in which
     // the elements are saved as
     // v_col = [1 6 2 7 3 8 4 9 5 10]
     //
-    // Our goal here is to build a RowMajor Matrix (independently it is RowMajor/ColMajor)
+    // Our goal here is to build a RowMajor Matrix (independently it is RowMajor/ColumnMajor)
     // starting from the raw vactor (v_row, v_col)
     //
     // From the Eigen documentation https://eigen.tuxfamily.org/dox/classEigen_1_1Stride.html
@@ -162,8 +162,8 @@ toEigen(const MatrixView<double>& mat)
     //    - inner_stride = 2 = number of rows of A
     //    - outer_stride = 1
 
-    const int innerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? mat.rows() : 1;
-    const int outerStride = (mat.storageOrder() == StorageOrder::ColMajor) ? 1 : mat.cols();
+    const int innerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? mat.rows() : 1;
+    const int outerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? 1 : mat.cols();
 
     return Eigen::Map<MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),

--- a/src/core/include/iDynTree/Core/MatrixView.h
+++ b/src/core/include/iDynTree/Core/MatrixView.h
@@ -57,16 +57,7 @@ namespace iDynTree
     } // namespace MatrixViewIntenal
 
     /**
-     * Type of storage ordering
-     */
-    enum class StorageOrder
-    {
-        RowMajor,
-        ColMajor
-    };
-
-    /**
-     * MatrixView implements a view interface of Matrices. Both RowMajor and ColMajor matrices are
+     * MatrixView implements a view interface of Matrices. Both RowMajor and ColumnMajor matrices are
      * supported.
      * @note The user should define the storage ordering when the MatrixView is created (the default
      order is RowMajor). However if the MatrixView is generated:
@@ -88,11 +79,11 @@ namespace iDynTree
         index_type m_rows;
         index_type m_cols;
 
-        StorageOrder m_storageOrder;
+        MatrixStorageOrdering m_storageOrder;
 
         index_type rawIndex(index_type row, index_type col) const
         {
-            if (m_storageOrder == StorageOrder::RowMajor)
+            if (m_storageOrder == MatrixStorageOrdering::RowMajor)
             {
                 return (col + this->m_cols * row);
             } else
@@ -104,7 +95,7 @@ namespace iDynTree
     public:
 
         MatrixView()
-            : MatrixView(nullptr, 0, 0, StorageOrder::RowMajor)
+            : MatrixView(nullptr, 0, 0, MatrixStorageOrdering::RowMajor)
         {}
         MatrixView(const MatrixView& other)
             : MatrixView(other.m_storage, other.m_rows, other.m_cols, other.m_storageOrder)
@@ -133,8 +124,8 @@ namespace iDynTree
             : MatrixView(matrix.data(),
                          matrix.rows(),
                          matrix.cols(),
-                         Container::IsRowMajor ? StorageOrder::RowMajor
-                                               : StorageOrder::ColMajor)
+                         Container::IsRowMajor ? MatrixStorageOrdering::RowMajor
+                                               : MatrixStorageOrdering::ColumnMajor)
         {
         }
 
@@ -146,7 +137,7 @@ namespace iDynTree
                                  && !MatrixViewInternal::has_IsRowMajor<Container>::value
                                  && !std::is_same<Container, MatrixView>::value,
                              int> = 0>
-        MatrixView(const Container& matrix, const StorageOrder& order = StorageOrder::RowMajor)
+        MatrixView(const Container& matrix, const MatrixStorageOrdering& order = MatrixStorageOrdering::RowMajor)
             : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), order)
         {
         }
@@ -161,8 +152,8 @@ namespace iDynTree
             : MatrixView(matrix.data(),
                          matrix.rows(),
                          matrix.cols(),
-                         Container::IsRowMajor ? StorageOrder::RowMajor
-                                               : StorageOrder::ColMajor)
+                         Container::IsRowMajor ? MatrixStorageOrdering::RowMajor
+                                               : MatrixStorageOrdering::ColumnMajor)
         {
         }
 
@@ -172,7 +163,7 @@ namespace iDynTree
                           && !MatrixViewInternal::has_IsRowMajor<Container>::value
                           && !std::is_same<Container, MatrixView>::value,
                       int> = 0>
-        MatrixView(Container& matrix, const StorageOrder& order = StorageOrder::RowMajor)
+        MatrixView(Container& matrix, const MatrixStorageOrdering& order = MatrixStorageOrdering::RowMajor)
             : MatrixView(matrix.data(), matrix.rows(), matrix.cols(), order)
         {
         }
@@ -182,7 +173,7 @@ namespace iDynTree
         MatrixView(pointer in_data,
                    index_type in_rows,
                    index_type in_cols,
-                   const StorageOrder& order = StorageOrder::RowMajor)
+                   const MatrixStorageOrdering& order = MatrixStorageOrdering::RowMajor)
             : m_storage(in_data)
             , m_rows(in_rows)
             , m_cols(in_cols)
@@ -190,7 +181,7 @@ namespace iDynTree
         {
         }
 
-        const StorageOrder& storageOrder() const noexcept
+        const MatrixStorageOrdering& storageOrder() const noexcept
         {
             return m_storageOrder;
         }
@@ -230,7 +221,7 @@ namespace iDynTree
     make_matrix_view(ElementType* ptr,
                      typename MatrixView<ElementType>::index_type rows,
                      typename MatrixView<ElementType>::index_type cols,
-                     const StorageOrder& order = StorageOrder::RowMajor)
+                     const MatrixStorageOrdering& order = MatrixStorageOrdering::RowMajor)
     {
         return MatrixView<ElementType>(ptr, rows, cols, order);
     }
@@ -262,7 +253,7 @@ namespace iDynTree
                   int> = 0>
     IDYNTREE_CONSTEXPR MatrixView<typename Container::value_type>
     make_matrix_view(Container& cont,
-                     const StorageOrder& order = StorageOrder::RowMajor)
+                     const MatrixStorageOrdering& order = MatrixStorageOrdering::RowMajor)
     {
         return MatrixView<typename Container::value_type>(cont, order);
     }
@@ -274,7 +265,7 @@ namespace iDynTree
                   int> = 0>
     IDYNTREE_CONSTEXPR MatrixView<const typename Container::value_type>
     make_matrix_view(const Container& cont,
-                     const StorageOrder& order = StorageOrder::RowMajor)
+                     const MatrixStorageOrdering& order = MatrixStorageOrdering::RowMajor)
     {
         return MatrixView<const typename Container::value_type>(cont, order);
     }


### PR DESCRIPTION
`MatrixStorageOrdering` is defined in `Utility.h` there is no reason to define a custom `enum class` for describing the ordering 