### PR TITLE
GitHub Actions CI: Enable test on Conda Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,6 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
 
     - name: Test [Conda]
-      # Test disabled on Windows due to https://github.com/robotology/idyntree/issues/787
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build


### PR DESCRIPTION
The tests were disabled due to https://github.com/robotology/idyntree/issues/787, that was fixed by https://github.com/conda-forge/ipopt-feedstock/pull/58 . 

As https://github.com/conda-forge/ipopt-feedstock/pull/58 was merged, we can re-enable tests when using conda-provided dependencies also on Windows. 