### PR TITLE
Bump iDynTree version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased Major]
+## [Unreleased]
+
+## [2.0.0] - 2020-11-22
 
 ### Added
 - Added a new CMake option `IDYNTREE_COMPILES_TOOLS` to disable compilation of iDynTree tools.
@@ -40,8 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python2 will not be maintained past 2020 and its support has been dropped (https://github.com/robotology/idyntree/pull/726).
 - Remove the need to call `iDynTree.init_helpers()` and `iDynTree.init_numpy_helpers()` from Python (https://github.com/robotology/idyntree/pull/726).
 - Remove headers and methods that were deprecated in iDynTree 1.0 (https://github.com/robotology/idyntree/pull/751).
-
-## [Unreleased]
 
 ## [1.2.0] - 2020-10-17
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 1.99.2
+project(iDynTree VERSION 2.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
After this PR is merged, I will merge devel in master and release iDynTree 2.0.0 .

Fix https://github.com/robotology/idyntree/issues/773 .