### PR TITLE
Optimize iDynTreeWrappers [WIP]

### DIFF
--- a/bindings/matlab/+iDynTreeWrappers/README.md
+++ b/bindings/matlab/+iDynTreeWrappers/README.md
@@ -1,4 +1,4 @@
-# idyntree high-level-wrappers
+# iDynTree high-level-wrappers
 
 A collection of Matlab/Octave functions that wraps the functionalities of (mainly) the iDyntree class `KinDynComputations`. For further information on the single wrapper, refer to the description included in each function.
 
@@ -73,6 +73,8 @@ The purpose of the wrapper is therefore to provide a simpler and easy-to-use int
 
 Not proper wrappers, they wrap more than one method of the class each. **Requirements:** compile iDyntree with Irrlicht `(IDYNTREE_USES_IRRLICHT = ON)`.
 
+**Warning**: the visualizer class may be deprecated in a future release.
+
 - [initializeVisualizer](initializeVisualizer.m)
 - [visualizerSetup](visualizerSetup.m)
 - [updateVisualizer](updateVisualizer.m)
@@ -80,9 +82,11 @@ Not proper wrappers, they wrap more than one method of the class each. **Require
 ## Matlab Native visualization
 
 Not actual wrappers, they use the iDynTreeWrappers in combination with the MATLAB patch plotting functions to visualize the robot.
+
 **Disclaimers**:
-- This visualization **has not been tested** with Octave.
-- At the moment, there is **no support** for .dae mesh files.
+
+1) This visualization **has not been tested** with Octave.
+2) At the moment, there is **no support** for `.dae` mesh file format.
 
 - [prepareVisualization](prepareVisualization.m)
 - [updateVisualization](updateVisualization.m)

--- a/bindings/matlab/+iDynTreeWrappers/generalizedBiasForces.m
+++ b/bindings/matlab/+iDynTreeWrappers/generalizedBiasForces.m
@@ -1,7 +1,7 @@
 function h = generalizedBiasForces(KinDynModel)
 
     % GENERALIZEDBIASFORCES retrieves the generalized bias forces from 
-    %                            the reduced model. 
+    %                       the reduced model. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -20,11 +20,8 @@ function h = generalizedBiasForces(KinDynModel)
 
     %% ------------Initialization----------------
     
-    % create the vector that must be populated with the bias forces
-    h_iDyntree = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
-    
     % get the bias forces
-    ack = KinDynModel.kinDynComp.generalizedBiasForces(h_iDyntree);
+    ack = KinDynModel.kinDynComp.generalizedBiasForces(KinDynModel.dynamics.h_iDyntree);
     
     % check for errors
     if ~ack
@@ -33,7 +30,7 @@ function h = generalizedBiasForces(KinDynModel)
     
     % convert to Matlab format: compute the base bias acc (h_b) and the
     % joint bias acc (h_s) and concatenate them
-    h_b = h_iDyntree.baseWrench.toMatlab;
-    h_s = h_iDyntree.jointTorques.toMatlab;   
+    h_b = KinDynModel.dynamics.h_iDyntree.baseWrench.toMatlab;
+    h_s = KinDynModel.dynamics.h_iDyntree.jointTorques.toMatlab;   
     h   = [h_b;h_s];
 end

--- a/bindings/matlab/+iDynTreeWrappers/generalizedGravityForces.m
+++ b/bindings/matlab/+iDynTreeWrappers/generalizedGravityForces.m
@@ -1,7 +1,7 @@
 function g = generalizedGravityForces(KinDynModel)
 
     % GENERALIZEDGRAVITYFORCES retrieves the generalized gravity forces 
-    %                               given the reduced model.
+    %                          given the reduced model.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -19,12 +19,9 @@ function g = generalizedGravityForces(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    % create the vector that must be populated with the gravity forces
-    g_iDyntree = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
-    
+
     % get the gravity forces
-    ack = KinDynModel.kinDynComp.generalizedGravityForces(g_iDyntree);
+    ack = KinDynModel.kinDynComp.generalizedGravityForces(KinDynModel.dynamics.g_iDyntree);
     
     % check for errors
     if ~ack  
@@ -33,7 +30,7 @@ function g = generalizedGravityForces(KinDynModel)
     
     % convert to Matlab format: compute the base gravity forces (g_b) and the
     % joint gravity forces (g_j) and concatenate them
-    g_b = g_iDyntree.baseWrench.toMatlab;
-    g_s = g_iDyntree.jointTorques.toMatlab;   
+    g_b = KinDynModel.dynamics.g_iDyntree.baseWrench.toMatlab;
+    g_s = KinDynModel.dynamics.g_iDyntree.jointTorques.toMatlab;   
     g   = [g_b; g_s];
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCenterOfMassJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCenterOfMassJacobian.m
@@ -18,12 +18,9 @@ function J_CoM = getCenterOfMassJacobian(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    % create the matrix that must be populated with the jacobian map
-    J_CoM_iDyntree = iDynTree.MatrixDynSize(3,KinDynModel.NDOF+6);
-    
+
     % get the free floating jacobian
-    ack = KinDynModel.kinDynComp.getCenterOfMassJacobian(J_CoM_iDyntree);
+    ack = KinDynModel.kinDynComp.getCenterOfMassJacobian(KinDynModel.kinematics.J_CoM_iDyntree);
     
     % check for errors
     if ~ack    
@@ -31,5 +28,5 @@ function J_CoM = getCenterOfMassJacobian(KinDynModel)
     end
     
     % convert to Matlab format
-    J_CoM = J_CoM_iDyntree.toMatlab;
+    J_CoM = KinDynModel.kinematics.J_CoM_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCentroidalTotalMomentum.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCentroidalTotalMomentum.m
@@ -1,8 +1,8 @@
 function totalMomentum = getCentroidalTotalMomentum(KinDynModel)
 
     % GETCENTROIDALTOTALMOMENTUM retrieves the centroidal momentum from the reduced
-    %                                 model. The quantity is expressed in a frame that depends
-    %                                 on the 'FrameVelocityReperesentation' settings.                               
+    %                            model. The quantity is expressed in a frame that depends
+    %                            on the 'FrameVelocityReperesentation' settings.                               
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getFloatingBase.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFloatingBase.m
@@ -1,7 +1,7 @@
 function baseLinkName = getFloatingBase(KinDynModel)
 
     % GETFLOATINGBASE retrieves the floating base link name from the 
-    %                      reduced model.
+    %                 reduced model.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getFrameFreeFloatingJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameFreeFloatingJacobian.m
@@ -1,7 +1,7 @@
 function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
 
     % GETFRAMEFREEFLOATINGJACOBIAN gets the free floating jacobian of a 
-    %                                   specified frame. 
+    %                              specified frame. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -21,12 +21,9 @@ function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    % create the matrix that must be populated with the jacobian map
-    J_frame_iDyntree = iDynTree.MatrixDynSize(6,KinDynModel.NDOF+6);
-    
+
     % get the free floating jacobian
-    ack = KinDynModel.kinDynComp.getFrameFreeFloatingJacobian(frameName,J_frame_iDyntree);
+    ack = KinDynModel.kinDynComp.getFrameFreeFloatingJacobian(frameName,KinDynModel.kinematics.J_frame_iDyntree);
     
     % check for errors
     if ~ack   
@@ -34,5 +31,5 @@ function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
     end
     
     % convert to Matlab format
-    J_frame = J_frame_iDyntree.toMatlab;
+    J_frame = KinDynModel.kinematics.J_frame_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameVelocityRepresentation.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameVelocityRepresentation.m
@@ -1,7 +1,7 @@
 function frameVelRepr = getFrameVelocityRepresentation(KinDynModel)
 
     % GETFRAMEVELOCITYREPRESENTATION retrieves the current frame velocity
-    %                                     representation. 
+    %                                representation. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getFreeFloatingMassMatrix.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFreeFloatingMassMatrix.m
@@ -18,12 +18,9 @@ function M = getFreeFloatingMassMatrix(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    % create the matrix that must be populated with the mass info
-    M_iDyntree = iDynTree.MatrixDynSize(KinDynModel.NDOF+6,KinDynModel.NDOF+6);
-    
+
     % get the mass matrix
-    ack = KinDynModel.kinDynComp.getFreeFloatingMassMatrix(M_iDyntree);
+    ack = KinDynModel.kinDynComp.getFreeFloatingMassMatrix(KinDynModel.dynamics.M_iDyntree);
     
     % check for errors
     if ~ack  
@@ -31,7 +28,7 @@ function M = getFreeFloatingMassMatrix(KinDynModel)
     end
     
     % convert to Matlab format
-    M = M_iDyntree.toMatlab;
+    M = KinDynModel.dynamics.M_iDyntree.toMatlab;
     
     % debug output
     if KinDynModel.DEBUG

--- a/bindings/matlab/+iDynTreeWrappers/getJointPos.m
+++ b/bindings/matlab/+iDynTreeWrappers/getJointPos.m
@@ -18,12 +18,9 @@ function jointPos = getJointPos(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    % create the vector that must be populated with the joint positions
-    jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+
     % get the joints positions
-    ack = KinDynModel.kinDynComp.getJointPos(jointPos_iDyntree);
+    ack = KinDynModel.kinDynComp.getJointPos(KinDynModel.kinematics.jointPos_iDyntree);
     
     % check for errors
     if ~ack   
@@ -31,5 +28,5 @@ function jointPos = getJointPos(KinDynModel)
     end
     
     % convert to Matlab format
-    jointPos = jointPos_iDyntree.toMatlab;
+    jointPos = KinDynModel.kinematics.jointPos_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getJointVel.m
+++ b/bindings/matlab/+iDynTreeWrappers/getJointVel.m
@@ -18,12 +18,9 @@ function jointVel = getJointVel(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-
-    % create the vector that must be populated with the joint velocities
-    jointVel_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
     
     % get the joints velocities
-    ack = KinDynModel.kinDynComp.getJointVel(jointVel_iDyntree);
+    ack = KinDynModel.kinDynComp.getJointVel(KinDynModel.kinematics.jointVel_iDyntree);
     
     % check for errors
     if ~ack   
@@ -31,5 +28,5 @@ function jointVel = getJointVel(KinDynModel)
     end
     
     % convert to Matlab format
-    jointVel = jointVel_iDyntree.toMatlab;
+    jointVel = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -1,118 +1,147 @@
-function [linkMeshInfo,map]=getMeshes(model,meshFilePrefix)
-% We use the iDyntree information to obtain the files containing the meshes
-% and we link them to their link names
-% Gets the mesh information for each link in the model.
-%     - Iputs:
-%         - `model` : iDyntree model loaded from a URDF.
-%         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-% `. `meshFilePrefix` should replace package to allow to find the rest of the path.
-%     - Outputs:
-%         - `map`        : Cell array having both the names of the meshes and the associated link
-%         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
-%
-% NOTE: at the moment only STL files are supported.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
+function [linkMeshInfo, map] = getMeshes(model, meshFilePrefix)
 
+    % GETMESHES uses the iDynTree information to obtain the files containing 
+    %           the meshes and links them to their link names.
+    %
+    % FORMAT: [linkMeshInfo, map] = getMeshes(model, meshFilePrefix)
+    %
+    % INPUTS:  - model: iDyntree model loaded from a URDF.
+    %          - meshFilePrefix: Path in which we can find the meshes. As an example 
+    %                           the path to the meshes in an iCub urdf is 
+    %                           'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'.
+    %                           'meshFilePrefix' should replace 'package' to 
+    %                            allow to find the rest of the path. 
+    %
+    % OUTPUTS: - map: Cell array having both the names of the meshes and the associated link
+    %          - linkMeshInfo: Struct array that contain the link name and a struct (`meshInfo`) 
+    %                          that contains the name of file or if is a simple geometry, the 
+    %                          triangulation (edges and vertices of the mesh) and the link to 
+    %                          geometry transform.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %          Modified by: Gabriele Nava (gabriele.nava@iit.it)
+    %    
+    % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
 
+    %% ------------Initialization----------------
 
-% get the linkSolidShapes containing the mesh information
-visual=model.visualSolidShapes;
-linkSolidShapesV=visual.linkSolidShapes;
-% get number of links
-numberOfLinks=linkSolidShapesV.size;
-linkMeshInfo=struct('meshInfo',{},'linkName',{});
-% get pointer to beggining of vector
-iterator=linkSolidShapesV.begin;
-% iterate getting the name of the mesh and the name of the link
-count=1;
-link_with_no_visual=[];
-for links=1:numberOfLinks
-    linkName=model.getLinkName(links-1);
-    linkMeshInfo(links).linkName=linkName;
-    solidarray=iterator.next;
-    solids_number=size(solidarray,2);
-    meshInfo=struct('meshFile',{},'mesh_triangles',{},'link_H_geom',{});
-    for solids=1:solids_number
-        if solidarray{solids}.isExternalMesh
-            externalMesh=solidarray{solids}.asExternalMesh;
-            scale=externalMesh.scale.toMatlab;
-            meshName=split(externalMesh.filename,':');
-            meshFile=meshName{2};
-            % Import an STL mesh, returning a PATCH-compatible face-vertex structure
-            if strcmp('package',meshName{1})
-                mesh_triangles = stlread([meshFilePrefix meshFile]);
+    % get the linkSolidShapes containing the mesh information
+    visual           = model.visualSolidShapes;
+    linkSolidShapesV = visual.linkSolidShapes;
+    
+    % get number of links
+    numberOfLinks    = linkSolidShapesV.size;
+    linkMeshInfo     = struct('meshInfo',{},'linkName',{});
+    
+    % get pointer to beggining of vector
+    iterator         = linkSolidShapesV.begin;
+    
+    % iterate getting the name of the mesh and the name of the link
+    count               = 1;
+    link_with_no_visual = [];
+    
+    for links = 1:numberOfLinks
+        
+        linkName                     = model.getLinkName(links-1);
+        linkMeshInfo(links).linkName = linkName;
+        solidarray                   = iterator.next;
+        solids_number                = size(solidarray,2);
+        meshInfo                     = struct('meshFile',{},'mesh_triangles',{},'link_H_geom',{});
+        
+        for solids = 1:solids_number
+            
+            if solidarray{solids}.isExternalMesh
+                
+                externalMesh = solidarray{solids}.asExternalMesh;
+                scale        = externalMesh.scale.toMatlab;
+                meshName     = split(externalMesh.filename,':');
+                meshFile     = meshName{2};
+                
+                % Import an STL mesh, returning a PATCH-compatible face-vertex structure
+                if strcmp('package',meshName{1})
+                    
+                    mesh_triangles = stlread([meshFilePrefix meshFile]);
+                else
+                    mesh_triangles = stlread(meshFile);
+                end
+                
+                meshInfo(solids).meshFile = meshFile;
+                meshInfo(solids).scale    = scale';
             else
-                mesh_triangles = stlread(meshFile);
+                meshInfo(solids).scale    = [1,1,1];
+                
+                if solidarray{solids}.isCylinder
+                    
+                    meshInfo(solids).meshFile = 'cylinder';
+                    length = solidarray{solids}.asCylinder.length;
+                    radius = solidarray{solids}.asCylinder.radius;
+                    mesh_triangles = calculateMeshFromCylinder(length,radius);
+                end
+                if solidarray{solids}.isBox
+                    
+                    meshInfo(solids).meshFile = 'box';
+                    box_dimensions(1) = solidarray{solids}.asBox.x;
+                    box_dimensions(2) = solidarray{solids}.asBox.y;
+                    box_dimensions(3) = solidarray{solids}.asBox.z;
+                    mesh_triangles = calculateMeshFromBox(box_dimensions);
+                end
+                if solidarray{solids}.isSphere
+                    
+                    meshInfo(solids).meshFile = 'sphere';
+                    radius = solidarray{solids}.asSphere.radius;
+                    mesh_triangles = calculateMeshFromSphere(radius);
+                end
             end
-            meshInfo(solids).meshFile=meshFile;
-            meshInfo(solids).scale=scale';
-        else
-            meshInfo(solids).scale=[1,1,1];
-            if solidarray{solids}.isCylinder
-                meshInfo(solids).meshFile='cylinder';
-                length=solidarray{solids}.asCylinder.length;
-                radius=solidarray{solids}.asCylinder.radius;
-                mesh_triangles=calculateMeshFromCylinder(length,radius);
-            end
-            if solidarray{solids}.isBox
-                meshInfo(solids).meshFile='box';
-                box_dimensions(1)=solidarray{solids}.asBox.x;
-                box_dimensions(2)=solidarray{solids}.asBox.y;
-                box_dimensions(3)=solidarray{solids}.asBox.z;
-                mesh_triangles=calculateMeshFromBox(box_dimensions);
-            end
-            if solidarray{solids}.isSphere
-                meshInfo(solids).meshFile='sphere';
-                radius=solidarray{solids}.asSphere.radius;
-                mesh_triangles=calculateMeshFromSphere(radius);
-            end
+            
+            link_H_geom                     = solidarray{solids}.link_H_geometry.asHomogeneousTransform.toMatlab;
+            meshInfo(solids).link_H_geom    = link_H_geom;
+            meshInfo(solids).mesh_triangles = mesh_triangles;
+            map(count,:)                    = [{meshInfo(solids).meshFile},{linkName}];
+            count                           = count+1;
         end
-        link_H_geom=solidarray{solids}.link_H_geometry.asHomogeneousTransform.toMatlab;
-        meshInfo(solids).link_H_geom=link_H_geom;
-        meshInfo(solids).mesh_triangles=mesh_triangles;
-        map(count,:)=[{meshInfo(solids).meshFile},{linkName}];
-        count=count+1;
+        
+        linkMeshInfo(links).meshInfo = meshInfo;
+        
+        if solids_number == 0
+            
+           link_with_no_visual = [link_with_no_visual links];
+        end
     end
-    linkMeshInfo(links).meshInfo=meshInfo;
-    if solids_number==0
-       link_with_no_visual=[ link_with_no_visual links];
-    end
-end
-% clean links with no visuals
-linkMeshInfo(link_with_no_visual)=[];
-
-end
-%% Create points and connectivity list for each geometry
-
-function [mesh_triangles]=calculateMeshFromSphere(radius)
-[X,Y,Z]=sphere;
-X = X * radius;
-Y = Y * radius;
-Z = Z * radius;
-[F,V]=mesh2tri(X,Y,Z,'f');
-mesh_triangles.Points=V;
-mesh_triangles.ConnectivityList = F;
+    
+    % clean links with no visuals
+    linkMeshInfo(link_with_no_visual) = [];
 end
 
-function [mesh_triangles]=calculateMeshFromBox(box_dimensions)
-mesh_triangles.Points = [0 0 0;1 0 0;1 1 0;0 1 0;0 0 1;1 0 1;1 1 1;0 1 1];
-mesh_triangles.Points(:,1)=mesh_triangles.Points(:,1)*box_dimensions(1)-box_dimensions(1)/2;
-mesh_triangles.Points(:,2)=mesh_triangles.Points(:,2)*box_dimensions(2)-box_dimensions(2)/2;
-mesh_triangles.Points(:,3)=mesh_triangles.Points(:,3)*box_dimensions(3)-box_dimensions(3)/2;
-mesh_triangles.ConnectivityList = [1 2 6 5;2 3 7 6;3 4 8 7;4 1 5 8;1 2 3 4;5 6 7 8];
+% Create points and connectivity list for each geometry
+function [mesh_triangles] = calculateMeshFromSphere(radius)
+    
+    [X,Y,Z] = sphere;
+    X       = X * radius;
+    Y       = Y * radius;
+    Z       = Z * radius;
+    [F,V]   = mesh2tri(X,Y,Z,'f');
+    mesh_triangles.Points           = V;
+    mesh_triangles.ConnectivityList = F;
 end
 
-function [mesh_triangles]=calculateMeshFromCylinder(length,radius)
-[X,Y,Z] = cylinder;
-X = X * radius;
-Y = Y * radius;
-Z = Z * length-length/2;
-[F,V]=mesh2tri(X,Y,Z,'f');
-mesh_triangles.Points=V;
-mesh_triangles.ConnectivityList = F;
+function [mesh_triangles] = calculateMeshFromBox(box_dimensions)
+
+    mesh_triangles.Points           = [0 0 0;1 0 0;1 1 0;0 1 0;0 0 1;1 0 1;1 1 1;0 1 1];
+    mesh_triangles.Points(:,1)      = mesh_triangles.Points(:,1)*box_dimensions(1)-box_dimensions(1)/2;
+    mesh_triangles.Points(:,2)      = mesh_triangles.Points(:,2)*box_dimensions(2)-box_dimensions(2)/2;
+    mesh_triangles.Points(:,3)      = mesh_triangles.Points(:,3)*box_dimensions(3)-box_dimensions(3)/2;
+    mesh_triangles.ConnectivityList = [1 2 6 5;2 3 7 6;3 4 8 7;4 1 5 8;1 2 3 4;5 6 7 8];
+end
+
+function [mesh_triangles] = calculateMeshFromCylinder(length,radius)
+
+    [X,Y,Z] = cylinder;
+    X       = X * radius;
+    Y       = Y * radius;
+    Z       = Z * length-length/2;
+    [F,V]   = mesh2tri(X,Y,Z,'f');
+    mesh_triangles.Points           = V;
+    mesh_triangles.ConnectivityList = F;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getModelVel.m
+++ b/bindings/matlab/+iDynTreeWrappers/getModelVel.m
@@ -1,7 +1,7 @@
 function stateVel = getModelVel(KinDynModel)
 
     % GETMODELVEL gets the joints and floating base velocities from the 
-    %                  reduced model.
+    %             reduced model.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -19,12 +19,9 @@ function stateVel = getModelVel(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    % create the vector that must be populated with the stae velocities
-    stateVel_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+ 
     % get the joints velocities
-    ack = KinDynModel.kinDynComp.getModelVel(stateVel_iDyntree);
+    ack = KinDynModel.kinDynComp.getModelVel(KinDynModel.kinematics.stateVel_iDyntree);
     
     % check for errors
     if ~ack  
@@ -32,5 +29,5 @@ function stateVel = getModelVel(KinDynModel)
     end
     
     % convert to Matlab format
-    stateVel = stateVel_iDyntree.toMatlab;
+    stateVel = KinDynModel.kinematics.stateVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getNrOfDegreesOfFreedom.m
+++ b/bindings/matlab/+iDynTreeWrappers/getNrOfDegreesOfFreedom.m
@@ -30,7 +30,7 @@ function nDof = getNrOfDegreesOfFreedom(KinDynModel)
         % check nDof is not empty
         if isempty(nDof)
             
-            error('[getNrOfDegreesOfFreedom]: nDof is empty.')
+            warning('[getNrOfDegreesOfFreedom]: nDof is empty.')
         end
                
         disp('[getNrOfDegreesOfFreedom]: done.')     

--- a/bindings/matlab/+iDynTreeWrappers/getRelativeJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRelativeJacobian.m
@@ -1,8 +1,8 @@
 function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
 
     % GETRELATIVEJACOBIAN gets the relative jacobian, i.e. the matrix that
-    %                          maps the velocity of frameVel expressed w.r.t.
-    %                          frameRef, to the joint velocity. 
+    %                     maps the velocity of frameVel expressed w.r.t.
+    %                     frameRef, to the joint velocity. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -25,11 +25,8 @@ function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
 
     %% ------------Initialization----------------
 
-    % create the matrix that must be populated with the jacobian map
-    J_frameVel_iDyntree = iDynTree.MatrixDynSize(6,KinDynModel.NDOF);
-    
     % get the relative jacobian
-    ack = KinDynModel.kinDynComp.getRelativeJacobian(frameVelID,frameRefID,J_frameVel_iDyntree);  
+    ack = KinDynModel.kinDynComp.getRelativeJacobian(frameVelID,frameRefID,KinDynModel.kinematics.J_frameVel_iDyntree);  
     
     % check for errors
     if ~ack  
@@ -37,5 +34,5 @@ function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
     end
     
     % covert to Matlab format
-    J_frameVel = J_frameVel_iDyntree.toMatlab; 
+    J_frameVel = KinDynModel.kinematics.J_frameVel_iDyntree.toMatlab; 
 end

--- a/bindings/matlab/+iDynTreeWrappers/getRelativeTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRelativeTransform.m
@@ -1,7 +1,7 @@
 function frame1_H_frame2 = getRelativeTransform(KinDynModel,frame1Name,frame2Name)
 
     % GETRELATIVETRANSFORM gets the transformation matrix between two specified 
-    %                           frames.
+    %                      frames.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRobotState.m
@@ -21,29 +21,24 @@ function [basePose,jointPos,baseVel,jointVel] = getRobotState(KinDynModel)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-
-    % define all the iDyntree required quantities
-    basePose_iDyntree   = iDynTree.Transform();
-    jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    baseVel_iDyntree    = iDynTree.Twist();
-    jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    gravityVec_iDyntree = iDynTree.Vector3();
     
     % get the floating base state
-    KinDynModel.kinDynComp.getRobotState(basePose_iDyntree,jointPos_iDyntree,baseVel_iDyntree,jointVel_iDyntree,gravityVec_iDyntree);
+    KinDynModel.kinDynComp.getRobotState(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree, ...
+                                         KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                                         KinDynModel.kinematics.gravityVec_iDyntree);
    
     % get the base position and orientation
-    baseRotation_iDyntree = basePose_iDyntree.getRotation;
-    baseOrigin_iDyntree   = basePose_iDyntree.getPosition;
+    baseRotation_iDyntree = KinDynModel.kinematics.basePose_iDyntree.getRotation;
+    baseOrigin_iDyntree   = KinDynModel.kinematics.basePose_iDyntree.getPosition;
     
     % covert to Matlab format
     baseRotation = baseRotation_iDyntree.toMatlab;
     baseOrigin   = baseOrigin_iDyntree.toMatlab;
     basePose     = [baseRotation, baseOrigin;
                        0,  0,  0,  1]; 
-    jointPos     = jointPos_iDyntree.toMatlab;
-    baseVel      = baseVel_iDyntree.toMatlab;
-    jointVel     = jointVel_iDyntree.toMatlab;   
+    jointPos     = KinDynModel.kinematics.jointPos_iDyntree.toMatlab;
+    baseVel      = KinDynModel.kinematics.baseVel_iDyntree.toMatlab;
+    jointVel     = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;   
     
     % Debug output
     if KinDynModel.DEBUG

--- a/bindings/matlab/+iDynTreeWrappers/getWorldBaseTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldBaseTransform.m
@@ -1,7 +1,7 @@
 function basePose = getWorldBaseTransform(KinDynModel)
 
-    % GETWORLDBASETRANSFORM gets the transformation matrix between the base frame
-    %                            and the inertial reference frame. 
+    % GETWORLDBASETRANSFORM gets the transformation matrix between the base
+    %                       frame and the inertial reference frame. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getWorldTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldTransform.m
@@ -1,7 +1,7 @@
 function w_H_frame = getWorldTransform(KinDynModel,frameName)
 
     % GETWORLDTRANSFORM gets the transformation matrix between a specified 
-    %                        frame and the inertial reference frame.
+    %                   frame and the inertial reference frame.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -23,8 +23,7 @@ function w_H_frame = getWorldTransform(KinDynModel,frameName)
 
     %% ------------Initialization----------------
     
-    % get the transformation between the frame and the world in Matlab
-    % format
+    % get the transformation between the frame and the world in Matlab format
     w_H_frame = KinDynModel.kinDynComp.getWorldTransform(frameName).asHomogeneousTransform.toMatlab;  
 
     % Debug output

--- a/bindings/matlab/+iDynTreeWrappers/getWorldTransformsAsHomogeneous.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldTransformsAsHomogeneous.m
@@ -1,7 +1,7 @@
 function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 
 % GETWORLDTRANSFORMASHOMOGENEOUS gets the transformation matrices between the specified
-%                        frames and the inertial reference frame.
+%                                frames and the inertial reference frame.
 %
 % This matlab function wraps a functionality of the iDyntree library.
 % For further info see also: https://github.com/robotology/idyntree
@@ -9,7 +9,8 @@ function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 % FORMAT:  w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameName)
 %
 % INPUTS:  - frameNames: a string vector that specifies the frames w.r.t. compute the
-%                       transfomation matrix;
+%                        transfomation matrix;
+%
 %          - KinDynModel: a structure containing the loaded model and additional info.
 %
 % OUTPUTS: - w_H_frames: [size(frameNames) x 4 x 4] from frame to world transformation matrices.
@@ -22,48 +23,48 @@ function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 
 %% ------------Initialization----------------
 
-% get the transformation between the frame and the world in Matlab
-% format
-transforms_idyn=KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(frameNames);
-w_H_frames= transforms_idyn.toMatlab();
-for it=1:frameNames.size
-    w_H_frame=squeeze(w_H_frames(it,:,:));
+    % get the transformation between the frame and the world in Matlab format
+    transforms_iDyntree = KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(frameNames);
+    w_H_frames          = transforms_iDyntree.toMatlab();
+
+    for i = 1:frameNames.size
     
-    % Debug output
-    if KinDynModel.DEBUG
-        w_R_frame          = w_H_frame(1:3,1:3);
+        w_H_frame = squeeze(w_H_frames(i,:,:));
+    
+        % Debug output
+        if KinDynModel.DEBUG
         
-        disp('[getWorldTransform]: debugging outputs...')
+            w_R_frame = w_H_frame(1:3,1:3);
         
-        % w_R_frame must be a valid rotation matrix
-        if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
+            disp('[getWorldTransformsAsHomogeneous]: debugging outputs...')
+        
+            % w_R_frame must be a valid rotation matrix
+            if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
             
-            error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-        end
+                error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
+            end
         
-        IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
+            IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
         
-        for kk = 1:size(IdentityMatr, 1)
+            for kk = 1:size(IdentityMatr, 1)
             
-            for jj = 1:size(IdentityMatr, 1)
+                for jj = 1:size(IdentityMatr, 1)
                 
-                if jj == kk
+                    if jj == kk
                     
-                    if abs(IdentityMatr(kk,jj)-1) > 0.9
+                        if abs(IdentityMatr(kk,jj)-1) > 0.9
                         
-                        error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-                    end
-                else
-                    if abs(IdentityMatr(kk,jj)) > 0.1
-                        
-                        error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
+                            error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
+                        end
+                    else
+                        if abs(IdentityMatr(kk,jj)) > 0.1
+                            
+                            error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
+                        end
                     end
                 end
             end
-        end
-        disp('[getWorldTransform]: done.')
+            disp('[getWorldTransformsAsHomogeneous]: done.')
+        end   
     end
-    
-end
-
 end

--- a/bindings/matlab/+iDynTreeWrappers/initializeVisualizer.m
+++ b/bindings/matlab/+iDynTreeWrappers/initializeVisualizer.m
@@ -1,7 +1,9 @@
 function Visualizer = initializeVisualizer(KinDynModel,debugMode)
 
     % INITIALIZEVISUALIZER opens the iDyntree visualizer and loads the reduced
-    %                           model into the visualizer.
+    %                      model into the visualizer.
+    %
+    % WARNING! This function is deprecated! Use prepareVisualization instead.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -22,8 +24,8 @@ function Visualizer = initializeVisualizer(KinDynModel,debugMode)
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
-    Visualizer.viz   = iDynTree.Visualizer();
+
+    Visualizer.viz = iDynTree.Visualizer();
     
     % load the model in the visualizer
     ack = Visualizer.viz.addModel(KinDynModel.kinDynComp.model(),'viz1');

--- a/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
+++ b/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
@@ -60,4 +60,22 @@ function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelNa
     KinDynModel.kinDynComp.setFloatingBase(KinDynModel.BASE_LINK);
     
     disp(['[loadReducedModel]: loaded model: ',[modelPath,modelName],', number of joints: ',num2str(KinDynModel.NDOF)]);
+    
+    % initialize all dynamics and kinematics quantities used inside the
+    % wrappers. This procedure optimizes the wrappers speed, as the
+    % iDyntree objects are created only once and then updated runtime
+    KinDynModel.kinematics.baseRotation_iDyntree = iDynTree.Rotation();
+    KinDynModel.kinematics.baseOrigin_iDyntree   = iDynTree.Position();
+    KinDynModel.kinematics.basePose_iDyntree     = iDynTree.Transform();
+    KinDynModel.kinematics.baseVel_iDyntree      = iDynTree.Twist();
+    KinDynModel.kinematics.jointPos_iDyntree     = iDynTree.VectorDynSize(KinDynModel.NDOF);
+    KinDynModel.kinematics.jointVel_iDyntree     = iDynTree.VectorDynSize(KinDynModel.NDOF);
+    KinDynModel.kinematics.stateVel_iDyntree     = iDynTree.VectorDynSize(6+KinDynModel.NDOF);
+    KinDynModel.kinematics.gravityVec_iDyntree   = iDynTree.Vector3(); 
+    KinDynModel.kinematics.J_CoM_iDyntree        = iDynTree.MatrixDynSize(3,KinDynModel.NDOF+6);
+    KinDynModel.kinematics.J_frame_iDyntree      = iDynTree.MatrixDynSize(6,KinDynModel.NDOF+6);
+    KinDynModel.kinematics.J_frameVel_iDyntree   = iDynTree.MatrixDynSize(6,KinDynModel.NDOF);      
+    KinDynModel.dynamics.M_iDyntree              = iDynTree.MatrixDynSize(KinDynModel.NDOF+6,KinDynModel.NDOF+6);
+    KinDynModel.dynamics.h_iDyntree              = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
+    KinDynModel.dynamics.g_iDyntree              = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
 end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
@@ -1,119 +1,152 @@
-function []=modifyLinkVisual(meshHandle,varargin)
-% Modifies a single `meshHandle` with the specified changes.
-%     - Inputs:
-%         - `meshHandle` : Struct containing the patch type of variable ( `modelMesh` field ) and the original information of the mesh in `fullMesh_bckup` field.
-%     - Optional Inputs:
-%         - `color` : Selects the color of the meshes.
-%         - `transparency` : Sets the alpha value of the patch. Is the
-%         level of transparency between 0 fully transparent and 1 solid.
-%         - `wireframe_rendering` : the reduction ratio of faces to
-%         wireframe. Follows convention of reducepatch.
-%         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
-%     - Outputs:
-%         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
-%         - `transform`    : The transform object for the link
-%         - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
-%         - `useDefault`  : Enables the use of the default values instead of ignoring non specified changes.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_color= [0.1843    0.3098    0.3098];
-default_transparency=0.5;
-default_style='fullMesh';
-default_wireframe_rendering=0.08;
-default_material='dull';
-default_useDefault=false;
-% accepted values
-expected_materials={'dull','metal','shiny'};
-expected_styles={'fullMesh','wireframe','invisible'};
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
-addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
-addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
-addParameter(p,'useDefault',default_useDefault);
+function [] = modifyLinkVisual(meshHandle, varargin)
 
-% parse inputs
-parse(p,meshHandle,varargin{:});
-options=p.Results;
-for nMeshes=1:length(meshHandle.modelMesh)
-    modelMesh=meshHandle.modelMesh(nMeshes);
-    if ~any(ismember(p.UsingDefaults,'color')) || options.useDefault
-        changeColor(modelMesh,options.color);
-    end
-    if ~any(ismember(p.UsingDefaults,'transparency')) || options.useDefault
-        alpha(modelMesh,options.transparency);
-    end
-    if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
-        material(modelMesh,options.material);
-    end
+    % MODYFYLINKVISUAL modifies a single meshHandle with the specified changes.
+    %
+    % FORMAT: [] = modifyLinkVisual(meshHandle, varargin) 
+    %
+    % INPUTS: - meshHandle: Struct containing the patch type of variable
+    %                       (modelMesh field) and the original information 
+    %                       of the mesh in fullMesh_bckup field.
+    %
+    % OPTIONAL INPUTS: - color: Selects the color of the meshes.
+    %                  - transparency: Sets the alpha value of the patch. Is the
+    %                                  level of transparency between 0 fully
+    %                                  transparent and 1 solid.
+    %                  - wireframe_rendering: the reduction ratio of faces to
+    %                                         wireframe. Follows convention 
+    %                                         of reducepatch.
+    %                  - style: Selects the style of display of meshes, 
+    %                           either fullMesh or wireframe.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %          Modified by: Gabriele Nava (gabriele.nava@iit.it)
+    %    
+    % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
 
+    %% ------------Initialization----------------
+    
+    % Input parser section
+    p               = inputParser;
+    p.StructExpand  = false;
+    p.KeepUnmatched = true;
+    
+    % Default values
+    default_color               = [0.1843 0.3098 0.3098];
+    default_transparency        =  0.5;
+    default_style               = 'fullMesh';
+    default_wireframe_rendering =  0.08;
+    default_material            = 'dull';
+    default_useDefault          =  false;
+    
+    % Accepted values
+    expected_materials = {'dull','metal','shiny'};
+    expected_styles    = {'fullMesh','wireframe','invisible'};
+    
+    % Add parameters and validity funcitons
+    addRequired(p,'structInput');
+    addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+    addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
+    addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
+    addParameter(p,'useDefault',default_useDefault);
 
-    if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
-        [isWF,noColor]=isWireframe(modelMesh);
-
-        if strcmpi(options.style,'wireframe') && ~isWF
-            if noColor
-                color=options.color;
-            else
-                color=modelMesh.FaceColor;
-            end
-            reducepatch(modelMesh,options.wireframe_rendering);
-            modelMesh.FaceColor='none';
-            modelMesh.EdgeColor=color;
+    % Parse inputs
+    parse(p,meshHandle,varargin{:});
+    options = p.Results;
+    
+    for nMeshes = 1:length(meshHandle.modelMesh)
+        
+        modelMesh = meshHandle.modelMesh(nMeshes);
+        
+        if ~any(ismember(p.UsingDefaults,'color')) || options.useDefault
+            
+            changeColor(modelMesh,options.color);
         end
-        if strcmpi(options.style,'fullMesh') && isWF % means full mesh
-            if noColor
-                color=options.color;
-            else
-                color=modelMesh.EdgeColor;
-            end
-            modelMesh.Vertices=meshHandle.fullMesh_bckup(nMeshes).vertices;
-            modelMesh.Faces=meshHandle.fullMesh_bckup(nMeshes).faces;
-            modelMesh.FaceColor=color;
-            modelMesh.EdgeColor='none';
+        if ~any(ismember(p.UsingDefaults,'transparency')) || options.useDefault
+            
+            alpha(modelMesh,options.transparency);
         end
-        if strcmpi(options.style,'invisible')% make invisible
-            modelMesh.Visible='off';
-        else
-            modelMesh.Visible='on';
+        if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
+            
+            material(modelMesh,options.material);
+        end
+        if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
+            
+            [isWF,noColor] = isWireframe(modelMesh);
+
+            if strcmpi(options.style,'wireframe') && ~isWF
+                
+                if noColor
+                    
+                    color = options.color;
+                else
+                    color = modelMesh.FaceColor;
+                end
+                
+                reducepatch(modelMesh,options.wireframe_rendering);
+                modelMesh.FaceColor = 'none';
+                modelMesh.EdgeColor = color;
+            end
+            if strcmpi(options.style,'fullMesh') && isWF
+            
+                if noColor
+                
+                    color = options.color;
+            
+                else                  
+                    color = modelMesh.EdgeColor;
+                end
+                
+                modelMesh.Vertices  =  meshHandle.fullMesh_bckup(nMeshes).vertices;          
+                modelMesh.Faces     =  meshHandle.fullMesh_bckup(nMeshes).faces;
+                modelMesh.FaceColor =  color;
+                modelMesh.EdgeColor = 'none';
+            end
+            if strcmpi(options.style,'invisible')
+                
+                % make invisible
+                modelMesh.Visible = 'off';
+            else
+                modelMesh.Visible = 'on';
+            end
         end
     end
 end
 
-    function []=changeColor(modelMesh,color)
-        if isWireframe(modelMesh)
-            modelMesh.EdgeColor=color;
-        else
-            modelMesh.FaceColor=color;
-        end
+% Utilities 
+function [] = changeColor(modelMesh,color)
+        
+    if isWireframe(modelMesh)
+      
+        modelMesh.EdgeColor = color;    
+    else
+        modelMesh.FaceColor = color;
     end
+end
 
-    function [isIt,noColor]=isWireframe(meshHandle)
-        % if there is a numeric value in edges and a char ('none') in faces
-        % then is wireframe
-        noColor=false;
-        if ischar(meshHandle.FaceColor) && ~ischar(meshHandle.EdgeColor)
-            isIt=true;
-        end
-        % As long as there is a color in faces is not wireframe
-        if ~ischar(meshHandle.FaceColor) && ischar(meshHandle.EdgeColor)
-            isIt=false;
-        end
-        % The mesh is invisble and not on purpose. Make it wireframe.
-        if ~exist('isIt','var')
-            isIt=true;
-            noColor=true;
-        end
+function [isIt, noColor] = isWireframe(meshHandle)
+
+    % If there is a numeric value in edges and a char ('none') in faces
+    % then is wireframe
+    noColor = false;
+    
+    if ischar(meshHandle.FaceColor) && ~ischar(meshHandle.EdgeColor)
+       
+        isIt = true;
+    end
+    
+    % As long as there is a color in faces is not wireframe
+    if ~ischar(meshHandle.FaceColor) && ischar(meshHandle.EdgeColor)
+      
+        isIt = false;
+    end
+    % The mesh is invisble and not on purpose. Make it wireframe.
+    if ~exist('isIt','var')
+         
+        isIt    = true;
+        noColor = true;
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
@@ -1,55 +1,79 @@
-function []=modifyLinksVisualization(Visualizer,varargin)
-% Allows the modifications of the meshes of the selected links. By default it will modify all objects in the Visualizer variable
-%   - `modifyLinksVisualization` : Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
-%       - Inputs:
-%             - `Visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables `linkNames`,`transforms` and `NOBJ`.
-%                 - `linkNames`  : variable that contains the link names.
-%                 - `meshHandles` : variable that has the handles of the mesh objects.
-%                 - `NOBJ` : variable that contains the number of visual objects to update.
-%       - Optional Inputs:
-%             - `linksToModify`  : Cell array containing the names of the links to modify
-%             - `linksIndices`   : array containing the indices of the links to modify
-% :exclamation:   Note: all extra variables are sent to `modifyLinkVisual`
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_linksToModify={'all'};
-default_linksIndices=-99;
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addParameter(p,'linksToModify',default_linksToModify,@(x) iscell(x));
-addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) && ~any(x>Visualizer.NOBJ));
+function [] = modifyLinksVisualization(Visualizer, varargin)
 
-% parse inputs
-parse(p,Visualizer,varargin{:});
-options=p.Results;
+    % MODIFYLINKSVISUALIZATION Allows the modifications of the meshes of the 
+    %                          selected links. By default it will modify all 
+    %                          objects in the Visualizer variable.
+    %
+    % NOTE: to be launched after setRobotState has been used.
+    %
+    % FORMAT: [] = modifyLinksVisualization(Visualizer, varargin)
+    %
+    % INPUTS: - Visualizer: variable output from the prepareVisualization
+    %                       function. It contains the relevant variables 
+    %                       linkNames, transforms and NOBJ.
+    %
+    %            * linkNames: variable that contains the link names.
+    %            * meshHandles: variable that has the handles of the mesh objects.
+    %            * NOBJ: variable that contains the number of visual objects to update.
+    %
+    % OPTIONAL INPUTS: - linksToModify: Cell array containing the names
+    %                                   of the links to modify.
+    %                  - linksIndices: Array containing the indices of
+    %                                  the links to modify.
+    %
+    % :exclamation: Note: all extra variables are sent to modifyLinkVisual.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %          Modified by: Gabriele Nava (gabriele.nava@iit.it)
+    %    
+    % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
 
-if ~any(ismember(p.UsingDefaults,'linksToModify'))  || ~any(ismember(p.UsingDefaults,'linksIndices'))
-    % select the indices of the links to modify
-    if ~any(ismember(p.UsingDefaults,'linksIndices'))
-        indices=options.linksIndices;
-    else
-        [~,indices_temp]=ismember(options.linksToModify,Visualizer.linkNames);
-        indices=nonzeros(indices_temp);
-        if length(indices_temp)~=length(indices)
-            notInModel=length(indices_temp)-length(indices);
-            indices_notInModel=find(indices_temp==0);
-            warndlg(sprintf('The list of links to modify contains %d names (positions [ %s ] ) that are not in the list of links of the model',notInModel,num2str(indices_notInModel')));
+    %% ------------Initialization----------------
+
+    % Input parser section
+    p               = inputParser;
+    p.StructExpand  = false;
+    p.KeepUnmatched = true;
+    
+    % Default values
+    default_linksToModify = {'all'};
+    default_linksIndices  = -99;
+    
+    % Add parameters and validity funcitons
+    addRequired(p,'structInput');
+    addParameter(p,'linksToModify',default_linksToModify,@(x) iscell(x));
+    addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) && ~any(x>Visualizer.NOBJ));
+
+    % Parse inputs
+    parse(p,Visualizer,varargin{:});
+    options = p.Results;
+
+    if ~any(ismember(p.UsingDefaults,'linksToModify')) || ~any(ismember(p.UsingDefaults,'linksIndices'))
+    
+        % Select the indices of the links to modify
+        if ~any(ismember(p.UsingDefaults,'linksIndices'))
+        
+            indices = options.linksIndices;
+        else
+            [~,indices_temp] = ismember(options.linksToModify,Visualizer.linkNames);
+            indices = nonzeros(indices_temp);
+            
+            if length(indices_temp) ~= length(indices)
+                
+                notInModel         = length(indices_temp)-length(indices);
+                indices_notInModel = find(indices_temp==0);
+                warndlg(sprintf('The list of links to modify contains %d names (positions [ %s ] ) that are not in the list of links of the model',notInModel,num2str(indices_notInModel')));
+            end
         end
+    else
+        % By default modify all links
+        indices = 1:Visualizer.NOBJ;
     end
-else
-    % by default modify all links
-    indices=1:Visualizer.NOBJ;
-end
 
-for it=1:length(indices)
-    iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});
+    for it = 1:length(indices)
+    
+        iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
+++ b/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
@@ -1,89 +1,108 @@
-function [meshHandles,transform]=plotMeshInWorld(linkMeshInfo,w_H_link,varargin)
-% Gets the mesh information for each link in the model.
-%     - Iputs:
-%         - `linkMeshInfo` : An individual `linkMeshInfo` from the array output variable from `getMeshes` function.
-%         - `w_H_link` : Homogeneous transform from the world to the link
-%     - Optional Inputs:
-%         - `color` : Selects the color of the meshes.
-%         - `transparency` : Sets the alpha value of the patch. Is the
-%         level of transparency between 0 fully transparent and 1 solid.
-%         - `wireframe_rendering` : the reduction ratio of faces to
-%         wireframe. Follows convention of reducepatch.
-%         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
-%     - Outputs:
-%         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
-%         - `transform`    : The transform object for the link
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_color= [0.1843    0.3098    0.3098];
-default_transparency=0.5;
-default_style='fullMesh';
-default_wireframe_rendering=0.08;
-% accepted values
-expected_styles={'fullMesh','wireframe'};
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addRequired(p,'w_H_link',@(x)validateattributes(x,{'numeric'},{'size',[4,4]}));
-addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
-addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
-% parse inputs
-parse(p,linkMeshInfo,w_H_link,varargin{:});
-options=p.Results;
+function [meshHandles, transform] = plotMeshInWorld(linkMeshInfo, w_H_link, varargin)
 
-%% Create a transform object %
-transform = hgtransform('Parent',gca);
-for mesh_number=1:length(linkMeshInfo.meshInfo)
+    % PLOTMESHINWORLD gets the mesh information for each link in the model.
+    %
+    % FORMAT: [meshHandles, transform] = plotMeshInWorld(linkMeshInfo, w_H_link, varargin)
+    %
+    % INPUTS: - linkMeshInfo: An individual linkMeshInfo from the array 
+    %                         output variable from getMeshes function.
+    %         - w_H_link: Homogeneous transform from the world to the link.
+    %
+    % OPTIONAL INPUTS: - color: Selects the color of the meshes.
+    %                  - transparency: Sets the alpha value of the patch. Is the
+    %                                  level of transparency between 0 fully 
+    %                                  transparent and 1 solid.
+    %                  - wireframe_rendering: the reduction ratio of faces to
+    %                                         wireframe. Follows convention of 
+    %                                         reducepatch.
+    %                  - style: Selects the style of display of meshes,
+    %                           either fullMesh or wireframe.
+    %
+    % OUTPUTS: - meshHandles: Struct that contains all the created handles 
+    %                         for the meshes. There can be more than one 
+    %                         mesh for each link.
+    %          - transform: The transform object for the link.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %          Modified by: Gabriele Nava (gabriele.nava@iit.it)
+    %    
+    % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
 
-    mesh_triangles=linkMeshInfo.meshInfo(mesh_number).mesh_triangles;
-    link_H_geom=linkMeshInfo.meshInfo(mesh_number).link_H_geom;
-    scale=linkMeshInfo.meshInfo(mesh_number).scale;
+    %% ------------Initialization----------------
+    
+    % Input parser section
+    p               = inputParser;
+    p.StructExpand  = false;
+    p.KeepUnmatched = true;
+    
+    % Default values
+    default_color               = [0.1843  0.3098  0.3098];
+    default_transparency        = 0.5;
+    default_style               = 'fullMesh';
+    default_wireframe_rendering = 0.08;
+    
+    % Accepted values
+    expected_styles = {'fullMesh','wireframe'};
+    
+    % Add parameters and validity functions
+    addRequired(p,'structInput');
+    addRequired(p,'w_H_link',@(x)validateattributes(x,{'numeric'},{'size',[4,4]}));
+    addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+    addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
+    
+    % Parse inputs
+    parse(p, linkMeshInfo, w_H_link, varargin{:});
+    options = p.Results;
 
-    % Change scale
-    % Scale the STL mesh
-    corrected_vertices=mesh_triangles.Points.*scale;
+    %% Create a transform object
+    transform = hgtransform('Parent',gca);
+    
+    for mesh_number = 1:length(linkMeshInfo.meshInfo)
 
-    % Applying transform to link frame to stl file  :
-    corrected_vertices=link_H_geom*[corrected_vertices';ones(1,size(corrected_vertices,1))];
-    corrected_vertices=corrected_vertices';
-    corrected_vertices=corrected_vertices(:,1:3);
+        mesh_triangles = linkMeshInfo.meshInfo(mesh_number).mesh_triangles;
+        link_H_geom    = linkMeshInfo.meshInfo(mesh_number).link_H_geom;
+        scale          = linkMeshInfo.meshInfo(mesh_number).scale;
 
-    % plot in figureusing patch
-    modelMesh(mesh_number) = ...
-        patch('Faces',mesh_triangles.ConnectivityList,'Vertices',corrected_vertices,...
-        'FaceColor',options.color , ...
-        'EdgeColor',  'none',        ...
-        'FaceLighting',    'gouraud',     ...
-        'AmbientStrength', 0.25);
+        % Scale the STL mesh
+        corrected_vertices = mesh_triangles.Points.*scale;
 
-    faces_bckup=modelMesh(mesh_number).Faces;
-    vertices_bckup=modelMesh(mesh_number).Vertices;
-    meshHandles.fullMesh_bckup(mesh_number).faces=faces_bckup;
-    meshHandles.fullMesh_bckup(mesh_number).vertices=vertices_bckup;
+        % Applying transform to link frame to stl file:
+        corrected_vertices = link_H_geom*[corrected_vertices';ones(1,size(corrected_vertices,1))];
+        corrected_vertices = corrected_vertices';
+        corrected_vertices = corrected_vertices(:,1:3);
 
-    if strcmp(options.style,'wireframe')
-        reducepatch(modelMesh(mesh_number),options.wireframe_rendering);
-        modelMesh(mesh_number).FaceColor='none';
-        modelMesh(mesh_number).EdgeColor=options.color;
+        % Plot in the figure using patch
+        modelMesh(mesh_number) = patch('Faces',mesh_triangles.ConnectivityList, ...
+                                       'Vertices',corrected_vertices, ...
+                                       'FaceColor',options.color , ...
+                                       'EdgeColor','none', ...
+                                       'FaceLighting','gouraud', ...
+                                       'AmbientStrength', 0.25);
+
+        faces_bckup    = modelMesh(mesh_number).Faces;
+        vertices_bckup = modelMesh(mesh_number).Vertices;
+        
+        meshHandles.fullMesh_bckup(mesh_number).faces    = faces_bckup;
+        meshHandles.fullMesh_bckup(mesh_number).vertices = vertices_bckup;
+
+        if strcmp(options.style,'wireframe')
+       
+            reducepatch(modelMesh(mesh_number),options.wireframe_rendering);
+            modelMesh(mesh_number).FaceColor = 'none';
+            modelMesh(mesh_number).EdgeColor = options.color;
+        end
+
+        % Parent transform as parent to the mesh
+        set(modelMesh(mesh_number),'Parent',transform);
+
+        % Set the object transparency
+        alpha(modelMesh(mesh_number),options.transparency);
     end
-
-    %parent transform as parent to the mesh
-    set(modelMesh(mesh_number),'Parent',transform);
-
-    % Set the object transparency
-    alpha(modelMesh(mesh_number),options.transparency);
-
-end
-set(transform,'Matrix',w_H_link);
-meshHandles.modelMesh=modelMesh;
+    
+    set(transform,'Matrix',w_H_link);
+    meshHandles.modelMesh = modelMesh;
 end

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -1,196 +1,248 @@
-function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,varargin)
-% Creates the figures, loads the meshes, handles some visual effects, and creates the transform objects
-% - Inputs:
-%   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
-%   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-%   `. `meshFilePrefix` should replace package to allow to find the rest of the path.
-% - Optional Inputs:
-%     - `view` : Selects the angle in which the figure is seen.
-%     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
-%     - `debug` : Enables having extra information for debugging purposes.
-%     - `groundOn` : Enables showing a plane as the ground.
-%     - `groundColor` : Selects the color of the ground.
-%     - `groundTransparency` : Selects the transparency of the ground.
-%     - `groundFrame` : Selects the frame in which the ground is attached.
-%     - `name` : The name of the figure 
-%     - `reuseFigure` : Enable the reuse of an already open figure. It can be the following values:
-%         - 'name': Reuse the figure with the same name (the figure is cleared before reusing it). The name must be set.
-%         - 'gcf': Reuse the figure returned by gcf.
-%         - 'none': Do not reuse the figure (Default).
-%     Note: all extra variables are sent to `plotMeshInWorld`
-%   - Outputs:
-%       - `Visualizer` : Struct containing the following fields
-%           - `transforms` : Is the transform objects array. There is one transform for each link
-%           - `linkNames`  : The name of the links in the same order of the transforms
-%           - `linkNames_idyn`  : The idyntree string vector equivalent to `linkNames`
-%           - `NOBJ` : Contains the number of visual objects in the visualizer
-%           - `meshHandles` : Has the handles of the mesh objects.
-%           - `parent`     : Contains the axes object of the parent figure.
-%           - `mainHandler`: Is the handle of the overall figure.
-%           - `DEBUG` : Flag stating if the debug mode was set or not.
-%           Fields included if debug mode is on:
-%           - `map`       : Cell array having both the names of the meshes and the associated link
-%           - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_view=[128.0181 16.8000];
-default_material='dull';
-default_debug=false;
-default_groundOn=false;
-default_groundColor=[0 0.5 0.5];
-default_groundTransparency=0.8;
-default_groundFrame='none';
-default_name='iDynTreeVisualizer';
-default_reuseFigure='none';
-% accepted values
-expected_materials={'dull','metal','shiny'};
-expected_reuseFigure={'name', 'gcf', 'none'};
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addRequired(p,'meshFilePrefix',@(x) isstring(x) || ischar(x));
-addParameter(p,'view',default_view,@isnumeric);
-addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
-addParameter(p,'debug',default_debug,@(x) islogical(x));
-addParameter(p,'groundOn',default_groundOn,@(x) islogical(x));
-addParameter(p,'groundColor',default_groundColor,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
-addParameter(p,'groundTransparency',default_groundTransparency,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'groundFrame',default_groundFrame,@(x) isstring(x) || ischar(x));
-addParameter(p,'name',default_name,@(x) isstring(x) || ischar(x));
-addParameter(p,'reuseFigure',default_reuseFigure,@(x) any(validatestring(x,expected_reuseFigure)));
+function [Visualizer, Objects] = prepareVisualization(KinDynModel, meshFilePrefix, varargin)
 
-% parse inputs
-parse(p,KinDynModel,meshFilePrefix,varargin{:});
-options=p.Results;
-isNameSet=~any(strcmp(p.UsingDefaults, 'name'));
-%% Get meshes from the model variable
-model=KinDynModel.kinDynComp.model;
-[linkMeshInfo,map]=iDynTreeWrappers.getMeshes(model,meshFilePrefix);
-numberOfLinks=length(linkMeshInfo);
-linkNames=cell(numberOfLinks,1);
-switch options.reuseFigure
-    case 'gcf'
-        mainHandler=gcf;
-        cla(mainHandler.Children);
-    case 'name'
-        figHandles = findobj('Type', 'figure', 'Name', options.name);
-        if isNameSet && ~isempty(figHandles)
-            mainHandler=figHandles(1,1);
+    % PREPAREVISUALIZATION creates the figure, loads the meshes, handles some 
+    %                      visual effects, and creates the transform objects.
+    %
+    % FORMAT: [Visualizer, Objects] = prepareVisualization(KinDynModel, meshFilePrefix, varargin)
+    %
+    % INPUTS: - KinDynModel: iDyntreewrappers main variable. Contains the model.
+    %         - meshFilePrefix: Path in which we can find the meshes. As an example 
+    %                           the path to the meshes in an iCub urdf is 
+    %                           'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'.
+    %                           'meshFilePrefix' should replace 'package' to 
+    %                            allow to find the rest of the path.
+    %
+    % OPTIONAL INPUTS: - view: Selects the angle in which the figure is seen.
+    %                  - material: Selects effect with which the patch is rendered. 
+    %                              Options are : 'dull','metal','shiny'.
+    %                  - debug: Enables extra information for debugging purposes.
+    %                  - groundOn: Enables showing a plane as the ground.
+    %                  - groundColor: Selects the color of the ground.
+    %                  - groundTransparency: Selects the transparency of the ground.
+    %                  - groundFrame: Selects the frame to which the ground is attached.
+    %                  - name: The name of the figure.
+    %                  - reuseFigure: Enable the reuse of an already open figure. 
+    %                                 It can be the following values:
+    %                      * 'name': Reuse the figure with the same name 
+    %                                (the figure is cleared before reusing it). 
+    %                                The name must be set.
+    %                      * 'gcf':  Reuse the figure returned by gcf.
+    %                      * 'none': Do not reuse the figure (Default).
+    %
+    % Note: all extra variables are sent to `plotMeshInWorld` function.
+    %
+    % OUTPUTS:  - Visualizer: Struct containing the following fields:
+    %
+    %               * transforms: The transform objects array. There is one transform for each link.
+    %               * linkNames: The name of the links in the same order of the transforms.
+    %               * linkNames_idyn: The iDynTree string vector equivalent to linkNames.
+    %               * NOBJ: Contains the number of visual objects in the visualizer.
+    %               * meshHandles: Has the handles of the mesh objects.
+    %               * parent: Contains the axes object of the parent figure.
+    %               * mainHandler: Is the handle of the overall figure.
+    %               * DEBUG: Flag stating if the debug mode was set or not.
+    %
+    %               Fields included if debug mode is on:
+    %
+    %               * map: Cell array having both the names of the meshes
+    %                      and the associated link.
+    %               * linkMeshInfo: Contains the link name and a struct
+    %                               (meshInfo) with the name of file or, if
+    %                               is a simple geometry, the triangulation 
+    %                               (edges and vertices of the mesh) and the
+    %                               link to geometry transform.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %          Modified by: Gabriele Nava (gabriele.nava@iit.it)
+    %    
+    % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
+
+    %% ------------Initialization----------------
+    
+    % Input parser definition
+    p               = inputParser;
+    p.StructExpand  = false;
+    p.KeepUnmatched = true;
+    
+    % Default values
+    default_view               = [128.0181 16.8000];
+    default_material           = 'dull';
+    default_debug              = false;
+    default_groundOn           = false;
+    default_groundColor        = [0 0.5 0.5];
+    default_groundTransparency = 0.8;
+    default_groundFrame        = 'none';
+    default_name               = 'iDynTreeVisualizer';
+    default_reuseFigure        = 'none';
+    
+    % Define accepted values
+    expected_materials   = {'dull','metal','shiny'};
+    expected_reuseFigure = {'name','gcf','none'};
+    
+    % Add parameters and validity functions to parser
+    addRequired(p,'structInput');
+    addRequired(p,'meshFilePrefix',@(x) isstring(x) || ischar(x));
+    addParameter(p,'view',default_view,@isnumeric);
+    addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
+    addParameter(p,'debug',default_debug,@(x) islogical(x));
+    addParameter(p,'groundOn',default_groundOn,@(x) islogical(x));
+    addParameter(p,'groundColor',default_groundColor,@(x)validateattributes(x,{'numeric'},{'numel',3}));
+    addParameter(p,'groundTransparency',default_groundTransparency,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'groundFrame',default_groundFrame,@(x) isstring(x) || ischar(x));
+    addParameter(p,'name',default_name,@(x) isstring(x) || ischar(x));
+    addParameter(p,'reuseFigure',default_reuseFigure,@(x) any(validatestring(x,expected_reuseFigure)));
+
+    % Parse inputs
+    parse(p,KinDynModel,meshFilePrefix,varargin{:});
+    options   =  p.Results;
+    isNameSet = ~any(strcmp(p.UsingDefaults, 'name'));
+    
+    %% Get meshes from the model variable
+    model              = KinDynModel.kinDynComp.model;
+    [linkMeshInfo,map] = iDynTreeWrappers.getMeshes(model,meshFilePrefix);
+    numberOfLinks      = length(linkMeshInfo);
+    linkNames          = cell(numberOfLinks,1);
+    
+    switch options.reuseFigure
+    
+        case 'gcf'
+            
+            mainHandler = gcf;
             cla(mainHandler.Children);
+    
+        case 'name'
+        
+            figHandles = findobj('Type', 'figure', 'Name', options.name);
+        
+            if isNameSet && ~isempty(figHandles)
+            
+                mainHandler = figHandles(1,1);
+                cla(mainHandler.Children);
+            else
+                mainHandler = figure;
+            end  
+            
+        otherwise           
+            mainHandler = figure;
+    end
+    
+    if isNameSet
+        
+        set(mainHandler,'Name', options.name,'numbertitle','off')
+    end
+    
+    % Set the figure as current figure such that gca works
+    set(0, 'CurrentFigure', mainHandler) 
+    parent = gca;
+    hold on
+    linkNames_idyn = iDynTree.StringVector();
+
+    for it=1:numberOfLinks
+        
+        w_H_link = iDynTreeWrappers.getWorldTransform(KinDynModel,linkMeshInfo(it).linkName);
+        [meshHandles(it,:),transforms(it)] = iDynTreeWrappers.plotMeshInWorld(linkMeshInfo(it),w_H_link,varargin{:});
+        linkNames{it} = linkMeshInfo(it).linkName;
+        linkNames_idyn.push_back(linkNames{it});
+    end
+
+    % Add a camera light, and tone down the specular highlighting
+    camlight('headlight');
+    material(options.material);
+
+    % Make axis pretty and add grid for visual reference
+    axis equal;
+    axis tight;
+    grid on;
+
+    % Apply views
+    view(parent,options.view);
+
+    % Add world reference frame
+    hold on;
+    currentAxisValues = axis;
+    axisRange         = currentAxisValues([2,4,6])-currentAxisValues([1,3,5]);
+    frameAxisSize     = min(axisRange)/4;
+    
+    % linewidth value 1 = to 0.35mm. It is better if we increase the linewidth
+    % in proportion to the axisSize of the frame.c
+    linewidthSize     = frameAxisSize*50;
+    plot3(parent, [0 frameAxisSize], [0 0], [0 0], 'r', 'linewidth', linewidthSize);
+    plot3(parent, [0 0], [0 frameAxisSize], [0 0], 'g', 'linewidth', linewidthSize);
+    plot3(parent, [0 0], [0 0], [0 frameAxisSize], 'b', 'linewidth', linewidthSize);
+    
+    axisTextDistance  = frameAxisSize+frameAxisSize*.2;
+    text(parent, axisTextDistance, 0, 0, 'x', 'color', 'r');
+    text(parent, 0, axisTextDistance, 0, 'y', 'color', 'g');
+    text(parent, 0, 0, axisTextDistance, 'z', 'color', 'b');
+
+    % Axis labels
+    title('Robot Visualizer ');
+    xlabel('{x}');
+    ylabel('{y}');
+    zlabel('{z}');
+
+    % Draw the ground
+    if options.groundOn
+    
+        % Create plane on x-y axis
+        normal_vector  = [0,0,1];
+        point_on_plane = [0,0,0];
+        d              = normal_vector*point_on_plane';
+        
+        x = [1 -1 -1  1]*max(axisRange(1:2)); % Generate data for x vertices
+        y = [1  1 -1 -1]*max(axisRange(1:2)); % Generate data for y vertices
+        z = 1/normal_vector(3)*(normal_vector(1)*x + normal_vector(2)*y + d); % Solve for z vertices data
+        
+        groundHandle   = patch('XData',x,'YData',y,'ZData',z,'FaceColor', options.groundColor);
+        alpha(groundHandle,options.groundTransparency);
+        
+        % apply transform
+        groundTransform = hgtransform('Parent',parent);
+        set(groundHandle,'Parent',groundTransform);
+        
+        if any(ismember(p.UsingDefaults,'groundFrame'))
+            
+            w_H_plane           = eye(4,4);
+            options.groundFrame = linkNames{1};
         else
-            mainHandler=figure;
+            w_H_plane_idyn      = KinDynModel.kinDynComp.getWorldTransform(options.groundFrame);
+            w_H_plane           = w_H_plane_idyn.asHomogeneousTransform.toMatlab();
+            w_H_plane(1:2,4)    = 0;
         end
-    otherwise
-        mainHandler=figure;
-end
-if isNameSet
-    set(mainHandler,'Name', options.name,'numbertitle','off')
-end
-set(0, 'CurrentFigure', mainHandler) %Set the figure as current figure such that gca works
-parent=gca;
-hold on
-linkNames_idyn=iDynTree.StringVector();
+        set(groundTransform,'Matrix',w_H_plane);
 
-for it=1:numberOfLinks
-    w_H_link=iDynTreeWrappers.getWorldTransform(KinDynModel,linkMeshInfo(it).linkName);
-    [meshHandles(it,:),transforms(it)]=iDynTreeWrappers.plotMeshInWorld(linkMeshInfo(it),w_H_link,varargin{:});
-    linkNames{it}=linkMeshInfo(it).linkName;
-    linkNames_idyn.push_back(linkNames{it});
-end
+        objectFrames_idyn = iDynTree.StringVector();
+        objectFrames_idyn.push_back(options.groundFrame);
 
-% Add a camera light, and tone down the specular highlighting
-camlight('headlight');
-material(options.material);
+        % Build Object struct
+        Objects.frames_idyn = objectFrames_idyn;
+        Objects.transform   = groundTransform;
+        Objects.frames      = options.groundFrame;
+        Objects.types       = {'plane'};
+        Objects.names       = {'ground'};
+        Objects.handle      = groundHandle;
 
-% Make axis pretty and add grid for visual reference
-axis equal;
-axis tight;
-grid on;
-
-% Apply views
-view(parent,options.view);
-
-% Add world reference frame
-hold on;
-currentAxisValues=axis;
-axisRange=currentAxisValues([2,4,6])-currentAxisValues([1,3,5]);
-frameAxisSize = min(axisRange)/4;
-% linewidth value 1 = to 0.35mm. It is better if we increase the linewidth
-% in proportion to the axisSize of the frame.c
-linewidthSize=frameAxisSize*50;
-plot3(parent, [0 frameAxisSize], [0 0], [0 0], 'r', 'linewidth', linewidthSize);
-plot3(parent, [0 0], [0 frameAxisSize], [0 0], 'g', 'linewidth', linewidthSize);
-plot3(parent, [0 0], [0 0], [0 frameAxisSize], 'b', 'linewidth', linewidthSize);
-axisTextDistance = frameAxisSize+frameAxisSize*.2;
-text(parent, axisTextDistance, 0, 0, 'x', 'color', 'r');
-text(parent, 0, axisTextDistance, 0, 'y', 'color', 'g');
-text(parent, 0, 0, axisTextDistance, 'z', 'color', 'b');
-
-% Axis labels
-title('Robot Visualizer ');
-xlabel('{x}');
-ylabel('{y}');
-zlabel('{z}');
-
-% Draw the ground
-if options.groundOn
-    % Create plane on x y axis
-    normal_vector=[0,0,1];
-    point_on_plane=[0,0,0];
-    d=normal_vector*point_on_plane';
-    x = [1 -1 -1 1]*max(axisRange(1:2)); % Generate data for x vertices
-    y = [1 1 -1 -1]*max(axisRange(1:2)); % Generate data for y vertices
-    z = 1/normal_vector(3)*(normal_vector(1)*x + normal_vector(2)*y + d); % Solve for z vertices data
-    groundHandle=patch('XData',x,'YData',y,'ZData',z,'FaceColor', options.groundColor);
-    alpha(groundHandle,options.groundTransparency);
-    % apply transform
-    groundTransform = hgtransform('Parent',parent);
-    set(groundHandle,'Parent',groundTransform);
-    if any(ismember(p.UsingDefaults,'groundFrame'))
-        w_H_plane=eye(4,4);
-        options.groundFrame=linkNames{1};
+        if options.debug
+            Objects.map = [Objects.names',Objects.frames'];
+        end
     else
-        w_H_plane_idyn=KinDynModel.kinDynComp.getWorldTransform(options.groundFrame);
-        w_H_plane= w_H_plane_idyn.asHomogeneousTransform.toMatlab();
-        w_H_plane(1:2,4)=0;
+        Objects=[];
     end
-    set(groundTransform,'Matrix',w_H_plane);
 
-    objectFrames_idyn=iDynTree.StringVector();
-    objectFrames_idyn.push_back(options.groundFrame);
+    % Build Output struct
+    Visualizer.transforms     = transforms;
+    Visualizer.linkNames_idyn = linkNames_idyn;
+    Visualizer.linkNames      = linkNames;
+    Visualizer.NOBJ           = length(transforms);
+    Visualizer.meshHandles    = meshHandles;
+    Visualizer.mainHandler    = mainHandler;
+    Visualizer.parent         = parent;
+    Visualizer.DEBUG          = options.debug;
 
-    % Build Object struct
-    Objects.frames_idyn=objectFrames_idyn;
-    Objects.transform=groundTransform;
-    Objects.frames=options.groundFrame;
-    Objects.types={'plane'};
-    Objects.names={'ground'};
-    Objects.handle=groundHandle;
-
-    if options.debug
-        Objects.map=[Objects.names',Objects.frames'];
+    if options.debug      
+        Visualizer.map = map;
+        Visualizer.linkMeshInfo = linkMeshInfo;
     end
-else
-    Objects=[];
-end
-
-% Build Output struct
-Visualizer.transforms=transforms;
-Visualizer.linkNames_idyn=linkNames_idyn;
-Visualizer.linkNames=linkNames;
-Visualizer.NOBJ=length(transforms);
-Visualizer.meshHandles=meshHandles;
-Visualizer.mainHandler=mainHandler;
-Visualizer.parent=parent;
-Visualizer.DEBUG=options.debug;
-
-if options.debug
-    Visualizer.map=map;
-    Visualizer.linkMeshInfo=linkMeshInfo;
 end

--- a/bindings/matlab/+iDynTreeWrappers/setJointPos.m
+++ b/bindings/matlab/+iDynTreeWrappers/setJointPos.m
@@ -1,7 +1,6 @@
 function [] = setJointPos(KinDynModel,jointPos)
 
-    % SETJOINTPOS sets the joints configuration for kino-dynamic 
-    %                  computations.
+    % SETJOINTPOS sets the joints configuration for kino-dynamic computations.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -33,17 +32,14 @@ function [] = setJointPos(KinDynModel,jointPos)
             
         disp('[setJointPos]: done.')     
     end
-    
-    % convert the joint position to a dynamic size vector
-    jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+
     for k = 0:length(jointPos)-1
         
-        jointPos_iDyntree.setVal(k,jointPos(k+1));
+        KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
     
     % set the current joint positions
-    ack = KinDynModel.kinDynComp.setJointPos(jointPos_iDyntree);
+    ack = KinDynModel.kinDynComp.setJointPos(KinDynModel.kinematics.jointPos_iDyntree);
     
     % check for errors
     if ~ack  

--- a/bindings/matlab/+iDynTreeWrappers/setRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/setRobotState.m
@@ -38,10 +38,6 @@ function [] = setRobotState(varargin)
 
     %% ------------Initialization----------------
 
-    persistent baseRotation_iDyntree baseOrigin_iDyntree ...
-               basePose_iDyntree baseVel_iDyntree jointPos_iDyntree ...
-               jointVel_iDyntree gravityVec_iDyntree
-        
     KinDynModel = varargin{1};
     
     % check the number of inputs
@@ -135,37 +131,27 @@ function [] = setRobotState(varargin)
                 
                 disp('[setRobotState]: done.')     
             end
-            
-            % define the quantities required to set the floating base
-            
-            if isempty(baseRotation_iDyntree)
-                
-                baseRotation_iDyntree = iDynTree.Rotation();
-                baseOrigin_iDyntree   = iDynTree.Position();
-                basePose_iDyntree     = iDynTree.Transform();
-                baseVel_iDyntree      = iDynTree.Twist();
-            end
-         
+
             % set the element of the rotation matrix and of the base
             % position vector
             for k = 0:2
                 
-                baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
+                KinDynModel.kinematics.baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
                 
                 for j = 0:2
                     
-                    baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+                    KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
                 end
             end      
             
             % add the rotation matrix and the position to basePose_iDyntree
-            basePose_iDyntree.setRotation(baseRotation_iDyntree);
-            basePose_iDyntree.setPosition(baseOrigin_iDyntree);
+            KinDynModel.kinematics.basePose_iDyntree.setRotation(KinDynModel.kinematics.baseRotation_iDyntree);
+            KinDynModel.kinematics.basePose_iDyntree.setPosition(KinDynModel.kinematics.baseOrigin_iDyntree);
             
             % set the base velocities
             for k = 0:5
                 
-                baseVel_iDyntree.setVal(k,baseVel(k+1));
+                KinDynModel.kinematics.baseVel_iDyntree.setVal(k,baseVel(k+1));
             end
             
         case 4
@@ -204,25 +190,17 @@ function [] = setRobotState(varargin)
             error('[setRobotState]: wrong number of inputs.')
     end
     
-    % define all the remaining quantities required for setting the system state
-    if isempty(jointPos_iDyntree)
-        
-        jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-        jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-        gravityVec_iDyntree = iDynTree.Vector3();
-    end
-         
     % set joints position and velocity
     for k = 0:length(jointPos)-1
         
-        jointVel_iDyntree.setVal(k,jointVel(k+1));
-        jointPos_iDyntree.setVal(k,jointPos(k+1));
+        KinDynModel.kinematics.jointVel_iDyntree.setVal(k,jointVel(k+1));
+        KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
     
     % set the gravity vector
     for k = 0:2
         
-       gravityVec_iDyntree.setVal(k,gravAcc(k+1));       
+       KinDynModel.kinematics.gravityVec_iDyntree.setVal(k,gravAcc(k+1));       
     end
     
     % set the current robot state
@@ -230,11 +208,14 @@ function [] = setRobotState(varargin)
         
         case 4
             
-            ack = KinDynModel.kinDynComp.setRobotState(jointPos_iDyntree,jointVel_iDyntree,gravityVec_iDyntree);
+            ack = KinDynModel.kinDynComp.setRobotState(KinDynModel.kinematics.jointPos_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                                                       KinDynModel.kinematics.gravityVec_iDyntree);
             
         case 6
             
-            ack = KinDynModel.kinDynComp.setRobotState(basePose_iDyntree,jointPos_iDyntree,baseVel_iDyntree,jointVel_iDyntree,gravityVec_iDyntree);
+            ack = KinDynModel.kinDynComp.setRobotState(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree, ...
+                                                       KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                                                       KinDynModel.kinematics.gravityVec_iDyntree);
     end
     
     % check for errors

--- a/bindings/matlab/+iDynTreeWrappers/setRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/setRobotState.m
@@ -38,6 +38,10 @@ function [] = setRobotState(varargin)
 
     %% ------------Initialization----------------
 
+    persistent baseRotation_iDyntree baseOrigin_iDyntree ...
+               basePose_iDyntree baseVel_iDyntree jointPos_iDyntree ...
+               jointVel_iDyntree gravityVec_iDyntree
+        
     KinDynModel = varargin{1};
     
     % check the number of inputs
@@ -133,11 +137,15 @@ function [] = setRobotState(varargin)
             end
             
             % define the quantities required to set the floating base
-            baseRotation_iDyntree = iDynTree.Rotation();
-            baseOrigin_iDyntree   = iDynTree.Position();
-            basePose_iDyntree     = iDynTree.Transform();
-            baseVel_iDyntree      = iDynTree.Twist();
             
+            if isempty(baseRotation_iDyntree)
+                
+                baseRotation_iDyntree = iDynTree.Rotation();
+                baseOrigin_iDyntree   = iDynTree.Position();
+                basePose_iDyntree     = iDynTree.Transform();
+                baseVel_iDyntree      = iDynTree.Twist();
+            end
+         
             % set the element of the rotation matrix and of the base
             % position vector
             for k = 0:2
@@ -197,9 +205,12 @@ function [] = setRobotState(varargin)
     end
     
     % define all the remaining quantities required for setting the system state
-    jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    gravityVec_iDyntree = iDynTree.Vector3();
+    if isempty(jointPos_iDyntree)
+        
+        jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
+        jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
+        gravityVec_iDyntree = iDynTree.Vector3();
+    end
          
     % set joints position and velocity
     for k = 0:length(jointPos)-1

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
@@ -1,22 +1,34 @@
-function []=updateVisualization(KinDynModel,Visualizer)
-% We use the transform handlers to update the robot image using the
-% iDyntree kinematics
-% Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
-%     - Inputs:
-%           - `KinDynModel`: iDyntreewrappers main variable. Contains the model.
-%           - `visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables linkNames,transforms and NOBJ
-%               - `linkNames`  : variable that contains the link names.
-%               - `transforms` : variable that contains transform objects that are parent of the meshes.
-%               - `NOBJ` : variable that contains the number of visual objects to update.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
+function [] = updateVisualization(KinDynModel, Visualizer)
 
-transforms_idyn=KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(Visualizer.linkNames_idyn);
-w_H_links= transforms_idyn.toMatlab();
-for it=1:Visualizer.NOBJ
-    Visualizer.transforms(it).Matrix=squeeze(w_H_links(it,:,:));
+    % UPDATEVISUALIZATION uses the transform handlers to update the robot
+    %                     image using the iDyntree kinematics.
+    %
+    % NOTE: to be launched after setRobotState has been used.
+    %
+    % FORMAT [] = updateVisualization(KinDynModel, Visualizer)
+    %
+    % INPUTS:  - KinDynModel: iDyntreewrappers main variable. Contains the model.
+    %          - Visualizer:  variable output from the prepareVisualization function. 
+    %                         It contains the relevant variables
+    %                         linkNames,transforms and NOBJ:
+    %
+    %              * linkNames: variable that contains the link names.
+    %              * transforms: contains transform objects that are parent of the meshes.
+    %              * NOBJ: variable that contains the number of visual objects to update.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %          Modified by: Gabriele Nava (gabriele.nava@iit.it)
+    %    
+    % Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
+
+    %% ------------Initialization----------------
+    transforms_idyn = KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(Visualizer.linkNames_idyn);
+    w_H_links       = transforms_idyn.toMatlab();
+    
+    for it = 1:Visualizer.NOBJ
+     
+        Visualizer.transforms(it).Matrix = squeeze(w_H_links(it,:,:));
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualizer.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualizer.m
@@ -3,6 +3,8 @@ function [] = updateVisualizer(Visualizer,KinDynModel,jointPos,basePose)
     % UPDATEVISUALIZER updates the iDyntree visualizer with the current
     %                  base pose and joints position.
     %
+    % WARNING! This function is deprecated! Use updateVisualization instead.
+    %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
     %
@@ -86,37 +88,29 @@ function [] = updateVisualizer(Visualizer,KinDynModel,jointPos,basePose)
             
         disp('[updateVisualizer]: done.')     
     end
-    
-    % convert joints position to a dynamic size vector
-    jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+
     for k = 0:length(jointPos)-1
         
-        jointPos_iDyntree.setVal(k,jointPos(k+1));
+        KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
-    
-    % define the quantities required to set the floating base pose
-    baseRotation_iDyntree = iDynTree.Rotation();
-    baseOrigin_iDyntree   = iDynTree.Position();
-    basePose_iDyntree     = iDynTree.Transform();
             
     % set the elements of the rotation matrix and of the base position vector
     for k = 0:2
                 
-        baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
+        KinDynModel.kinematics.baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
                 
         for j = 0:2
                     
-            baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+            KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
         end
     end
             
     % add the rotation matrix and the position to w_H_b_iDyntree
-    basePose_iDyntree.setRotation(baseRotation_iDyntree);
-    basePose_iDyntree.setPosition(baseOrigin_iDyntree);
+    KinDynModel.kinematics.basePose_iDyntree.setRotation(KinDynModel.kinematics.baseRotation_iDyntree);
+    KinDynModel.kinematics.basePose_iDyntree.setPosition(KinDynModel.kinematics.baseOrigin_iDyntree);
 
     % set the current joints position and world-to-base transform
-    ack = Visualizer.viz.modelViz(0).setPositions(basePose_iDyntree,jointPos_iDyntree);
+    ack = Visualizer.viz.modelViz(0).setPositions(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree);
        
     % check for errors
     if ~ack    

--- a/bindings/matlab/+iDynTreeWrappers/visualizerSetup.m
+++ b/bindings/matlab/+iDynTreeWrappers/visualizerSetup.m
@@ -1,7 +1,9 @@
 function [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,cameraPos,cameraTarget)
 
     % VISUALIZERSETUP modifies the visualization environment according to the 
-    %                      user specifications.
+    %                 user specifications.
+    %
+    % WARNING! This function is deprecated! Use prepareVisualization instead.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -24,7 +26,7 @@ function [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,camer
     % GNU Lesser General Public License v2.1 or any later version.
 
     %% ------------Initialization----------------
-    
+
     % disable environmental features  
     if disableViewInertialFrame
         


### PR DESCRIPTION
My story:

I am trying to use the [new iDynTree visualizer](https://github.com/robotology/idyntree/tree/master/bindings/matlab/%2BiDynTreeWrappers#matlab-native-visualization) with MATLAB. In my test, there is a free falling mass with initial upwards velocity and subject to a lateral force that falls down. Namely:

![singleMass_11_45](https://user-images.githubusercontent.com/12396934/95316398-0959e380-0894-11eb-8775-af725f82f14b.gif)

 I wanted to profile my visualization function, because it seemed to me the visualizer was pretty slow. Here is the result of running MATLAB profiler:

![Screenshot from 2020-10-07 11-34-32](https://user-images.githubusercontent.com/12396934/95316592-55a52380-0894-11eb-8501-21716ec6f175.png)

so, it seems that actually the call to `setRobotState` is the one which is affecting the most the performances. In order to optimize the function, I initialized only once the iDynTree quantites (such as, e.g.,  iDynTree.Rotation()) by defining them as persistent variables. This  halves the time required by `setRobotState` to update the robot pose:

![Screenshot from 2020-10-07 11-35-43](https://user-images.githubusercontent.com/12396934/95317168-175c3400-0895-11eb-9fb6-6fab57aa967c.png)









