### PR TITLE
Bump to 1.2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2020-10-17
+
 ### Added
 - Added the possibility of reusing an already opened figure with the MATLAB iDynTree Visualizer either if the name coincides or by using gcf.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(iDynTree VERSION 1.1.0
+project(iDynTree VERSION 1.2.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
This is necessary to do the release 1.2.0 version for the master branch that contains some critical deprecation for the upcoming iDynTree 2.0 release. 