### PR TITLE
Deprecate getSensorIndex with unsigned int instead of removing it

### DIFF
--- a/src/sensors/include/iDynTree/Sensors/Sensors.h
+++ b/src/sensors/include/iDynTree/Sensors/Sensors.h
@@ -331,6 +331,15 @@ namespace iDynTree {
             bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, std::ptrdiff_t & sensor_index) const;
 
             /**
+             * Get the index of a sensor of type sensor_type in this SensorList
+             *
+             * @return true if the sensor name is found, false otherwise.
+             *
+             * @deprecated Use the version that takes in input a  std::ptrdiff_t sensor_index 
+             */
+            IDYNTREE_DEPRECATED_WITH_MSG("Use std::ptrdiff_t for representing the SensorIndex.") bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, unsigned int & sensor_index) const;
+
+            /**
              * Get the index of a sensor of type sensor_type and with name sensor_name
              *
              * @return the sensor index if the sensor_name is found, -1 otherwise.

--- a/src/sensors/src/Sensors.cpp
+++ b/src/sensors/src/Sensors.cpp
@@ -202,6 +202,18 @@ bool SensorsList::getSensorIndex(const SensorType & sensor_type, const std::stri
     }
 }
 
+bool SensorsList::getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, unsigned int & sensor_index) const
+{
+    std::ptrdiff_t sensor_index_full ;
+    bool ret = this->getSensorIndex(sensor_type, _sensor_name, sensor_index_full);
+    if (ret) 
+    {
+        sensor_index = static_cast<unsigned int>(sensor_index_full);
+    }
+    return ret;
+}
+
+
 std::ptrdiff_t SensorsList::getSensorIndex(const SensorType& sensor_type, const std::string& _sensor_name) const
 {
     std::ptrdiff_t retVal;


### PR DESCRIPTION
In https://github.com/robotology/idyntree/pull/767 I was a bit too aggressive, and I removed a function that instead requires a proper cycle of deprecation. This fix the compilation of https://github.com/robotology/whole-body-estimators with the latest iDynTree .