### PR TITLE
 Cleanup size and indices attributes, return values and arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The minimum required CMake version to configure and compile iDynTree is now 3.16 (https://github.com/robotology/idyntree/pull/732).
 - The Python package name of the SWIG bindings changed from `iDynTree` to `idyntree.bindings` (https://github.com/robotology/idyntree/pull/733, https://github.com/robotology/idyntree/pull/735). To continue referring to iDynTree classes as `iDynTree.<ClassName>`, you can change your `import iDynTree` statements to `import idyntree.bindings as iDynTree`. Otherwise, you can use `import idyntree.bindings` to refer them as `idyntree.bindings.<ClassName>`.
 - Improve the use of `const` keyword  in `KinDynComputations`(https://github.com/robotology/idyntree/pull/736).
+- Cleanup size and indices attributes. For consistency with std and Eigen, all sizes and indices have been changed to use std::size_t for unsigned quantities and std::ptrdiff_t for signed quantities. The only exception is the index stored in the triplets of the iDynTree::SparseMatrix data structure, that have been left defined to int for compatibility with Eigen (https://github.com/robotology/idyntree/pull/767).
 
 ### Removed
 - Remove the CMake option IDYNTREE_USES_KDL and all the classes available when enabling it. They were deprecated in iDynTree 1.0 .

--- a/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef AccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1312, varargin{:});
+        tmp = iDynTreeMEX(1316, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1313, self);
+        iDynTreeMEX(1317, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1316, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1317, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1318, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1319, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1320, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1321, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1322, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1323, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1324, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1325, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1326, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1327, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1328, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1330, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = ArticulatedBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1229, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1233, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyAlgorithmInternalBuffers.m
@@ -9,38 +9,18 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1207, varargin{:});
+        tmp = iDynTreeMEX(1211, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1208, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1212, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1209, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1213, self, varargin{:});
     end
     function varargout = S(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1210, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1211, self, varargin{1});
-      end
-    end
-    function varargout = U(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1212, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1213, self, varargin{1});
-      end
-    end
-    function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -50,7 +30,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1215, self, varargin{1});
       end
     end
-    function varargout = u(self, varargin)
+    function varargout = U(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -60,7 +40,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1217, self, varargin{1});
       end
     end
-    function varargout = linksVel(self, varargin)
+    function varargout = D(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -70,7 +50,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1219, self, varargin{1});
       end
     end
-    function varargout = linksBiasAcceleration(self, varargin)
+    function varargout = u(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -80,7 +60,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1221, self, varargin{1});
       end
     end
-    function varargout = linksAccelerations(self, varargin)
+    function varargout = linksVel(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -90,7 +70,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1223, self, varargin{1});
       end
     end
-    function varargout = linkABIs(self, varargin)
+    function varargout = linksBiasAcceleration(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -100,7 +80,7 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1225, self, varargin{1});
       end
     end
-    function varargout = linksBiasWrench(self, varargin)
+    function varargout = linksAccelerations(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -110,9 +90,29 @@ classdef ArticulatedBodyAlgorithmInternalBuffers < SwigRef
         iDynTreeMEX(1227, self, varargin{1});
       end
     end
+    function varargout = linkABIs(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1228, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1229, self, varargin{1});
+      end
+    end
+    function varargout = linksBiasWrench(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1230, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1231, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1228, self);
+        iDynTreeMEX(1232, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyInertia.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ArticulatedBodyInertia.m
@@ -9,57 +9,57 @@ classdef ArticulatedBodyInertia < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(581, varargin{:});
+        tmp = iDynTreeMEX(585, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearLinearSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(582, self, varargin{:});
-    end
-    function varargout = getLinearAngularSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(583, self, varargin{:});
-    end
-    function varargout = getAngularAngularSubmatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(584, self, varargin{:});
-    end
-    function varargout = applyInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(586, self, varargin{:});
     end
-    function varargout = asMatrix(self,varargin)
+    function varargout = getLinearAngularSubmatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(587, self, varargin{:});
     end
-    function varargout = getInverse(self,varargin)
+    function varargout = getAngularAngularSubmatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(588, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(589, self, varargin{:});
-    end
-    function varargout = minus(self,varargin)
+    function varargout = applyInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(590, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = asMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(591, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = getInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(592, self, varargin{:});
+    end
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(593, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(594, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(595, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(596, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(595, self);
+        iDynTreeMEX(599, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(585, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(589, varargin{:});
     end
     function varargout = ABADyadHelper(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(593, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(597, varargin{:});
     end
     function varargout = ABADyadHelperLin(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(594, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(598, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
@@ -7,30 +7,30 @@ classdef AttitudeEstimatorState < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1585, self);
+        varargout{1} = iDynTreeMEX(1589, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1586, self, varargin{1});
+        iDynTreeMEX(1590, self, varargin{1});
       end
     end
     function varargout = m_angular_velocity(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1587, self);
+        varargout{1} = iDynTreeMEX(1591, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1588, self, varargin{1});
+        iDynTreeMEX(1592, self, varargin{1});
       end
     end
     function varargout = m_gyroscope_bias(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1589, self);
+        varargout{1} = iDynTreeMEX(1593, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1590, self, varargin{1});
+        iDynTreeMEX(1594, self, varargin{1});
       end
     end
     function self = AttitudeEstimatorState(varargin)
@@ -39,14 +39,14 @@ classdef AttitudeEstimatorState < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1591, varargin{:});
+        tmp = iDynTreeMEX(1595, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1592, self);
+        iDynTreeMEX(1596, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
@@ -7,68 +7,68 @@ classdef AttitudeMahonyFilter < iDynTree.IAttitudeEstimator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1616, varargin{:});
+        tmp = iDynTreeMEX(1620, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = useMagnetoMeterMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
-    end
-    function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1618, self, varargin{:});
-    end
-    function varargout = setGainkp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1619, self, varargin{:});
-    end
-    function varargout = setGainki(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1620, self, varargin{:});
-    end
-    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
     end
-    function varargout = setGravityDirection(self,varargin)
+    function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
     end
-    function varargout = setParameters(self,varargin)
+    function varargout = setGainkp(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
     end
-    function varargout = getParameters(self,varargin)
+    function varargout = setGainki(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
     end
-    function varargout = updateFilterWithMeasurements(self,varargin)
+    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
     end
-    function varargout = propagateStates(self,varargin)
+    function varargout = setGravityDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
+    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
+    function varargout = getParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = updateFilterWithMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getInternalStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
+    end
+    function varargout = getInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1637, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1638, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1635, self);
+        iDynTreeMEX(1639, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
@@ -7,33 +7,13 @@ classdef AttitudeMahonyFilterParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1604, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1605, self, varargin{1});
-      end
-    end
-    function varargout = kp(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1606, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1607, self, varargin{1});
-      end
-    end
-    function varargout = ki(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1608, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1609, self, varargin{1});
       end
     end
-    function varargout = use_magnetometer_measurements(self, varargin)
+    function varargout = kp(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,7 +23,7 @@ classdef AttitudeMahonyFilterParameters < SwigRef
         iDynTreeMEX(1611, self, varargin{1});
       end
     end
-    function varargout = confidence_magnetometer_measurements(self, varargin)
+    function varargout = ki(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -53,20 +33,40 @@ classdef AttitudeMahonyFilterParameters < SwigRef
         iDynTreeMEX(1613, self, varargin{1});
       end
     end
+    function varargout = use_magnetometer_measurements(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1614, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1615, self, varargin{1});
+      end
+    end
+    function varargout = confidence_magnetometer_measurements(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1616, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1617, self, varargin{1});
+      end
+    end
     function self = AttitudeMahonyFilterParameters(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1614, varargin{:});
+        tmp = iDynTreeMEX(1618, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1615, self);
+        iDynTreeMEX(1619, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
@@ -11,74 +11,74 @@ classdef AttitudeQuaternionEKF < iDynTree.IAttitudeEstimator & iDynTree.Discrete
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1681, varargin{:});
+        tmp = iDynTreeMEX(1685, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
-    end
-    function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
-    end
-    function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
-    end
-    function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
-    end
-    function varargout = setBiasCorrelationTimeFactor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
     end
-    function varargout = useMagnetometerMeasurements(self,varargin)
+    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1687, self, varargin{:});
     end
-    function varargout = setMeasurementNoiseVariance(self,varargin)
+    function varargout = setGravityDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1688, self, varargin{:});
     end
-    function varargout = setSystemNoiseVariance(self,varargin)
+    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1689, self, varargin{:});
     end
-    function varargout = setInitialStateCovariance(self,varargin)
+    function varargout = setBiasCorrelationTimeFactor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1690, self, varargin{:});
     end
-    function varargout = initializeFilter(self,varargin)
+    function varargout = useMagnetometerMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1691, self, varargin{:});
     end
-    function varargout = updateFilterWithMeasurements(self,varargin)
+    function varargout = setMeasurementNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1692, self, varargin{:});
     end
-    function varargout = propagateStates(self,varargin)
+    function varargout = setSystemNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1693, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
+    function varargout = setInitialStateCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1694, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
+    function varargout = initializeFilter(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = updateFilterWithMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getInternalStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
+    end
+    function varargout = getInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1702, self);
+        iDynTreeMEX(1706, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
@@ -7,33 +7,13 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1659, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1660, self, varargin{1});
-      end
-    end
-    function varargout = bias_correlation_time_factor(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1661, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1662, self, varargin{1});
-      end
-    end
-    function varargout = accelerometer_noise_variance(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1663, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1664, self, varargin{1});
       end
     end
-    function varargout = magnetometer_noise_variance(self, varargin)
+    function varargout = bias_correlation_time_factor(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,7 +23,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1666, self, varargin{1});
       end
     end
-    function varargout = gyroscope_noise_variance(self, varargin)
+    function varargout = accelerometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -53,7 +33,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1668, self, varargin{1});
       end
     end
-    function varargout = gyro_bias_noise_variance(self, varargin)
+    function varargout = magnetometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -63,7 +43,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1670, self, varargin{1});
       end
     end
-    function varargout = initial_orientation_error_variance(self, varargin)
+    function varargout = gyroscope_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -73,7 +53,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1672, self, varargin{1});
       end
     end
-    function varargout = initial_ang_vel_error_variance(self, varargin)
+    function varargout = gyro_bias_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -83,7 +63,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1674, self, varargin{1});
       end
     end
-    function varargout = initial_gyro_bias_error_variance(self, varargin)
+    function varargout = initial_orientation_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -93,7 +73,7 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1676, self, varargin{1});
       end
     end
-    function varargout = use_magnetometer_measurements(self, varargin)
+    function varargout = initial_ang_vel_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -103,20 +83,40 @@ classdef AttitudeQuaternionEKFParameters < SwigRef
         iDynTreeMEX(1678, self, varargin{1});
       end
     end
+    function varargout = initial_gyro_bias_error_variance(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1679, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1680, self, varargin{1});
+      end
+    end
+    function varargout = use_magnetometer_measurements(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1681, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1682, self, varargin{1});
+      end
+    end
     function self = AttitudeQuaternionEKFParameters(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1679, varargin{:});
+        tmp = iDynTreeMEX(1683, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1680, self);
+        iDynTreeMEX(1684, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Axis.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Axis.m
@@ -9,62 +9,62 @@ classdef Axis < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(533, varargin{:});
+        tmp = iDynTreeMEX(537, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
-    end
-    function varargout = getOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(535, self, varargin{:});
-    end
-    function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(536, self, varargin{:});
-    end
-    function varargout = setOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(537, self, varargin{:});
-    end
-    function varargout = getRotationTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(538, self, varargin{:});
     end
-    function varargout = getRotationTransformDerivative(self,varargin)
+    function varargout = getOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(539, self, varargin{:});
     end
-    function varargout = getRotationTwist(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(540, self, varargin{:});
     end
-    function varargout = getRotationSpatialAcc(self,varargin)
+    function varargout = setOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(541, self, varargin{:});
     end
-    function varargout = getTranslationTransform(self,varargin)
+    function varargout = getRotationTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(542, self, varargin{:});
     end
-    function varargout = getTranslationTransformDerivative(self,varargin)
+    function varargout = getRotationTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(543, self, varargin{:});
     end
-    function varargout = getTranslationTwist(self,varargin)
+    function varargout = getRotationTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(544, self, varargin{:});
     end
-    function varargout = getTranslationSpatialAcc(self,varargin)
+    function varargout = getRotationSpatialAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(545, self, varargin{:});
     end
-    function varargout = isParallel(self,varargin)
+    function varargout = getTranslationTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(546, self, varargin{:});
     end
-    function varargout = reverse(self,varargin)
+    function varargout = getTranslationTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(547, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getTranslationTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(548, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = getTranslationSpatialAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(549, self, varargin{:});
+    end
+    function varargout = isParallel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(550, self, varargin{:});
+    end
+    function varargout = reverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(551, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(552, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(553, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(550, self);
+        iDynTreeMEX(554, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
@@ -7,37 +7,37 @@ classdef BerdyDynamicVariable < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1527, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1528, self, varargin{1});
-      end
-    end
-    function varargout = id(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1529, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1530, self, varargin{1});
-      end
-    end
-    function varargout = range(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1531, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1532, self, varargin{1});
       end
     end
+    function varargout = id(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1533, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1534, self, varargin{1});
+      end
+    end
+    function varargout = range(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1535, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1536, self, varargin{1});
+      end
+    end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1533, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1537, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1534, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1538, self, varargin{:});
     end
     function self = BerdyDynamicVariable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdyDynamicVariable < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1535, varargin{:});
+        tmp = iDynTreeMEX(1539, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1536, self);
+        iDynTreeMEX(1540, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
@@ -9,104 +9,104 @@ classdef BerdyHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1537, varargin{:});
+        tmp = iDynTreeMEX(1541, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1538, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1539, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1540, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1541, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1542, self, varargin{:});
     end
-    function varargout = getOptions(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1543, self, varargin{:});
     end
-    function varargout = getNrOfDynamicVariables(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1544, self, varargin{:});
     end
-    function varargout = getNrOfDynamicEquations(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1545, self, varargin{:});
     end
-    function varargout = getNrOfSensorsMeasurements(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1546, self, varargin{:});
     end
-    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
+    function varargout = getOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1547, self, varargin{:});
     end
-    function varargout = getBerdyMatrices(self,varargin)
+    function varargout = getNrOfDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1548, self, varargin{:});
     end
-    function varargout = getSensorsOrdering(self,varargin)
+    function varargout = getNrOfDynamicEquations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1549, self, varargin{:});
     end
-    function varargout = getRangeSensorVariable(self,varargin)
+    function varargout = getNrOfSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1550, self, varargin{:});
     end
-    function varargout = getRangeDOFSensorVariable(self,varargin)
+    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1551, self, varargin{:});
     end
-    function varargout = getRangeJointSensorVariable(self,varargin)
+    function varargout = getBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1552, self, varargin{:});
     end
-    function varargout = getRangeLinkSensorVariable(self,varargin)
+    function varargout = getSensorsOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1553, self, varargin{:});
     end
-    function varargout = getRangeLinkVariable(self,varargin)
+    function varargout = getRangeSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1554, self, varargin{:});
     end
-    function varargout = getRangeJointVariable(self,varargin)
+    function varargout = getRangeDOFSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1555, self, varargin{:});
     end
-    function varargout = getRangeDOFVariable(self,varargin)
+    function varargout = getRangeJointSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1556, self, varargin{:});
     end
-    function varargout = getDynamicVariablesOrdering(self,varargin)
+    function varargout = getRangeLinkSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1557, self, varargin{:});
     end
-    function varargout = serializeDynamicVariables(self,varargin)
+    function varargout = getRangeLinkVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1558, self, varargin{:});
     end
-    function varargout = serializeSensorVariables(self,varargin)
+    function varargout = getRangeJointVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1559, self, varargin{:});
     end
-    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
+    function varargout = getRangeDOFVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1560, self, varargin{:});
     end
-    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
+    function varargout = getDynamicVariablesOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1561, self, varargin{:});
     end
-    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
+    function varargout = serializeDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1562, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+    function varargout = serializeSensorVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1563, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
     end
-    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1565, self, varargin{:});
     end
-    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1566, self, varargin{:});
     end
-    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1567, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1568, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1569, self, varargin{:});
+    end
+    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1570, self, varargin{:});
+    end
+    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1571, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1568, self);
+        iDynTreeMEX(1572, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
@@ -9,32 +9,12 @@ classdef BerdyOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1498, varargin{:});
+        tmp = iDynTreeMEX(1502, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = berdyVariant(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1499, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1500, self, varargin{1});
-      end
-    end
-    function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1501, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1502, self, varargin{1});
-      end
-    end
-    function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -44,7 +24,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1504, self, varargin{1});
       end
     end
-    function varargout = includeAllJointTorquesAsSensors(self, varargin)
+    function varargout = includeAllNetExternalWrenchesAsDynamicVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -54,7 +34,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1506, self, varargin{1});
       end
     end
-    function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
+    function varargout = includeAllJointAccelerationsAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -64,7 +44,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1508, self, varargin{1});
       end
     end
-    function varargout = includeFixedBaseExternalWrench(self, varargin)
+    function varargout = includeAllJointTorquesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -74,7 +54,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1510, self, varargin{1});
       end
     end
-    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
+    function varargout = includeAllNetExternalWrenchesAsSensors(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -84,7 +64,7 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1512, self, varargin{1});
       end
     end
-    function varargout = baseLink(self, varargin)
+    function varargout = includeFixedBaseExternalWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -94,12 +74,32 @@ classdef BerdyOptions < SwigRef
         iDynTreeMEX(1514, self, varargin{1});
       end
     end
+    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1515, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1516, self, varargin{1});
+      end
+    end
+    function varargout = baseLink(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1517, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1518, self, varargin{1});
+      end
+    end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1515, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1519, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1516, self);
+        iDynTreeMEX(1520, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
@@ -7,37 +7,37 @@ classdef BerdySensor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1517, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1518, self, varargin{1});
-      end
-    end
-    function varargout = id(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1519, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1520, self, varargin{1});
-      end
-    end
-    function varargout = range(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1521, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1522, self, varargin{1});
       end
     end
+    function varargout = id(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1523, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1524, self, varargin{1});
+      end
+    end
+    function varargout = range(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1525, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1526, self, varargin{1});
+      end
+    end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1523, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1527, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1524, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1528, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -45,14 +45,14 @@ classdef BerdySensor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1525, varargin{:});
+        tmp = iDynTreeMEX(1529, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1526, self);
+        iDynTreeMEX(1530, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
@@ -9,58 +9,58 @@ classdef BerdySparseMAPSolver < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1569, varargin{:});
+        tmp = iDynTreeMEX(1573, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1570, self);
+        iDynTreeMEX(1574, self);
         self.SwigClear();
       end
     end
     function varargout = setDynamicsConstraintsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1571, self, varargin{:});
-    end
-    function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1572, self, varargin{:});
-    end
-    function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1573, self, varargin{:});
-    end
-    function varargout = setMeasurementsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1574, self, varargin{:});
-    end
-    function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1575, self, varargin{:});
     end
-    function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
+    function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1576, self, varargin{:});
     end
-    function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
+    function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1577, self, varargin{:});
     end
-    function varargout = measurementsPriorCovarianceInverse(self,varargin)
+    function varargout = setMeasurementsPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1578, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1579, self, varargin{:});
     end
-    function varargout = initialize(self,varargin)
+    function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1580, self, varargin{:});
     end
-    function varargout = updateEstimateInformationFixedBase(self,varargin)
+    function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1581, self, varargin{:});
     end
-    function varargout = updateEstimateInformationFloatingBase(self,varargin)
+    function varargout = measurementsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1582, self, varargin{:});
     end
-    function varargout = doEstimate(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1583, self, varargin{:});
     end
-    function varargout = getLastEstimate(self,varargin)
+    function varargout = initialize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1584, self, varargin{:});
+    end
+    function varargout = updateEstimateInformationFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1585, self, varargin{:});
+    end
+    function varargout = updateEstimateInformationFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1586, self, varargin{:});
+    end
+    function varargout = doEstimate(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1587, self, varargin{:});
+    end
+    function varargout = getLastEstimate(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1588, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Box.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Box.m
@@ -2,30 +2,30 @@ classdef Box < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1004, self);
+        iDynTreeMEX(1008, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
-    end
-    function varargout = getX(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
-    end
-    function varargout = setX(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1007, self, varargin{:});
-    end
-    function varargout = getY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1008, self, varargin{:});
-    end
-    function varargout = setY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1009, self, varargin{:});
     end
-    function varargout = getZ(self,varargin)
+    function varargout = getX(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1010, self, varargin{:});
     end
-    function varargout = setZ(self,varargin)
+    function varargout = setX(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1011, self, varargin{:});
+    end
+    function varargout = getY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1012, self, varargin{:});
+    end
+    function varargout = setY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1013, self, varargin{:});
+    end
+    function varargout = getZ(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
+    end
+    function varargout = setZ(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
     end
     function self = Box(varargin)
       self@iDynTree.SolidShape(SwigRef.Null);
@@ -34,7 +34,7 @@ classdef Box < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1012, varargin{:});
+        tmp = iDynTreeMEX(1016, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/ClassicalAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ClassicalAcc.m
@@ -7,30 +7,30 @@ classdef ClassicalAcc < iDynTree.Vector6
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(518, varargin{:});
+        tmp = iDynTreeMEX(522, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(519, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(523, self, varargin{:});
     end
     function varargout = fromSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(521, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(525, self, varargin{:});
     end
     function varargout = toSpatial(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(522, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(526, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(523, self);
+        iDynTreeMEX(527, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(520, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(524, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,33 +7,13 @@ classdef ColorViz < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1789, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1790, self, varargin{1});
-      end
-    end
-    function varargout = g(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1791, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1792, self, varargin{1});
-      end
-    end
-    function varargout = b(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1793, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1794, self, varargin{1});
       end
     end
-    function varargout = a(self, varargin)
+    function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,20 +23,40 @@ classdef ColorViz < SwigRef
         iDynTreeMEX(1796, self, varargin{1});
       end
     end
+    function varargout = b(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1797, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1798, self, varargin{1});
+      end
+    end
+    function varargout = a(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1799, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1800, self, varargin{1});
+      end
+    end
     function self = ColorViz(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1797, varargin{:});
+        tmp = iDynTreeMEX(1801, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1798, self);
+        iDynTreeMEX(1802, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
+++ b/bindings/matlab/autogenerated/+iDynTree/CompositeRigidBodyAlgorithm.m
@@ -1,3 +1,3 @@
 function varargout = CompositeRigidBodyAlgorithm(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1206, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1210, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentum.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentum(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1203, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1207, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ComputeLinearAndAngularMomentumDerivativeBias.m
@@ -1,3 +1,3 @@
 function varargout = ComputeLinearAndAngularMomentumDerivativeBias(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1204, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1208, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ContactWrench.m
@@ -4,13 +4,13 @@ classdef ContactWrench < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = contactId(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1133, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1137, self, varargin{:});
     end
     function varargout = contactPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1134, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1138, self, varargin{:});
     end
     function varargout = contactWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1135, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
     end
     function self = ContactWrench(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -18,14 +18,14 @@ classdef ContactWrench < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1136, varargin{:});
+        tmp = iDynTreeMEX(1140, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1137, self);
+        iDynTreeMEX(1141, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
@@ -4,35 +4,15 @@ classdef ConvexHullProjectionConstraint < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = setActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
     end
     function varargout = isActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
     end
     function varargout = getNrOfConstraints(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1903, self, varargin{:});
     end
     function varargout = projectedConvexHull(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1900, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1901, self, varargin{1});
-      end
-    end
-    function varargout = A(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1902, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1903, self, varargin{1});
-      end
-    end
-    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -42,7 +22,7 @@ classdef ConvexHullProjectionConstraint < SwigRef
         iDynTreeMEX(1905, self, varargin{1});
       end
     end
-    function varargout = P(self, varargin)
+    function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -52,7 +32,7 @@ classdef ConvexHullProjectionConstraint < SwigRef
         iDynTreeMEX(1907, self, varargin{1});
       end
     end
-    function varargout = Pdirection(self, varargin)
+    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -62,7 +42,7 @@ classdef ConvexHullProjectionConstraint < SwigRef
         iDynTreeMEX(1909, self, varargin{1});
       end
     end
-    function varargout = AtimesP(self, varargin)
+    function varargout = P(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -72,7 +52,7 @@ classdef ConvexHullProjectionConstraint < SwigRef
         iDynTreeMEX(1911, self, varargin{1});
       end
     end
-    function varargout = o(self, varargin)
+    function varargout = Pdirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -82,40 +62,60 @@ classdef ConvexHullProjectionConstraint < SwigRef
         iDynTreeMEX(1913, self, varargin{1});
       end
     end
+    function varargout = AtimesP(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1914, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1915, self, varargin{1});
+      end
+    end
+    function varargout = o(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1916, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1917, self, varargin{1});
+      end
+    end
     function varargout = buildConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
     end
     function varargout = supportFrameIndices(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1915, self);
+        varargout{1} = iDynTreeMEX(1919, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1916, self, varargin{1});
+        iDynTreeMEX(1920, self, varargin{1});
       end
     end
     function varargout = absoluteFrame_X_supportFrame(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1917, self);
+        varargout{1} = iDynTreeMEX(1921, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1918, self, varargin{1});
+        iDynTreeMEX(1922, self, varargin{1});
       end
     end
     function varargout = project(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
     end
     function varargout = computeMargin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
     end
     function varargout = setProjectionAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
     end
     function varargout = projectAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
     end
     function self = ConvexHullProjectionConstraint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -123,14 +123,14 @@ classdef ConvexHullProjectionConstraint < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1923, varargin{:});
+        tmp = iDynTreeMEX(1927, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1924, self);
+        iDynTreeMEX(1928, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Cylinder.m
@@ -2,24 +2,24 @@ classdef Cylinder < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1013, self);
+        iDynTreeMEX(1017, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1014, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
     end
     function varargout = getLength(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1015, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1019, self, varargin{:});
     end
     function varargout = setLength(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1016, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1020, self, varargin{:});
     end
     function varargout = getRadius(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1017, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
     end
     function varargout = setRadius(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1018, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
     end
     function self = Cylinder(varargin)
       self@iDynTree.SolidShape(SwigRef.Null);
@@ -28,7 +28,7 @@ classdef Cylinder < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1019, varargin{:});
+        tmp = iDynTreeMEX(1023, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialForceArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialForceArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1088, varargin{:});
+        tmp = iDynTreeMEX(1092, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1093, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1091, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1095, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1092, self);
+        iDynTreeMEX(1096, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOFSpatialMotionArray.m
@@ -9,23 +9,23 @@ classdef DOFSpatialMotionArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1093, varargin{:});
+        tmp = iDynTreeMEX(1097, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1094, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1098, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1095, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1099, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1096, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1097, self);
+        iDynTreeMEX(1101, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(730);
+    varargout{1} = iDynTreeMEX(734);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(731,varargin{1});
+    iDynTreeMEX(735,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = DOF_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(732);
+    varargout{1} = iDynTreeMEX(736);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(733,varargin{1});
+    iDynTreeMEX(737,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Direction.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Direction.m
@@ -7,39 +7,39 @@ classdef Direction < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(524, varargin{:});
+        tmp = iDynTreeMEX(528, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = Normalize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(525, self, varargin{:});
-    end
-    function varargout = isParallel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(526, self, varargin{:});
-    end
-    function varargout = isPerpendicular(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(527, self, varargin{:});
-    end
-    function varargout = reverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(528, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(529, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = isParallel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(530, self, varargin{:});
+    end
+    function varargout = isPerpendicular(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(531, self, varargin{:});
+    end
+    function varargout = reverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(532, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(533, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(534, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(532, self);
+        iDynTreeMEX(536, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Default(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(531, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(535, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
@@ -4,65 +4,65 @@ classdef DiscreteExtendedKalmanFilterHelper < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = ekf_f(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
-    end
-    function varargout = ekf_h(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1637, self, varargin{:});
-    end
-    function varargout = ekfComputeJacobianF(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1638, self, varargin{:});
-    end
-    function varargout = ekfComputeJacobianH(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1639, self, varargin{:});
-    end
-    function varargout = ekfPredict(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1640, self, varargin{:});
     end
-    function varargout = ekfUpdate(self,varargin)
+    function varargout = ekf_h(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1641, self, varargin{:});
     end
-    function varargout = ekfInit(self,varargin)
+    function varargout = ekfComputeJacobianF(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1642, self, varargin{:});
     end
-    function varargout = ekfReset(self,varargin)
+    function varargout = ekfComputeJacobianH(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1643, self, varargin{:});
     end
-    function varargout = ekfSetMeasurementVector(self,varargin)
+    function varargout = ekfPredict(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
     end
-    function varargout = ekfSetInputVector(self,varargin)
+    function varargout = ekfUpdate(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
     end
-    function varargout = ekfSetInitialState(self,varargin)
+    function varargout = ekfInit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
     end
-    function varargout = ekfSetStateCovariance(self,varargin)
+    function varargout = ekfReset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
     end
-    function varargout = ekfSetSystemNoiseCovariance(self,varargin)
+    function varargout = ekfSetMeasurementVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
     end
-    function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
+    function varargout = ekfSetInputVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
     end
-    function varargout = ekfSetStateSize(self,varargin)
+    function varargout = ekfSetInitialState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
     end
-    function varargout = ekfSetInputSize(self,varargin)
+    function varargout = ekfSetStateCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
     end
-    function varargout = ekfSetOutputSize(self,varargin)
+    function varargout = ekfSetSystemNoiseCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
     end
-    function varargout = ekfGetStates(self,varargin)
+    function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1653, self, varargin{:});
     end
-    function varargout = ekfGetStateCovariance(self,varargin)
+    function varargout = ekfSetStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1654, self, varargin{:});
+    end
+    function varargout = ekfSetInputSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1655, self, varargin{:});
+    end
+    function varargout = ekfSetOutputSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1656, self, varargin{:});
+    end
+    function varargout = ekfGetStates(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1657, self, varargin{:});
+    end
+    function varargout = ekfGetStateCovariance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1658, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1655, self);
+        iDynTreeMEX(1659, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Dummy.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Dummy.m
@@ -9,14 +9,14 @@ classdef Dummy < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(485, varargin{:});
+        tmp = iDynTreeMEX(489, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(486, self);
+        iDynTreeMEX(490, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicMatrixView.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicMatrixView.m
@@ -9,26 +9,26 @@ classdef DynamicMatrixView < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(716, varargin{:});
+        tmp = iDynTreeMEX(720, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = storageOrder(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(717, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(721, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(718, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(722, self, varargin{:});
     end
     function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(719, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(723, self, varargin{:});
     end
     function varargout = cols(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(720, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(724, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(721, self);
+        iDynTreeMEX(725, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DynamicSpan.m
@@ -9,78 +9,78 @@ classdef DynamicSpan < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(695, varargin{:});
+        tmp = iDynTreeMEX(699, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(696, self);
+        iDynTreeMEX(700, self);
         self.SwigClear();
       end
     end
     function varargout = first(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(697, self, varargin{:});
-    end
-    function varargout = last(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(698, self, varargin{:});
-    end
-    function varargout = subspan(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(699, self, varargin{:});
-    end
-    function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(700, self, varargin{:});
-    end
-    function varargout = size_bytes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(701, self, varargin{:});
     end
-    function varargout = empty(self,varargin)
+    function varargout = last(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(702, self, varargin{:});
     end
-    function varargout = brace(self,varargin)
+    function varargout = subspan(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(703, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(704, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = size_bytes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(705, self, varargin{:});
     end
-    function varargout = at(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(706, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(707, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(708, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(709, self, varargin{:});
     end
-    function varargout = cbegin(self,varargin)
+    function varargout = at(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(710, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(711, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(712, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(713, self, varargin{:});
     end
-    function varargout = crbegin(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(714, self, varargin{:});
     end
-    function varargout = crend(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(715, self, varargin{:});
+    end
+    function varargout = rbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(716, self, varargin{:});
+    end
+    function varargout = rend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(717, self, varargin{:});
+    end
+    function varargout = crbegin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(718, self, varargin{:});
+    end
+    function varargout = crend(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(719, self, varargin{:});
     end
   end
   methods(Static)
     function v = extent()
-      v = iDynTreeMEX(694);
+      v = iDynTreeMEX(698);
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExtWrenchesAndJointTorquesEstimator.m
@@ -9,52 +9,52 @@ classdef ExtWrenchesAndJointTorquesEstimator < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1471, varargin{:});
+        tmp = iDynTreeMEX(1475, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1472, self);
+        iDynTreeMEX(1476, self);
         self.SwigClear();
       end
     end
     function varargout = setModelAndSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1473, self, varargin{:});
-    end
-    function varargout = loadModelAndSensorsFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1474, self, varargin{:});
-    end
-    function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1475, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1476, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1477, self, varargin{:});
     end
-    function varargout = submodels(self,varargin)
+    function varargout = loadModelAndSensorsFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1478, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+    function varargout = loadModelAndSensorsFromFileWithSpecifiedDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1479, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1480, self, varargin{:});
     end
-    function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1481, self, varargin{:});
     end
-    function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
+    function varargout = submodels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1482, self, varargin{:});
     end
-    function varargout = checkThatTheModelIsStill(self,varargin)
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1483, self, varargin{:});
     end
-    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1484, self, varargin{:});
+    end
+    function varargout = computeExpectedFTSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1485, self, varargin{:});
+    end
+    function varargout = estimateExtWrenchesAndJointTorques(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1486, self, varargin{:});
+    end
+    function varargout = checkThatTheModelIsStill(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1487, self, varargin{:});
+    end
+    function varargout = estimateLinkNetWrenchesWithoutGravity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1488, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ExternalMesh.m
@@ -2,24 +2,24 @@ classdef ExternalMesh < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1020, self);
+        iDynTreeMEX(1024, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1021, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
     end
     function varargout = getFilename(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1022, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1026, self, varargin{:});
     end
     function varargout = setFilename(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1023, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1027, self, varargin{:});
     end
     function varargout = getScale(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1024, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1028, self, varargin{:});
     end
     function varargout = setScale(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1025, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
     end
     function self = ExternalMesh(varargin)
       self@iDynTree.SolidShape(SwigRef.Null);
@@ -28,7 +28,7 @@ classdef ExternalMesh < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1026, varargin{:});
+        tmp = iDynTreeMEX(1030, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(734);
+    varargout{1} = iDynTreeMEX(738);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(735,varargin{1});
+    iDynTreeMEX(739,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FRAME_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = FRAME_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(736);
+    varargout{1} = iDynTreeMEX(740);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(737,varargin{1});
+    iDynTreeMEX(741,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FixedJoint.m
@@ -7,103 +7,103 @@ classdef FixedJoint < iDynTree.IJoint
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(820, varargin{:});
+        tmp = iDynTreeMEX(824, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(821, self);
+        iDynTreeMEX(825, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(824, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(825, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(826, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(827, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(828, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(829, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(830, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(831, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(832, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(833, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(834, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(835, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(836, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(837, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(838, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(839, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(840, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(841, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(842, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(843, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(844, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(845, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(846, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(847, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(848, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(849, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(850, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(851, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(852, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(853, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(854, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1201, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1205, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardBiasAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardBiasAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1202, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1206, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1199, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1203, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPosVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPosVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1200, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1204, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardPositionKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardPositionKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1197, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1201, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = ForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1198, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1202, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FrameFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef FrameFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1098, varargin{:});
+        tmp = iDynTreeMEX(1102, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1099, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1100, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1101, self);
+        iDynTreeMEX(1105, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingAcc.m
@@ -9,26 +9,26 @@ classdef FreeFloatingAcc < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1127, varargin{:});
+        tmp = iDynTreeMEX(1131, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1128, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1132, self, varargin{:});
     end
     function varargout = baseAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1129, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1133, self, varargin{:});
     end
     function varargout = jointAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1130, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1134, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1131, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1135, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1132, self);
+        iDynTreeMEX(1136, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingGeneralizedTorques.m
@@ -9,26 +9,26 @@ classdef FreeFloatingGeneralizedTorques < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1115, varargin{:});
+        tmp = iDynTreeMEX(1119, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1120, self, varargin{:});
     end
     function varargout = baseWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1117, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1121, self, varargin{:});
     end
     function varargout = jointTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1118, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1122, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1119, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1123, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1120, self);
+        iDynTreeMEX(1124, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingMassMatrix.m
@@ -7,17 +7,17 @@ classdef FreeFloatingMassMatrix < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1106, varargin{:});
+        tmp = iDynTreeMEX(1110, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1107, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1108, self);
+        iDynTreeMEX(1112, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingPos.m
@@ -9,26 +9,26 @@ classdef FreeFloatingPos < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1109, varargin{:});
+        tmp = iDynTreeMEX(1113, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1110, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1114, self, varargin{:});
     end
     function varargout = worldBasePos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1111, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1115, self, varargin{:});
     end
     function varargout = jointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1112, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1116, self, varargin{:});
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1113, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1117, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1114, self);
+        iDynTreeMEX(1118, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
+++ b/bindings/matlab/autogenerated/+iDynTree/FreeFloatingVel.m
@@ -9,26 +9,26 @@ classdef FreeFloatingVel < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1121, varargin{:});
+        tmp = iDynTreeMEX(1125, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1122, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1126, self, varargin{:});
     end
     function varargout = baseVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1123, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1127, self, varargin{:});
     end
     function varargout = jointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1124, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1128, self, varargin{:});
     end
     function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1125, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1129, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1126, self);
+        iDynTreeMEX(1130, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/GeomVector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GeomVector3.m
@@ -7,41 +7,41 @@ classdef GeomVector3 < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(424, varargin{:});
+        tmp = iDynTreeMEX(428, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeCoordFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(425, self, varargin{:});
-    end
-    function varargout = compose(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(426, self, varargin{:});
-    end
-    function varargout = inverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(427, self, varargin{:});
-    end
-    function varargout = dot(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(428, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(429, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
+    function varargout = compose(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(430, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(431, self, varargin{:});
     end
-    function varargout = exp(self,varargin)
+    function varargout = dot(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(432, self, varargin{:});
     end
-    function varargout = cross(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(433, self, varargin{:});
+    end
+    function varargout = minus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(434, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(435, self, varargin{:});
+    end
+    function varargout = exp(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(436, self, varargin{:});
+    end
+    function varargout = cross(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(437, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(434, self);
+        iDynTreeMEX(438, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GyroscopeSensor.m
@@ -7,55 +7,55 @@ classdef GyroscopeSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1327, varargin{:});
+        tmp = iDynTreeMEX(1331, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1328, self);
+        iDynTreeMEX(1332, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1329, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1330, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1331, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1332, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1333, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1334, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1335, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1336, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1337, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1338, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1339, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1340, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1341, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1342, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1343, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1344, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1345, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
@@ -5,39 +5,39 @@ classdef IAttitudeEstimator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1593, self);
+        iDynTreeMEX(1597, self);
         self.SwigClear();
       end
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1594, self, varargin{:});
-    end
-    function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1595, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1596, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1597, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1599, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1602, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getInternalStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1603, self, varargin{:});
+    end
+    function varargout = getInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1604, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1605, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
     end
     function self = IAttitudeEstimator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,18 +5,18 @@ classdef ICamera < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1785, self);
+        iDynTreeMEX(1789, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
     end
     function varargout = setTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
     end
     function varargout = setUpVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1792, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,33 +5,33 @@ classdef IEnvironment < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1813, self);
+        iDynTreeMEX(1817, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
-    end
-    function varargout = setElementVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
-    end
-    function varargout = setBackgroundColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
-    end
-    function varargout = setAmbientLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
-    end
-    function varargout = getLights(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
     end
-    function varargout = addLight(self,varargin)
+    function varargout = setElementVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
     end
-    function varargout = lightViz(self,varargin)
+    function varargout = setBackgroundColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
     end
-    function varargout = removeLight(self,varargin)
+    function varargout = setAmbientLight(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
+    end
+    function varargout = getLights(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
+    end
+    function varargout = addLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
+    end
+    function varargout = lightViz(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
+    end
+    function varargout = removeLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1822, self);
+        iDynTreeMEX(1826, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
-    end
-    function varargout = getNrOfJets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
-    end
-    function varargout = getJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
-    end
-    function varargout = setJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
-    end
-    function varargout = setJetColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
     end
-    function varargout = setJetsDimensions(self,varargin)
+    function varargout = getNrOfJets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
     end
-    function varargout = setJetsIntensity(self,varargin)
+    function varargout = getJetDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
+    end
+    function varargout = setJetDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
+    end
+    function varargout = setJetColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
+    end
+    function varargout = setJetsDimensions(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
+    end
+    function varargout = setJetsIntensity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJoint.m
@@ -5,108 +5,108 @@ classdef IJoint < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(786, self);
+        iDynTreeMEX(790, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
-    end
-    function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(789, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(790, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(791, self, varargin{:});
     end
-    function varargout = getFirstAttachedLink(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(792, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(793, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(794, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(795, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(796, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(797, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(798, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(799, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(800, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(801, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(802, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(803, self, varargin{:});
     end
-    function varargout = setIndex(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(804, self, varargin{:});
     end
-    function varargout = getIndex(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(805, self, varargin{:});
     end
-    function varargout = setPosCoordsOffset(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(806, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(807, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(808, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(809, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(810, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = getPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(811, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = setDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(812, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = getDOFsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(813, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(814, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(815, self, varargin{:});
     end
-    function varargout = isRevoluteJoint(self,varargin)
+    function varargout = getPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(816, self, varargin{:});
     end
-    function varargout = isFixedJoint(self,varargin)
+    function varargout = getMinPosLimit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(817, self, varargin{:});
     end
-    function varargout = asRevoluteJoint(self,varargin)
+    function varargout = getMaxPosLimit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(818, self, varargin{:});
     end
-    function varargout = asFixedJoint(self,varargin)
+    function varargout = setPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(819, self, varargin{:});
+    end
+    function varargout = isRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(820, self, varargin{:});
+    end
+    function varargout = isFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(821, self, varargin{:});
+    end
+    function varargout = asRevoluteJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(822, self, varargin{:});
+    end
+    function varargout = asFixedJoint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(823, self, varargin{:});
     end
     function self = IJoint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1799, self);
+        iDynTreeMEX(1803, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
-    end
-    function varargout = setType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
-    end
-    function varargout = getType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
-    end
-    function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
-    end
-    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
     end
-    function varargout = setDirection(self,varargin)
+    function varargout = setType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
     end
-    function varargout = getDirection(self,varargin)
+    function varargout = getType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
     end
-    function varargout = setAmbientColor(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
     end
-    function varargout = getAmbientColor(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
     end
-    function varargout = setSpecularColor(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
     end
-    function varargout = getSpecularColor(self,varargin)
+    function varargout = getDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
     end
-    function varargout = setDiffuseColor(self,varargin)
+    function varargout = setAmbientColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
     end
-    function varargout = getDiffuseColor(self,varargin)
+    function varargout = getAmbientColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
+    end
+    function varargout = setSpecularColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
+    end
+    function varargout = getSpecularColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
+    end
+    function varargout = setDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
+    end
+    function varargout = getDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,57 +5,57 @@ classdef IModelVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1837, self);
+        iDynTreeMEX(1841, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
-    end
-    function varargout = setLinkPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
-    end
-    function varargout = getInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
-    end
-    function varargout = setModelVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
-    function varargout = setModelColor(self,varargin)
+    function varargout = setLinkPositions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
     end
-    function varargout = resetModelColor(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
     end
-    function varargout = setLinkColor(self,varargin)
+    function varargout = getInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
     end
-    function varargout = resetLinkColor(self,varargin)
+    function varargout = setModelVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
     end
-    function varargout = getLinkNames(self,varargin)
+    function varargout = setModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
     end
-    function varargout = setLinkVisibility(self,varargin)
+    function varargout = resetModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
     end
-    function varargout = getFeatures(self,varargin)
+    function varargout = setLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
     end
-    function varargout = setFeatureVisibility(self,varargin)
+    function varargout = resetLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
     end
-    function varargout = jets(self,varargin)
+    function varargout = getLinkNames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
     end
-    function varargout = getWorldModelTransform(self,varargin)
+    function varargout = setLinkVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = getFeatures(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
+    end
+    function varargout = setFeatureVisibility(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
+    end
+    function varargout = jets(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1855, self, varargin{:});
+    end
+    function varargout = getWorldModelTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1856, self, varargin{:});
+    end
+    function varargout = getWorldLinkTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1857, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,27 +5,27 @@ classdef IVectorsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1830, self);
+        iDynTreeMEX(1834, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
-    end
-    function varargout = getNrOfVectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
-    end
-    function varargout = getVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
-    end
-    function varargout = updateVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
-    end
-    function varargout = setVectorColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
     end
-    function varargout = setVectorsAspect(self,varargin)
+    function varargout = getNrOfVectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
+    end
+    function varargout = getVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
+    end
+    function varargout = updateVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
+    end
+    function varargout = setVectorColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
+    end
+    function varargout = setVectorsAspect(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseDynamicsInertialParametersRegressor.m
@@ -1,3 +1,3 @@
 function varargout = InverseDynamicsInertialParametersRegressor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1230, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1234, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
@@ -9,187 +9,187 @@ classdef InverseKinematics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1926, varargin{:});
+        tmp = iDynTreeMEX(1930, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1927, self);
+        iDynTreeMEX(1931, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
-    end
-    function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
-    end
-    function varargout = setJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
-    end
-    function varargout = getJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
-    end
-    function varargout = clearProblem(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
     end
-    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
+    function varargout = setModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
-    function varargout = setCurrentRobotConfiguration(self,varargin)
+    function varargout = setJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
     end
-    function varargout = setJointConfiguration(self,varargin)
+    function varargout = getJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
     end
-    function varargout = setRotationParametrization(self,varargin)
+    function varargout = clearProblem(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
     end
-    function varargout = rotationParametrization(self,varargin)
+    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
     end
-    function varargout = setMaxIterations(self,varargin)
+    function varargout = setCurrentRobotConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
     end
-    function varargout = maxIterations(self,varargin)
+    function varargout = setJointConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
-    function varargout = setMaxCPUTime(self,varargin)
+    function varargout = setRotationParametrization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
-    function varargout = maxCPUTime(self,varargin)
+    function varargout = rotationParametrization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
     end
-    function varargout = setCostTolerance(self,varargin)
+    function varargout = setMaxIterations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
-    function varargout = costTolerance(self,varargin)
+    function varargout = maxIterations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
     end
-    function varargout = setConstraintsTolerance(self,varargin)
+    function varargout = setMaxCPUTime(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
     end
-    function varargout = constraintsTolerance(self,varargin)
+    function varargout = maxCPUTime(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
     end
-    function varargout = setVerbosity(self,varargin)
+    function varargout = setCostTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
     end
-    function varargout = linearSolverName(self,varargin)
+    function varargout = costTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
     end
-    function varargout = setLinearSolverName(self,varargin)
+    function varargout = setConstraintsTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
     end
-    function varargout = addFrameConstraint(self,varargin)
+    function varargout = constraintsTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
     end
-    function varargout = addFramePositionConstraint(self,varargin)
+    function varargout = setVerbosity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
     end
-    function varargout = addFrameRotationConstraint(self,varargin)
+    function varargout = linearSolverName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
     end
-    function varargout = activateFrameConstraint(self,varargin)
+    function varargout = setLinearSolverName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
     end
-    function varargout = deactivateFrameConstraint(self,varargin)
+    function varargout = addFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
     end
-    function varargout = isFrameConstraintActive(self,varargin)
+    function varargout = addFramePositionConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
     end
-    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
+    function varargout = addFrameRotationConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
     end
-    function varargout = getCenterOfMassProjectionMargin(self,varargin)
+    function varargout = activateFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
     end
-    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
+    function varargout = deactivateFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
     end
-    function varargout = addTarget(self,varargin)
+    function varargout = isFrameConstraintActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1958, self, varargin{:});
     end
-    function varargout = addPositionTarget(self,varargin)
+    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1959, self, varargin{:});
     end
-    function varargout = addRotationTarget(self,varargin)
+    function varargout = getCenterOfMassProjectionMargin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
     end
-    function varargout = updateTarget(self,varargin)
+    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1961, self, varargin{:});
     end
-    function varargout = updatePositionTarget(self,varargin)
+    function varargout = addTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1962, self, varargin{:});
     end
-    function varargout = updateRotationTarget(self,varargin)
+    function varargout = addPositionTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1963, self, varargin{:});
     end
-    function varargout = setDefaultTargetResolutionMode(self,varargin)
+    function varargout = addRotationTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1964, self, varargin{:});
     end
-    function varargout = defaultTargetResolutionMode(self,varargin)
+    function varargout = updateTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1965, self, varargin{:});
     end
-    function varargout = setTargetResolutionMode(self,varargin)
+    function varargout = updatePositionTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1966, self, varargin{:});
     end
-    function varargout = targetResolutionMode(self,varargin)
+    function varargout = updateRotationTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
     end
-    function varargout = setDesiredFullJointsConfiguration(self,varargin)
+    function varargout = setDefaultTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
     end
-    function varargout = setDesiredReducedJointConfiguration(self,varargin)
+    function varargout = defaultTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
     end
-    function varargout = setFullJointsInitialCondition(self,varargin)
+    function varargout = setTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
     end
-    function varargout = setReducedInitialCondition(self,varargin)
+    function varargout = targetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1971, self, varargin{:});
     end
-    function varargout = solve(self,varargin)
+    function varargout = setDesiredFullJointsConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1972, self, varargin{:});
     end
-    function varargout = getFullJointsSolution(self,varargin)
+    function varargout = setDesiredReducedJointConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
     end
-    function varargout = getReducedSolution(self,varargin)
+    function varargout = setFullJointsInitialCondition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
     end
-    function varargout = getPoseForFrame(self,varargin)
+    function varargout = setReducedInitialCondition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
     end
-    function varargout = fullModel(self,varargin)
+    function varargout = solve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
     end
-    function varargout = reducedModel(self,varargin)
+    function varargout = getFullJointsSolution(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
     end
-    function varargout = setCOMTarget(self,varargin)
+    function varargout = getReducedSolution(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
     end
-    function varargout = setCOMAsConstraint(self,varargin)
+    function varargout = getPoseForFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
     end
-    function varargout = setCOMAsConstraintTolerance(self,varargin)
+    function varargout = fullModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
     end
-    function varargout = isCOMAConstraint(self,varargin)
+    function varargout = reducedModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
     end
-    function varargout = isCOMTargetActive(self,varargin)
+    function varargout = setCOMTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
     end
-    function varargout = deactivateCOMTarget(self,varargin)
+    function varargout = setCOMAsConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
     end
-    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+    function varargout = setCOMAsConstraintTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
+    end
+    function varargout = isCOMAConstraint(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
+    end
+    function varargout = isCOMTargetActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
+    end
+    function varargout = deactivateCOMTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
+    end
+    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(726);
+    varargout{1} = iDynTreeMEX(730);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(727,varargin{1});
+    iDynTreeMEX(731,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = JOINT_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(728);
+    varargout{1} = iDynTreeMEX(732);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(729,varargin{1});
+    iDynTreeMEX(733,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointDOFsDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointDOFsDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1084, varargin{:});
+        tmp = iDynTreeMEX(1088, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1089, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1090, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1087, self);
+        iDynTreeMEX(1091, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointPosDoubleArray.m
@@ -7,20 +7,20 @@ classdef JointPosDoubleArray < iDynTree.VectorDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1080, varargin{:});
+        tmp = iDynTreeMEX(1084, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1085, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1082, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1086, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1083, self);
+        iDynTreeMEX(1087, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JointSensor.m
@@ -2,24 +2,24 @@ classdef JointSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1243, self);
+        iDynTreeMEX(1247, self);
         self.SwigClear();
       end
     end
     function varargout = getParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
     end
     function varargout = getParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1245, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1249, self, varargin{:});
     end
     function varargout = setParentJoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
     end
     function varargout = setParentJointIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1247, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1251, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1248, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
     end
     function self = JointSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -9,175 +9,175 @@ classdef KinDynComputations < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1704, varargin{:});
+        tmp = iDynTreeMEX(1708, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1705, self);
+        iDynTreeMEX(1709, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1707, self, varargin{:});
-    end
-    function varargout = setFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1708, self, varargin{:});
-    end
-    function varargout = getFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1709, self, varargin{:});
-    end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1710, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1711, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = setFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1712, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = getFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1713, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1714, self, varargin{:});
     end
-    function varargout = getFloatingBase(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1715, self, varargin{:});
     end
-    function varargout = setFloatingBase(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1716, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1717, self, varargin{:});
     end
-    function varargout = getRobotModel(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1718, self, varargin{:});
     end
-    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1719, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1720, self, varargin{:});
     end
-    function varargout = setJointPos(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1721, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = getRobotModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1722, self, varargin{:});
     end
-    function varargout = getRobotState(self,varargin)
+    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1723, self, varargin{:});
     end
-    function varargout = getWorldBaseTransform(self,varargin)
+    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1724, self, varargin{:});
     end
-    function varargout = getBaseTwist(self,varargin)
+    function varargout = setJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1725, self, varargin{:});
     end
-    function varargout = getJointPos(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1726, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = getRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1727, self, varargin{:});
     end
-    function varargout = getModelVel(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1728, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1729, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1730, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1731, self, varargin{:});
     end
-    function varargout = getWorldTransformsAsHomogeneous(self,varargin)
+    function varargout = getModelVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
     end
-    function varargout = getRelativeTransformExplicit(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
     end
-    function varargout = getFrameVel(self,varargin)
+    function varargout = getWorldTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
     end
-    function varargout = getFrameAcc(self,varargin)
+    function varargout = getWorldTransformsAsHomogeneous(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobian(self,varargin)
+    function varargout = getRelativeTransformExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
     end
-    function varargout = getRelativeJacobian(self,varargin)
+    function varargout = getRelativeTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1738, self, varargin{:});
     end
-    function varargout = getRelativeJacobianExplicit(self,varargin)
+    function varargout = getFrameVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1739, self, varargin{:});
     end
-    function varargout = getFrameBiasAcc(self,varargin)
+    function varargout = getFrameAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1740, self, varargin{:});
     end
-    function varargout = getCenterOfMassPosition(self,varargin)
+    function varargout = getFrameFreeFloatingJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1741, self, varargin{:});
     end
-    function varargout = getCenterOfMassVelocity(self,varargin)
+    function varargout = getRelativeJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1742, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = getRelativeJacobianExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1743, self, varargin{:});
     end
-    function varargout = getCenterOfMassBiasAcc(self,varargin)
+    function varargout = getFrameBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1744, self, varargin{:});
     end
-    function varargout = getAverageVelocity(self,varargin)
+    function varargout = getCenterOfMassPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1745, self, varargin{:});
     end
-    function varargout = getAverageVelocityJacobian(self,varargin)
+    function varargout = getCenterOfMassVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1746, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocity(self,varargin)
+    function varargout = getCenterOfMassJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1747, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
+    function varargout = getCenterOfMassBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1748, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentum(self,varargin)
+    function varargout = getAverageVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1749, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentumJacobian(self,varargin)
+    function varargout = getAverageVelocityJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1750, self, varargin{:});
     end
-    function varargout = getCentroidalTotalMomentum(self,varargin)
+    function varargout = getCentroidalAverageVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1751, self, varargin{:});
     end
-    function varargout = getCentroidalTotalMomentumJacobian(self,varargin)
+    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1752, self, varargin{:});
     end
-    function varargout = getFreeFloatingMassMatrix(self,varargin)
+    function varargout = getLinearAngularMomentum(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1753, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = getLinearAngularMomentumJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1754, self, varargin{:});
     end
-    function varargout = generalizedBiasForces(self,varargin)
+    function varargout = getCentroidalTotalMomentum(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1755, self, varargin{:});
     end
-    function varargout = generalizedGravityForces(self,varargin)
+    function varargout = getCentroidalTotalMomentumJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1756, self, varargin{:});
     end
-    function varargout = generalizedExternalForces(self,varargin)
+    function varargout = getFreeFloatingMassMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1757, self, varargin{:});
     end
-    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+    function varargout = inverseDynamics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1758, self, varargin{:});
+    end
+    function varargout = generalizedBiasForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
+    end
+    function varargout = generalizedGravityForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
+    end
+    function varargout = generalizedExternalForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
+    end
+    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(722);
+    varargout{1} = iDynTreeMEX(726);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(723,varargin{1});
+    iDynTreeMEX(727,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_INVALID_NAME.m
@@ -2,9 +2,9 @@ function varargout = LINK_INVALID_NAME(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(724);
+    varargout{1} = iDynTreeMEX(728);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(725,varargin{1});
+    iDynTreeMEX(729,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Link.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Link.m
@@ -9,29 +9,29 @@ classdef Link < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(779, varargin{:});
+        tmp = iDynTreeMEX(783, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = inertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(780, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
     end
     function varargout = setInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(781, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(785, self, varargin{:});
     end
     function varargout = getInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(782, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(786, self, varargin{:});
     end
     function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(783, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(787, self, varargin{:});
     end
     function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(784, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(788, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(785, self);
+        iDynTreeMEX(789, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkAccArray.m
@@ -9,29 +9,29 @@ classdef LinkAccArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(772, varargin{:});
+        tmp = iDynTreeMEX(776, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(773, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(774, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(778, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(775, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(779, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(776, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(780, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(777, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(781, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(778, self);
+        iDynTreeMEX(782, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkArticulatedBodyInertias.m
@@ -9,23 +9,23 @@ classdef LinkArticulatedBodyInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(760, varargin{:});
+        tmp = iDynTreeMEX(764, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(761, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(765, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(762, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(766, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(763, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(767, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(764, self);
+        iDynTreeMEX(768, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkContactWrenches.m
@@ -9,35 +9,35 @@ classdef LinkContactWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1138, varargin{:});
+        tmp = iDynTreeMEX(1142, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1139, self, varargin{:});
-    end
-    function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1140, self, varargin{:});
-    end
-    function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1141, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1142, self, varargin{:});
-    end
-    function varargout = contactWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1143, self, varargin{:});
     end
-    function varargout = computeNetWrenches(self,varargin)
+    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1144, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = setNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1145, self, varargin{:});
+    end
+    function varargout = getNrOfLinks(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1146, self, varargin{:});
+    end
+    function varargout = contactWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1147, self, varargin{:});
+    end
+    function varargout = computeNetWrenches(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1148, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1149, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1146, self);
+        iDynTreeMEX(1150, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkInertias.m
@@ -9,23 +9,23 @@ classdef LinkInertias < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(755, varargin{:});
+        tmp = iDynTreeMEX(759, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(756, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(760, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(757, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(761, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(758, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(762, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(759, self);
+        iDynTreeMEX(763, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkPositions.m
@@ -9,29 +9,29 @@ classdef LinkPositions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(740, varargin{:});
+        tmp = iDynTreeMEX(744, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(741, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(745, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(742, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(746, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(743, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(747, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(744, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(748, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(745, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(749, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(746, self);
+        iDynTreeMEX(750, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkSensor.m
@@ -2,30 +2,30 @@ classdef LinkSensor < iDynTree.Sensor
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1249, self);
+        iDynTreeMEX(1253, self);
         self.SwigClear();
       end
     end
     function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1250, self, varargin{:});
-    end
-    function varargout = getParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1251, self, varargin{:});
-    end
-    function varargout = getLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1252, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1253, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1254, self, varargin{:});
     end
-    function varargout = setLinkSensorTransform(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1255, self, varargin{:});
     end
-    function varargout = isConsistent(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1256, self, varargin{:});
+    end
+    function varargout = setParentLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1257, self, varargin{:});
+    end
+    function varargout = setParentLinkIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1258, self, varargin{:});
+    end
+    function varargout = setLinkSensorTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1259, self, varargin{:});
+    end
+    function varargout = isConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1260, self, varargin{:});
     end
     function self = LinkSensor(varargin)
       self@iDynTree.Sensor(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkUnknownWrenchContacts.m
@@ -9,41 +9,41 @@ classdef LinkUnknownWrenchContacts < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1436, varargin{:});
+        tmp = iDynTreeMEX(1440, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1437, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1438, self, varargin{:});
-    end
-    function varargout = getNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1439, self, varargin{:});
-    end
-    function varargout = setNrOfContactsForLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1440, self, varargin{:});
-    end
-    function varargout = addNewContactForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1441, self, varargin{:});
     end
-    function varargout = addNewContactInFrame(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1442, self, varargin{:});
     end
-    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
+    function varargout = getNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1443, self, varargin{:});
     end
-    function varargout = contactWrench(self,varargin)
+    function varargout = setNrOfContactsForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1444, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = addNewContactForLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1445, self, varargin{:});
+    end
+    function varargout = addNewContactInFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1446, self, varargin{:});
+    end
+    function varargout = addNewUnknownFullWrenchInFrameOrigin(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1447, self, varargin{:});
+    end
+    function varargout = contactWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1448, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1449, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1446, self);
+        iDynTreeMEX(1450, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkVelArray.m
@@ -9,29 +9,29 @@ classdef LinkVelArray < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(765, varargin{:});
+        tmp = iDynTreeMEX(769, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(766, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(770, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(767, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(771, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(768, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(772, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(769, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(773, self, varargin{:});
     end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(770, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(774, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(771, self);
+        iDynTreeMEX(775, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinkWrenches.m
@@ -9,32 +9,32 @@ classdef LinkWrenches < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(747, varargin{:});
+        tmp = iDynTreeMEX(751, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(748, self, varargin{:});
-    end
-    function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(749, self, varargin{:});
-    end
-    function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(750, self, varargin{:});
-    end
-    function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(751, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(752, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(753, self, varargin{:});
+    end
+    function varargout = getNrOfLinks(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(754, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(755, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(756, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(757, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(754, self);
+        iDynTreeMEX(758, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/LinksSolidShapesVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LinksSolidShapesVector.m
@@ -4,49 +4,49 @@ classdef LinksSolidShapesVector < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = pop(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
-    end
-    function varargout = setbrace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1174, self, varargin{:});
-    end
-    function varargout = append(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1175, self, varargin{:});
-    end
-    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1176, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1177, self, varargin{:});
     end
-    function varargout = swap(self,varargin)
+    function varargout = setbrace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1178, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = append(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1179, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1180, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1181, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = swap(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1182, self, varargin{:});
     end
-    function varargout = clear(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1183, self, varargin{:});
     end
-    function varargout = get_allocator(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1184, self, varargin{:});
     end
-    function varargout = pop_back(self,varargin)
+    function varargout = rbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1185, self, varargin{:});
     end
-    function varargout = erase(self,varargin)
+    function varargout = rend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1186, self, varargin{:});
+    end
+    function varargout = clear(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1187, self, varargin{:});
+    end
+    function varargout = get_allocator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
+    end
+    function varargout = pop_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
     end
     function self = LinksSolidShapesVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -54,38 +54,38 @@ classdef LinksSolidShapesVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1187, varargin{:});
+        tmp = iDynTreeMEX(1191, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = push_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1188, self, varargin{:});
-    end
-    function varargout = front(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1189, self, varargin{:});
-    end
-    function varargout = back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1190, self, varargin{:});
-    end
-    function varargout = assign(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1191, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1192, self, varargin{:});
     end
-    function varargout = insert(self,varargin)
+    function varargout = front(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1193, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = back(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1194, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = assign(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1195, self, varargin{:});
+    end
+    function varargout = resize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1196, self, varargin{:});
+    end
+    function varargout = insert(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1197, self, varargin{:});
+    end
+    function varargout = reserve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1198, self, varargin{:});
+    end
+    function varargout = capacity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1199, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1196, self);
+        iDynTreeMEX(1200, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Material.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Material.m
@@ -9,35 +9,35 @@ classdef Material < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(972, varargin{:});
+        tmp = iDynTreeMEX(976, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = name(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
-    end
-    function varargout = hasColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
-    end
-    function varargout = color(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
-    end
-    function varargout = setColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(976, self, varargin{:});
-    end
-    function varargout = hasTexture(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(977, self, varargin{:});
     end
-    function varargout = texture(self,varargin)
+    function varargout = hasColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(978, self, varargin{:});
     end
-    function varargout = setTexture(self,varargin)
+    function varargout = color(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(979, self, varargin{:});
+    end
+    function varargout = setColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(980, self, varargin{:});
+    end
+    function varargout = hasTexture(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(981, self, varargin{:});
+    end
+    function varargout = texture(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
+    end
+    function varargout = setTexture(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(980, self);
+        iDynTreeMEX(984, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix10x16.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix10x16.m
@@ -9,53 +9,53 @@ classdef Matrix10x16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(295, varargin{:});
+        tmp = iDynTreeMEX(299, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(296, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(297, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(298, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(299, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(300, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(301, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(302, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(303, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(304, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(305, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(306, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(307, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(308, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(309, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(310, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(311, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(312, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(309, self);
+        iDynTreeMEX(313, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix1x6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix1x6.m
@@ -9,53 +9,53 @@ classdef Matrix1x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(205, varargin{:});
+        tmp = iDynTreeMEX(209, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(206, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(207, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(208, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(209, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(210, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(211, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(212, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(213, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(214, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(215, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(216, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(217, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(218, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(219, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(220, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(221, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(222, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(219, self);
+        iDynTreeMEX(223, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix2x3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix2x3.m
@@ -9,53 +9,53 @@ classdef Matrix2x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(220, varargin{:});
+        tmp = iDynTreeMEX(224, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(221, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(222, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(223, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(224, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(225, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(226, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(227, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(228, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(229, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(230, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(231, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(232, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(233, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(234, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(235, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(236, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(237, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(234, self);
+        iDynTreeMEX(238, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix3x3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix3x3.m
@@ -9,53 +9,53 @@ classdef Matrix3x3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(235, varargin{:});
+        tmp = iDynTreeMEX(239, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(236, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(237, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(238, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(239, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(240, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(241, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(242, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(243, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(244, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(245, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(246, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(247, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(248, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(249, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(250, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(251, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(252, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(249, self);
+        iDynTreeMEX(253, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4.m
@@ -9,53 +9,53 @@ classdef Matrix4x4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(250, varargin{:});
+        tmp = iDynTreeMEX(254, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(251, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(252, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(253, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(254, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(255, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(256, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(257, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(258, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(259, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(260, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(261, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(262, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(263, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(264, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(265, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(266, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(264, self);
+        iDynTreeMEX(268, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
@@ -4,49 +4,49 @@ classdef Matrix4x4Vector < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = pop(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
-    end
-    function varargout = setbrace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
-    end
-    function varargout = append(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
-    end
-    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
     end
-    function varargout = swap(self,varargin)
+    function varargout = setbrace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = append(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = swap(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
     end
-    function varargout = clear(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
     end
-    function varargout = get_allocator(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
     end
-    function varargout = pop_back(self,varargin)
+    function varargout = rbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
     end
-    function varargout = erase(self,varargin)
+    function varargout = rend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
+    end
+    function varargout = clear(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
+    end
+    function varargout = get_allocator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
+    end
+    function varargout = pop_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
     end
     function self = Matrix4x4Vector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -54,41 +54,41 @@ classdef Matrix4x4Vector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1774, varargin{:});
+        tmp = iDynTreeMEX(1778, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = push_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
-    end
-    function varargout = front(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
-    end
-    function varargout = back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
-    end
-    function varargout = assign(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
     end
-    function varargout = insert(self,varargin)
+    function varargout = front(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = back(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = assign(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
+    end
+    function varargout = insert(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
+    end
+    function varargout = reserve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
+    end
+    function varargout = capacity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1784, self);
+        iDynTreeMEX(1788, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix6x10.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix6x10.m
@@ -9,53 +9,53 @@ classdef Matrix6x10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(280, varargin{:});
+        tmp = iDynTreeMEX(284, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(281, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(282, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(283, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(284, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(285, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(286, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(287, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(288, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(289, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(290, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(291, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(292, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(293, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(294, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(295, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(296, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(297, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(294, self);
+        iDynTreeMEX(298, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix6x6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix6x6.m
@@ -9,53 +9,53 @@ classdef Matrix6x6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(265, varargin{:});
+        tmp = iDynTreeMEX(269, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(266, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(267, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(268, self, varargin{:});
-    end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(269, self, varargin{:});
-    end
-    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(270, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(271, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(272, self, varargin{:});
     end
-    function varargout = fillRowMajorBuffer(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(273, self, varargin{:});
     end
-    function varargout = fillColMajorBuffer(self,varargin)
+    function varargout = cols(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(274, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(275, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(276, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = fillRowMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(277, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillColMajorBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(278, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(279, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(280, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(281, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(282, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(279, self);
+        iDynTreeMEX(283, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Model.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Model.m
@@ -9,133 +9,133 @@ classdef Model < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1039, varargin{:});
+        tmp = iDynTreeMEX(1043, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = copy(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1040, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1041, self);
+        iDynTreeMEX(1045, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1042, self, varargin{:});
-    end
-    function varargout = getLinkName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1043, self, varargin{:});
-    end
-    function varargout = getLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1044, self, varargin{:});
-    end
-    function varargout = isValidLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1045, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1046, self, varargin{:});
     end
-    function varargout = addLink(self,varargin)
+    function varargout = getLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1047, self, varargin{:});
     end
-    function varargout = getNrOfJoints(self,varargin)
+    function varargout = getLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1048, self, varargin{:});
     end
-    function varargout = getJointName(self,varargin)
+    function varargout = isValidLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1049, self, varargin{:});
     end
-    function varargout = getTotalMass(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1050, self, varargin{:});
     end
-    function varargout = getJointIndex(self,varargin)
+    function varargout = addLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1051, self, varargin{:});
     end
-    function varargout = getJoint(self,varargin)
+    function varargout = getNrOfJoints(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1052, self, varargin{:});
     end
-    function varargout = isValidJointIndex(self,varargin)
+    function varargout = getJointName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1053, self, varargin{:});
     end
-    function varargout = isLinkNameUsed(self,varargin)
+    function varargout = getTotalMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1054, self, varargin{:});
     end
-    function varargout = isJointNameUsed(self,varargin)
+    function varargout = getJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1055, self, varargin{:});
     end
-    function varargout = isFrameNameUsed(self,varargin)
+    function varargout = getJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1056, self, varargin{:});
     end
-    function varargout = addJoint(self,varargin)
+    function varargout = isValidJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1057, self, varargin{:});
     end
-    function varargout = addJointAndLink(self,varargin)
+    function varargout = isLinkNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1058, self, varargin{:});
     end
-    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
+    function varargout = isJointNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1059, self, varargin{:});
     end
-    function varargout = getNrOfPosCoords(self,varargin)
+    function varargout = isFrameNameUsed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1060, self, varargin{:});
     end
-    function varargout = getNrOfDOFs(self,varargin)
+    function varargout = addJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1061, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = addJointAndLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1062, self, varargin{:});
     end
-    function varargout = addAdditionalFrameToLink(self,varargin)
+    function varargout = insertLinkToExistingJointAndAddJointForDisplacedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1063, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getNrOfPosCoords(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1064, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1065, self, varargin{:});
     end
-    function varargout = isValidFrameIndex(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1066, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = addAdditionalFrameToLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1067, self, varargin{:});
     end
-    function varargout = getFrameLink(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1068, self, varargin{:});
     end
-    function varargout = getLinkAdditionalFrames(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1069, self, varargin{:});
     end
-    function varargout = getNrOfNeighbors(self,varargin)
+    function varargout = isValidFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1070, self, varargin{:});
     end
-    function varargout = getNeighbor(self,varargin)
+    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1071, self, varargin{:});
     end
-    function varargout = setDefaultBaseLink(self,varargin)
+    function varargout = getFrameLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1072, self, varargin{:});
     end
-    function varargout = getDefaultBaseLink(self,varargin)
+    function varargout = getLinkAdditionalFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1073, self, varargin{:});
     end
-    function varargout = computeFullTreeTraversal(self,varargin)
+    function varargout = getNrOfNeighbors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1074, self, varargin{:});
     end
-    function varargout = getInertialParameters(self,varargin)
+    function varargout = getNeighbor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1075, self, varargin{:});
     end
-    function varargout = updateInertialParameters(self,varargin)
+    function varargout = setDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1076, self, varargin{:});
     end
-    function varargout = visualSolidShapes(self,varargin)
+    function varargout = getDefaultBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1077, self, varargin{:});
     end
-    function varargout = collisionSolidShapes(self,varargin)
+    function varargout = computeFullTreeTraversal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1078, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getInertialParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1079, self, varargin{:});
+    end
+    function varargout = updateInertialParameters(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1080, self, varargin{:});
+    end
+    function varargout = visualSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1081, self, varargin{:});
+    end
+    function varargout = collisionSolidShapes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1082, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1083, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelCalibrationHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelCalibrationHelper.m
@@ -9,37 +9,37 @@ classdef ModelCalibrationHelper < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1415, varargin{:});
+        tmp = iDynTreeMEX(1419, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1416, self);
+        iDynTreeMEX(1420, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1417, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1418, self, varargin{:});
-    end
-    function varargout = updateModelInertialParametersToString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1419, self, varargin{:});
-    end
-    function varargout = updateModelInertialParametersToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1420, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1421, self, varargin{:});
     end
-    function varargout = sensors(self,varargin)
+    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1422, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = updateModelInertialParametersToString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1423, self, varargin{:});
+    end
+    function varargout = updateModelInertialParametersToFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1424, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1425, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1426, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1427, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporter.m
@@ -9,40 +9,40 @@ classdef ModelExporter < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1405, varargin{:});
+        tmp = iDynTreeMEX(1409, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1406, self);
+        iDynTreeMEX(1410, self);
         self.SwigClear();
       end
     end
     function varargout = exportingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1407, self, varargin{:});
-    end
-    function varargout = setExportingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1408, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1409, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1410, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1411, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = setExportingOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1412, self, varargin{:});
     end
-    function varargout = exportModelToString(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1413, self, varargin{:});
     end
-    function varargout = exportModelToFile(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1414, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1415, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1416, self, varargin{:});
+    end
+    function varargout = exportModelToString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1417, self, varargin{:});
+    end
+    function varargout = exportModelToFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1418, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelExporterOptions.m
@@ -7,30 +7,30 @@ classdef ModelExporterOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1397, self);
+        varargout{1} = iDynTreeMEX(1401, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1398, self, varargin{1});
+        iDynTreeMEX(1402, self, varargin{1});
       end
     end
     function varargout = exportFirstBaseLinkAdditionalFrameAsFakeURDFBase(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1399, self);
+        varargout{1} = iDynTreeMEX(1403, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1400, self, varargin{1});
+        iDynTreeMEX(1404, self, varargin{1});
       end
     end
     function varargout = robotExportedName(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1401, self);
+        varargout{1} = iDynTreeMEX(1405, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1402, self, varargin{1});
+        iDynTreeMEX(1406, self, varargin{1});
       end
     end
     function self = ModelExporterOptions(varargin)
@@ -39,14 +39,14 @@ classdef ModelExporterOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1403, varargin{:});
+        tmp = iDynTreeMEX(1407, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1404, self);
+        iDynTreeMEX(1408, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelLoader.m
@@ -9,46 +9,46 @@ classdef ModelLoader < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1385, varargin{:});
+        tmp = iDynTreeMEX(1389, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1386, self);
+        iDynTreeMEX(1390, self);
         self.SwigClear();
       end
     end
     function varargout = parsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1387, self, varargin{:});
-    end
-    function varargout = setParsingOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1388, self, varargin{:});
-    end
-    function varargout = loadModelFromString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1389, self, varargin{:});
-    end
-    function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1390, self, varargin{:});
-    end
-    function varargout = loadReducedModelFromFullModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1391, self, varargin{:});
     end
-    function varargout = loadReducedModelFromString(self,varargin)
+    function varargout = setParsingOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1392, self, varargin{:});
     end
-    function varargout = loadReducedModelFromFile(self,varargin)
+    function varargout = loadModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1393, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = loadModelFromFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1394, self, varargin{:});
     end
-    function varargout = sensors(self,varargin)
+    function varargout = loadReducedModelFromFullModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1395, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = loadReducedModelFromString(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1396, self, varargin{:});
+    end
+    function varargout = loadReducedModelFromFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1397, self, varargin{:});
+    end
+    function varargout = model(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1398, self, varargin{:});
+    end
+    function varargout = sensors(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1399, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1400, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelParserOptions.m
@@ -7,20 +7,20 @@ classdef ModelParserOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1379, self);
+        varargout{1} = iDynTreeMEX(1383, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1380, self, varargin{1});
+        iDynTreeMEX(1384, self, varargin{1});
       end
     end
     function varargout = originalFilename(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1381, self);
+        varargout{1} = iDynTreeMEX(1385, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1382, self, varargin{1});
+        iDynTreeMEX(1386, self, varargin{1});
       end
     end
     function self = ModelParserOptions(varargin)
@@ -29,14 +29,14 @@ classdef ModelParserOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1383, varargin{:});
+        tmp = iDynTreeMEX(1387, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1384, self);
+        iDynTreeMEX(1388, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ModelSolidShapes.m
@@ -5,7 +5,7 @@ classdef ModelSolidShapes < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1027, self);
+        iDynTreeMEX(1031, self);
         self.SwigClear();
       end
     end
@@ -15,22 +15,22 @@ classdef ModelSolidShapes < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1028, varargin{:});
+        tmp = iDynTreeMEX(1032, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1029, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1033, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1030, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1034, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1031, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1035, self, varargin{:});
     end
     function varargout = getLinkSolidShapes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1032, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1036, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MomentumFreeFloatingJacobian.m
@@ -7,20 +7,20 @@ classdef MomentumFreeFloatingJacobian < iDynTree.MatrixDynSize
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1102, varargin{:});
+        tmp = iDynTreeMEX(1106, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1103, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1107, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1104, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1108, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1105, self);
+        iDynTreeMEX(1109, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl1.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl1 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(851, self);
+        iDynTreeMEX(855, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(852, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(853, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(854, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(855, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(856, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(857, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(858, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(859, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(860, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(861, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
     end
     function self = MovableJointImpl1(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl2.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl2 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(860, self);
+        iDynTreeMEX(864, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(861, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(862, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(863, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(864, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(865, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(866, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(867, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(868, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(869, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
     end
     function self = MovableJointImpl2(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl3.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl3 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(869, self);
+        iDynTreeMEX(873, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(870, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(871, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(872, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(873, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(874, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(875, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(876, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(877, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(878, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(880, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(881, self, varargin{:});
     end
     function self = MovableJointImpl3(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl4.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl4 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(878, self);
+        iDynTreeMEX(882, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(879, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(880, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(881, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(882, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(883, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(884, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(885, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(886, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(887, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
     end
     function self = MovableJointImpl4(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl5.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl5 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(887, self);
+        iDynTreeMEX(891, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(888, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(889, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(890, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(891, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(892, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(893, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(894, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(895, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(896, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(899, self, varargin{:});
     end
     function self = MovableJointImpl5(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/MovableJointImpl6.m
@@ -2,33 +2,33 @@ classdef MovableJointImpl6 < iDynTree.IJoint
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(896, self);
+        iDynTreeMEX(900, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfPosCoords(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(897, self, varargin{:});
-    end
-    function varargout = getNrOfDOFs(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(898, self, varargin{:});
-    end
-    function varargout = setIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(899, self, varargin{:});
-    end
-    function varargout = getIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(900, self, varargin{:});
-    end
-    function varargout = setPosCoordsOffset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(901, self, varargin{:});
     end
-    function varargout = getPosCoordsOffset(self,varargin)
+    function varargout = getNrOfDOFs(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(902, self, varargin{:});
     end
-    function varargout = setDOFsOffset(self,varargin)
+    function varargout = setIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(903, self, varargin{:});
     end
-    function varargout = getDOFsOffset(self,varargin)
+    function varargout = getIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(904, self, varargin{:});
+    end
+    function varargout = setPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(905, self, varargin{:});
+    end
+    function varargout = getPosCoordsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(906, self, varargin{:});
+    end
+    function varargout = setDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
+    end
+    function varargout = getDOFsOffset(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
     end
     function self = MovableJointImpl6(varargin)
       self@iDynTree.IJoint(SwigRef.Null);

--- a/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NR_OF_SENSOR_TYPES.m
@@ -1,3 +1,3 @@
 function v = NR_OF_SENSOR_TYPES()
-  v = iDynTreeMEX(1231);
+  v = iDynTreeMEX(1235);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Neighbor.m
@@ -7,20 +7,20 @@ classdef Neighbor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1033, self);
+        varargout{1} = iDynTreeMEX(1037, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1034, self, varargin{1});
+        iDynTreeMEX(1038, self, varargin{1});
       end
     end
     function varargout = neighborJoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1035, self);
+        varargout{1} = iDynTreeMEX(1039, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1036, self, varargin{1});
+        iDynTreeMEX(1040, self, varargin{1});
       end
     end
     function self = Neighbor(varargin)
@@ -29,14 +29,14 @@ classdef Neighbor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1037, varargin{:});
+        tmp = iDynTreeMEX(1041, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1038, self);
+        iDynTreeMEX(1042, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon.m
@@ -7,10 +7,10 @@ classdef Polygon < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1879, self);
+        varargout{1} = iDynTreeMEX(1883, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1880, self, varargin{1});
+        iDynTreeMEX(1884, self, varargin{1});
       end
     end
     function self = Polygon(varargin)
@@ -19,36 +19,36 @@ classdef Polygon < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1881, varargin{:});
+        tmp = iDynTreeMEX(1885, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
     end
     function varargout = applyTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1888, self);
+        iDynTreeMEX(1892, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = XYRectangleFromOffsets(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(1887, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(1891, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
@@ -7,10 +7,10 @@ classdef Polygon2D < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1889, self);
+        varargout{1} = iDynTreeMEX(1893, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1890, self, varargin{1});
+        iDynTreeMEX(1894, self, varargin{1});
       end
     end
     function self = Polygon2D(varargin)
@@ -19,26 +19,26 @@ classdef Polygon2D < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1891, varargin{:});
+        tmp = iDynTreeMEX(1895, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1896, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1896, self);
+        iDynTreeMEX(1900, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Position.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Position.m
@@ -7,57 +7,57 @@ classdef Position < iDynTree.PositionRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(409, varargin{:});
+        tmp = iDynTreeMEX(413, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(410, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(414, self, varargin{:});
     end
     function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(411, self, varargin{:});
-    end
-    function varargout = changeCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(412, self, varargin{:});
-    end
-    function varargout = changePointOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(415, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = changeCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(416, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(417, self, varargin{:});
-    end
-    function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(418, self, varargin{:});
-    end
-    function varargout = mtimes(self,varargin)
+    function varargout = changePointOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(419, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(420, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(421, self, varargin{:});
+    end
+    function varargout = uminus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(422, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(423, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(424, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(425, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(423, self);
+        iDynTreeMEX(427, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(413, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(417, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(414, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(418, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(422, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(426, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PositionRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PositionRaw.m
@@ -7,39 +7,39 @@ classdef PositionRaw < iDynTree.Vector3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(400, varargin{:});
+        tmp = iDynTreeMEX(404, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changePoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
-    end
-    function varargout = changeRefPoint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(402, self, varargin{:});
-    end
-    function varargout = changePointOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(405, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = changeRefPoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(406, self, varargin{:});
     end
+    function varargout = changePointOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(409, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(410, self, varargin{:});
+    end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(407, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(411, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(408, self);
+        iDynTreeMEX(412, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(403, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(407, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(404, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(408, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PrismaticJoint.m
@@ -7,85 +7,85 @@ classdef PrismaticJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(930, varargin{:});
+        tmp = iDynTreeMEX(934, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(931, self);
+        iDynTreeMEX(935, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(934, self, varargin{:});
-    end
-    function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(935, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(936, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(937, self, varargin{:});
     end
-    function varargout = getAxis(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(938, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(939, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(940, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(941, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(942, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(943, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(944, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(945, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(946, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(947, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(948, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(949, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(950, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(951, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(952, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(953, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(954, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(955, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(956, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RNEADynamicPhase.m
@@ -1,3 +1,3 @@
 function varargout = RNEADynamicPhase(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1205, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1209, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RevoluteJoint.m
@@ -7,85 +7,85 @@ classdef RevoluteJoint < iDynTree.MovableJointImpl1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(905, varargin{:});
+        tmp = iDynTreeMEX(909, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(906, self);
+        iDynTreeMEX(910, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(907, self, varargin{:});
-    end
-    function varargout = setAttachedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(908, self, varargin{:});
-    end
-    function varargout = setRestTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(909, self, varargin{:});
-    end
-    function varargout = setAxis(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(910, self, varargin{:});
-    end
-    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(911, self, varargin{:});
     end
-    function varargout = getSecondAttachedLink(self,varargin)
+    function varargout = setAttachedLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(912, self, varargin{:});
     end
-    function varargout = getAxis(self,varargin)
+    function varargout = setRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(913, self, varargin{:});
     end
-    function varargout = getRestTransform(self,varargin)
+    function varargout = setAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(914, self, varargin{:});
     end
-    function varargout = getTransform(self,varargin)
+    function varargout = getFirstAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(915, self, varargin{:});
     end
-    function varargout = getTransformDerivative(self,varargin)
+    function varargout = getSecondAttachedLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(916, self, varargin{:});
     end
-    function varargout = getMotionSubspaceVector(self,varargin)
+    function varargout = getAxis(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(917, self, varargin{:});
     end
-    function varargout = computeChildPosVelAcc(self,varargin)
+    function varargout = getRestTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(918, self, varargin{:});
     end
-    function varargout = computeChildVel(self,varargin)
+    function varargout = getTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(919, self, varargin{:});
     end
-    function varargout = computeChildVelAcc(self,varargin)
+    function varargout = getTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(920, self, varargin{:});
     end
-    function varargout = computeChildAcc(self,varargin)
+    function varargout = getMotionSubspaceVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(921, self, varargin{:});
     end
-    function varargout = computeChildBiasAcc(self,varargin)
+    function varargout = computeChildPosVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(922, self, varargin{:});
     end
-    function varargout = computeJointTorque(self,varargin)
+    function varargout = computeChildVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(923, self, varargin{:});
     end
-    function varargout = hasPosLimits(self,varargin)
+    function varargout = computeChildVelAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(924, self, varargin{:});
     end
-    function varargout = enablePosLimits(self,varargin)
+    function varargout = computeChildAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(925, self, varargin{:});
     end
-    function varargout = getPosLimits(self,varargin)
+    function varargout = computeChildBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(926, self, varargin{:});
     end
-    function varargout = getMinPosLimit(self,varargin)
+    function varargout = computeJointTorque(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(927, self, varargin{:});
     end
-    function varargout = getMaxPosLimit(self,varargin)
+    function varargout = hasPosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(928, self, varargin{:});
     end
-    function varargout = setPosLimits(self,varargin)
+    function varargout = enablePosLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(929, self, varargin{:});
+    end
+    function varargout = getPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(930, self, varargin{:});
+    end
+    function varargout = getMinPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(931, self, varargin{:});
+    end
+    function varargout = getMaxPosLimit(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(932, self, varargin{:});
+    end
+    function varargout = setPosLimits(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(933, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/RigidBodyInertiaNonLinearParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RigidBodyInertiaNonLinearParametrization.m
@@ -7,33 +7,13 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(596, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(597, self, varargin{1});
-      end
-    end
-    function varargout = com(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(598, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(599, self, varargin{1});
-      end
-    end
-    function varargout = link_R_centroidal(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(600, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(601, self, varargin{1});
       end
     end
-    function varargout = centralSecondMomentOfMass(self, varargin)
+    function varargout = com(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,29 +23,49 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
         iDynTreeMEX(603, self, varargin{1});
       end
     end
+    function varargout = link_R_centroidal(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(604, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(605, self, varargin{1});
+      end
+    end
+    function varargout = centralSecondMomentOfMass(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(606, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(607, self, varargin{1});
+      end
+    end
     function varargout = getLinkCentroidalTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(604, self, varargin{:});
-    end
-    function varargout = fromRigidBodyInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(605, self, varargin{:});
-    end
-    function varargout = fromInertialParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(606, self, varargin{:});
-    end
-    function varargout = toRigidBodyInertia(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(607, self, varargin{:});
-    end
-    function varargout = isPhysicallyConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(608, self, varargin{:});
     end
-    function varargout = asVectorWithRotationAsVec(self,varargin)
+    function varargout = fromRigidBodyInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(609, self, varargin{:});
     end
-    function varargout = fromVectorWithRotationAsVec(self,varargin)
+    function varargout = fromInertialParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(610, self, varargin{:});
     end
-    function varargout = getGradientWithRotationAsVec(self,varargin)
+    function varargout = toRigidBodyInertia(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(611, self, varargin{:});
+    end
+    function varargout = isPhysicallyConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(612, self, varargin{:});
+    end
+    function varargout = asVectorWithRotationAsVec(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(613, self, varargin{:});
+    end
+    function varargout = fromVectorWithRotationAsVec(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(614, self, varargin{:});
+    end
+    function varargout = getGradientWithRotationAsVec(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(615, self, varargin{:});
     end
     function self = RigidBodyInertiaNonLinearParametrization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -73,14 +73,14 @@ classdef RigidBodyInertiaNonLinearParametrization < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(612, varargin{:});
+        tmp = iDynTreeMEX(616, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(613, self);
+        iDynTreeMEX(617, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Rotation.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Rotation.m
@@ -7,114 +7,114 @@ classdef Rotation < iDynTree.RotationRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(628, varargin{:});
+        tmp = iDynTreeMEX(632, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(629, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(633, self, varargin{:});
     end
     function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(630, self, varargin{:});
-    end
-    function varargout = changeCoordinateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(631, self, varargin{:});
-    end
-    function varargout = changeCoordFrameOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(634, self, varargin{:});
     end
-    function varargout = inverse(self,varargin)
+    function varargout = changeCoordinateFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(635, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(636, self, varargin{:});
-    end
-    function varargout = log(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(637, self, varargin{:});
-    end
-    function varargout = fromQuaternion(self,varargin)
+    function varargout = changeCoordFrameOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(638, self, varargin{:});
     end
-    function varargout = getRPY(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(639, self, varargin{:});
     end
-    function varargout = asRPY(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(640, self, varargin{:});
     end
-    function varargout = getQuaternion(self,varargin)
+    function varargout = log(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(641, self, varargin{:});
     end
-    function varargout = asQuaternion(self,varargin)
+    function varargout = fromQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(642, self, varargin{:});
     end
+    function varargout = getRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(643, self, varargin{:});
+    end
+    function varargout = asRPY(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(644, self, varargin{:});
+    end
+    function varargout = getQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(645, self, varargin{:});
+    end
+    function varargout = asQuaternion(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(646, self, varargin{:});
+    end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(659, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(663, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(660, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(661, self);
+        iDynTreeMEX(665, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(632, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(636, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(633, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(637, varargin{:});
     end
     function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(643, varargin{:});
-    end
-    function varargout = RotY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(644, varargin{:});
-    end
-    function varargout = RotZ(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(645, varargin{:});
-    end
-    function varargout = RotAxis(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(646, varargin{:});
-    end
-    function varargout = RotAxisDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(647, varargin{:});
     end
-    function varargout = RPY(varargin)
+    function varargout = RotY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(648, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivative(varargin)
+    function varargout = RotZ(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(649, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
+    function varargout = RotAxis(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(650, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
+    function varargout = RotAxisDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(651, varargin{:});
     end
-    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
+    function varargout = RPY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(652, varargin{:});
     end
-    function varargout = QuaternionRightTrivializedDerivative(varargin)
+    function varargout = RPYRightTrivializedDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(653, varargin{:});
     end
-    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
+    function varargout = RPYRightTrivializedDerivativeRateOfChange(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(654, varargin{:});
     end
-    function varargout = Identity(varargin)
+    function varargout = RPYRightTrivializedDerivativeInverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(655, varargin{:});
     end
-    function varargout = RotationFromQuaternion(varargin)
+    function varargout = RPYRightTrivializedDerivativeInverseRateOfChange(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(656, varargin{:});
     end
-    function varargout = leftJacobian(varargin)
+    function varargout = QuaternionRightTrivializedDerivative(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(657, varargin{:});
     end
-    function varargout = leftJacobianInverse(varargin)
+    function varargout = QuaternionRightTrivializedDerivativeInverse(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(658, varargin{:});
+    end
+    function varargout = Identity(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(659, varargin{:});
+    end
+    function varargout = RotationFromQuaternion(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(660, varargin{:});
+    end
+    function varargout = leftJacobian(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(661, varargin{:});
+    end
+    function varargout = leftJacobianInverse(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(662, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationRaw.m
@@ -7,54 +7,54 @@ classdef RotationRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(614, varargin{:});
+        tmp = iDynTreeMEX(618, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = changeOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(615, self, varargin{:});
-    end
-    function varargout = changeRefOrientFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(616, self, varargin{:});
-    end
-    function varargout = changeCoordFrameOf(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(619, self, varargin{:});
     end
+    function varargout = changeRefOrientFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(620, self, varargin{:});
+    end
+    function varargout = changeCoordFrameOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(623, self, varargin{:});
+    end
     function varargout = toString(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(625, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(629, self, varargin{:});
     end
     function varargout = display(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(626, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(630, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(627, self);
+        iDynTreeMEX(631, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(617, varargin{:});
-    end
-    function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(618, varargin{:});
-    end
-    function varargout = RotX(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(620, varargin{:});
-    end
-    function varargout = RotY(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(621, varargin{:});
     end
-    function varargout = RotZ(varargin)
+    function varargout = inverse2(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(622, varargin{:});
     end
+    function varargout = RotX(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(624, varargin{:});
+    end
+    function varargout = RotY(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(625, varargin{:});
+    end
+    function varargout = RotZ(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(626, varargin{:});
+    end
     function varargout = RPY(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(623, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(627, varargin{:});
     end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(624, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(628, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/RotationalInertiaRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RotationalInertiaRaw.m
@@ -7,21 +7,21 @@ classdef RotationalInertiaRaw < iDynTree.Matrix3x3
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(551, varargin{:});
+        tmp = iDynTreeMEX(555, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(553, self);
+        iDynTreeMEX(557, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(552, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(556, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Sensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sensor.m
@@ -5,30 +5,30 @@ classdef Sensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1235, self);
+        iDynTreeMEX(1239, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1236, self, varargin{:});
-    end
-    function varargout = getSensorType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1237, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1238, self, varargin{:});
-    end
-    function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1239, self, varargin{:});
-    end
-    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1240, self, varargin{:});
     end
-    function varargout = isConsistent(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1241, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1242, self, varargin{:});
+    end
+    function varargout = setName(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1243, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1244, self, varargin{:});
+    end
+    function varargout = isConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1245, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1246, self, varargin{:});
     end
     function self = Sensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsList.m
@@ -9,61 +9,61 @@ classdef SensorsList < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1257, varargin{:});
+        tmp = iDynTreeMEX(1261, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1258, self);
+        iDynTreeMEX(1262, self);
         self.SwigClear();
       end
     end
     function varargout = addSensor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1259, self, varargin{:});
-    end
-    function varargout = setSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1260, self, varargin{:});
-    end
-    function varargout = getSerialization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1261, self, varargin{:});
-    end
-    function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1262, self, varargin{:});
-    end
-    function varargout = getSensorIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1263, self, varargin{:});
     end
-    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
+    function varargout = setSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1264, self, varargin{:});
     end
-    function varargout = getSensor(self,varargin)
+    function varargout = getSerialization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1265, self, varargin{:});
     end
-    function varargout = isConsistent(self,varargin)
+    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1266, self, varargin{:});
     end
-    function varargout = removeSensor(self,varargin)
+    function varargout = getSensorIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1267, self, varargin{:});
     end
-    function varargout = removeAllSensorsOfType(self,varargin)
+    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1268, self, varargin{:});
     end
-    function varargout = getSixAxisForceTorqueSensor(self,varargin)
+    function varargout = getSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1269, self, varargin{:});
     end
-    function varargout = getAccelerometerSensor(self,varargin)
+    function varargout = isConsistent(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1270, self, varargin{:});
     end
-    function varargout = getGyroscopeSensor(self,varargin)
+    function varargout = removeSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1271, self, varargin{:});
     end
-    function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
+    function varargout = removeAllSensorsOfType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1272, self, varargin{:});
     end
-    function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
+    function varargout = getSixAxisForceTorqueSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1273, self, varargin{:});
+    end
+    function varargout = getAccelerometerSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1274, self, varargin{:});
+    end
+    function varargout = getGyroscopeSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1275, self, varargin{:});
+    end
+    function varargout = getThreeAxisAngularAccelerometerSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1276, self, varargin{:});
+    end
+    function varargout = getThreeAxisForceTorqueContactSensor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1277, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SensorsMeasurements.m
@@ -9,37 +9,37 @@ classdef SensorsMeasurements < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1274, varargin{:});
+        tmp = iDynTreeMEX(1278, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1275, self);
+        iDynTreeMEX(1279, self);
         self.SwigClear();
       end
     end
     function varargout = setNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1276, self, varargin{:});
-    end
-    function varargout = getNrOfSensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1277, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1278, self, varargin{:});
-    end
-    function varargout = toVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1279, self, varargin{:});
-    end
-    function varargout = setMeasurement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1280, self, varargin{:});
     end
-    function varargout = getMeasurement(self,varargin)
+    function varargout = getNrOfSensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1281, self, varargin{:});
     end
-    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1282, self, varargin{:});
+    end
+    function varargout = toVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1283, self, varargin{:});
+    end
+    function varargout = setMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1284, self, varargin{:});
+    end
+    function varargout = getMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1285, self, varargin{:});
+    end
+    function varargout = getSizeOfAllSensorsMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1286, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SimpleLeggedOdometry.m
@@ -9,40 +9,40 @@ classdef SimpleLeggedOdometry < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1485, varargin{:});
+        tmp = iDynTreeMEX(1489, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1486, self);
+        iDynTreeMEX(1490, self);
         self.SwigClear();
       end
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1487, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1488, self, varargin{:});
-    end
-    function varargout = updateKinematics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1489, self, varargin{:});
-    end
-    function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1490, self, varargin{:});
-    end
-    function varargout = changeFixedFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1491, self, varargin{:});
     end
-    function varargout = getCurrentFixedLink(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1492, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = updateKinematics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1493, self, varargin{:});
     end
-    function varargout = getWorldFrameTransform(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1494, self, varargin{:});
+    end
+    function varargout = changeFixedFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1495, self, varargin{:});
+    end
+    function varargout = getCurrentFixedLink(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1496, self, varargin{:});
+    end
+    function varargout = getWorldLinkTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1497, self, varargin{:});
+    end
+    function varargout = getWorldFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1498, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SixAxisForceTorqueSensor.m
@@ -7,97 +7,97 @@ classdef SixAxisForceTorqueSensor < iDynTree.JointSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1283, varargin{:});
+        tmp = iDynTreeMEX(1287, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1284, self);
+        iDynTreeMEX(1288, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1285, self, varargin{:});
-    end
-    function varargout = setFirstLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1286, self, varargin{:});
-    end
-    function varargout = setSecondLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1287, self, varargin{:});
-    end
-    function varargout = getFirstLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1288, self, varargin{:});
-    end
-    function varargout = getSecondLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1289, self, varargin{:});
     end
-    function varargout = setFirstLinkName(self,varargin)
+    function varargout = setFirstLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1290, self, varargin{:});
     end
-    function varargout = setSecondLinkName(self,varargin)
+    function varargout = setSecondLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1291, self, varargin{:});
     end
-    function varargout = getFirstLinkName(self,varargin)
+    function varargout = getFirstLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1292, self, varargin{:});
     end
-    function varargout = getSecondLinkName(self,varargin)
+    function varargout = getSecondLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1293, self, varargin{:});
     end
-    function varargout = setParentJoint(self,varargin)
+    function varargout = setFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1294, self, varargin{:});
     end
-    function varargout = setParentJointIndex(self,varargin)
+    function varargout = setSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1295, self, varargin{:});
     end
-    function varargout = setAppliedWrenchLink(self,varargin)
+    function varargout = getFirstLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1296, self, varargin{:});
     end
-    function varargout = getName(self,varargin)
+    function varargout = getSecondLinkName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1297, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = setParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1298, self, varargin{:});
     end
-    function varargout = getParentJoint(self,varargin)
+    function varargout = setParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1299, self, varargin{:});
     end
-    function varargout = getParentJointIndex(self,varargin)
+    function varargout = setAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1300, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1301, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1302, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1303, self, varargin{:});
     end
-    function varargout = getAppliedWrenchLink(self,varargin)
+    function varargout = getParentJointIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1304, self, varargin{:});
     end
-    function varargout = isLinkAttachedToSensor(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1305, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1306, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLink(self,varargin)
+    function varargout = updateIndices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1307, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+    function varargout = getAppliedWrenchLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1308, self, varargin{:});
     end
-    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+    function varargout = isLinkAttachedToSensor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1309, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1310, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = getWrenchAppliedOnLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1311, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLinkMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1312, self, varargin{:});
+    end
+    function varargout = getWrenchAppliedOnLinkInverseMatrix(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1313, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1314, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1315, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SolidShape.m
@@ -5,60 +5,60 @@ classdef SolidShape < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(981, self);
+        iDynTreeMEX(985, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(982, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(983, self, varargin{:});
-    end
-    function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(984, self, varargin{:});
-    end
-    function varargout = isNameValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(985, self, varargin{:});
-    end
-    function varargout = getLink_H_geometry(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(986, self, varargin{:});
     end
-    function varargout = setLink_H_geometry(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(987, self, varargin{:});
     end
-    function varargout = isMaterialSet(self,varargin)
+    function varargout = setName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(988, self, varargin{:});
     end
-    function varargout = getMaterial(self,varargin)
+    function varargout = isNameValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(989, self, varargin{:});
     end
-    function varargout = setMaterial(self,varargin)
+    function varargout = getLink_H_geometry(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(990, self, varargin{:});
     end
-    function varargout = isSphere(self,varargin)
+    function varargout = setLink_H_geometry(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(991, self, varargin{:});
     end
-    function varargout = isBox(self,varargin)
+    function varargout = isMaterialSet(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(992, self, varargin{:});
     end
-    function varargout = isCylinder(self,varargin)
+    function varargout = getMaterial(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(993, self, varargin{:});
     end
-    function varargout = isExternalMesh(self,varargin)
+    function varargout = setMaterial(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(994, self, varargin{:});
     end
-    function varargout = asSphere(self,varargin)
+    function varargout = isSphere(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(995, self, varargin{:});
     end
-    function varargout = asBox(self,varargin)
+    function varargout = isBox(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(996, self, varargin{:});
     end
-    function varargout = asCylinder(self,varargin)
+    function varargout = isCylinder(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(997, self, varargin{:});
     end
-    function varargout = asExternalMesh(self,varargin)
+    function varargout = isExternalMesh(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(998, self, varargin{:});
+    end
+    function varargout = asSphere(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(999, self, varargin{:});
+    end
+    function varargout = asBox(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
+    end
+    function varargout = asCylinder(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
+    end
+    function varargout = asExternalMesh(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
     end
     function self = SolidShape(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/SolidShapesVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SolidShapesVector.m
@@ -4,49 +4,49 @@ classdef SolidShapesVector < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = pop(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1147, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1148, self, varargin{:});
-    end
-    function varargout = setbrace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1149, self, varargin{:});
-    end
-    function varargout = append(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1150, self, varargin{:});
-    end
-    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1151, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1152, self, varargin{:});
     end
-    function varargout = swap(self,varargin)
+    function varargout = setbrace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1153, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = append(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1154, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1155, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1156, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = swap(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1157, self, varargin{:});
     end
-    function varargout = clear(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1158, self, varargin{:});
     end
-    function varargout = get_allocator(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1159, self, varargin{:});
     end
-    function varargout = pop_back(self,varargin)
+    function varargout = rbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1160, self, varargin{:});
     end
-    function varargout = erase(self,varargin)
+    function varargout = rend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1161, self, varargin{:});
+    end
+    function varargout = clear(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1162, self, varargin{:});
+    end
+    function varargout = get_allocator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
+    end
+    function varargout = pop_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1165, self, varargin{:});
     end
     function self = SolidShapesVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -54,38 +54,38 @@ classdef SolidShapesVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1162, varargin{:});
+        tmp = iDynTreeMEX(1166, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = push_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1163, self, varargin{:});
-    end
-    function varargout = front(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1164, self, varargin{:});
-    end
-    function varargout = back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1165, self, varargin{:});
-    end
-    function varargout = assign(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1166, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1167, self, varargin{:});
     end
-    function varargout = insert(self,varargin)
+    function varargout = front(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1168, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = back(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1169, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = assign(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1170, self, varargin{:});
+    end
+    function varargout = resize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1171, self, varargin{:});
+    end
+    function varargout = insert(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1172, self, varargin{:});
+    end
+    function varargout = reserve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1173, self, varargin{:});
+    end
+    function varargout = capacity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1174, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1171, self);
+        iDynTreeMEX(1175, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SparseMatrixColMajor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SparseMatrixColMajor.m
@@ -9,60 +9,66 @@ classdef SparseMatrixColMajor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(167, varargin{:});
+        tmp = iDynTreeMEX(169, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(168, self);
+        iDynTreeMEX(170, self);
         self.SwigClear();
       end
     end
     function varargout = numberOfNonZeros(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(169, self, varargin{:});
-    end
-    function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(170, self, varargin{:});
-    end
-    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(171, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(172, self, varargin{:});
     end
-    function varargout = setFromConstTriplets(self,varargin)
+    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(173, self, varargin{:});
     end
-    function varargout = setFromTriplets(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(174, self, varargin{:});
     end
-    function varargout = getValue(self,varargin)
+    function varargout = setFromConstTriplets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(175, self, varargin{:});
     end
-    function varargout = setValue(self,varargin)
+    function varargout = setFromTriplets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(176, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(177, self, varargin{:});
-    end
-    function varargout = columns(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(178, self, varargin{:});
     end
-    function varargout = description(self,varargin)
+    function varargout = getValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(179, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = setValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(180, self, varargin{:});
     end
-    function varargout = toMatlabDense(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(181, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = columns(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(182, self, varargin{:});
+    end
+    function varargout = description(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(183, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(184, self, varargin{:});
+    end
+    function varargout = toMatlabDense(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(185, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(186, self, varargin{:});
     end
   end
   methods(Static)
+    function varargout = sparseMatrixFromTriplets(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(177, varargin{:});
+    end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SparseMatrixRowMajor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SparseMatrixRowMajor.m
@@ -38,31 +38,37 @@ classdef SparseMatrixRowMajor < SwigRef
     function varargout = setFromTriplets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(158, self, varargin{:});
     end
-    function varargout = getValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(159, self, varargin{:});
-    end
-    function varargout = setValue(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(160, self, varargin{:});
     end
-    function varargout = rows(self,varargin)
+    function varargout = getValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(161, self, varargin{:});
     end
-    function varargout = columns(self,varargin)
+    function varargout = setValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(162, self, varargin{:});
     end
-    function varargout = description(self,varargin)
+    function varargout = rows(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(163, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = columns(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(164, self, varargin{:});
     end
-    function varargout = toMatlabDense(self,varargin)
+    function varargout = description(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(165, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = toMatlab(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(166, self, varargin{:});
+    end
+    function varargout = toMatlabDense(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(167, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(168, self, varargin{:});
     end
   end
   methods(Static)
+    function varargout = sparseMatrixFromTriplets(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(159, varargin{:});
+    end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialAcc.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialAcc.m
@@ -7,23 +7,23 @@ classdef SpatialAcc < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(513, varargin{:});
+        tmp = iDynTreeMEX(517, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(514, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(518, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(515, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(519, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(516, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(520, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(517, self);
+        iDynTreeMEX(521, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVector.m
@@ -7,19 +7,19 @@ classdef SpatialForceVector < iDynTree.SpatialForceVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(494, varargin{:});
+        tmp = iDynTreeMEX(498, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(495, self);
+        iDynTreeMEX(499, self);
         self.SwigClear();
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(496, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(500, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialForceVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialForceVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(460, varargin{:});
+        tmp = iDynTreeMEX(464, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
-    end
-    function varargout = getAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(462, self, varargin{:});
-    end
-    function varargout = setLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(463, self, varargin{:});
-    end
-    function varargout = setAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(464, self, varargin{:});
-    end
-    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(465, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(466, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = setLinearVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(467, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(468, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(469, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(470, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(471, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
+    function varargout = size(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(472, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(473, self, varargin{:});
+    end
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(474, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(475, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(476, self, varargin{:});
+    function varargout = dot(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(478, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(477, self, varargin{:});
-    end
-    function varargout = asVector(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(479, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(480, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = uminus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(481, self, varargin{:});
     end
+    function varargout = asVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(483, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(484, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(485, self, varargin{:});
+    end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(482, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(486, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(483, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(487, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(484, self);
+        iDynTreeMEX(488, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(472, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(476, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(473, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(477, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(478, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(482, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialInertia.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialInertia.m
@@ -7,63 +7,63 @@ classdef SpatialInertia < iDynTree.SpatialInertiaRaw
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(564, varargin{:});
+        tmp = iDynTreeMEX(568, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = asMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(566, self, varargin{:});
-    end
-    function varargout = applyInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(567, self, varargin{:});
-    end
-    function varargout = getInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(568, self, varargin{:});
-    end
-    function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(569, self, varargin{:});
-    end
-    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(570, self, varargin{:});
     end
-    function varargout = biasWrench(self,varargin)
+    function varargout = applyInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(571, self, varargin{:});
     end
-    function varargout = biasWrenchDerivative(self,varargin)
+    function varargout = getInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(572, self, varargin{:});
     end
-    function varargout = asVector(self,varargin)
+    function varargout = plus(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(573, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(574, self, varargin{:});
     end
-    function varargout = fromVector(self,varargin)
+    function varargout = biasWrench(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(575, self, varargin{:});
     end
-    function varargout = isPhysicallyConsistent(self,varargin)
+    function varargout = biasWrenchDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(576, self, varargin{:});
+    end
+    function varargout = asVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(578, self, varargin{:});
+    end
+    function varargout = fromVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(579, self, varargin{:});
+    end
+    function varargout = isPhysicallyConsistent(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(580, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(580, self);
+        iDynTreeMEX(584, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(565, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(569, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(573, varargin{:});
-    end
-    function varargout = momentumRegressor(varargin)
      [varargout{1:nargout}] = iDynTreeMEX(577, varargin{:});
     end
+    function varargout = momentumRegressor(varargin)
+     [varargout{1:nargout}] = iDynTreeMEX(581, varargin{:});
+    end
     function varargout = momentumDerivativeRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(578, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(582, varargin{:});
     end
     function varargout = momentumDerivativeSlotineLiRegressor(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(579, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(583, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialInertiaRaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialInertiaRaw.m
@@ -9,42 +9,42 @@ classdef SpatialInertiaRaw < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(554, varargin{:});
+        tmp = iDynTreeMEX(558, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromRotationalInertiaWrtCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(555, self, varargin{:});
-    end
-    function varargout = getMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(556, self, varargin{:});
-    end
-    function varargout = getCenterOfMass(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(557, self, varargin{:});
-    end
-    function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(558, self, varargin{:});
-    end
-    function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(559, self, varargin{:});
     end
-    function varargout = multiply(self,varargin)
+    function varargout = getMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(560, self, varargin{:});
+    end
+    function varargout = getCenterOfMass(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(561, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = getRotationalInertiaWrtFrameOrigin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(562, self, varargin{:});
+    end
+    function varargout = getRotationalInertiaWrtCenterOfMass(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(563, self, varargin{:});
+    end
+    function varargout = multiply(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(565, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(566, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(563, self);
+        iDynTreeMEX(567, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = combine(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(560, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(564, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMomentum.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMomentum.m
@@ -7,23 +7,23 @@ classdef SpatialMomentum < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(508, varargin{:});
+        tmp = iDynTreeMEX(512, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(509, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(513, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(510, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(514, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(511, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(515, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(512, self);
+        iDynTreeMEX(516, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVector.m
@@ -7,29 +7,29 @@ classdef SpatialMotionVector < iDynTree.SpatialMotionVectorBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(487, varargin{:});
+        tmp = iDynTreeMEX(491, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(488, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(492, self, varargin{:});
     end
     function varargout = cross(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(489, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(493, self, varargin{:});
     end
     function varargout = asCrossProductMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(490, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(494, self, varargin{:});
     end
     function varargout = asCrossProductMatrixWrench(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(491, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(495, self, varargin{:});
     end
     function varargout = exp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(492, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(496, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(493, self);
+        iDynTreeMEX(497, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorBase.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SpatialMotionVectorBase.m
@@ -9,87 +9,87 @@ classdef SpatialMotionVectorBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(435, varargin{:});
+        tmp = iDynTreeMEX(439, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(436, self, varargin{:});
-    end
-    function varargout = getAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(437, self, varargin{:});
-    end
-    function varargout = setLinearVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(438, self, varargin{:});
-    end
-    function varargout = setAngularVec3(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(439, self, varargin{:});
-    end
-    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(440, self, varargin{:});
     end
-    function varargout = getVal(self,varargin)
+    function varargout = getAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(441, self, varargin{:});
     end
-    function varargout = setVal(self,varargin)
+    function varargout = setLinearVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(442, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setAngularVec3(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(443, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = paren(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(444, self, varargin{:});
     end
-    function varargout = changePoint(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(445, self, varargin{:});
     end
-    function varargout = changeCoordFrame(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(446, self, varargin{:});
     end
-    function varargout = dot(self,varargin)
+    function varargout = size(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(447, self, varargin{:});
+    end
+    function varargout = zero(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(448, self, varargin{:});
+    end
+    function varargout = changePoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(449, self, varargin{:});
     end
-    function varargout = plus(self,varargin)
+    function varargout = changeCoordFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(450, self, varargin{:});
     end
-    function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(451, self, varargin{:});
+    function varargout = dot(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(453, self, varargin{:});
     end
-    function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(452, self, varargin{:});
-    end
-    function varargout = asVector(self,varargin)
+    function varargout = plus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(454, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = minus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(455, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = uminus(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(456, self, varargin{:});
     end
+    function varargout = asVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(458, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(459, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(460, self, varargin{:});
+    end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(457, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(461, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(458, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(462, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(459, self);
+        iDynTreeMEX(463, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(447, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(451, varargin{:});
     end
     function varargout = inverse(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(448, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(452, varargin{:});
     end
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(453, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(457, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Sphere.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Sphere.m
@@ -2,18 +2,18 @@ classdef Sphere < iDynTree.SolidShape
   methods
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(999, self);
+        iDynTreeMEX(1003, self);
         self.SwigClear();
       end
     end
     function varargout = clone(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1000, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1004, self, varargin{:});
     end
     function varargout = getRadius(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1001, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1005, self, varargin{:});
     end
     function varargout = setRadius(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1002, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1006, self, varargin{:});
     end
     function self = Sphere(varargin)
       self@iDynTree.SolidShape(SwigRef.Null);
@@ -22,7 +22,7 @@ classdef Sphere < iDynTree.SolidShape
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1003, varargin{:});
+        tmp = iDynTreeMEX(1007, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TRAVERSAL_INVALID_INDEX.m
@@ -2,9 +2,9 @@ function varargout = TRAVERSAL_INVALID_INDEX(varargin)
   narginchk(0,1)
   if nargin==0
     nargoutchk(0,1)
-    varargout{1} = iDynTreeMEX(738);
+    varargout{1} = iDynTreeMEX(742);
   else
     nargoutchk(0,0)
-    iDynTreeMEX(739,varargin{1});
+    iDynTreeMEX(743,varargin{1});
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisAngularAccelerometerSensor.m
@@ -7,55 +7,55 @@ classdef ThreeAxisAngularAccelerometerSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1342, varargin{:});
+        tmp = iDynTreeMEX(1346, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1343, self);
+        iDynTreeMEX(1347, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1344, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1345, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1346, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1347, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1348, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1349, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1350, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1351, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1352, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1353, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1354, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1355, self, varargin{:});
     end
-    function varargout = predictMeasurement(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1356, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1357, self, varargin{:});
+    end
+    function varargout = clone(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1358, self, varargin{:});
+    end
+    function varargout = updateIndices(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1359, self, varargin{:});
+    end
+    function varargout = predictMeasurement(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1360, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ThreeAxisForceTorqueContactSensor.m
@@ -7,64 +7,64 @@ classdef ThreeAxisForceTorqueContactSensor < iDynTree.LinkSensor
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1357, varargin{:});
+        tmp = iDynTreeMEX(1361, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1358, self);
+        iDynTreeMEX(1362, self);
         self.SwigClear();
       end
     end
     function varargout = setName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1359, self, varargin{:});
-    end
-    function varargout = setLinkSensorTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1360, self, varargin{:});
-    end
-    function varargout = setParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1361, self, varargin{:});
-    end
-    function varargout = setParentLinkIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1362, self, varargin{:});
-    end
-    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1363, self, varargin{:});
     end
-    function varargout = getSensorType(self,varargin)
+    function varargout = setLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1364, self, varargin{:});
     end
-    function varargout = getParentLink(self,varargin)
+    function varargout = setParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1365, self, varargin{:});
     end
-    function varargout = getParentLinkIndex(self,varargin)
+    function varargout = setParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1366, self, varargin{:});
     end
-    function varargout = getLinkSensorTransform(self,varargin)
+    function varargout = getName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1367, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getSensorType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1368, self, varargin{:});
     end
-    function varargout = clone(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1369, self, varargin{:});
     end
-    function varargout = updateIndices(self,varargin)
+    function varargout = getParentLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1370, self, varargin{:});
     end
-    function varargout = setLoadCellLocations(self,varargin)
+    function varargout = getLinkSensorTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1371, self, varargin{:});
     end
-    function varargout = getLoadCellLocations(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1372, self, varargin{:});
     end
-    function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
+    function varargout = clone(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1373, self, varargin{:});
     end
-    function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
+    function varargout = updateIndices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1374, self, varargin{:});
+    end
+    function varargout = setLoadCellLocations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1375, self, varargin{:});
+    end
+    function varargout = getLoadCellLocations(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1376, self, varargin{:});
+    end
+    function varargout = computeThreeAxisForceTorqueFromLoadCellMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1377, self, varargin{:});
+    end
+    function varargout = computeCenterOfPressureFromLoadCellMeasurements(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1378, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Transform.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Transform.m
@@ -9,66 +9,66 @@ classdef Transform < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(662, varargin{:});
+        tmp = iDynTreeMEX(666, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = fromHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(663, self, varargin{:});
-    end
-    function varargout = getRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(664, self, varargin{:});
-    end
-    function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(665, self, varargin{:});
-    end
-    function varargout = setRotation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(666, self, varargin{:});
-    end
-    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(667, self, varargin{:});
     end
-    function varargout = inverse(self,varargin)
+    function varargout = getRotation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(668, self, varargin{:});
+    end
+    function varargout = getPosition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(669, self, varargin{:});
+    end
+    function varargout = setRotation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(670, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(671, self, varargin{:});
     end
-    function varargout = asHomogeneousTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(673, self, varargin{:});
-    end
-    function varargout = asAdjointTransform(self,varargin)
+    function varargout = inverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(674, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrench(self,varargin)
+    function varargout = mtimes(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(675, self, varargin{:});
     end
-    function varargout = log(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(676, self, varargin{:});
-    end
-    function varargout = toString(self,varargin)
+    function varargout = asHomogeneousTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(677, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = asAdjointTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(678, self, varargin{:});
+    end
+    function varargout = asAdjointTransformWrench(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(679, self, varargin{:});
+    end
+    function varargout = log(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(680, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(681, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(682, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(679, self);
+        iDynTreeMEX(683, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = compose(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(668, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(672, varargin{:});
     end
     function varargout = inverse2(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(669, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(673, varargin{:});
     end
     function varargout = Identity(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(672, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(676, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
+++ b/bindings/matlab/autogenerated/+iDynTree/TransformDerivative.m
@@ -9,51 +9,51 @@ classdef TransformDerivative < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(680, varargin{:});
+        tmp = iDynTreeMEX(684, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(681, self);
+        iDynTreeMEX(685, self);
         self.SwigClear();
       end
     end
     function varargout = getRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(682, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(686, self, varargin{:});
     end
     function varargout = getPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(683, self, varargin{:});
-    end
-    function varargout = setRotationDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(684, self, varargin{:});
-    end
-    function varargout = setPositionDerivative(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(685, self, varargin{:});
-    end
-    function varargout = asHomogeneousTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(687, self, varargin{:});
     end
-    function varargout = asAdjointTransformDerivative(self,varargin)
+    function varargout = setRotationDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(688, self, varargin{:});
     end
-    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+    function varargout = setPositionDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(689, self, varargin{:});
     end
-    function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(690, self, varargin{:});
-    end
-    function varargout = derivativeOfInverse(self,varargin)
+    function varargout = asHomogeneousTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(691, self, varargin{:});
     end
-    function varargout = transform(self,varargin)
+    function varargout = asAdjointTransformDerivative(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(692, self, varargin{:});
+    end
+    function varargout = asAdjointTransformWrenchDerivative(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(693, self, varargin{:});
+    end
+    function varargout = mtimes(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(694, self, varargin{:});
+    end
+    function varargout = derivativeOfInverse(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(695, self, varargin{:});
+    end
+    function varargout = transform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(696, self, varargin{:});
     end
   end
   methods(Static)
     function varargout = Zero(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(686, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(690, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Traversal.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Traversal.m
@@ -9,61 +9,61 @@ classdef Traversal < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(955, varargin{:});
+        tmp = iDynTreeMEX(959, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(956, self);
+        iDynTreeMEX(960, self);
         self.SwigClear();
       end
     end
     function varargout = getNrOfVisitedLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(957, self, varargin{:});
-    end
-    function varargout = getLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(958, self, varargin{:});
-    end
-    function varargout = getBaseLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(959, self, varargin{:});
-    end
-    function varargout = getParentLink(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(960, self, varargin{:});
-    end
-    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(961, self, varargin{:});
     end
-    function varargout = getParentLinkFromLinkIndex(self,varargin)
+    function varargout = getLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(962, self, varargin{:});
     end
-    function varargout = getParentJointFromLinkIndex(self,varargin)
+    function varargout = getBaseLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(963, self, varargin{:});
     end
-    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
+    function varargout = getParentLink(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(964, self, varargin{:});
     end
-    function varargout = reset(self,varargin)
+    function varargout = getParentJoint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(965, self, varargin{:});
     end
-    function varargout = addTraversalBase(self,varargin)
+    function varargout = getParentLinkFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(966, self, varargin{:});
     end
-    function varargout = addTraversalElement(self,varargin)
+    function varargout = getParentJointFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(967, self, varargin{:});
     end
-    function varargout = isParentOf(self,varargin)
+    function varargout = getTraversalIndexFromLinkIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(968, self, varargin{:});
     end
-    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+    function varargout = reset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(969, self, varargin{:});
     end
-    function varargout = getParentLinkIndexFromJointIndex(self,varargin)
+    function varargout = addTraversalBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(970, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = addTraversalElement(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(971, self, varargin{:});
+    end
+    function varargout = isParentOf(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(972, self, varargin{:});
+    end
+    function varargout = getChildLinkIndexFromJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(973, self, varargin{:});
+    end
+    function varargout = getParentLinkIndexFromJointIndex(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(974, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(975, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Twist.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Twist.m
@@ -7,26 +7,26 @@ classdef Twist < iDynTree.SpatialMotionVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(497, varargin{:});
+        tmp = iDynTreeMEX(501, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(498, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(502, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(499, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(503, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(500, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(504, self, varargin{:});
     end
     function varargout = mtimes(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(501, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(505, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(502, self);
+        iDynTreeMEX(506, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
+++ b/bindings/matlab/autogenerated/+iDynTree/UnknownWrenchContact.m
@@ -9,32 +9,12 @@ classdef UnknownWrenchContact < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1424, varargin{:});
+        tmp = iDynTreeMEX(1428, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = unknownType(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1425, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1426, self, varargin{1});
-      end
-    end
-    function varargout = contactPoint(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1427, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1428, self, varargin{1});
-      end
-    end
-    function varargout = forceDirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -44,7 +24,7 @@ classdef UnknownWrenchContact < SwigRef
         iDynTreeMEX(1430, self, varargin{1});
       end
     end
-    function varargout = knownWrench(self, varargin)
+    function varargout = contactPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -54,7 +34,7 @@ classdef UnknownWrenchContact < SwigRef
         iDynTreeMEX(1432, self, varargin{1});
       end
     end
-    function varargout = contactId(self, varargin)
+    function varargout = forceDirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -64,9 +44,29 @@ classdef UnknownWrenchContact < SwigRef
         iDynTreeMEX(1434, self, varargin{1});
       end
     end
+    function varargout = knownWrench(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1435, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1436, self, varargin{1});
+      end
+    end
+    function varargout = contactId(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1437, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1438, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1435, self);
+        iDynTreeMEX(1439, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector10.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector10.m
@@ -9,62 +9,62 @@ classdef Vector10 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(364, varargin{:});
+        tmp = iDynTreeMEX(368, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(365, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(366, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(367, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(368, self, varargin{:});
-    end
-    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(369, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(370, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(371, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(372, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(373, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(374, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(375, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(376, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(377, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(378, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(379, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(380, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(381, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(382, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(383, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(384, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(381, self);
+        iDynTreeMEX(385, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector16.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector16.m
@@ -9,62 +9,62 @@ classdef Vector16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(382, varargin{:});
+        tmp = iDynTreeMEX(386, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(383, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(384, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(385, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(386, self, varargin{:});
-    end
-    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(387, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(388, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(389, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(390, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(391, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(392, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(393, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(394, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(395, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(396, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(397, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(398, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(399, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(400, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(401, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(402, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(399, self);
+        iDynTreeMEX(403, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector3.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector3.m
@@ -9,62 +9,62 @@ classdef Vector3 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(310, varargin{:});
+        tmp = iDynTreeMEX(314, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(311, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(312, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(313, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(314, self, varargin{:});
-    end
-    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(315, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(316, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(317, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(318, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(319, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(320, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(321, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(322, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(323, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(324, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(325, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(326, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(327, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(328, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(329, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(330, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(327, self);
+        iDynTreeMEX(331, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector4.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector4.m
@@ -9,62 +9,62 @@ classdef Vector4 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(328, varargin{:});
+        tmp = iDynTreeMEX(332, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(329, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(330, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(331, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(332, self, varargin{:});
-    end
-    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(333, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(334, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(335, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(336, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(337, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(338, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(339, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(340, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(341, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(342, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(343, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(344, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(345, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(346, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(347, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(348, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(345, self);
+        iDynTreeMEX(349, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Vector6.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Vector6.m
@@ -9,62 +9,62 @@ classdef Vector6 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(346, varargin{:});
+        tmp = iDynTreeMEX(350, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(347, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(348, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(349, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(350, self, varargin{:});
-    end
-    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(351, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(352, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(353, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(354, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(355, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(356, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(357, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(358, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(359, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(360, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(361, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(362, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(363, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(364, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(365, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(366, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(363, self);
+        iDynTreeMEX(367, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/VectorDynSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VectorDynSize.m
@@ -9,76 +9,76 @@ classdef VectorDynSize < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(183, varargin{:});
+        tmp = iDynTreeMEX(187, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(184, self);
+        iDynTreeMEX(188, self);
         self.SwigClear();
       end
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(185, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(186, self, varargin{:});
-    end
-    function varargout = getVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(187, self, varargin{:});
-    end
-    function varargout = setVal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(188, self, varargin{:});
-    end
-    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(189, self, varargin{:});
     end
-    function varargout = cend(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(190, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = getVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(191, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = setVal(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(192, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = cbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(193, self, varargin{:});
     end
-    function varargout = data(self,varargin)
+    function varargout = cend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(194, self, varargin{:});
     end
-    function varargout = zero(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(195, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(196, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(197, self, varargin{:});
     end
-    function varargout = shrink_to_fit(self,varargin)
+    function varargout = data(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(198, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = zero(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(199, self, varargin{:});
     end
-    function varargout = fillBuffer(self,varargin)
+    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(200, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(201, self, varargin{:});
     end
-    function varargout = display(self,varargin)
+    function varargout = shrink_to_fit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(202, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = capacity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(203, self, varargin{:});
     end
-    function varargout = fromMatlab(self,varargin)
+    function varargout = fillBuffer(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(204, self, varargin{:});
+    end
+    function varargout = toString(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(205, self, varargin{:});
+    end
+    function varargout = display(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(206, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(207, self, varargin{:});
+    end
+    function varargout = fromMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(208, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,55 +9,55 @@ classdef Visualizer < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1864, varargin{:});
+        tmp = iDynTreeMEX(1868, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1865, self);
+        iDynTreeMEX(1869, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1866, self, varargin{:});
-    end
-    function varargout = getNrOfVisualizedModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
-    end
-    function varargout = getModelInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
-    end
-    function varargout = getModelInstanceIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
-    end
-    function varargout = addModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
     end
-    function varargout = modelViz(self,varargin)
+    function varargout = getNrOfVisualizedModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
     end
-    function varargout = camera(self,varargin)
+    function varargout = getModelInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
     end
-    function varargout = enviroment(self,varargin)
+    function varargout = getModelInstanceIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
     end
-    function varargout = vectors(self,varargin)
+    function varargout = addModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
     end
-    function varargout = run(self,varargin)
+    function varargout = modelViz(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
     end
-    function varargout = draw(self,varargin)
+    function varargout = camera(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
-    function varargout = drawToFile(self,varargin)
+    function varargout = enviroment(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
     end
-    function varargout = close(self,varargin)
+    function varargout = vectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
+    end
+    function varargout = run(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
+    end
+    function varargout = draw(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
+    end
+    function varargout = drawToFile(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
+    end
+    function varargout = close(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,33 +7,13 @@ classdef VisualizerOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1854, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1855, self, varargin{1});
-      end
-    end
-    function varargout = winWidth(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1856, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1857, self, varargin{1});
-      end
-    end
-    function varargout = winHeight(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1858, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1859, self, varargin{1});
       end
     end
-    function varargout = rootFrameArrowsDimension(self, varargin)
+    function varargout = winWidth(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,20 +23,40 @@ classdef VisualizerOptions < SwigRef
         iDynTreeMEX(1861, self, varargin{1});
       end
     end
+    function varargout = winHeight(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1862, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1863, self, varargin{1});
+      end
+    end
+    function varargout = rootFrameArrowsDimension(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1864, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1865, self, varargin{1});
+      end
+    end
     function self = VisualizerOptions(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1862, varargin{:});
+        tmp = iDynTreeMEX(1866, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1863, self);
+        iDynTreeMEX(1867, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Wrench.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Wrench.m
@@ -7,23 +7,23 @@ classdef Wrench < iDynTree.SpatialForceVector
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(503, varargin{:});
+        tmp = iDynTreeMEX(507, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = plus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(504, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(508, self, varargin{:});
     end
     function varargout = minus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(505, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(509, self, varargin{:});
     end
     function varargout = uminus(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(506, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(510, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(507, self);
+        iDynTreeMEX(511, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeLinkNetWrenchesWithoutGravity.m
@@ -1,3 +1,3 @@
 function varargout = computeLinkNetWrenchesWithoutGravity(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1469, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1473, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDF.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDF(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1377, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1381, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dofsListFromURDFString.m
@@ -1,3 +1,3 @@
 function varargout = dofsListFromURDFString(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1378, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1382, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamic_extent.m
@@ -1,3 +1,3 @@
 function v = dynamic_extent()
-  v = iDynTreeMEX(693);
+  v = iDynTreeMEX(697);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelAccKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelAccKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1467, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1471, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/dynamicsEstimationForwardVelKinematics.m
@@ -1,3 +1,3 @@
 function varargout = dynamicsEstimationForwardVelKinematics(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1468, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1472, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1466, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1470, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesBuffers.m
@@ -9,44 +9,24 @@ classdef estimateExternalWrenchesBuffers < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1447, varargin{:});
+        tmp = iDynTreeMEX(1451, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1448, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1452, self, varargin{:});
     end
     function varargout = getNrOfSubModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1449, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1453, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1450, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1454, self, varargin{:});
     end
     function varargout = isConsistent(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1451, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1455, self, varargin{:});
     end
     function varargout = A(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1452, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1453, self, varargin{1});
-      end
-    end
-    function varargout = x(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1454, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1455, self, varargin{1});
-      end
-    end
-    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -56,7 +36,7 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1457, self, varargin{1});
       end
     end
-    function varargout = pinvA(self, varargin)
+    function varargout = x(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -66,7 +46,7 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1459, self, varargin{1});
       end
     end
-    function varargout = b_contacts_subtree(self, varargin)
+    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -76,7 +56,7 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1461, self, varargin{1});
       end
     end
-    function varargout = subModelBase_H_link(self, varargin)
+    function varargout = pinvA(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -86,9 +66,29 @@ classdef estimateExternalWrenchesBuffers < SwigRef
         iDynTreeMEX(1463, self, varargin{1});
       end
     end
+    function varargout = b_contacts_subtree(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1464, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1465, self, varargin{1});
+      end
+    end
+    function varargout = subModelBase_H_link(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1466, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1467, self, varargin{1});
+      end
+    end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1464, self);
+        iDynTreeMEX(1468, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateExternalWrenchesWithoutInternalFT.m
@@ -1,3 +1,3 @@
 function varargout = estimateExternalWrenchesWithoutInternalFT(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1465, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1469, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
@@ -1,3 +1,3 @@
 function varargout = estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1703, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1707, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateLinkContactWrenchesFromLinkNetExternalWrenches.m
@@ -1,3 +1,3 @@
 function varargout = estimateLinkContactWrenchesFromLinkNetExternalWrenches(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1470, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1474, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
+++ b/bindings/matlab/autogenerated/+iDynTree/getSensorTypeSize.m
@@ -1,3 +1,3 @@
 function varargout = getSensorTypeSize(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1234, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1238, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
@@ -1,3 +1,3 @@
 function v = input_dimensions()
-  v = iDynTreeMEX(1658);
+  v = iDynTreeMEX(1662);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isDOFBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isDOFBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1497, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1501, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isJointBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1496, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1500, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isJointSensor.m
@@ -1,3 +1,3 @@
 function varargout = isJointSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1233, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1237, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkBerdyDynamicVariable.m
@@ -1,3 +1,3 @@
 function varargout = isLinkBerdyDynamicVariable(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1495, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1499, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/isLinkSensor.m
@@ -1,3 +1,3 @@
 function varargout = isLinkSensor(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1232, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1236, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_with_magnetometer()
-  v = iDynTreeMEX(1656);
+  v = iDynTreeMEX(1660);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_without_magnetometer()
-  v = iDynTreeMEX(1657);
+  v = iDynTreeMEX(1661);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurements.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurements(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1375, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1379, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
+++ b/bindings/matlab/autogenerated/+iDynTree/predictSensorsMeasurementsFromRawBuffers.m
@@ -1,3 +1,3 @@
 function varargout = predictSensorsMeasurementsFromRawBuffers(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1376, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1380, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
@@ -1,3 +1,3 @@
 function varargout = sizeOfRotationParametrization(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1925, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1929, varargin{:});
 end

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -23,18 +23,34 @@ import_array();
 // NumPy typemaps for vectors
 %apply (double* IN_ARRAY1, int DIM1) {(double* in, int size)};
 %apply (double** ARGOUTVIEWM_ARRAY1, int* DIM1) {(double** out, int* size)};
+%apply (double* IN_ARRAY1, int DIM1) {(double* in, std::size_t size)};
+%apply (double** ARGOUTVIEWM_ARRAY1, int* DIM1) {(double** out, std::size_t* size)};
+%apply (double* IN_ARRAY1, int DIM1) {(double* in, std::ptrdiff_t size)};
+%apply (double** ARGOUTVIEWM_ARRAY1, int* DIM1) {(double** out, std::ptrdiff_t* size)};
 
 // NumPy typemaps for matrices
 %apply (double* IN_ARRAY2, int DIM1, int DIM2) {(double* in, int i, int j)};
 %apply (double** ARGOUTVIEWM_ARRAY2, int* DIM1, int* DIM2) {(double** out, int* i, int* j)};
+%apply (double* IN_ARRAY2, int DIM1, int DIM2) {(double* in, std::size_t i, std::size_t j)};
+%apply (double** ARGOUTVIEWM_ARRAY2, int* DIM1, int* DIM2) {(double** out, std::size_t* i, std::size_t* j)};
+%apply (double* IN_ARRAY2, int DIM1, int DIM2) {(double* in, std::ptrdiff_t i, std::ptrdiff_t j)};
+%apply (double** ARGOUTVIEWM_ARRAY2, int* DIM1, int* DIM2) {(double** out, std::ptrdiff_t* i, std::ptrdiff_t* j)};
 
 // NumPy typemaps for vectors / matrices constructors
 %apply (double* IN_ARRAY1, int DIM1) {(const double* in_data, const unsigned in_size)};
 %apply (double* IN_ARRAY2, int DIM1, int DIM2) {(const double* in_data, const unsigned in_rows, const unsigned in_cols)};
+%apply (double* IN_ARRAY1, int DIM1) {(const double* in_data, const std::size_t in_size)};
+%apply (double* IN_ARRAY2, int DIM1, int DIM2) {(const double* in_data, const std::size_t in_rows, const std::size_t in_cols)};
+%apply (double* IN_ARRAY1, int DIM1) {(const double* in_data, const std::ptrdiff_t in_size)};
+%apply (double* IN_ARRAY2, int DIM1, int DIM2) {(const double* in_data, const std::ptrdiff_t in_rows, const std::ptrdiff_t in_cols)};
 
 // NumPy typemaps for SpatialVector constructor
 %apply (double* IN_ARRAY1, int DIM1) {(const double* linear_data, const unsigned linear_size)};
 %apply (double* IN_ARRAY1, int DIM1) {(const double* angular_data, const unsigned angular_size)};
+%apply (double* IN_ARRAY1, int DIM1) {(const double* linear_data, const std::size_t linear_size)};
+%apply (double* IN_ARRAY1, int DIM1) {(const double* angular_data, const std::size_t angular_size)};
+%apply (double* IN_ARRAY1, int DIM1) {(const double* linear_data, const std::ptrdiff_t linear_size)};
+%apply (double* IN_ARRAY1, int DIM1) {(const double* angular_data, const std::ptrdiff_t angular_size)};
 
 // Map the <Class>::reservedToString method to __str__ so that print(<Object>) automatically works in Python
 %rename(__str__) reservedToString;

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -11,6 +11,8 @@
 #ifndef IDYNTREE_EIGEN_HELPERS_H
 #define IDYNTREE_EIGEN_HELPERS_H
 
+#include <cstddef>
+
 #include <Eigen/Dense>
 #include <iDynTree/Core/VectorDynSize.h>
 #include <iDynTree/Core/VectorFixSize.h>
@@ -113,8 +115,8 @@ toEigen(const MatrixView<const double>& mat)
     //    - inner_stride = 2 = number of rows of A
     //    - outer_stride = 1
 
-    const int innerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? mat.rows() : 1;
-    const int outerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? 1 : mat.cols();
+    const std::ptrdiff_t innerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? mat.rows() : 1;
+    const std::ptrdiff_t outerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? 1 : mat.cols();
 
     return Eigen::Map<const MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),
@@ -162,8 +164,8 @@ toEigen(const MatrixView<double>& mat)
     //    - inner_stride = 2 = number of rows of A
     //    - outer_stride = 1
 
-    const int innerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? mat.rows() : 1;
-    const int outerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? 1 : mat.cols();
+    const std::ptrdiff_t innerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? mat.rows() : 1;
+    const std::ptrdiff_t outerStride = (mat.storageOrder() == MatrixStorageOrdering::ColumnMajor) ? 1 : mat.cols();
 
     return Eigen::Map<MatrixRowMajor, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(
         mat.data(),
@@ -405,3 +407,4 @@ inline void setSubVector(VectorDynSize& vec,
 }
 
 #endif /* IDYNTREE_EIGEN_HELPERS_H */
+

--- a/src/core/include/iDynTree/Core/MatrixDynSize.h
+++ b/src/core/include/iDynTree/Core/MatrixDynSize.h
@@ -31,7 +31,7 @@ namespace iDynTree
          * element corresponding to row and col, using row
          * major ordering.
          */
-        unsigned int rawIndexRowMajor(int row, int col) const;
+        std::size_t rawIndexRowMajor(std::size_t row, std::size_t col) const;
 
         /**
          * Return the raw index in the data vector of the
@@ -42,12 +42,12 @@ namespace iDynTree
          *          this function is used just in the fillColMajorBuffer
          *          method.
          */
-        unsigned int rawIndexColMajor(int row, int col) const;
+        std::size_t rawIndexColMajor(std::size_t row, std::size_t col) const;
 
         /**
          * Set the capacity of the vector, resizing the buffer pointed by m_data.
          */
-        void changeCapacityAndCopyData(const unsigned int _newCapacity);
+        void changeCapacityAndCopyData(const std::size_t _newCapacity);
 
     protected:
         /**
@@ -58,13 +58,13 @@ namespace iDynTree
          * \warning this class stores data using the row major order
          */
         double * m_data;
-        unsigned int m_rows;
-        unsigned int m_cols;
+        std::size_t m_rows;
+        std::size_t m_cols;
 
         /**
          * The buffer to which m_data is pointing is m_capacity*sizeof(double).
          */
-        unsigned int m_capacity;
+        std::size_t m_capacity;
 
     public:
         /**
@@ -80,7 +80,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        MatrixDynSize(unsigned int _rows, unsigned int _cols);
+        MatrixDynSize(std::size_t _rows, std::size_t _cols);
 
         /**
          * Constructor from a C-style matrix.
@@ -89,7 +89,7 @@ namespace iDynTree
          * \warning this class stores data using the row major order
          * \warning performs dynamic memory allocation operations
          */
-        MatrixDynSize(const double * in_data, const unsigned int in_rows, const unsigned int in_cols);
+        MatrixDynSize(const double * in_data, const std::size_t in_rows, const std::size_t in_cols);
 
         /**
          * Copy constructor
@@ -141,12 +141,12 @@ namespace iDynTree
          *          In doubt, don't use them and rely on more high level functions.
          */
         ///@{
-        double operator()(const unsigned int row, const unsigned int col) const;
-        double& operator()(const unsigned int row, const unsigned int col);
-        double getVal(const unsigned int row, const unsigned int col) const;
-        bool setVal(const unsigned int row, const unsigned int col, const double new_el);
-        unsigned int rows() const;
-        unsigned int cols() const;
+        double operator()(const std::size_t row, const std::size_t col) const;
+        double& operator()(const std::size_t row, const std::size_t col);
+        double getVal(const std::size_t row, const std::size_t col) const;
+        bool setVal(const std::size_t row, const std::size_t col, const double new_el);
+        std::size_t rows() const;
+        std::size_t cols() const;
         ///@}
 
         /**
@@ -178,7 +178,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations if newRows*newCols > capacity()
          */
-        void resize(const unsigned int _newRows, const unsigned int _newCols);
+        void resize(const std::size_t _newRows, const std::size_t _newCols);
 
         /**
          * Increase the capacity of the matrix, preserving old content.
@@ -251,3 +251,4 @@ namespace iDynTree
 }
 
 #endif /* IDYNTREE_MATRIX_DYN_SIZE_H */
+

--- a/src/core/include/iDynTree/Core/MatrixFixSize.h
+++ b/src/core/include/iDynTree/Core/MatrixFixSize.h
@@ -37,7 +37,7 @@ namespace iDynTree
          * element corresponding to row and col, using row
          * major ordering.
          */
-        unsigned int rawIndexRowMajor(int row, int col) const;
+        std::size_t rawIndexRowMajor(std::size_t row, std::size_t col) const;
 
         /**
          * Return the raw index in the data vector of the
@@ -48,7 +48,7 @@ namespace iDynTree
          *          this function is used just in the fillColMajorBuffer
          *          method.
          */
-        unsigned int rawIndexColMajor(int row, int col) const;
+        std::size_t rawIndexColMajor(std::size_t row, std::size_t col) const;
 
     protected:
         /**
@@ -75,7 +75,7 @@ namespace iDynTree
          *
          * \warning this class stores data using the row major order
          */
-        MatrixFixSize(const double * in_data, const unsigned int in_rows, const unsigned int in_cols);
+        MatrixFixSize(const double * in_data, const std::size_t in_rows, const std::size_t in_cols);
 
         /**
          * Constructor from a MatrixView
@@ -90,12 +90,12 @@ namespace iDynTree
          *
          */
         ///@{
-        double operator()(const unsigned int row, const unsigned int col) const;
-        double& operator()(const unsigned int row, const unsigned int col);
-        double getVal(const unsigned int row, const unsigned int col) const;
-        bool setVal(const unsigned int row, const unsigned int col, const double new_el);
-        unsigned int rows() const;
-        unsigned int cols() const;
+        double operator()(const std::size_t row, const std::size_t col) const;
+        double& operator()(const std::size_t row, const std::size_t col);
+        double getVal(const std::size_t row, const std::size_t col) const;
+        bool setVal(const std::size_t row, const std::size_t col, const double new_el);
+        std::size_t rows() const;
+        std::size_t cols() const;
         ///@}
 
         MatrixFixSize & operator=(iDynTree::MatrixView<const double> mat);
@@ -180,8 +180,8 @@ namespace iDynTree
 
     template<unsigned int nRows, unsigned int nCols>
     MatrixFixSize<nRows,nCols>::MatrixFixSize(const double* in_data,
-                                              const unsigned int in_rows,
-                                              const unsigned int in_cols)
+                                              const std::size_t in_rows,
+                                              const std::size_t in_cols)
     {
         if( in_rows != nRows ||
             in_cols != nCols )
@@ -206,9 +206,9 @@ namespace iDynTree
         }
         else
         {
-            for(unsigned int row=0; row < nRows; row++ )
+            for(std::size_t row=0; row < nRows; row++ )
             {
-                for(unsigned int col=0; col < nCols; col++ )
+                for(std::size_t col=0; col < nCols; col++ )
                 {
                     this->m_data[rawIndexRowMajor(row,col)] = other(row, col);
                 }
@@ -219,9 +219,9 @@ namespace iDynTree
     template<unsigned int nRows, unsigned int nCols>
     void MatrixFixSize<nRows,nCols>::zero()
     {
-        for(unsigned int row=0; row < this->rows(); row++ )
+        for(std::size_t row=0; row < this->rows(); row++ )
         {
-            for(unsigned int col=0; col < this->cols(); col++ )
+            for(std::size_t col=0; col < this->cols(); col++ )
             {
                 this->m_data[rawIndexRowMajor(row,col)] = 0.0;
             }
@@ -229,13 +229,13 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    unsigned int MatrixFixSize<nRows,nCols>::rows() const
+    std::size_t MatrixFixSize<nRows,nCols>::rows() const
     {
         return nRows;
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    unsigned int MatrixFixSize<nRows,nCols>::cols() const
+    std::size_t MatrixFixSize<nRows,nCols>::cols() const
     {
         return nCols;
     }
@@ -257,9 +257,9 @@ namespace iDynTree
         assert(nCols == mat.cols());
         assert(nRows == mat.rows());
 
-        for(unsigned int i = 0; i < nRows; i++)
+        for(std::size_t i = 0; i < nRows; i++)
         {
-            for(unsigned int j = 0; j < nCols; j++)
+            for(std::size_t j = 0; j < nCols; j++)
             {
                 this->m_data[this->rawIndexRowMajor(i,j)] = mat(i, j);
             }
@@ -268,7 +268,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    double& MatrixFixSize<nRows,nCols>::operator()(const unsigned int row, const unsigned int col)
+    double& MatrixFixSize<nRows,nCols>::operator()(const std::size_t row, const std::size_t col)
     {
         assert(row < nRows);
         assert(col < nCols);
@@ -276,7 +276,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    double MatrixFixSize<nRows,nCols>::operator()(const unsigned int row, const unsigned int col) const
+    double MatrixFixSize<nRows,nCols>::operator()(const std::size_t row, const std::size_t col) const
     {
         assert(row < nRows);
         assert(col < nCols);
@@ -284,7 +284,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    double MatrixFixSize<nRows,nCols>::getVal(const unsigned int row, const unsigned int col) const
+    double MatrixFixSize<nRows,nCols>::getVal(const std::size_t row, const std::size_t col) const
     {
         if( row >= this->rows() ||
             col  >= this->cols() )
@@ -297,7 +297,7 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    bool MatrixFixSize<nRows,nCols>::setVal(const unsigned int row, const unsigned int col, const double new_el)
+    bool MatrixFixSize<nRows,nCols>::setVal(const std::size_t row, const std::size_t col, const double new_el)
     {
         if( row >= this->rows() ||
             col   >= this->cols() )
@@ -321,9 +321,9 @@ namespace iDynTree
     template<unsigned int nRows, unsigned int nCols>
     void MatrixFixSize<nRows,nCols>::fillColMajorBuffer(double* colMajorBuf) const
     {
-        for(unsigned int row = 0; row < this->rows(); row++ )
+        for(std::size_t row = 0; row < this->rows(); row++ )
         {
-            for(unsigned int col = 0; col < this->cols(); col++ )
+            for(std::size_t col = 0; col < this->cols(); col++ )
             {
                 colMajorBuf[this->rawIndexColMajor(row,col)] =
                     this->m_data[this->rawIndexRowMajor(row,col)];
@@ -332,13 +332,13 @@ namespace iDynTree
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    unsigned int MatrixFixSize<nRows,nCols>::rawIndexRowMajor(int row, int col) const
+    std::size_t MatrixFixSize<nRows,nCols>::rawIndexRowMajor(std::size_t row, std::size_t col) const
     {
         return (nCols*row + col);
     }
 
     template<unsigned int nRows, unsigned int nCols>
-    unsigned int MatrixFixSize<nRows,nCols>::rawIndexColMajor(int row, int col) const
+    std::size_t MatrixFixSize<nRows,nCols>::rawIndexColMajor(std::size_t row, std::size_t col) const
     {
         return (row + nRows*col);
     }
@@ -348,9 +348,9 @@ namespace iDynTree
     {
         std::stringstream ss;
 
-        for(unsigned int row=0; row < this->rows(); row++ )
+        for(std::size_t row=0; row < this->rows(); row++ )
         {
-            for(unsigned int col=0; col < this->cols(); col++ )
+            for(std::size_t col=0; col < this->cols(); col++ )
             {
                 ss << this->m_data[this->rawIndexRowMajor(row,col)] << " ";
             }
@@ -383,3 +383,4 @@ namespace iDynTree
 }
 
 #endif /* IDYNTREE_MATRIX_FIX_SIZE_H */
+

--- a/src/core/include/iDynTree/Core/SparseMatrix.h
+++ b/src/core/include/iDynTree/Core/SparseMatrix.h
@@ -21,7 +21,7 @@ namespace iDynTree {
 
     template <MatrixStorageOrdering ordering>
     class SparseMatrix;
-    
+
     class Triplet;
     class Triplets;
 }
@@ -48,12 +48,12 @@ private:
                                      */
 
 
-    unsigned m_allocatedSize; /**< size of the memory allocated for m_values and m_innerIndices */
+    std::size_t m_allocatedSize; /**< size of the memory allocated for m_values and m_innerIndices */
 
-    unsigned m_rows;
-    unsigned m_columns;
+    std::size_t m_rows;
+    std::size_t m_columns;
 
-    void initializeMatrix(unsigned outerSize, const double* vector, unsigned vectorSize);
+    void initializeMatrix(std::size_t outerSize, const double* vector, std::size_t vectorSize);
 
     /**
      * Insert a new element at the specified position
@@ -64,7 +64,7 @@ private:
      * @param value value to be inserted
      * @return index in m_values of the inserted element
      */
-    unsigned insert(unsigned row, unsigned col, double value);
+    std::size_t insert(std::size_t row, std::size_t col, double value);
 
     /**
      * Check if the element at row-col is present in the matrix.
@@ -78,7 +78,7 @@ private:
      * @param[out] index if found contains the index, if not the index of the next element
      * @return true if the value has been found
      */
-    bool valueIndexForOuterAndInnerIndices(unsigned outerIndex, unsigned innerIndex, unsigned& valueIndex) const;
+    bool valueIndexForOuterAndInnerIndices(std::size_t outerIndex, std::size_t innerIndex, std::size_t& valueIndex) const;
 
 public:
 
@@ -91,10 +91,10 @@ public:
      * Creates a zero sparse matrix with the specified dimensions
      *
      */
-    SparseMatrix(unsigned rows, unsigned cols);
+    SparseMatrix(std::size_t rows, std::size_t cols);
 
 
-    SparseMatrix(unsigned rows, unsigned cols,
+    SparseMatrix(std::size_t rows, std::size_t cols,
                  const iDynTree::VectorDynSize& memoryReserveDescription);
 
     template <iDynTree::MatrixStorageOrdering otherOrdering>
@@ -114,7 +114,7 @@ public:
      *
      * @return the number of non zero elements
      */
-    unsigned numberOfNonZeros() const;
+    std::size_t numberOfNonZeros() const;
 
     /**
      * Resize the matrix to the specified new dimensions
@@ -124,7 +124,7 @@ public:
      * @param rows the new number of rows of this matrix
      * @param columns the new number of columns of this matrix
      */
-    void resize(unsigned rows, unsigned columns);
+    void resize(std::size_t rows, std::size_t columns);
 
     /**
      * Resize the matrix to the specified new dimensions
@@ -135,9 +135,9 @@ public:
      * @param columns the new number of columns of this matrix
      * @param innerIndicesInformation information on the NNZ for each column (row), used to reserve memory in advance. It depends on the storage ordering
      */
-    void resize(unsigned rows, unsigned columns, const iDynTree::VectorDynSize &innerIndicesInformation);
+    void resize(std::size_t rows, std::size_t columns, const iDynTree::VectorDynSize &innerIndicesInformation);
 
-    void reserve(unsigned nonZeroElements);
+    void reserve(std::size_t nonZeroElements);
 
 
     /**
@@ -186,8 +186,8 @@ public:
      */
     void setFromTriplets(iDynTree::Triplets& triplets);
 
-    static SparseMatrix sparseMatrixFromTriplets(unsigned rows,
-                                                 unsigned cols,
+    static SparseMatrix sparseMatrixFromTriplets(std::size_t rows,
+                                                 std::size_t cols,
                                                  const iDynTree::Triplets& nonZeroElements);
 
 
@@ -199,7 +199,7 @@ public:
      * @param col column index
      * @return the value at the specified row and column
      */
-    double operator()(unsigned row, unsigned col) const;
+    double operator()(std::size_t row, std::size_t col) const;
 
     /**
      * Access operation to the element of the matrix identified by row-col
@@ -210,14 +210,14 @@ public:
      * @param col column index
      * @return reference to the value at the specified row and column
      */
-    double& operator()(unsigned row, unsigned col);
+    double& operator()(std::size_t row, std::size_t col);
 
-    inline double getValue(unsigned row, unsigned col) const
+    inline double getValue(std::size_t row, std::size_t col) const
     {
         return this->operator()(row, col);
     }
 
-    inline void setValue(unsigned row, unsigned col, double newValue)
+    inline void setValue(std::size_t row, std::size_t col, double newValue)
     {
         double &value = this->operator()(row, col);
         value = newValue;
@@ -228,13 +228,13 @@ public:
      * Returns the number of rows of the matrix
      * @return the number of rows
      */
-    unsigned rows() const;
+    std::size_t rows() const;
 
     /**
      * Returns the number of columns of the matrix
      * @return the number of columns
      */
-    unsigned columns() const;
+    std::size_t columns() const;
 
     //Raw buffers access
     double * valuesBuffer();
@@ -294,7 +294,7 @@ public:
         int m_column;
         double *m_value;
 
-        TripletRef(unsigned row, unsigned column, double *value);
+        TripletRef(std::size_t row, std::size_t column, double *value);
         friend class iDynTree::SparseMatrix<ordering>::Iterator;
 
     public:

--- a/src/core/include/iDynTree/Core/Triplets.h
+++ b/src/core/include/iDynTree/Core/Triplets.h
@@ -11,6 +11,7 @@
 #ifndef IDYNTREE_TRIPLETS_H
 #define IDYNTREE_TRIPLETS_H
 
+#include <iDynTree/Core/MatrixFixSize.h>
 #include <iDynTree/Core/Utils.h>
 
 #include <iterator>
@@ -23,8 +24,6 @@ namespace iDynTree {
     class Triplets;
 
     class MatrixDynSize;
-    template <unsigned rows, unsigned cols>
-    class MatrixFixSize;
 
     template <MatrixStorageOrdering ordering>
     class SparseMatrix;
@@ -39,13 +38,13 @@ public:
     static bool rowMajorCompare(const iDynTree::Triplet& a, const iDynTree::Triplet &b);
     static bool columnMajorCompare(const iDynTree::Triplet& a, const iDynTree::Triplet &b);
 
-    Triplet(unsigned row, unsigned column, double value);
+    Triplet(std::size_t row, std::size_t column, double value);
 
     bool operator<(const iDynTree::Triplet&) const;
     bool operator==(const iDynTree::Triplet&) const;
 
-    unsigned row;
-    unsigned column;
+    std::size_t row;
+    std::size_t column;
     double value;
 };
 
@@ -56,30 +55,30 @@ class iDynTree::Triplets
 
 public:
 
-    void reserve(unsigned size);
+    void reserve(std::size_t size);
     void clear();
 
-    template <unsigned rows, unsigned cols>
-    inline void addSubMatrix(unsigned startingRow,
-                             unsigned startingColumn,
+    template <unsigned int rows, unsigned int cols>
+    inline void addSubMatrix(std::size_t startingRow,
+                             std::size_t startingColumn,
                              const MatrixFixSize<rows, cols> &matrix)
     {
         //if enough memory has been reserved this should be a noop
         m_triplets.reserve(m_triplets.size() + (rows * cols));
-        for (unsigned row = 0; row < rows; ++row) {
-            for (unsigned col = 0; col < cols; ++col) {
+        for (std::size_t row = 0; row < rows; ++row) {
+            for (std::size_t col = 0; col < cols; ++col) {
                 m_triplets.push_back(Triplet(startingRow + row, startingColumn + col, matrix(row, col)));
             }
         }
     }
 
-    void addSubMatrix(unsigned startingRow,
-                      unsigned startingColumn,
+    void addSubMatrix(std::size_t startingRow,
+                      std::size_t startingColumn,
                       const MatrixDynSize&);
 
     template <MatrixStorageOrdering ordering>
-    void addSubMatrix(unsigned startingRow,
-                      unsigned startingColumn,
+    void addSubMatrix(std::size_t startingRow,
+                      std::size_t startingColumn,
                       const SparseMatrix<ordering>& matrix)
     {
         //if enough memory has been reserved this should be a noop
@@ -103,34 +102,34 @@ public:
                           startingRow.size);
     }
 
-    void addDiagonalMatrix(unsigned startingRow,
-                           unsigned startingColumn,
+    void addDiagonalMatrix(std::size_t startingRow,
+                           std::size_t startingColumn,
                            double value,
-                           unsigned diagonalMatrixSize);
+                           std::size_t diagonalMatrixSize);
 
     void pushTriplet(const Triplet& triplet);
 
-    template <unsigned rows, unsigned cols>
-    inline void setSubMatrix(unsigned startingRow,
-                             unsigned startingColumn,
+    template <std::size_t rows, std::size_t cols>
+    inline void setSubMatrix(std::size_t startingRow,
+                             std::size_t startingColumn,
                              const MatrixFixSize<rows, cols> &matrix)
     {
         //if enough memory has been reserved this should be a noop
         m_triplets.reserve(m_triplets.size() + (rows * cols));
-        for (unsigned row = 0; row < rows; ++row) {
-            for (unsigned col = 0; col < cols; ++col) {
+        for (std::size_t row = 0; row < rows; ++row) {
+            for (std::size_t col = 0; col < cols; ++col) {
                 setTriplet(Triplet(startingRow + row, startingColumn + col, matrix(row, col)));
             }
         }
     }
 
-    void setSubMatrix(unsigned startingRow,
-                      unsigned startingColumn,
+    void setSubMatrix(std::size_t startingRow,
+                      std::size_t startingColumn,
                       const MatrixDynSize&);
 
     template <MatrixStorageOrdering ordering>
-    void setSubMatrix(unsigned startingRow,
-                      unsigned startingColumn,
+    void setSubMatrix(std::size_t startingRow,
+                      std::size_t startingColumn,
                       const SparseMatrix<ordering>& matrix)
     {
         //if enough memory has been reserved this should be a noop
@@ -154,16 +153,16 @@ public:
                           startingRow.size);
     }
 
-    void setDiagonalMatrix(unsigned startingRow,
-                           unsigned startingColumn,
+    void setDiagonalMatrix(std::size_t startingRow,
+                           std::size_t startingColumn,
                            double value,
-                           unsigned diagonalMatrixSize);
+                           std::size_t diagonalMatrixSize);
 
 
     void setTriplet(const Triplet& triplet);
 
     bool isEmpty() const;
-    unsigned size() const;
+    std::size_t size() const;
 
     std::string description() const;
 

--- a/src/core/include/iDynTree/Core/VectorDynSize.h
+++ b/src/core/include/iDynTree/Core/VectorDynSize.h
@@ -38,17 +38,17 @@ namespace iDynTree
         /**
          * Size of the vector.
          */
-        unsigned int m_size;
+        std::size_t m_size;
 
         /**
          * The buffer to which m_data is pointing is m_capacity*sizeof(double).
          */
-        unsigned int m_capacity;
+        std::size_t m_capacity;
 
         /**
          * Set the capacity of the vector, resizing the buffer pointed by m_data.
          */
-        void changeCapacityAndCopyData(const unsigned int _newCapacity);
+        void changeCapacityAndCopyData(const std::size_t _newCapacity);
 
     public:
         /**
@@ -63,7 +63,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        VectorDynSize(unsigned int _size);
+        VectorDynSize(std::size_t _size);
 
         /**
          * Constructor from a C-style array.
@@ -72,7 +72,7 @@ namespace iDynTree
          *
          * \warning performs dynamic memory allocation operations
          */
-        VectorDynSize(const double * in_data, const unsigned int in_size);
+        VectorDynSize(const double * in_data, const std::size_t in_size);
 
         /**
          * Copy constructor
@@ -127,17 +127,17 @@ namespace iDynTree
          * Methods exposing a vector-like interface to PositionRaw.
          */
         ///@{
-        double operator()(const unsigned int index) const;
+        double operator()(const std::size_t index) const;
 
-        double& operator()(const unsigned int index);
+        double& operator()(const std::size_t index);
 
-        double operator[](const unsigned int index) const;
+        double operator[](const std::size_t index) const;
 
-        double& operator[](const unsigned int index);
+        double& operator[](const std::size_t index);
 
-        double getVal(const unsigned int index) const;
+        double getVal(const std::size_t index) const;
 
-        bool setVal(const unsigned int index, const double new_el);
+        bool setVal(const std::size_t index, const double new_el);
 
         /**
          * Returns a const iterator to the beginning of the vector
@@ -181,7 +181,7 @@ namespace iDynTree
          */
         double* end() noexcept;
 
-        unsigned int size() const;
+        std::size_t size() const;
 
         ///@}
 
@@ -211,7 +211,7 @@ namespace iDynTree
          * \warning performs dynamic memory allocation operations if newCapacity > capacity()
          * \note if newCapacity <= capacity(), this method does nothing and the capacity will remain unchanged.
          */
-        void reserve(const unsigned int newCapacity);
+        void reserve(const std::size_t newCapacity);
 
         /**
          * Change the size of the vector preserving old content.
@@ -219,7 +219,7 @@ namespace iDynTree
          * @param newSize the new size of the vector
          * \warning performs dynamic memory allocation operations if newSize > capacity()
          */
-        void resize(const unsigned int newSize);
+        void resize(const std::size_t newSize);
 
         /**
          * Change the capacity of the vector to match the size.

--- a/src/core/include/iDynTree/Core/VectorFixSize.h
+++ b/src/core/include/iDynTree/Core/VectorFixSize.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <sstream>
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 
 namespace iDynTree
@@ -52,7 +53,7 @@ namespace iDynTree
          *
          * Print an error an build a vector full of zeros if in_size is not size().
          */
-        VectorFixSize(const double * in_data, const unsigned int in_size);
+        VectorFixSize(const double * in_data, const std::size_t in_size);
 
 #if !defined(SWIG_VERSION) || SWIG_VERSION >= 0x030000
         /**
@@ -68,17 +69,17 @@ namespace iDynTree
          * Methods exposing a vector-like interface to VectorFixSize.
          */
         ///@{
-        double operator()(const unsigned int index) const;
+        double operator()(const std::size_t index) const;
 
-        double& operator()(const unsigned int index);
+        double& operator()(const std::size_t index);
 
-        double operator[](const unsigned int index) const;
+        double operator[](const std::size_t index) const;
 
-        double& operator[](const unsigned int index);
+        double& operator[](const std::size_t index);
 
-        double getVal(const unsigned int index) const;
+        double getVal(const std::size_t index) const;
 
-        bool setVal(const unsigned int index, const double new_el);
+        bool setVal(const std::size_t index, const double new_el);
 
         /**
          * Returns a const iterator to the beginning of the vector
@@ -122,7 +123,7 @@ namespace iDynTree
          */
         double* end() noexcept;
 
-        unsigned int size() const;
+        std::size_t size() const;
 
         ///@}
 
@@ -205,7 +206,7 @@ namespace iDynTree
 
     template<unsigned int VecSize>
     VectorFixSize<VecSize>::VectorFixSize(const double* in_data,
-                                 const unsigned int in_size)
+                                 const std::size_t in_size)
     {
         if( in_size != VecSize )
         {
@@ -230,7 +231,7 @@ namespace iDynTree
     template<unsigned int VecSize>
     void VectorFixSize<VecSize>::zero()
     {
-        for(unsigned int i=0; i < VecSize; i++ )
+        for(std::size_t i=0; i < VecSize; i++ )
         {
             this->m_data[i] = 0.0;
         }
@@ -286,7 +287,7 @@ namespace iDynTree
     }
 
     template<unsigned int VecSize>
-    unsigned int VectorFixSize<VecSize>::size() const
+    std::size_t VectorFixSize<VecSize>::size() const
     {
         return VecSize;
     }
@@ -301,35 +302,35 @@ namespace iDynTree
 #endif
 
     template<unsigned int VecSize>
-    double VectorFixSize<VecSize>::operator()(const unsigned int index) const
+    double VectorFixSize<VecSize>::operator()(const std::size_t index) const
     {
         assert(index < VecSize);
         return this->m_data[index];
     }
 
     template<unsigned int VecSize>
-    double & VectorFixSize<VecSize>::operator()(const unsigned int index)
+    double & VectorFixSize<VecSize>::operator()(const std::size_t index)
     {
         assert(index < VecSize);
         return this->m_data[index];
     }
 
     template<unsigned int VecSize>
-    double VectorFixSize<VecSize>::operator[](const unsigned int index) const
+    double VectorFixSize<VecSize>::operator[](const std::size_t index) const
     {
         assert(index < VecSize);
         return this->m_data[index];
     }
 
     template<unsigned int VecSize>
-    double & VectorFixSize<VecSize>::operator[](const unsigned int index)
+    double & VectorFixSize<VecSize>::operator[](const std::size_t index)
     {
         assert(index < VecSize);
         return this->m_data[index];
     }
 
     template<unsigned int VecSize>
-    double VectorFixSize<VecSize>::getVal(const unsigned int index) const
+    double VectorFixSize<VecSize>::getVal(const std::size_t index) const
     {
         if( index >= this->size() )
         {
@@ -341,7 +342,7 @@ namespace iDynTree
     }
 
     template<unsigned int VecSize>
-    bool VectorFixSize<VecSize>::setVal(const unsigned int index, const double new_el)
+    bool VectorFixSize<VecSize>::setVal(const std::size_t index, const double new_el)
     {
         if( index >= this->size() )
         {
@@ -357,7 +358,7 @@ namespace iDynTree
     template<unsigned int VecSize>
     void VectorFixSize<VecSize>::fillBuffer(double* buf) const
     {
-        for(unsigned int i=0; i < this->size(); i++ )
+        for(std::size_t i=0; i < this->size(); i++ )
         {
             buf[i] = this->m_data[i];
         }
@@ -368,7 +369,7 @@ namespace iDynTree
     {
         std::stringstream ss;
 
-        for(unsigned int i=0; i < this->size(); i++ )
+        for(std::size_t i=0; i < this->size(); i++ )
         {
             ss << this->m_data[i] << " ";
         }
@@ -381,7 +382,7 @@ namespace iDynTree
     {
         std::stringstream ss;
 
-        for(unsigned int i=0; i < this->size(); i++ )
+        for(std::size_t i=0; i < this->size(); i++ )
         {
             ss << this->m_data[i] << " ";
         }

--- a/src/core/src/MatrixDynSize.cpp
+++ b/src/core/src/MatrixDynSize.cpp
@@ -24,8 +24,8 @@ MatrixDynSize::MatrixDynSize(): m_data(0), m_rows(0), m_cols(0), m_capacity(0)
 
 }
 
-MatrixDynSize::MatrixDynSize(unsigned int _rows,
-                             unsigned int _cols): m_rows(_rows),
+MatrixDynSize::MatrixDynSize(std::size_t _rows,
+                             std::size_t _cols): m_rows(_rows),
                                                   m_cols(_cols)
 {
     if( this->m_rows*this->m_cols == 0 )
@@ -56,9 +56,9 @@ MatrixDynSize::MatrixDynSize(MatrixView<const double> other) : m_rows(other.rows
         this->m_data = new double[this->m_capacity];
 
         // copy the matrix
-        for(unsigned int i = 0; i < m_rows; i++)
+        for(std::size_t i = 0; i < m_rows; i++)
         {
-            for(unsigned int j = 0; j < m_cols; j++)
+            for(std::size_t j = 0; j < m_cols; j++)
             {
                 this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
             }
@@ -67,8 +67,8 @@ MatrixDynSize::MatrixDynSize(MatrixView<const double> other) : m_rows(other.rows
 }
 
 MatrixDynSize::MatrixDynSize(const double* in_data,
-                             const unsigned int in_rows,
-                             const unsigned int in_cols): m_rows(in_rows),
+                             const std::size_t in_rows,
+                             const std::size_t in_cols): m_rows(in_rows),
                                                           m_cols(in_cols)
 {
     if( this->m_rows*this->m_cols == 0 )
@@ -106,7 +106,7 @@ MatrixDynSize& MatrixDynSize::operator=(const MatrixDynSize& other)
     // Copy the new rows and columns
     m_rows = other.m_rows;
     m_cols = other.m_cols;
-    unsigned requiredCapacity = m_rows * m_cols;
+    std::size_t requiredCapacity = m_rows * m_cols;
 
     // if other is empty, return
     if (requiredCapacity == 0) return  *this;
@@ -135,7 +135,7 @@ MatrixDynSize& MatrixDynSize::operator=(MatrixView<const double> other)
     m_rows = other.rows();
     m_cols = other.cols();
 
-    const unsigned requiredCapacity = m_rows * m_cols;
+    const std::size_t requiredCapacity = m_rows * m_cols;
 
     // if other is empty, return
     if (requiredCapacity == 0) return  *this;
@@ -154,9 +154,9 @@ MatrixDynSize& MatrixDynSize::operator=(MatrixView<const double> other)
         m_capacity = requiredCapacity;
     }
 
-    for(unsigned int i = 0; i < m_rows; i++)
+    for(std::size_t i = 0; i < m_rows; i++)
     {
-        for(unsigned int j = 0; j < m_cols; j++)
+        for(std::size_t j = 0; j < m_cols; j++)
         {
             this->m_data[this->rawIndexRowMajor(i,j)] = other(i, j);
         }
@@ -176,21 +176,21 @@ MatrixDynSize::~MatrixDynSize()
 
 void MatrixDynSize::zero()
 {
-    for(unsigned int row=0; row < this->rows(); row++ )
+    for(std::size_t row=0; row < this->rows(); row++ )
     {
-        for(unsigned int col=0; col < this->cols(); col++ )
+        for(std::size_t col=0; col < this->cols(); col++ )
         {
             this->m_data[rawIndexRowMajor(row,col)] = 0.0;
         }
     }
 }
 
-unsigned int MatrixDynSize::rows() const
+std::size_t MatrixDynSize::rows() const
 {
     return this->m_rows;
 }
 
-unsigned int MatrixDynSize::cols() const
+std::size_t MatrixDynSize::cols() const
 {
     return this->m_cols;
 }
@@ -205,21 +205,21 @@ const double* MatrixDynSize::data() const
     return this->m_data;
 }
 
-double& MatrixDynSize::operator()(const unsigned int row, const unsigned int col)
+double& MatrixDynSize::operator()(const std::size_t row, const std::size_t col)
 {
     assert(row < this->rows());
     assert(col < this->cols());
     return this->m_data[rawIndexRowMajor(row,col)];
 }
 
-double MatrixDynSize::operator()(const unsigned int row, const unsigned int col) const
+double MatrixDynSize::operator()(const std::size_t row, const std::size_t col) const
 {
     assert(row < this->rows());
     assert(col < this->cols());
     return this->m_data[rawIndexRowMajor(row,col)];
 }
 
-double MatrixDynSize::getVal(const unsigned int row, const unsigned int col) const
+double MatrixDynSize::getVal(const std::size_t row, const std::size_t col) const
 {
     if( row > this->rows() ||
         col  > this->cols() )
@@ -231,7 +231,7 @@ double MatrixDynSize::getVal(const unsigned int row, const unsigned int col) con
     return this->m_data[rawIndexRowMajor(row,col)];
 }
 
-bool MatrixDynSize::setVal(const unsigned int row, const unsigned int col, const double new_el)
+bool MatrixDynSize::setVal(const std::size_t row, const std::size_t col, const double new_el)
 {
     if( row > this->rows() ||
         col   > this->cols() )
@@ -272,7 +272,7 @@ void MatrixDynSize::shrink_to_fit()
     changeCapacityAndCopyData(this->m_rows*this->m_cols);
 }
 
-void MatrixDynSize::changeCapacityAndCopyData(const unsigned int _newCapacity)
+void MatrixDynSize::changeCapacityAndCopyData(const std::size_t _newCapacity)
 {
     // same capacity => do nothing
     if (m_capacity == _newCapacity) return;
@@ -299,7 +299,7 @@ void MatrixDynSize::changeCapacityAndCopyData(const unsigned int _newCapacity)
     m_data = newBuffer;
 }
 
-void MatrixDynSize::resize(const unsigned int _newRows, const unsigned int _newCols)
+void MatrixDynSize::resize(const std::size_t _newRows, const std::size_t _newCols)
 {
     if( (_newRows == this->rows()) &&
         (_newCols == this->cols()) )
@@ -322,9 +322,9 @@ void MatrixDynSize::fillRowMajorBuffer(double* rowMajorBuf) const
 
 void MatrixDynSize::fillColMajorBuffer(double* colMajorBuf) const
 {
-    for(unsigned int row = 0; row < this->rows(); row++ )
+    for(std::size_t row = 0; row < this->rows(); row++ )
     {
-        for(unsigned int col = 0; col < this->cols(); col++ )
+        for(std::size_t col = 0; col < this->cols(); col++ )
         {
             colMajorBuf[this->rawIndexColMajor(row,col)] =
                 this->m_data[this->rawIndexRowMajor(row,col)];
@@ -332,12 +332,12 @@ void MatrixDynSize::fillColMajorBuffer(double* colMajorBuf) const
     }
 }
 
-unsigned int MatrixDynSize::rawIndexRowMajor(int row, int col) const
+std::size_t MatrixDynSize::rawIndexRowMajor(std::size_t row, std::size_t col) const
 {
     return (this->m_cols*row + col);
 }
 
-unsigned int MatrixDynSize::rawIndexColMajor(int row, int col) const
+std::size_t MatrixDynSize::rawIndexColMajor(std::size_t row, std::size_t col) const
 {
     return (row + this->m_rows*col);
 }
@@ -347,9 +347,9 @@ std::string MatrixDynSize::toString() const
 {
     std::stringstream ss;
 
-    for(unsigned int row=0; row < this->rows(); row++ )
+    for(std::size_t row=0; row < this->rows(); row++ )
     {
-        for(unsigned int col=0; col < this->cols(); col++ )
+        for(std::size_t col=0; col < this->cols(); col++ )
         {
             ss << this->m_data[this->rawIndexRowMajor(row,col)] << " ";
         }

--- a/src/core/src/SparseMatrix.cpp
+++ b/src/core/src/SparseMatrix.cpp
@@ -32,16 +32,16 @@ namespace iDynTree {
     SparseMatrix<ordering>::SparseMatrix() : SparseMatrix(0, 0) {}
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    SparseMatrix<ordering>::SparseMatrix(unsigned rows, unsigned cols)
+    SparseMatrix<ordering>::SparseMatrix(std::size_t rows, std::size_t cols)
     : SparseMatrix(rows, cols, iDynTree::VectorDynSize())
     { }
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    void SparseMatrix<ordering>::initializeMatrix(unsigned outerSize, const double* vector, unsigned vectorSize)
+    void SparseMatrix<ordering>::initializeMatrix(std::size_t outerSize, const double* vector, std::size_t vectorSize)
     {
         m_outerStarts.assign(outerSize + 1, 0);
 
-        for (unsigned i = 0; i < vectorSize; ++i) {
+        for (std::size_t i = 0; i < vectorSize; ++i) {
             m_allocatedSize += vector[i];
         }
 
@@ -65,7 +65,7 @@ namespace iDynTree {
     , m_columns(other.m_columns) {}
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    unsigned SparseMatrix<ordering>::numberOfNonZeros() const
+    std::size_t SparseMatrix<ordering>::numberOfNonZeros() const
     {
         return m_values.size();
     }
@@ -86,7 +86,7 @@ namespace iDynTree {
     }
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    void SparseMatrix<ordering>::resize(unsigned rows, unsigned columns)
+    void SparseMatrix<ordering>::resize(std::size_t rows, std::size_t columns)
     {
         VectorDynSize empty; //this does not allocate memory
         resize(rows, columns, empty);
@@ -94,7 +94,7 @@ namespace iDynTree {
 
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    void SparseMatrix<ordering>::reserve(unsigned nonZeroElements)
+    void SparseMatrix<ordering>::reserve(std::size_t nonZeroElements)
     {
         if (nonZeroElements <= m_allocatedSize) return; //do nothing
 
@@ -114,7 +114,7 @@ namespace iDynTree {
     }
 
     template <MatrixStorageOrdering ordering>
-    bool SparseMatrix<ordering>::valueIndexForOuterAndInnerIndices(unsigned outerIndex, unsigned innerIndex, unsigned& valueIndex) const
+    bool SparseMatrix<ordering>::valueIndexForOuterAndInnerIndices(std::size_t outerIndex, std::size_t innerIndex, std::size_t& valueIndex) const
     {
         //We can use std::lower_bound to between rowNZIndex and rowNZIndex + rowNNZ
         //They are already sorted. The only critical point is if we have -1 in the matrix
@@ -145,7 +145,7 @@ namespace iDynTree {
         }
 
         if (*foundIndex >= 0
-            && static_cast<unsigned>(*foundIndex) == innerIndex) {
+            && static_cast<std::size_t>(*foundIndex) == innerIndex) {
             //found
             return true;
         }
@@ -154,7 +154,7 @@ namespace iDynTree {
     }
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    unsigned SparseMatrix<ordering>::insert(unsigned outerIndex, unsigned innerIndex, double value)
+    std::size_t SparseMatrix<ordering>::insert(std::size_t outerIndex, std::size_t innerIndex, double value)
     {
         //first: check if there is space in the arrays
         if (m_allocatedSize <= m_values.size()) {
@@ -162,7 +162,7 @@ namespace iDynTree {
         }
 
         //find insertion position
-        unsigned insertionIndex = 0;
+        std::size_t insertionIndex = 0;
         if (valueIndexForOuterAndInnerIndices(outerIndex, innerIndex, insertionIndex)) {
             //???: what if the element exists alredy in the matrix?
             return insertionIndex;
@@ -172,7 +172,7 @@ namespace iDynTree {
         m_values.resize(m_values.size() + 1);
         m_innerIndices.resize(m_innerIndices.size() + 1);
 
-        for (unsigned i = m_values.size() - 1; i > insertionIndex && i > 0; --i) {
+        for (std::size_t i = m_values.size() - 1; i > insertionIndex && i > 0; --i) {
             m_values(i) = m_values(i - 1);
             m_innerIndices[i] = m_innerIndices[i - 1];
         }
@@ -180,7 +180,7 @@ namespace iDynTree {
         m_values(insertionIndex) = value;
         m_innerIndices[insertionIndex] = innerIndex;
         //update row NNZ
-        for (unsigned nextOuterIndex = outerIndex; nextOuterIndex < m_outerStarts.size() - 1; ++nextOuterIndex) {
+        for (std::size_t nextOuterIndex = outerIndex; nextOuterIndex < m_outerStarts.size() - 1; ++nextOuterIndex) {
             m_outerStarts[nextOuterIndex + 1]++;
         }
 
@@ -196,8 +196,8 @@ namespace iDynTree {
 
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    SparseMatrix<ordering> SparseMatrix<ordering>::sparseMatrixFromTriplets(unsigned rows,
-                                                                            unsigned cols,
+    SparseMatrix<ordering> SparseMatrix<ordering>::sparseMatrixFromTriplets(std::size_t rows,
+                                                                            std::size_t cols,
                                                                             const iDynTree::Triplets& nonZeroElements)
     {
         SparseMatrix newMatrix(rows, cols);
@@ -206,10 +206,10 @@ namespace iDynTree {
     }
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    unsigned SparseMatrix<ordering>::rows() const { return m_rows; }
+    std::size_t SparseMatrix<ordering>::rows() const { return m_rows; }
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    unsigned SparseMatrix<ordering>::columns() const { return m_columns; }
+    std::size_t SparseMatrix<ordering>::columns() const { return m_columns; }
 
     template <iDynTree::MatrixStorageOrdering ordering>
     double * SparseMatrix<ordering>::valuesBuffer() { return m_values.data(); }
@@ -251,8 +251,8 @@ namespace iDynTree {
                 stream << it->value << "(" << it->row << ", " << it->column << ") ";
             }
         } else {
-            for (unsigned row = 0; row < rows(); ++row) {
-                for (unsigned col = 0; col < columns(); ++col) {
+            for (std::size_t row = 0; row < rows(); ++row) {
+                for (std::size_t col = 0; col < columns(); ++col) {
                     stream << this->operator()(row, col) << " ";
                 }
                 stream << std::endl;
@@ -268,15 +268,15 @@ namespace iDynTree {
     {
         std::ostringstream stream;
         stream << "Values: \n";
-        for (unsigned i = 0; i < m_values.size(); ++i) {
+        for (std::size_t i = 0; i < m_values.size(); ++i) {
             stream << m_values(i) << " ";
         }
         stream << "\nInner indices: \n";
-        for (unsigned i = 0; i < m_values.size(); ++i) {
+        for (std::size_t i = 0; i < m_values.size(); ++i) {
             stream << m_innerIndices[i] << " ";
         }
         stream << "\nOuter indices: \n";
-        for (unsigned i = 0; i < m_rows + 1; ++i) {
+        for (std::size_t i = 0; i < m_rows + 1; ++i) {
             stream << m_outerStarts[i] << " ";
         }
         stream << "\n";
@@ -314,7 +314,7 @@ namespace iDynTree {
 
     // MARK: - Row-Major implementation
     template <>
-    SparseMatrix<iDynTree::RowMajor>::SparseMatrix(unsigned rows, unsigned cols, const iDynTree::VectorDynSize& memoryReserveDescription)
+    SparseMatrix<iDynTree::RowMajor>::SparseMatrix(std::size_t rows, std::size_t cols, const iDynTree::VectorDynSize& memoryReserveDescription)
     : m_allocatedSize(0)
     , m_rows(rows)
     , m_columns(cols)
@@ -323,12 +323,12 @@ namespace iDynTree {
     }
 
     template <>
-    double SparseMatrix<iDynTree::RowMajor>::operator()(unsigned int row, unsigned int col) const
+    double SparseMatrix<iDynTree::RowMajor>::operator()(std::size_t row, std::size_t col) const
     {
         assert(row >= 0 && row < rows()
                && col >= 0 && col < columns());
 
-        unsigned index = 0;
+        std::size_t index = 0;
         double value = 0;
         if (valueIndexForOuterAndInnerIndices(row, col, index)) {
             value = m_values(index);
@@ -337,12 +337,12 @@ namespace iDynTree {
     }
 
     template <>
-    double& SparseMatrix<iDynTree::RowMajor>::operator()(unsigned int row, unsigned int col)
+    double& SparseMatrix<iDynTree::RowMajor>::operator()(std::size_t row, std::size_t col)
     {
         assert(row >= 0 && row < rows()
                && col >= 0 && col < columns());
 
-        unsigned index = 0;
+        std::size_t index = 0;
         if (valueIndexForOuterAndInnerIndices(row, col, index)) {
             return m_values(index);
         } else {
@@ -351,7 +351,7 @@ namespace iDynTree {
     }
 
     template <>
-    void SparseMatrix<iDynTree::RowMajor>::resize(unsigned rows, unsigned columns, const iDynTree::VectorDynSize &columnNNZInformation)
+    void SparseMatrix<iDynTree::RowMajor>::resize(std::size_t rows, std::size_t columns, const iDynTree::VectorDynSize &columnNNZInformation)
     {
         //Avoid destroying the matrix if the size is the same
         if (m_rows == rows && m_columns == columns)
@@ -384,10 +384,10 @@ namespace iDynTree {
         m_outerStarts.assign(m_rows + 1, 0); //reset vector
 
 
-        unsigned lastRow = 0;
-        unsigned lastColumn = 0;
-        unsigned innerIndex = 0;
-        unsigned lastIndex = innerIndex;
+        std::size_t lastRow = 0;
+        std::size_t lastColumn = 0;
+        std::size_t innerIndex = 0;
+        std::size_t lastIndex = innerIndex;
         m_values(0) = 0; //initialize the first element
 
         for (std::vector<Triplet>::const_iterator iterator(triplets.begin());
@@ -466,7 +466,7 @@ namespace iDynTree {
 
     // MARK: - Column-Major implementation
     template <>
-    SparseMatrix<iDynTree::ColumnMajor>::SparseMatrix(unsigned rows, unsigned cols, const iDynTree::VectorDynSize& memoryReserveDescription)
+    SparseMatrix<iDynTree::ColumnMajor>::SparseMatrix(std::size_t rows, std::size_t cols, const iDynTree::VectorDynSize& memoryReserveDescription)
     : m_allocatedSize(0)
     , m_rows(rows)
     , m_columns(cols)
@@ -475,12 +475,12 @@ namespace iDynTree {
     }
 
     template <>
-    double SparseMatrix<iDynTree::ColumnMajor>::operator()(unsigned int row, unsigned int col) const
+    double SparseMatrix<iDynTree::ColumnMajor>::operator()(std::size_t row, std::size_t col) const
     {
         assert(row >= 0 && row < rows()
                && col >= 0 && col < columns());
 
-        unsigned index = 0;
+        std::size_t index = 0;
         double value = 0;
         if (valueIndexForOuterAndInnerIndices(col, row, index)) {
             value = m_values(index);
@@ -489,12 +489,12 @@ namespace iDynTree {
     }
 
     template <>
-    double& SparseMatrix<iDynTree::ColumnMajor>::operator()(unsigned int row, unsigned int col)
+    double& SparseMatrix<iDynTree::ColumnMajor>::operator()(std::size_t row, std::size_t col)
     {
         assert(row >= 0 && row < rows()
                && col >= 0 && col < columns());
 
-        unsigned index = 0;
+        std::size_t index = 0;
         if (valueIndexForOuterAndInnerIndices(col, row, index)) {
             return m_values(index);
         } else {
@@ -503,7 +503,7 @@ namespace iDynTree {
     }
 
     template <>
-    void SparseMatrix<iDynTree::ColumnMajor>::resize(unsigned rows, unsigned columns, const iDynTree::VectorDynSize &columnNNZInformation)
+    void SparseMatrix<iDynTree::ColumnMajor>::resize(std::size_t rows, std::size_t columns, const iDynTree::VectorDynSize &columnNNZInformation)
     {
         //Avoid destroying the matrix if the size is the same
         if (m_rows == rows && m_columns == columns)
@@ -536,10 +536,10 @@ namespace iDynTree {
         m_outerStarts.assign(m_columns + 1, 0); //reset vector
 
 
-        unsigned lastRow = 0;
-        unsigned lastColumn = 0;
-        unsigned innerIndex = 0;
-        unsigned lastIndex = innerIndex;
+        std::size_t lastRow = 0;
+        std::size_t lastColumn = 0;
+        std::size_t innerIndex = 0;
+        std::size_t lastIndex = innerIndex;
         m_values(0) = 0; //initialize the first element
 
         for (std::vector<Triplet>::const_iterator iterator(triplets.begin());
@@ -619,7 +619,7 @@ namespace iDynTree {
     // MARK: - Iterator implementation
 
     template <iDynTree::MatrixStorageOrdering ordering>
-    SparseMatrix<ordering>::Iterator::TripletRef::TripletRef(unsigned row, unsigned column, double *value)
+    SparseMatrix<ordering>::Iterator::TripletRef::TripletRef(std::size_t row, std::size_t column, double *value)
     : m_row(row)
     , m_column(column)
     , m_value(value) {}
@@ -651,7 +651,7 @@ namespace iDynTree {
             return *this;
         }
         m_index++;
-        if (static_cast<unsigned>(m_index) >= m_matrix.m_values.size()) {
+        if (static_cast<std::size_t>(m_index) >= m_matrix.m_values.size()) {
             //Out of range
             m_index = -1;
         } else {
@@ -715,7 +715,7 @@ namespace iDynTree {
         if (--m_nonZerosInOuterDirection <= 0) {
             //increment row
             m_currentTriplet.m_row++;
-            while (static_cast<unsigned>(m_currentTriplet.m_row) < m_matrix.rows()) {
+            while (static_cast<std::size_t>(m_currentTriplet.m_row) < m_matrix.rows()) {
                 //compute row NNZ
                 m_nonZerosInOuterDirection = m_matrix.m_outerStarts[m_currentTriplet.m_row + 1]
                 - m_matrix.m_outerStarts[m_currentTriplet.m_row];
@@ -736,7 +736,7 @@ namespace iDynTree {
 
         if (--m_nonZerosInOuterDirection <= 0) {
             m_currentTriplet.m_column++;
-            while (static_cast<unsigned>(m_currentTriplet.m_column) < m_matrix.columns()) {
+            while (static_cast<std::size_t>(m_currentTriplet.m_column) < m_matrix.columns()) {
                 //compute row NNZ
                 m_nonZerosInOuterDirection = m_matrix.m_outerStarts[m_currentTriplet.m_column + 1]
                 - m_matrix.m_outerStarts[m_currentTriplet.m_column];
@@ -785,7 +785,7 @@ namespace iDynTree {
         if (--m_nonZerosInOuterDirection <= 0) {
             //increment row
             m_currentTriplet.row++;
-            while (static_cast<unsigned>(m_currentTriplet.row) < m_matrix.rows()) {
+            while (static_cast<std::size_t>(m_currentTriplet.row) < m_matrix.rows()) {
                 //compute row NNZ
                 m_nonZerosInOuterDirection = m_matrix.m_outerStarts[m_currentTriplet.row + 1]
                 - m_matrix.m_outerStarts[m_currentTriplet.row];
@@ -807,7 +807,7 @@ namespace iDynTree {
         if (--m_nonZerosInOuterDirection <= 0) {
             //increment row
             m_currentTriplet.column++;
-            while (static_cast<unsigned>(m_currentTriplet.column) < m_matrix.columns()) {
+            while (static_cast<std::size_t>(m_currentTriplet.column) < m_matrix.columns()) {
                 //compute row NNZ
                 m_nonZerosInOuterDirection = m_matrix.m_outerStarts[m_currentTriplet.column + 1]
                 - m_matrix.m_outerStarts[m_currentTriplet.column];
@@ -828,7 +828,7 @@ namespace iDynTree {
             return *this;
         }
         m_index++;
-        if (static_cast<unsigned>(m_index) >= m_matrix.m_values.size()) {
+        if (static_cast<std::size_t>(m_index) >= m_matrix.m_values.size()) {
             //Out of range
             m_index = -1;
         } else {
@@ -863,27 +863,27 @@ namespace iDynTree {
         return &m_matrix == &((&it)->m_matrix) //check that we are pointing to the same matrix
         && m_index == it.m_index;
     }
-    
+
     template <iDynTree::MatrixStorageOrdering ordering>
     typename SparseMatrix<ordering>::ConstIterator::reference SparseMatrix<ordering>::ConstIterator::operator*()
     {
         return m_currentTriplet;
     }
-    
+
     template <iDynTree::MatrixStorageOrdering ordering>
     typename SparseMatrix<ordering>::ConstIterator::pointer SparseMatrix<ordering>::ConstIterator::operator->()
     {
         return &m_currentTriplet;
     }
-    
+
     template <iDynTree::MatrixStorageOrdering ordering>
-    
+
     bool SparseMatrix<ordering>::ConstIterator::isValid() const
     {
         return m_index >= 0
         && true; //TODO: check if we are < than end or >= begin
     }
-    
+
 }
 
 // MARK: - Explicit instantiation of available templates

--- a/src/core/src/Triplets.cpp
+++ b/src/core/src/Triplets.cpp
@@ -18,7 +18,7 @@
 
 namespace iDynTree {
 
-    Triplet::Triplet(unsigned _row, unsigned _column, double _value)
+    Triplet::Triplet(std::size_t _row, std::size_t _column, double _value)
     : row(_row)
     , column(_column)
     , value(_value) {}
@@ -45,7 +45,7 @@ namespace iDynTree {
         || (a.column == b.column && a.row < b.row);
     }
 
-    void Triplets::reserve(unsigned size)
+    void Triplets::reserve(std::size_t size)
     {
         m_triplets.reserve(size);
     }
@@ -55,36 +55,36 @@ namespace iDynTree {
         m_triplets.clear();
     }
 
-    void Triplets::addSubMatrix(unsigned startingRow,
-                                unsigned startingColumn,
+    void Triplets::addSubMatrix(std::size_t startingRow,
+                                std::size_t startingColumn,
                                 const MatrixDynSize &matrix)
     {
-        unsigned rows = matrix.rows();
-        unsigned cols = matrix.cols();
+        std::size_t rows = matrix.rows();
+        std::size_t cols = matrix.cols();
 
         //if enough memory has been reserved this should be a noop
         m_triplets.reserve(m_triplets.size() + (rows * cols));
-        for (unsigned row = 0; row < rows; ++row) {
-            for (unsigned col = 0; col < cols; ++col) {
+        for (std::size_t row = 0; row < rows; ++row) {
+            for (std::size_t col = 0; col < cols; ++col) {
                 m_triplets.push_back(Triplet(startingRow + row, startingColumn + col, matrix(row, col)));
             }
         }
     }
 
-    void Triplets::addDiagonalMatrix(unsigned startingRow,
-                                     unsigned startingColumn,
+    void Triplets::addDiagonalMatrix(std::size_t startingRow,
+                                     std::size_t startingColumn,
                                      double value,
-                                     unsigned diagonalMatrixSize)
+                                     std::size_t diagonalMatrixSize)
     {
         //if enough memory has been reserved this should be a noop
         m_triplets.reserve(m_triplets.size() + diagonalMatrixSize);
-        for (unsigned i = 0; i < diagonalMatrixSize; ++i) {
+        for (std::size_t i = 0; i < diagonalMatrixSize; ++i) {
             m_triplets.push_back(Triplet(startingRow + i, startingColumn + i, value));
         }
     }
 
     bool Triplets::isEmpty() const { return m_triplets.empty(); }
-    unsigned Triplets::size() const { return m_triplets.size(); }
+    std::size_t Triplets::size() const { return m_triplets.size(); }
 
     std::vector<iDynTree::Triplet>::const_iterator Triplets::begin() const { return m_triplets.begin(); }
     std::vector<iDynTree::Triplet>::iterator Triplets::begin() { return m_triplets.begin(); }
@@ -97,30 +97,30 @@ namespace iDynTree {
     }
 
 
-    void Triplets::setSubMatrix(unsigned startingRow,
-                                unsigned startingColumn,
+    void Triplets::setSubMatrix(std::size_t startingRow,
+                                std::size_t startingColumn,
                                 const MatrixDynSize &matrix)
     {
-        unsigned rows = matrix.rows();
-        unsigned cols = matrix.cols();
+        std::size_t rows = matrix.rows();
+        std::size_t cols = matrix.cols();
 
         //if enough memory has been reserved this should be a noop
         m_triplets.reserve(m_triplets.size() + (rows * cols));
-        for (unsigned row = 0; row < rows; ++row) {
-            for (unsigned col = 0; col < cols; ++col) {
+        for (std::size_t row = 0; row < rows; ++row) {
+            for (std::size_t col = 0; col < cols; ++col) {
                 setTriplet(Triplet(startingRow + row, startingColumn + col, matrix(row, col)));
             }
         }
     }
 
-    void Triplets::setDiagonalMatrix(unsigned startingRow,
-                                     unsigned startingColumn,
+    void Triplets::setDiagonalMatrix(std::size_t startingRow,
+                                     std::size_t startingColumn,
                                      double value,
-                                     unsigned diagonalMatrixSize)
+                                     std::size_t diagonalMatrixSize)
     {
         //if enough memory has been reserved this should be a noop
         m_triplets.reserve(m_triplets.size() + diagonalMatrixSize);
-        for (unsigned i = 0; i < diagonalMatrixSize; ++i) {
+        for (std::size_t i = 0; i < diagonalMatrixSize; ++i) {
             setTriplet(Triplet(startingRow + i, startingColumn + i, value));
         }
     }

--- a/src/core/src/VectorDynSize.cpp
+++ b/src/core/src/VectorDynSize.cpp
@@ -24,7 +24,7 @@ VectorDynSize::VectorDynSize(): m_data(0), m_size(0), m_capacity(0)
 
 }
 
-VectorDynSize::VectorDynSize(unsigned int _size): m_size(_size), m_capacity(_size)
+VectorDynSize::VectorDynSize(std::size_t _size): m_size(_size), m_capacity(_size)
 {
     if( this->m_size == 0 )
     {
@@ -40,7 +40,7 @@ VectorDynSize::VectorDynSize(unsigned int _size): m_size(_size), m_capacity(_siz
 
 
 VectorDynSize::VectorDynSize(const double* in_data,
-                             const unsigned int in_size): m_size(in_size), m_capacity(in_size)
+                             const std::size_t in_size): m_size(in_size), m_capacity(in_size)
 {
     if( this->m_size == 0 )
     {
@@ -106,7 +106,7 @@ VectorDynSize &VectorDynSize::operator=(Span<const double> vec)
     // if the size don't match, reallocate the data
     if( this->m_size != vec.size() )
     {
-        resize(static_cast<unsigned int>(vec.size()));
+        resize(static_cast<std::size_t>(vec.size()));
     }
 
     // After reallocation, the size should match
@@ -124,14 +124,14 @@ VectorDynSize &VectorDynSize::operator=(Span<const double> vec)
 
 void VectorDynSize::zero()
 {
-    for(unsigned int i=0; i < this->size(); i++ )
+    for(std::size_t i=0; i < this->size(); i++ )
     {
         this->m_data[i] = 0.0;
     }
 }
 
 
-unsigned int VectorDynSize::size() const
+std::size_t VectorDynSize::size() const
 {
     return this->m_size;
 }
@@ -147,30 +147,30 @@ const double* VectorDynSize::data() const
     return this->m_data;
 }
 
-double& VectorDynSize::operator()(unsigned int index)
+double& VectorDynSize::operator()(std::size_t index)
 {
     assert(index < this->size());
     return this->m_data[index];
 }
 
-double VectorDynSize::operator()(unsigned int index) const
+double VectorDynSize::operator()(std::size_t index) const
 {
     return this->m_data[index];
 }
 
-double& VectorDynSize::operator[](unsigned int index)
-{
-    assert(index < this->size());
-    return this->m_data[index];
-}
-
-double VectorDynSize::operator[](unsigned int index) const
+double& VectorDynSize::operator[](std::size_t index)
 {
     assert(index < this->size());
     return this->m_data[index];
 }
 
-double VectorDynSize::getVal(const unsigned int index) const
+double VectorDynSize::operator[](std::size_t index) const
+{
+    assert(index < this->size());
+    return this->m_data[index];
+}
+
+double VectorDynSize::getVal(const std::size_t index) const
 {
     if( index >= this->size() )
     {
@@ -181,7 +181,7 @@ double VectorDynSize::getVal(const unsigned int index) const
     return this->m_data[index];
 }
 
-bool VectorDynSize::setVal(const unsigned int index, const double new_el)
+bool VectorDynSize::setVal(const std::size_t index, const double new_el)
 {
     if( index >= this->size() )
     {
@@ -224,7 +224,7 @@ double* VectorDynSize::end() noexcept
     return this->m_data + this->m_size;
 }
 
-void VectorDynSize::changeCapacityAndCopyData(const unsigned int _newCapacity)
+void VectorDynSize::changeCapacityAndCopyData(const std::size_t _newCapacity)
 {
     //Corner case: zero capacity
     if (_newCapacity == 0) {
@@ -249,7 +249,7 @@ void VectorDynSize::changeCapacityAndCopyData(const unsigned int _newCapacity)
     this->m_data = localBuf;
 }
 
-void VectorDynSize::reserve(const unsigned int _newCapacity)
+void VectorDynSize::reserve(const std::size_t _newCapacity)
 {
     assert(this->m_size <= this->m_capacity);
 
@@ -261,7 +261,7 @@ void VectorDynSize::reserve(const unsigned int _newCapacity)
     this->changeCapacityAndCopyData(_newCapacity);
 }
 
-void VectorDynSize::resize(const unsigned int _newSize)
+void VectorDynSize::resize(const std::size_t _newSize)
 {
     //Possible cases:
     // 1) Reduce size -> don't touch capacity. Lose elements > _newSize
@@ -291,7 +291,7 @@ void VectorDynSize::shrink_to_fit()
 
 void VectorDynSize::fillBuffer(double* buf) const
 {
-    for(unsigned int i=0; i < this->size(); i++ )
+    for(std::size_t i=0; i < this->size(); i++ )
     {
         buf[i] = this->m_data[i];
     }
@@ -302,7 +302,7 @@ std::string VectorDynSize::toString() const
 {
     std::stringstream ss;
 
-    for(unsigned int i=0; i < this->size(); i++ )
+    for(std::size_t i=0; i < this->size(); i++ )
     {
         ss << this->m_data[i] << " ";
     }

--- a/src/high-level/src/KinDynComputations.cpp
+++ b/src/high-level/src/KinDynComputations.cpp
@@ -367,7 +367,7 @@ int KinDynComputations::getFrameIndex(const std::string& frameName) const
     return index;
 }
 
-std::string KinDynComputations::getFrameName(int frameIndex) const
+std::string KinDynComputations::getFrameName(FrameIndex frameIndex) const
 {
     return this->pimpl->m_robot_model.getFrameName(frameIndex);
 }

--- a/src/icub/include/iDynTree/skinDynLibConversions.h
+++ b/src/icub/include/iDynTree/skinDynLibConversions.h
@@ -128,7 +128,7 @@ public:
      */
     bool getSkinDynLibAlias(const Model & model,
                             const LinkIndex iDynTree_link_index,
-                                  LinkIndex & iDynTree_frame_index,
+                                  FrameIndex & iDynTree_frame_index,
                              int & skinDynLib_body_part,
                              int & skinDynLib_link_index) const;
 
@@ -137,8 +137,8 @@ public:
      */
     bool skinDynLib2iDynTree(const int skinDynLib_body_part,
                              const int skinDynLib_link_index,
-                             int & iDynTree_link_index,
-                             int & iDynTree_frame_index) const;
+                             LinkIndex & iDynTree_link_index,
+                             FrameIndex & iDynTree_frame_index) const;
     /**
      * Remove a alias in the form (body_part, link_index) for a link
      */

--- a/src/icub/src/skinDynLibConversions.cpp
+++ b/src/icub/src/skinDynLibConversions.cpp
@@ -86,7 +86,7 @@ bool skinDynLibConversionsHelper::getSkinDynLibAlias(const Model& model,
 }
 
 bool skinDynLibConversionsHelper::getSkinDynLibAlias(const Model& model,
-                                                     const int iDynTree_link_index, int & iDynTree_frame_index,
+                                                     const LinkIndex iDynTree_link_index, FrameIndex & iDynTree_frame_index,
                                                      int & skinDynLib_body_part, int & skinDynLib_link_index) const
 {
   if( iDynTree_link_index < 0 || iDynTree_link_index >= static_cast<LinkIndex>(model.getNrOfLinks()) ) return false;
@@ -131,8 +131,8 @@ bool skinDynLibConversionsHelper::removeSkinDynLibAlias(const Model& model, std:
 
 bool skinDynLibConversionsHelper::skinDynLib2iDynTree(const int skinDynLib_body_part,
                                                       const int skinDynLib_link_index,
-                                                      int & iDynTree_link_index,
-                                                       int & iDynTree_frame_index) const
+                                                      LinkIndex & iDynTree_link_index,
+                                                      FrameIndex & iDynTree_frame_index) const
 {
     skinDynLibLinkID skinID;
     skinID.body_part = skinDynLib_body_part;

--- a/src/model/include/iDynTree/Model/ContactWrench.h
+++ b/src/model/include/iDynTree/Model/ContactWrench.h
@@ -41,7 +41,7 @@ namespace iDynTree
          * This id is propagated to the contact wrench data structure.
          * It is implemented mainly for compatibility with the skinDynLib library.
          */
-        unsigned long m_contactId;
+        std::size_t m_contactId;
 
     public:
         /**
@@ -71,11 +71,11 @@ namespace iDynTree
          */
         Wrench   & contactWrench();
 
-        unsigned long& contactId();
+        std::size_t& contactId();
 
         const Position & contactPoint() const;
         const Wrench   & contactWrench() const;
-        const unsigned long& contactId() const;
+        const std::size_t& contactId() const;
 
     };
 
@@ -96,7 +96,7 @@ namespace iDynTree
          *
          * @param[in] nrOfLinks the size of the vector.
          */
-        LinkContactWrenches(unsigned int nrOfLinks = 0);
+        LinkContactWrenches(std::size_t nrOfLinks = 0);
         LinkContactWrenches(const Model & model);
 
         /**
@@ -104,7 +104,7 @@ namespace iDynTree
          *
          * @param[in] nrOfLinks the number of links to which resize this object
          */
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const Model & model);
 
         /**

--- a/src/model/include/iDynTree/Model/Indices.h
+++ b/src/model/include/iDynTree/Model/Indices.h
@@ -11,6 +11,7 @@
 #ifndef IDYNTREE_INDICES_H
 #define IDYNTREE_INDICES_H
 
+#include <cstddef>
 #include <string>
 
 // Workaround for SWIG problems with GenerateExportHeader-generated code
@@ -22,24 +23,23 @@
 
 namespace iDynTree
 {
-    typedef int LinkIndex;
+    typedef std::ptrdiff_t LinkIndex;
     IDYNTREE_MODEL_EXPORT extern LinkIndex LINK_INVALID_INDEX;
     IDYNTREE_MODEL_EXPORT extern std::string LINK_INVALID_NAME;
 
-    typedef int JointIndex;
-    IDYNTREE_MODEL_EXPORT extern int JOINT_INVALID_INDEX;
+    typedef std::ptrdiff_t JointIndex;
+    IDYNTREE_MODEL_EXPORT extern std::ptrdiff_t JOINT_INVALID_INDEX;
     IDYNTREE_MODEL_EXPORT extern std::string JOINT_INVALID_NAME;
 
-    typedef int DOFIndex;
-    IDYNTREE_MODEL_EXPORT extern int DOF_INVALID_INDEX;
+    typedef std::ptrdiff_t DOFIndex;
+    IDYNTREE_MODEL_EXPORT extern std::ptrdiff_t DOF_INVALID_INDEX;
     IDYNTREE_MODEL_EXPORT extern std::string DOF_INVALID_NAME;
 
-
-    typedef int FrameIndex;
-    IDYNTREE_MODEL_EXPORT extern int FRAME_INVALID_INDEX;
+    typedef std::ptrdiff_t FrameIndex;
+    IDYNTREE_MODEL_EXPORT extern std::ptrdiff_t FRAME_INVALID_INDEX;
     IDYNTREE_MODEL_EXPORT extern std::string FRAME_INVALID_NAME;
 
-    typedef int TraversalIndex;
+    typedef std::ptrdiff_t TraversalIndex;
     IDYNTREE_MODEL_EXPORT extern TraversalIndex TRAVERSAL_INVALID_INDEX;
 
 }

--- a/src/model/include/iDynTree/Model/JointState.h
+++ b/src/model/include/iDynTree/Model/JointState.h
@@ -29,10 +29,10 @@ namespace iDynTree
     class JointPosDoubleArray: public VectorDynSize
     {
     public:
-        JointPosDoubleArray(unsigned int nrOfDOFs = 0);
+        JointPosDoubleArray(std::size_t nrOfDOFs = 0);
         JointPosDoubleArray(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfDOFs);
+        void resize(std::size_t nrOfDOFs);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const iDynTree::Model & model) const;
@@ -47,10 +47,10 @@ namespace iDynTree
     class JointDOFsDoubleArray: public VectorDynSize
     {
     public:
-        JointDOFsDoubleArray(unsigned int nrOfDOFs = 0);
+        JointDOFsDoubleArray(std::size_t nrOfDOFs = 0);
         JointDOFsDoubleArray(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfDOFs);
+        void resize(std::size_t nrOfDOFs);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const iDynTree::Model & model) const;
@@ -73,10 +73,10 @@ namespace iDynTree
         std::vector<iDynTree::SpatialForceVector> m_dofSpatialForce;
 
     public:
-        DOFSpatialForceArray(unsigned int nrOfDOFs = 0);
+        DOFSpatialForceArray(std::size_t nrOfDOFs = 0);
         DOFSpatialForceArray(const iDynTree::Model & model);
 
-        void resize(const unsigned int nrOfDOFs);
+        void resize(const std::size_t nrOfDOFs);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const iDynTree::Model & model) const;
@@ -97,10 +97,10 @@ namespace iDynTree
         std::vector<iDynTree::SpatialMotionVector> m_dofSpatialMotion;
 
     public:
-        DOFSpatialMotionArray(unsigned int nrOfDOFs = 0);
+        DOFSpatialMotionArray(std::size_t nrOfDOFs = 0);
         DOFSpatialMotionArray(const iDynTree::Model & model);
 
-        void resize(const unsigned int nrOfDOFs);
+        void resize(const std::size_t nrOfDOFs);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const iDynTree::Model & model) const;

--- a/src/model/include/iDynTree/Model/LinkState.h
+++ b/src/model/include/iDynTree/Model/LinkState.h
@@ -31,10 +31,10 @@ namespace iDynTree
         std::vector<iDynTree::Transform> m_linkPos;
 
     public:
-        LinkPositions(unsigned int nrOfLinks = 0);
+        LinkPositions(std::size_t nrOfLinks = 0);
         LinkPositions(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const Model& model) const;
@@ -73,7 +73,7 @@ namespace iDynTree
          *
          * @param[in] nrOfLinks the size of the vector.
          */
-        LinkWrenches(unsigned int nrOfLinks = 0);
+        LinkWrenches(std::size_t nrOfLinks = 0);
         LinkWrenches(const iDynTree::Model & model);
 
         /**
@@ -81,7 +81,7 @@ namespace iDynTree
          *
          * @param[in] nrOfLinks new size for the vector
          */
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const Model& model) const;
@@ -138,10 +138,10 @@ namespace iDynTree
         std::vector<iDynTree::SpatialInertia> m_linkInertials;
 
     public:
-        LinkInertias(unsigned int nrOfLinks = 0);
+        LinkInertias(std::size_t nrOfLinks = 0);
         LinkInertias(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const Model& model) const;
@@ -163,10 +163,10 @@ namespace iDynTree
         std::vector<iDynTree::ArticulatedBodyInertia> m_linkABIs;
 
     public:
-        LinkArticulatedBodyInertias(unsigned int nrOfLinks = 0);
+        LinkArticulatedBodyInertias(std::size_t nrOfLinks = 0);
         LinkArticulatedBodyInertias(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const Model& model) const;
@@ -186,10 +186,10 @@ namespace iDynTree
         std::vector<iDynTree::Twist> m_linkTwist;
 
     public:
-        LinkVelArray(unsigned int nrOfLinks = 0);
+        LinkVelArray(std::size_t nrOfLinks = 0);
         LinkVelArray(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const Model& model) const;
@@ -214,10 +214,10 @@ namespace iDynTree
         std::vector<iDynTree::SpatialAcc> m_linkAcc;
 
     public:
-        LinkAccArray(unsigned int nrOfLinks = 0);
+        LinkAccArray(std::size_t nrOfLinks = 0);
         LinkAccArray(const iDynTree::Model & model);
 
-        void resize(unsigned int nrOfLinks);
+        void resize(std::size_t nrOfLinks);
         void resize(const iDynTree::Model & model);
 
         bool isConsistent(const Model& model) const;
@@ -225,7 +225,7 @@ namespace iDynTree
         iDynTree::SpatialAcc & operator()(const LinkIndex link);
         const iDynTree::SpatialAcc & operator()(const LinkIndex link) const;
 
-        unsigned int getNrOfLinks() const;
+        std::size_t getNrOfLinks() const;
 
         std::string toString(const Model & model) const;
 

--- a/src/model/src/ContactWrench.cpp
+++ b/src/model/src/ContactWrench.cpp
@@ -36,19 +36,19 @@ const Wrench& ContactWrench::contactWrench() const
     return m_contactWrench;
 }
 
-long unsigned int& ContactWrench::contactId()
+std::size_t& ContactWrench::contactId()
 {
     return m_contactId;
 }
 
 
-const long unsigned int& ContactWrench::contactId() const
+const std::size_t& ContactWrench::contactId() const
 {
     return m_contactId;
 }
 
 
-LinkContactWrenches::LinkContactWrenches(unsigned int nrOfLinks)
+LinkContactWrenches::LinkContactWrenches(std::size_t nrOfLinks)
 {
     this->resize(nrOfLinks);
 }
@@ -64,7 +64,7 @@ void LinkContactWrenches::resize(const iDynTree::Model& model)
     resize(model.getNrOfLinks());
 }
 
-void LinkContactWrenches::resize(unsigned int nrOfLinks)
+void LinkContactWrenches::resize(std::size_t nrOfLinks)
 {
     // To avoid dynamic memory allocation at runtime
     // we make sure that the vector have at least spaces for 3 contacts
@@ -112,7 +112,7 @@ bool LinkContactWrenches::computeNetWrenches(LinkNetExternalWrenches& netWrenche
         netWrenches.resize(m_linkContactWrenches.size());
     }
 
-    for(LinkIndex l=0; l < nrOfLinks; l++)
+    for(LinkIndex l=0; l < static_cast<LinkIndex>(nrOfLinks); l++)
     {
         netWrenches(l).zero();
 

--- a/src/model/src/JointState.cpp
+++ b/src/model/src/JointState.cpp
@@ -17,7 +17,7 @@
 namespace iDynTree
 {
 
-JointPosDoubleArray::JointPosDoubleArray(unsigned int nrOfPosCoords): VectorDynSize(nrOfPosCoords)
+JointPosDoubleArray::JointPosDoubleArray(std::size_t nrOfPosCoords): VectorDynSize(nrOfPosCoords)
 {
 
 }
@@ -32,7 +32,7 @@ void JointPosDoubleArray::resize(const iDynTree::Model& model)
     resize(model.getNrOfPosCoords());
 }
 
-void JointPosDoubleArray::resize(unsigned int nrOfPosCoords)
+void JointPosDoubleArray::resize(std::size_t nrOfPosCoords)
 {
     VectorDynSize::resize(nrOfPosCoords);
     this->zero();
@@ -49,7 +49,7 @@ JointPosDoubleArray::~JointPosDoubleArray()
 }
 
 
-JointDOFsDoubleArray::JointDOFsDoubleArray(unsigned int nrOfDOFs): VectorDynSize(nrOfDOFs)
+JointDOFsDoubleArray::JointDOFsDoubleArray(std::size_t nrOfDOFs): VectorDynSize(nrOfDOFs)
 {
 
 }
@@ -64,7 +64,7 @@ void JointDOFsDoubleArray::resize(const iDynTree::Model& model)
     resize(model.getNrOfDOFs());
 }
 
-void JointDOFsDoubleArray::resize(unsigned int nrOfDOFs)
+void JointDOFsDoubleArray::resize(std::size_t nrOfDOFs)
 {
     VectorDynSize::resize(nrOfDOFs);
     this->zero();
@@ -80,7 +80,7 @@ JointDOFsDoubleArray::~JointDOFsDoubleArray()
 
 }
 
-DOFSpatialForceArray::DOFSpatialForceArray(unsigned int nrOfDOFs)
+DOFSpatialForceArray::DOFSpatialForceArray(std::size_t nrOfDOFs)
 {
     resize(nrOfDOFs);
 }
@@ -95,7 +95,7 @@ void DOFSpatialForceArray::resize(const iDynTree::Model& model)
     resize(model.getNrOfDOFs());
 }
 
-void DOFSpatialForceArray::resize(const unsigned int nrOfDOFs)
+void DOFSpatialForceArray::resize(const std::size_t nrOfDOFs)
 {
     this->m_dofSpatialForce.resize(nrOfDOFs,iDynTree::SpatialForceVector::Zero());
 }
@@ -122,7 +122,7 @@ DOFSpatialForceArray::~DOFSpatialForceArray()
 }
 
 
-DOFSpatialMotionArray::DOFSpatialMotionArray(unsigned int nrOfDOFs)
+DOFSpatialMotionArray::DOFSpatialMotionArray(std::size_t nrOfDOFs)
 {
     resize(nrOfDOFs);
 }
@@ -142,7 +142,7 @@ bool DOFSpatialMotionArray::isConsistent(const Model& model) const
     return (this->m_dofSpatialMotion.size() == model.getNrOfDOFs());
 }
 
-void DOFSpatialMotionArray::resize(const unsigned int nrOfDOFs)
+void DOFSpatialMotionArray::resize(const std::size_t nrOfDOFs)
 {
     this->m_dofSpatialMotion.resize(nrOfDOFs,iDynTree::SpatialMotionVector::Zero());
 }

--- a/src/model/src/LinkState.cpp
+++ b/src/model/src/LinkState.cpp
@@ -16,7 +16,7 @@
 namespace iDynTree
 {
 
-LinkPositions::LinkPositions(unsigned int nrOfLinks)
+LinkPositions::LinkPositions(std::size_t nrOfLinks)
 {
     resize(nrOfLinks);
 }
@@ -31,7 +31,7 @@ void LinkPositions::resize(const Model& model)
     resize(model.getNrOfLinks());
 }
 
-void LinkPositions::resize(unsigned int nrOfLinks)
+void LinkPositions::resize(std::size_t nrOfLinks)
 {
     Transform identityTransform = Transform::Identity();
     this->m_linkPos.resize(nrOfLinks);
@@ -86,7 +86,7 @@ LinkWrenches::LinkWrenches(const Model& model)
     resize(model);
 }
 
-LinkWrenches::LinkWrenches(unsigned int nrOfLinks)
+LinkWrenches::LinkWrenches(std::size_t nrOfLinks)
 {
     resize(nrOfLinks);
 }
@@ -96,7 +96,7 @@ void LinkWrenches::resize(const Model& model)
     this->resize(model.getNrOfLinks());
 }
 
-void LinkWrenches::resize(unsigned int nrOfLinks)
+void LinkWrenches::resize(std::size_t nrOfLinks)
 {
     iDynTree::Wrench zeroWrench = iDynTree::Wrench::Zero();
     this->m_linkWrenches.resize(nrOfLinks,zeroWrench);
@@ -149,7 +149,7 @@ LinkWrenches::~LinkWrenches()
     resize(0);
 }
 
-LinkInertias::LinkInertias(unsigned int nrOfLinks)
+LinkInertias::LinkInertias(std::size_t nrOfLinks)
 {
     this->resize(nrOfLinks);
 }
@@ -164,7 +164,7 @@ void LinkInertias::resize(const Model& model)
     this->resize(model.getNrOfLinks());
 }
 
-void LinkInertias::resize(unsigned int nrOfLinks)
+void LinkInertias::resize(std::size_t nrOfLinks)
 {
     /**
      * We reset the vector elements to be zero because the resize is
@@ -202,7 +202,7 @@ LinkVelArray::LinkVelArray(const Model& model)
     resize(model);
 }
 
-LinkVelArray::LinkVelArray(unsigned int nrOfLinks)
+LinkVelArray::LinkVelArray(std::size_t nrOfLinks)
 {
     resize(nrOfLinks);
 }
@@ -222,7 +222,7 @@ void LinkVelArray::resize(const Model& model)
     resize(model.getNrOfLinks());
 }
 
-void LinkVelArray::resize(unsigned int nrOfLinks)
+void LinkVelArray::resize(std::size_t nrOfLinks)
 {
     iDynTree::Twist zeroTwist = iDynTree::Twist::Zero();
     this->m_linkTwist.resize(nrOfLinks,zeroTwist);
@@ -261,7 +261,7 @@ LinkAccArray::LinkAccArray(const Model& model)
     resize(model);
 }
 
-LinkAccArray::LinkAccArray(unsigned int nrOfLinks)
+LinkAccArray::LinkAccArray(std::size_t nrOfLinks)
 {
     resize(nrOfLinks);
 }
@@ -281,7 +281,7 @@ void LinkAccArray::resize(const Model& model)
     resize(model.getNrOfLinks());
 }
 
-void LinkAccArray::resize(unsigned int nrOfLinks)
+void LinkAccArray::resize(std::size_t nrOfLinks)
 {
     iDynTree::SpatialAcc zeroAcc = iDynTree::SpatialAcc::Zero();
     this->m_linkAcc.resize(nrOfLinks,zeroAcc);
@@ -292,7 +292,7 @@ bool LinkAccArray::isConsistent(const Model& model) const
     return (this->m_linkAcc.size() == model.getNrOfLinks());
 }
 
-unsigned int LinkAccArray::getNrOfLinks() const
+std::size_t LinkAccArray::getNrOfLinks() const
 {
     return this->m_linkAcc.size();
 }
@@ -319,7 +319,7 @@ LinkArticulatedBodyInertias::LinkArticulatedBodyInertias(const Model& model)
     resize(model);
 }
 
-LinkArticulatedBodyInertias::LinkArticulatedBodyInertias(unsigned int nrOfLinks)
+LinkArticulatedBodyInertias::LinkArticulatedBodyInertias(std::size_t nrOfLinks)
 {
     resize(nrOfLinks);
 }
@@ -339,7 +339,7 @@ void LinkArticulatedBodyInertias::resize(const Model& model)
     resize(model.getNrOfLinks());
 }
 
-void LinkArticulatedBodyInertias::resize(unsigned int nrOfLinks)
+void LinkArticulatedBodyInertias::resize(std::size_t nrOfLinks)
 {
     ArticulatedBodyInertia abi;
     abi.zero();

--- a/src/model_io/urdf/include/private/URDFParsingUtils.h
+++ b/src/model_io/urdf/include/private/URDFParsingUtils.h
@@ -72,6 +72,14 @@ std::string inline intToString(const int inInt)
     return ss.str();
 }
 
+std::string inline intToString(const size_t inInt)
+{
+    std::stringstream ss;
+    ss << inInt;
+    return ss.str();
+}
+
+
 /**
  * Split string along spaces
  */

--- a/src/sensors/include/iDynTree/Sensors/Sensors.h
+++ b/src/sensors/include/iDynTree/Sensors/Sensors.h
@@ -70,7 +70,7 @@ namespace iDynTree {
         return !isLinkSensor(type);
     }
 
-    inline unsigned int getSensorTypeSize(const SensorType type)
+    inline std::size_t getSensorTypeSize(const SensorType type)
     {
         switch(type)
         {
@@ -171,7 +171,7 @@ namespace iDynTree {
          *
          * @return the index of the parent (Junction or Link) of the sensor.
          */
-        virtual int getParentJointIndex() const = 0;
+        virtual JointIndex getParentJointIndex() const = 0;
 
         /**
          * Set the name of the parent Joint.
@@ -181,7 +181,7 @@ namespace iDynTree {
         /**
          * Set the numeric index of the parent joint of the sensor.
          */
-        virtual bool setParentJointIndex(const int &) = 0;
+        virtual bool setParentJointIndex(const JointIndex &) = 0;
 
         /**
          * Check if the sensor is consistent with the specified model.
@@ -305,7 +305,7 @@ namespace iDynTree {
              * @param[in] sensor constant reference to the Sensor to add.
              * @return the sensor index of the newly added sensor, or -1 in case of error.
              */
-            int addSensor(const Sensor & sensor);
+            std::ptrdiff_t addSensor(const Sensor & sensor);
 
             /**
              * Change the serialization of a specific sensor type.
@@ -321,14 +321,14 @@ namespace iDynTree {
              * Get the number of sensors of type sensor_type in this SensorsList .
              * @return the number of sensors of type sensor_type
              */
-            unsigned int getNrOfSensors(const SensorType & sensor_type) const;
+            std::size_t getNrOfSensors(const SensorType & sensor_type) const;
 
             /**
              * Get the index of a sensor of type sensor_type in this SensorList
              *
              * @return true if the sensor name is found, false otherwise.
              */
-            bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, unsigned int & sensor_index) const;
+            bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, std::ptrdiff_t & sensor_index) const;
 
             /**
              * Get the index of a sensor of type sensor_type and with name sensor_name
@@ -338,7 +338,7 @@ namespace iDynTree {
              * \note Some languages do not support well in-output parameters, so we provided this
              *       method as an alternative to the three-arguments getSensorIndex
              */
-            int getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name) const;
+            std::ptrdiff_t getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name) const;
 
             /**
              * Get the total size of sensor measurements.
@@ -351,7 +351,7 @@ namespace iDynTree {
              *
              * \return the pointer of sensor, of 0 if sensor_index is out of bounds
              */
-            Sensor * getSensor(const SensorType & sensor_type, int sensor_index) const;
+            Sensor * getSensor(const SensorType & sensor_type, std::ptrdiff_t sensor_index) const;
 
             /**
              * Check if all the sensors in the list are consistent with the specified model.
@@ -359,7 +359,7 @@ namespace iDynTree {
             bool isConsistent(const Model& model) const;
 
             bool removeSensor(const SensorType & sensor_type, const std::string & _sensor_name);
-            bool removeSensor(const SensorType & sensor_type, const unsigned int sensor_index);
+            bool removeSensor(const SensorType & sensor_type, const std::ptrdiff_t sensor_index);
             bool removeAllSensorsOfType(const SensorType & sensor_type);
 
             iterator allSensorsIterator();
@@ -543,13 +543,13 @@ namespace iDynTree {
              * Set the number of sensors of type sensor_type in this SensorsTree .
              * @return true if all went right, false otherwise
              */
-            bool setNrOfSensors(const SensorType & sensor_type, unsigned int nrOfSensors);
+            bool setNrOfSensors(const SensorType & sensor_type, std::size_t nrOfSensors);
 
             /**
              * Get the number of sensors of type sensor_type in this SensorsMeasurements .
              * @return the number of sensors of type sensor_type
              */
-            unsigned int getNrOfSensors(const SensorType & sensor_type) const;
+            std::size_t getNrOfSensors(const SensorType & sensor_type) const;
 
             /**
              * Resize and reset the measurement vectors
@@ -570,10 +570,10 @@ namespace iDynTree {
              * and the specified sensor_type uses Wrench as its measurement type.
              */
             bool setMeasurement(const SensorType & sensor_type,
-                                const unsigned int & sensor_index,
+                                const std::ptrdiff_t & sensor_index,
                                 const iDynTree::Wrench & measurement);
             bool setMeasurement(const SensorType & sensor_type,
-                                const unsigned int & sensor_index,
+                                const std::ptrdiff_t & sensor_index,
                                 const Vector3 & measurement);
 
 
@@ -584,10 +584,10 @@ namespace iDynTree {
              * and the specified sensor_type uses its appropriate type as its measurement type.
              */
             bool getMeasurement(const SensorType & sensor_type,
-                                const unsigned int & sensor_index,
+                                const std::ptrdiff_t & sensor_index,
                                 iDynTree::Wrench & measurement) const;
             bool getMeasurement(const SensorType & sensor_type,
-                                const unsigned int & sensor_index,
+                                const std::ptrdiff_t & sensor_index,
                                 Vector3& measurement) const;
 
             /**

--- a/src/sensors/include/iDynTree/Sensors/SixAxisForceTorqueSensor.h
+++ b/src/sensors/include/iDynTree/Sensors/SixAxisForceTorqueSensor.h
@@ -72,14 +72,14 @@ namespace iDynTree {
          *
          * @return true if link_index is one of the two links attached to the FT sensor, false otherwise.
          */
-        bool setFirstLinkSensorTransform(const int link_index, const iDynTree::Transform & link_H_sensor) const;
+        bool setFirstLinkSensorTransform(const LinkIndex link_index, const iDynTree::Transform & link_H_sensor) const;
 
         /**
          * Set the transform from the sensor to a the second link attached to the sensor.
          *
          * @return true if link_index is one of the two links attached to the FT sensor, false otherwise.
          */
-        bool setSecondLinkSensorTransform(const int link_index, const iDynTree::Transform & link_H_sensor) const;
+        bool setSecondLinkSensorTransform(const LinkIndex link_index, const iDynTree::Transform & link_H_sensor) const;
 
         /**
          * Get the index of the first link attached to the sensor.
@@ -119,7 +119,7 @@ namespace iDynTree {
         bool setParentJoint(const std::string &parent);
 
         // Documented in JointSensor
-        bool setParentJointIndex(const int &parent_index);
+        bool setParentJointIndex(const JointIndex &parent_index);
 
         /**
          * The Six Axis Force Torque sensor measure the Force Torque (wrench)
@@ -127,7 +127,7 @@ namespace iDynTree {
          * on which the measured force is applied.
          * @return the index of the link on which the measure force is applied.
          */
-        bool setAppliedWrenchLink(const int applied_wrench_index);
+        bool setAppliedWrenchLink(const LinkIndex applied_wrench_index);
 
         /**
          * Documented in the sensor
@@ -167,13 +167,13 @@ namespace iDynTree {
          * on which the measured force is applied.
          * @return the index of the link on which the measure force is applied.
          */
-        int getAppliedWrenchLink() const;
+        LinkIndex getAppliedWrenchLink() const;
 
         /**
          * Check if a given link is attached to this FT sensor.
          * @return true if link_index is attached to the ft sensor, false otherwise
          */
-        bool isLinkAttachedToSensor(const int link_index) const;
+        bool isLinkAttachedToSensor(const LinkIndex link_index) const;
 
 
         /**
@@ -181,7 +181,7 @@ namespace iDynTree {
          *
          * @return true if link_index is one of the two links attached to the FT sensor, false otherwise.
          */
-        bool getLinkSensorTransform(const int link_index, iDynTree::Transform & link_H_sensor) const;
+        bool getLinkSensorTransform(const LinkIndex link_index, iDynTree::Transform & link_H_sensor) const;
 
 
         /**
@@ -192,7 +192,7 @@ namespace iDynTree {
          *
          * @return true if link_index is one of the two links attached to the FT sensor, false otherwise.
          */
-        bool getWrenchAppliedOnLink(const int link_index,
+        bool getWrenchAppliedOnLink(const LinkIndex link_index,
                                     const iDynTree::Wrench & measured_wrench,
                                     iDynTree::Wrench & wrench_applied_on_link ) const;
 

--- a/src/sensors/src/AccelerometerSensor.cpp
+++ b/src/sensors/src/AccelerometerSensor.cpp
@@ -24,9 +24,9 @@ struct AccelerometerSensor::AccelerometerPrivateAttributes
     std::string name;
     // Transform from the link to the sensor
     Transform link_H_sensor;
-    // Index of the parent junction
-    int parent_link_index;
-    // Name of the parent junction
+    // Index of the parent link
+    LinkIndex parent_link_index;
+    // Name of the parent link
      std::string parent_link_name;
     // Name of the link to which the Accelerometer is connected
 };
@@ -96,7 +96,7 @@ std::string AccelerometerSensor::getParentLink() const
     return(this->pimpl->parent_link_name);
 }
 
-int AccelerometerSensor::getParentLinkIndex() const
+LinkIndex AccelerometerSensor::getParentLinkIndex() const
 {
     return(this->pimpl->parent_link_index);
 }

--- a/src/sensors/src/GyroscopeSensor.cpp
+++ b/src/sensors/src/GyroscopeSensor.cpp
@@ -23,7 +23,7 @@ struct GyroscopeSensor::GyroscopePrivateAttributes
    // Transform from the link to the sensor
     Transform link_H_sensor;
     // Index of the parent link
-     int parent_link_index;
+    LinkIndex parent_link_index;
     // Name of the parent link
      std::string parent_link_name;
 };
@@ -79,7 +79,7 @@ bool GyroscopeSensor::setParentLink(const std::string& parent)
     return true;
 }
 
-bool GyroscopeSensor::setParentLinkIndex(const int &parent_index)
+bool GyroscopeSensor::setParentLinkIndex(const LinkIndex &parent_index)
 {
     this->pimpl->parent_link_index = parent_index;
     return true;

--- a/src/sensors/src/SixAxisForceTorqueSensor.cpp
+++ b/src/sensors/src/SixAxisForceTorqueSensor.cpp
@@ -77,21 +77,21 @@ bool SixAxisForceTorqueSensor::setName(const std::string& _name)
 }
 
 
-bool SixAxisForceTorqueSensor::setAppliedWrenchLink(const int applied_wrench_index)
+bool SixAxisForceTorqueSensor::setAppliedWrenchLink(const LinkIndex applied_wrench_index)
 {
     this->pimpl->appliedWrenchLink = applied_wrench_index;
     return true;
 }
 
 
-bool SixAxisForceTorqueSensor::setFirstLinkSensorTransform(const int link_index, const iDynTree::Transform& link_H_sensor) const
+bool SixAxisForceTorqueSensor::setFirstLinkSensorTransform(const LinkIndex link_index, const iDynTree::Transform& link_H_sensor) const
 {
     this->pimpl->link1 = link_index;
     this->pimpl->link1_H_sensor = link_H_sensor;
     return true;
 }
 
-bool SixAxisForceTorqueSensor::setSecondLinkSensorTransform(const int link_index, const iDynTree::Transform& link_H_sensor) const
+bool SixAxisForceTorqueSensor::setSecondLinkSensorTransform(const LinkIndex link_index, const iDynTree::Transform& link_H_sensor) const
 {
     this->pimpl->link2 = link_index;
     this->pimpl->link2_H_sensor = link_H_sensor;
@@ -104,7 +104,7 @@ bool SixAxisForceTorqueSensor::setParentJoint(const std::string& parent)
     return true;
 }
 
-bool SixAxisForceTorqueSensor::setParentJointIndex(const int &parent_index)
+bool SixAxisForceTorqueSensor::setParentJointIndex(const JointIndex &parent_index)
 {
     this->pimpl->parent_junction_index = parent_index;
     return true;
@@ -188,7 +188,7 @@ SensorType SixAxisForceTorqueSensor::getSensorType() const
 }
 
 
-int SixAxisForceTorqueSensor::getAppliedWrenchLink() const
+LinkIndex SixAxisForceTorqueSensor::getAppliedWrenchLink() const
 {
     return this->pimpl->appliedWrenchLink;
 }
@@ -203,14 +203,14 @@ JointIndex SixAxisForceTorqueSensor::getParentJointIndex() const
     return this->pimpl->parent_junction_index;
 }
 
-bool SixAxisForceTorqueSensor::isLinkAttachedToSensor(const int link_index) const
+bool SixAxisForceTorqueSensor::isLinkAttachedToSensor(const LinkIndex link_index) const
 {
     return (this->pimpl->link1 == link_index ||
             this->pimpl->link2 == link_index );
 }
 
 
-bool SixAxisForceTorqueSensor::getLinkSensorTransform(const int link_index, iDynTree::Transform& link_H_sensor) const
+bool SixAxisForceTorqueSensor::getLinkSensorTransform(const LinkIndex link_index, iDynTree::Transform& link_H_sensor) const
 {
     if( this->pimpl->link1 == link_index )
     {
@@ -227,7 +227,7 @@ bool SixAxisForceTorqueSensor::getLinkSensorTransform(const int link_index, iDyn
     return false;
 }
 
-bool SixAxisForceTorqueSensor::getWrenchAppliedOnLink(const int link_index,
+bool SixAxisForceTorqueSensor::getWrenchAppliedOnLink(const LinkIndex link_index,
                                                       const Wrench& measured_wrench,
                                                       iDynTree::Wrench& wrench_applied_on_link) const
 {

--- a/src/sensors/src/ThreeAxisAngularAccelerometerSensor.cpp
+++ b/src/sensors/src/ThreeAxisAngularAccelerometerSensor.cpp
@@ -26,9 +26,9 @@ struct ThreeAxisAngularAccelerometerSensor::ThreeAxisAngularAccelerometerPrivate
     std::string name;
     // Transform from the link to the sensor
     Transform link_H_sensor;
-    // Index of the parent junction
-    int parent_link_index;
-    // Name of the parent junction
+    // Index of the parent link
+    iDynTree::LinkIndex parent_link_index;
+    // Name of the parent link
      std::string parent_link_name;
     // Name of the link to which the Accelerometer is connected
 };
@@ -98,7 +98,7 @@ std::string ThreeAxisAngularAccelerometerSensor::getParentLink() const
     return(this->pimpl->parent_link_name);
 }
 
-int ThreeAxisAngularAccelerometerSensor::getParentLinkIndex() const
+iDynTree::LinkIndex ThreeAxisAngularAccelerometerSensor::getParentLinkIndex() const
 {
     return(this->pimpl->parent_link_index);
 }

--- a/src/sensors/src/ThreeAxisForceTorqueContactSensor.cpp
+++ b/src/sensors/src/ThreeAxisForceTorqueContactSensor.cpp
@@ -23,7 +23,7 @@ struct ThreeAxisForceTorqueContactSensor::ThreeAxisForceTorqueContactSensorPriva
 {
     std::string name;
     Transform link_H_sensor;
-    int parent_link_index;
+    LinkIndex parent_link_index;
     std::string parent_link_name;
 
     std::vector<Position> m_loadCellLocations;
@@ -94,7 +94,7 @@ std::string ThreeAxisForceTorqueContactSensor::getParentLink() const
     return(this->pimpl->parent_link_name);
 }
 
-int ThreeAxisForceTorqueContactSensor::getParentLinkIndex() const
+LinkIndex ThreeAxisForceTorqueContactSensor::getParentLinkIndex() const
 {
     return(this->pimpl->parent_link_index);
 }


### PR DESCRIPTION
It just started for solving some warnings: 
~~~
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(116,49): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<const double>::index_type' to 'int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(116,27): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<const double>::index_type' to 'const int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(117,49): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<const double>::index_type' to 'int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(117,27): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<const double>::index_type' to 'const int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(165,49): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<double>::index_type' to 'int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(165,27): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<double>::index_type' to 'const int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(166,49): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<double>::index_type' to 'int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(166,27): warning C4244: 'initializing': conversion from 'iDynTree::MatrixView<double>::index_type' to 'const int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
C:\src\idyntree\src\core\include\iDynTree/Core/EigenHelpers.h(374,14): warning C4244: 'argument': conversion from 'const ptrdiff_t' to 'const unsigned int', possible loss of data [C:\src\idyntree\build\src\core\idyntree-core.vcxproj]
~~~

And as usual it escalated to a large scale change. However, it is better to do this before the iDynTree 2 releases as it changes (slightly) the API and the ABI.

For consistency with std and Eigen, all sizes and indices have been changed to use `std::size_t` for unsigned quantities and `std::ptrdiff_t` for signed quantities. The only exception is the index stored in the triplets of the iDynTree::SparseMatrix data structure, that have been left defined to `int` for compatibility with Eigen.