### PR TITLE
Restore the linking of iDynTreeMEX target on MATLAB libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed compilation of MATLAB bindings on macOS and Windows (https://github.com/robotology/idyntree/pull/789).
+
 ## [2.0.1] - 2020-11-24
 
 ### Fixed 

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -106,7 +106,7 @@ if(IDYNTREE_USES_MATLAB)
                PREFIX ""
                SUFFIX .mex)
 
-  target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} idyntree-core)
+  target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} idyntree-core ${Matlab_LIBRARIES})
   target_include_directories(${target_name} PUBLIC ${Matlab_INCLUDE_DIRS})
   set_target_properties(${target_name} PROPERTIES PREFIX "" SUFFIX .${Matlab_MEX_EXTENSION})
 


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/788 . 

This was a regression from https://github.com/robotology/idyntree/pull/746, in particular from here https://github.com/robotology/idyntree/pull/746/files#diff-9d10f303173345085f88ea98e48217c2a1facafafbdeb9d41cd94060ed45d5b7L95 in which the line: 
~~~cmake
swig_link_libraries(${mexname} ${Matlab_LIBRARIES} ${IDYNTREE_LIBRARIES} idyntree-core) 
~~~
was removed, but only: 
~~~cmake
target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} idyntree-core) 
~~~
was added back. 