### PR TITLE
Fix C4566 Visual Studio warning

### DIFF
--- a/src/core/include/iDynTree/Core/TestUtils.h
+++ b/src/core/include/iDynTree/Core/TestUtils.h
@@ -229,7 +229,12 @@ namespace iDynTree
      */
     inline void printMatrixWrongElements(std::string name, std::vector< std::vector<TestMatrixMismatch> > & correctElems)
     {
-        std::cerr << name << "( \u2714 match, (expected,got:error) mismatch): \n";
+#ifndef _WIN32
+#define IDYNTREE_MATCH_CHARACTER "\u2714"
+#else
+#define IDYNTREE_MATCH_CHARACTER "o"
+#endif
+        std::cerr << name << "( " IDYNTREE_MATCH_CHARACTER " match, (expected,got:error) mismatch): \n";
 
         size_t rows = correctElems.size();
         size_t cols = correctElems[0].size();
@@ -239,7 +244,7 @@ namespace iDynTree
             {
                 if( correctElems[row][col].match )
                 {
-                    std::cerr << "\u2714";
+                    std::cerr << IDYNTREE_MATCH_CHARACTER;
                 }
                 else
                 {


### PR DESCRIPTION
The `printMatrixWrongElements` function in TestUtils uses the `✔` U+2714 Unicode character to show that an element of matrix matched the expected value. While this is nice, in Visual Studio (due to how Unicode characters are handled on Windows) this creates the warning:
~~~
C:\src\idyntree-ipopt-tests\src\core\include\iDynTree/Core/TestUtils.h(232,30): warning C4566: character represented by universal-character-name '\u2714' cannot be represented in the current code page (1252) [C:\src\idyntree-ipopt-tests\build-conda2\src\tests\integration\iCubTorqueEstimationIntegrationTest.vcxproj]
C:\src\idyntree-ipopt-tests\src\core\include\iDynTree/Core/TestUtils.h(242,34): warning C4566: character represented by universal-character-name '\u2714' cannot be represented in the current code page (1252) [C:\src\idyntree-ipopt-tests\build-conda2\src\tests\integration\iCubTorqueEstimationIntegrationTest.vcxproj]
  iCubTorqueEstimationIntegrationTest.vcxproj -> C:\src\idyntree-ipopt-tests\build-conda2\bin\Release\iCubTorqueEstimationIntegrationTest.exe
  Building Custom Rule C:/src/idyntree-ipopt-tests/src/model_io/urdf/tests/CMakeLists.txt
~~~
before every test. 

This PR fixes the warning using another character (`o`) when compiling the tests on Windows.