### PR TITLE
GitHub Action: remove use of deprecated set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         unzip vcpkg-robotology.zip -d C:/
         rm vcpkg-robotology.zip
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
-        echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
+        echo "VCPKG_INSTALLATION_ROOT=C:\robotology\vcpkg" >> $GITHUB_ENV
    
     # Print environment variables to simplify development and debugging
     - name: Environment Variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         unzip vcpkg-robotology.zip -d C:/
         rm vcpkg-robotology.zip
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
-        echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> ${GITHUB_ENV}
+        echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         
     - name: Additional vcpkg Dependencies [Windows]
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
         rm vcpkg-robotology.zip
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
         echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
-        
+   
+    # Print environment variables to simplify development and debugging
+    - name: Environment Variables
+      shell: bash
+      run: env
+
     - name: Additional vcpkg Dependencies [Windows]
       if: matrix.os == 'windows-latest'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
   YCM_TAG: v0.11.1
   YARP_TAG: v3.3.2
   ICUB_TAG: v1.15.0
+  # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg  
+  VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
   
 jobs:
   build:
@@ -52,14 +54,7 @@ jobs:
         wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology.zip
         unzip vcpkg-robotology.zip -d C:/
         rm vcpkg-robotology.zip
-        # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
-        echo "VCPKG_INSTALLATION_ROOT=C:\robotology\vcpkg" >> $GITHUB_ENV
    
-    # Print environment variables to simplify development and debugging
-    - name: Environment Variables
-      shell: bash
-      run: env
-
     - name: Additional vcpkg Dependencies [Windows]
       if: matrix.os == 'windows-latest'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         unzip vcpkg-robotology.zip -d C:/
         rm vcpkg-robotology.zip
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
-        echo "::set-env name=VCPKG_INSTALLATION_ROOT::C:/robotology/vcpkg"
+        echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> ${GITHUB_ENV}
         
     - name: Additional vcpkg Dependencies [Windows]
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ . 