### PR TITLE
CI: Enable tests on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,6 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Test
-      # Workaround for https://github.com/robotology/idyntree/issues/694
-      if: matrix.os != 'ubuntu-20.04'
       shell: bash
       run: |
         cd build


### PR DESCRIPTION
Apparently the test failures (valgrind for Ipopt and Octave) in https://github.com/robotology/idyntree/issues/694 probably were due to problems in our dependencies that were fixed. 