### PR TITLE
solid-shapes: expose bounding box helper methods in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ``getFileLocationOnLocalFileSystem`` method in ``ExternalMesh`` that attempts to find the mesh location in the local file system. This is now used by the ``Visualizer`` when loading the robot model (https://github.com/robotology/idyntree/pull/798)
 - Add the possibility to extract submatrix with MatrixView (https://github.com/robotology/idyntree/pull/800)
 
+### Changed
+- Promoted the functions `computeBoundingBoxFromShape` and `computeBoxVertices` to public in the `idyntree-solid-shapes` library (https://github.com/robotology/idyntree/pull/801).
+
 ## [2.0.2] - 2020-12-04
 
 ### Fixed 

--- a/src/solid-shapes/include/iDynTree/InertialParametersSolidShapesHelpers.h
+++ b/src/solid-shapes/include/iDynTree/InertialParametersSolidShapesHelpers.h
@@ -12,6 +12,7 @@
 #define IDYNTREE_INERTIAL_PARAMETERS_HELPERS_H
 
 #include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/SolidShapes.h>
 
 namespace iDynTree
 {
@@ -32,8 +33,27 @@ namespace iDynTree
 bool estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(const double totalMass,
                                                                  iDynTree::Model& model,
                                                                  VectorDynSize& estimatedInertialParams);
+/**
+ * @brief Compute bounding box from a solid shape object
+ *
+ * @param[in] geom The link collision as a iDynTree solid shape object
+ * @param[out] box The bounding box for the solid shape object
+ * @return true if all went well, false otherwise .
+ *
+ * @note If the shape is an ExternalMesh type, this function requires IDYNTREE_USES_ASSIMP to be true, otherwise it always returns false.
+ * @note If the shape is an ExternalMesh type, an Axis-Aligned Bounding Box (AABB) is computed from the mesh vertices. 
+ *       This means that the returned bounding box is neither unique nor a minimum volume bounding box for the given mesh.
+ *       The axes alignment to compute AABB is done with respect to the frame associated with the shape.
+ */
+bool computeBoundingBoxFromShape(const SolidShape& geom, Box& box);
 
-
+/**
+ * @brief Get the bounding box vertices in the link frame
+ *
+ * @param[in] box The link collision solid shape as a Box object.
+ * @return vector of vertex positions in the link frame.
+ */
+std::vector<Position> computeBoxVertices(const Box box);
 }
 
 #endif /* IDYNTREE_INERTIAL_PARAMETERS_HELPERS_H */

--- a/src/solid-shapes/src/InertialParametersSolidShapesHelpers.cpp
+++ b/src/solid-shapes/src/InertialParametersSolidShapesHelpers.cpp
@@ -226,85 +226,6 @@ bool BBFromExternalShape(ExternalMesh* extMesh, Box& box)
     }
 }
 
-bool BBFromShape(SolidShape* geom, Box& box)
-{
-    // Extract BB from shape, this would be benefic from being moved as a method in the SolidShape interface
-    if (geom->isBox())
-    {
-        // If shape is a box, just copy it
-        Box* pBox = static_cast<Box*>(geom);
-        box = *pBox;
-        box.setLink_H_geometry(geom->getLink_H_geometry());
-        return true;
-    }
-
-    if (geom->isSphere())
-    {
-        // If shape is a sphere all the side of the BB are the diameter of the sphere
-        Sphere* pSphere = static_cast<Sphere*>(geom);
-        box.setX(2.0*pSphere->getRadius());
-        box.setY(2.0*pSphere->getRadius());
-        box.setZ(2.0*pSphere->getRadius());
-        box.setLink_H_geometry(geom->getLink_H_geometry());
-        return true;
-    }
-
-    if (geom->isCylinder())
-    {
-        // If shape is a cylinder the x and y side of the BB are the diameter of the cylinder,
-        // while the z side is the lenght of the cylinder
-        Cylinder* pCylinder = static_cast<Cylinder*>(geom);
-        box.setX(2.0*pCylinder->getRadius());
-        box.setY(2.0*pCylinder->getRadius());
-        box.setZ(pCylinder->getLength());
-        box.setLink_H_geometry(geom->getLink_H_geometry());
-        return true;
-    }
-
-    if (geom->isExternalMesh())
-    {
-        // If shape is an external mesh, we need to load the mesh and extract the BB
-        ExternalMesh* pExtMesh = static_cast<ExternalMesh*>(geom);
-        return BBFromExternalShape(pExtMesh, box);
-    }
-
-    return false;
-}
-
-/**
- * Compute vertices of the bounding box, computed in link frame
- */
-std::vector<Position> computeBoxVertices(const Box box)
-{
-    std::vector<Position> vertices;
-
-    // + + +
-    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, +box.getY()/2, +box.getZ()/2));
-
-    // + + -
-    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, +box.getY()/2, -box.getZ()/2));
-
-    // + - +
-    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, -box.getY()/2, +box.getZ()/2));
-
-    // + - -
-    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, -box.getY()/2, -box.getZ()/2));
-
-    // - + +
-    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, +box.getY()/2, +box.getZ()/2));
-
-    // - + -
-    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, +box.getY()/2, -box.getZ()/2));
-
-    // - - +
-    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, -box.getY()/2, +box.getZ()/2));
-
-    // - - -
-    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, -box.getY()/2, -box.getZ()/2));
-
-    return vertices;
-}
-
 /**
  * Compute the axis aligned bounding box out of a vector of axis aligned bounding boxes.
  */
@@ -349,7 +270,7 @@ bool getBoundingBoxOfLinkGeometries(iDynTree::Model& model,
         {
             iDynTree::Box shapeBoundingBox;
             SolidShape * shape = model.collisionSolidShapes().getLinkSolidShapes()[lnkIdx][shapeIdx];
-            bool ok = BBFromShape(shape, shapeBoundingBox);
+            bool ok = computeBoundingBoxFromShape(*shape, shapeBoundingBox);
             if (!ok) return false;
             shapesBBsInLinkFrame.push_back(shapeBoundingBox);
         }
@@ -361,6 +282,89 @@ bool getBoundingBoxOfLinkGeometries(iDynTree::Model& model,
     return true;
 }
 #endif
+
+/**
+ * Compute vertices of the bounding box, computed in link frame
+ */
+std::vector<Position> computeBoxVertices(const Box box)
+{
+    std::vector<Position> vertices;
+
+    // + + +
+    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, +box.getY()/2, +box.getZ()/2));
+
+    // + + -
+    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, +box.getY()/2, -box.getZ()/2));
+
+    // + - +
+    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, -box.getY()/2, +box.getZ()/2));
+
+    // + - -
+    vertices.push_back(box.getLink_H_geometry()*Position(+box.getX()/2, -box.getY()/2, -box.getZ()/2));
+
+    // - + +
+    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, +box.getY()/2, +box.getZ()/2));
+
+    // - + -
+    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, +box.getY()/2, -box.getZ()/2));
+
+    // - - +
+    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, -box.getY()/2, +box.getZ()/2));
+
+    // - - -
+    vertices.push_back(box.getLink_H_geometry()*Position(-box.getX()/2, -box.getY()/2, -box.getZ()/2));
+
+    return vertices;
+}
+
+bool computeBoundingBoxFromShape(const SolidShape& geom, Box& box)
+{
+    // Extract BB from shape, this would be benefic from being moved as a method in the SolidShape interface
+    if (geom.isBox())
+    {
+        // If shape is a box, just copy it
+        Box* pBox = const_cast<Box*>(geom.asBox());
+        box = *pBox;
+        box.setLink_H_geometry(geom.getLink_H_geometry());
+        return true;
+    }
+
+    if (geom.isSphere())
+    {
+        // If shape is a sphere all the side of the BB are the diameter of the sphere
+        Sphere* pSphere = const_cast<Sphere *>(geom.asSphere());
+        box.setX(2.0*pSphere->getRadius());
+        box.setY(2.0*pSphere->getRadius());
+        box.setZ(2.0*pSphere->getRadius());
+        box.setLink_H_geometry(geom.getLink_H_geometry());
+        return true;
+    }
+
+    if (geom.isCylinder())
+    {
+        // If shape is a cylinder the x and y side of the BB are the diameter of the cylinder,
+        // while the z side is the lenght of the cylinder
+        Cylinder* pCylinder = const_cast<Cylinder *>(geom.asCylinder());
+        box.setX(2.0*pCylinder->getRadius());
+        box.setY(2.0*pCylinder->getRadius());
+        box.setZ(pCylinder->getLength());
+        box.setLink_H_geometry(geom.getLink_H_geometry());
+        return true;
+    }
+    
+#ifdef IDYNTREE_USES_ASSIMP
+    if (geom.isExternalMesh())
+    {
+        // If shape is an external mesh, we need to load the mesh and extract the BB
+        ExternalMesh* pExtMesh = const_cast<ExternalMesh *>(geom.asExternalMesh());
+        return BBFromExternalShape(pExtMesh, box);
+    }    
+#else
+    reportError("", "computeBoundingBoxFromShape", "IDYNTREE_USES_ASSIMP CMake option need to be set to ON to use computeBoundingBoxFromShape");
+#endif
+    return false;
+    
+}
 
 bool estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(const double totalMass,
                                                                  iDynTree::Model& model,


### PR DESCRIPTION
Some already implemented useful methods to convert solid shapes to bounding box and getting vertices of bounding box is being exposed in the public headers.

- if the solid shape is an external mesh, the conversion function requires the iDynTree  to be compiled with dependency ASSIMP.