### PR TITLE
Transform idyntree-yarp and idyntree-icub in header only libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Promoted the functions `computeBoundingBoxFromShape` and `computeBoxVertices` to public in the `idyntree-solid-shapes` library (https://github.com/robotology/idyntree/pull/801).
+- The `idyntree-yarp` and `idyntree-icub` libraries are now header-only, and are always installed even if `IDYNTREE_USES_YARP` or `IDYNTREE_USES_ICUB_MAIN` are set to `OFF`, to simplify deployment of the library. The downstream libraries that want to use them need to find and link `YARP` and `ICUB` CMake packages on their own (https://github.com/robotology/idyntree/pull/807).
 
 ## [2.0.2] - 2020-12-04
 
-### Fixed 
+### Fixed
 - Fixed compilation of MATLAB bindings on macOS and Windows (https://github.com/robotology/idyntree/pull/789, https://github.com/robotology/idyntree/pull/790).
 
 ## [2.0.1] - 2020-11-24

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,15 +57,6 @@ if(NOT IDYNTREE_ONLY_DOCS)
     # add the actual components of the library
     add_subdirectory(src)
 
-    # List exported CMake package dependencies
-    set(_IDYNTREE_EXPORTED_DEPENDENCIES "")
-    if(IDYNTREE_USES_YARP)
-        list(APPEND _IDYNTREE_EXPORTED_DEPENDENCIES YARP)
-    endif()
-    if(IDYNTREE_USES_ICUB_MAIN)
-        list(APPEND _IDYNTREE_EXPORTED_DEPENDENCIES ICUB)
-    endif()
-
     # List exported CMake package dependencies when the library is compiled as static
     set(_IDYNTREE_EXPORTED_DEPENDENCIES_ONLY_STATIC "")
     list(APPEND _IDYNTREE_EXPORTED_DEPENDENCIES_ONLY_STATIC LibXml2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,13 +30,8 @@ if (IDYNTREE_COMPILES_OPTIMALCONTROL)
   add_subdirectory(optimalcontrol)
 endif()
 
-if(IDYNTREE_USES_YARP)
-    add_subdirectory(yarp)
-endif()
-
-if(IDYNTREE_USES_ICUB_MAIN)
-    add_subdirectory(icub)
-endif()
+add_subdirectory(yarp)
+add_subdirectory(icub)
 
 add_subdirectory(visualization)
 

--- a/src/icub/CMakeLists.txt
+++ b/src/icub/CMakeLists.txt
@@ -14,7 +14,7 @@ SET(iDynTree_ICUB_header include/iDynTree/iKinConversions.h
 SOURCE_GROUP("Header Files" FILES ${iDynTree_ICUB_header})
 
 set(libraryname idyntree-icub)
-add_library(${libraryname} INTERFACE ${iDynTree_ICUB_source} ${iDynTree_ICUB_header})
+add_library(${libraryname} INTERFACE)
 add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 set_target_properties(${libraryname} PROPERTIES PUBLIC_HEADER "${iDynTree_ICUB_header}")

--- a/src/icub/CMakeLists.txt
+++ b/src/icub/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
 #
 # Licensed under either the GNU Lesser General Public License v3.0 :
 # https://www.gnu.org/licenses/lgpl-3.0.html
@@ -6,38 +6,23 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-SET(iDynTree_ICUB_source src/iKinConversions.cpp
-                         src/skinDynLibConversions.cpp)
-
 SET(iDynTree_ICUB_header include/iDynTree/iKinConversions.h
-                         include/iDynTree/skinDynLibConversions.h)
+                         include/iDynTree/iKinConversionsImplementation.h
+                         include/iDynTree/skinDynLibConversions.h
+                         include/iDynTree/skinDynLibConversionsImplementation.h)
 
-SOURCE_GROUP("Source Files" FILES ${iDynTree_ICUB_source})
 SOURCE_GROUP("Header Files" FILES ${iDynTree_ICUB_header})
 
-include(AddInstallRPATHSupport)
-add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/bin"
-                          LIB_DIRS "${CMAKE_INSTALL_PREFIX}/lib"
-                          DEPENDS IDYNTREE_ENABLE_RPATH
-                          USE_LINK_PATH)
-
 set(libraryname idyntree-icub)
-add_library(${libraryname} ${iDynTree_ICUB_source} ${iDynTree_ICUB_header})
+add_library(${libraryname} INTERFACE ${iDynTree_ICUB_source} ${iDynTree_ICUB_header})
 add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 
 set_target_properties(${libraryname} PROPERTIES PUBLIC_HEADER "${iDynTree_ICUB_header}")
 
-
-target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+target_include_directories(${libraryname} INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(${libraryname} LINK_PUBLIC iKin skinDynLib idyntree-core idyntree-model idyntree-yarp idyntree-estimation)
-
-target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS})
-
-target_include_directories(${libraryname} PRIVATE SYSTEM ${skinDynLib_INCLUDE_DIRS})
-target_include_directories(${libraryname} PRIVATE SYSTEM ${iKin_INCLUDE_DIRS})
-
+target_link_libraries(${libraryname} INTERFACE idyntree-core idyntree-model idyntree-yarp idyntree-estimation)
 
 install(TARGETS ${libraryname}
         EXPORT iDynTree

--- a/src/icub/include/iDynTree/iKinConversions.h
+++ b/src/icub/include/iDynTree/iKinConversions.h
@@ -95,4 +95,6 @@ bool iKinLimbFromDHChain(const DHChain & dhChain,
 
 }
 
+#include "iKinConversionsImplementation.h"
+
 #endif

--- a/src/icub/include/iDynTree/iKinConversionsImplementation.h
+++ b/src/icub/include/iDynTree/iKinConversionsImplementation.h
@@ -8,6 +8,9 @@
  * at your option.
  */
 
+#ifndef IDYNTREE_IKIN_CONVERSIONS_IMPLEMENTATION_H
+#define IDYNTREE_IKIN_CONVERSIONS_IMPLEMENTATION_H
+
 #include <iDynTree/iKinConversions.h>
 #include <iDynTree/Model/DenavitHartenberg.h>
 
@@ -20,7 +23,7 @@
 namespace iDynTree
 {
 
-DHLink iKinLink2DHLink(const iCub::iKin::iKinLink & ikinlink)
+inline DHLink iKinLink2DHLink(const iCub::iKin::iKinLink & ikinlink)
 {
     DHLink ret;
 
@@ -34,14 +37,14 @@ DHLink iKinLink2DHLink(const iCub::iKin::iKinLink & ikinlink)
     return ret;
 }
 
-iCub::iKin::iKinLink DHLink2iKinLink(const DHLink & dhLink)
+inline iCub::iKin::iKinLink DHLink2iKinLink(const DHLink & dhLink)
 {
     return iCub::iKin::iKinLink(dhLink.A,dhLink.D,
                                 dhLink.Alpha,dhLink.Offset,
                                 dhLink.Min,dhLink.Max);
 }
 
-bool DHChainFromiKinChain(iCub::iKin::iKinChain& ikinChain,
+inline bool DHChainFromiKinChain(iCub::iKin::iKinChain& ikinChain,
                                 DHChain& dhChain)
 {
     assert(ikinChain.getN() == ikinChain.getDOF());
@@ -66,7 +69,7 @@ bool DHChainFromiKinChain(iCub::iKin::iKinChain& ikinChain,
     return true;
 }
 
-bool modelFromiKinChain(iCub::iKin::iKinChain& ikinChain, Model& output)
+inline bool modelFromiKinChain(iCub::iKin::iKinChain& ikinChain, Model& output)
 {
     DHChain chain;
     bool ok = DHChainFromiKinChain(ikinChain, chain);
@@ -81,14 +84,14 @@ bool modelFromiKinChain(iCub::iKin::iKinChain& ikinChain, Model& output)
     return ok;
 }
 
-iKinLimbImported::iKinLimbImported(): iCub::iKin::iKinLimb()
+inline iKinLimbImported::iKinLimbImported(): iCub::iKin::iKinLimb()
 {
 }
 
-iKinLimbImported::~iKinLimbImported()
+inline iKinLimbImported::~iKinLimbImported()
 {}
 
-bool iKinLimbImported::fromDHChain(const DHChain &dhChain)
+inline bool iKinLimbImported::fromDHChain(const DHChain &dhChain)
 {
     // Cleanup existing data
     dispose();
@@ -110,7 +113,7 @@ bool iKinLimbImported::fromDHChain(const DHChain &dhChain)
     return true;
 }
 
-bool iKinLimbImported::fromModel(const Model &model,
+inline bool iKinLimbImported::fromModel(const Model &model,
                                  const std::string &baseFrame,
                                  const std::string &distalFrame)
 {
@@ -120,7 +123,7 @@ bool iKinLimbImported::fromModel(const Model &model,
     return conversionSuccessful;
 }
 
-bool iKinLimbFromDHChain(const DHChain & dhChain,
+inline bool iKinLimbFromDHChain(const DHChain & dhChain,
                          iCub::iKin::iKinLimb& ikinLimb)
 {
     iKinLimbImported ikinLimbImported;
@@ -132,7 +135,7 @@ bool iKinLimbFromDHChain(const DHChain & dhChain,
     return ok;
 }
 
-bool iKinLimbFromModel(const Model & model,
+inline bool iKinLimbFromModel(const Model & model,
                        const std::string& baseFrame,
                        const std::string& distalFrame,
                        iCub::iKin::iKinLimb & ikinLimb)
@@ -144,3 +147,5 @@ bool iKinLimbFromModel(const Model & model,
 }
 
 }
+
+#endif

--- a/src/icub/include/iDynTree/skinDynLibConversions.h
+++ b/src/icub/include/iDynTree/skinDynLibConversions.h
@@ -188,4 +188,6 @@ public:
 
 }
 
+#include "skinDynLibConversionsImplementation.h"
+
 #endif

--- a/src/icub/include/iDynTree/skinDynLibConversionsImplementation.h
+++ b/src/icub/include/iDynTree/skinDynLibConversionsImplementation.h
@@ -8,6 +8,9 @@
  * at your option.
  */
 
+#ifndef IDYNTREE_SKINDYNLIB_CONVERSIONS_IMPLEMENTATION_H
+#define IDYNTREE_SKINDYNLIB_CONVERSIONS_IMPLEMENTATION_H
+
 #include <iDynTree/skinDynLibConversions.h>
 
 #include <iDynTree/Core/Position.h>
@@ -389,3 +392,5 @@ bool skinDynLibConversionsHelper::updateSkinContactListFromLinkContactWrenches(c
 
 
 }
+
+#endif

--- a/src/tests/icub_consistency/CMakeLists.txt
+++ b/src/tests/icub_consistency/CMakeLists.txt
@@ -14,7 +14,7 @@ macro(add_icub_consistency_test testName)
     set(testname   ConsistencyTest${testName})
     add_executable(${testbinary} ${testsrc})
     target_link_libraries(${testbinary} PRIVATE idyntree-yarp idyntree-high-level idyntree-icub idyntree-core
-                                                idyntree-model idyntree-estimation idyntree-testmodels Eigen3::Eigen)
+                                                idyntree-model idyntree-estimation idyntree-testmodels iKin Eigen3::Eigen)
     add_test(NAME ${testname} COMMAND ${testbinary})
 
     if(IDYNTREE_RUN_VALGRIND_TESTS)

--- a/src/tests/yarp_benchmark/CMakeLists.txt
+++ b/src/tests/yarp_benchmark/CMakeLists.txt
@@ -10,7 +10,7 @@ macro(add_yarp_benchmark benchmarkName)
     set(testsrc ${benchmarkName}Benchmark.cpp)
     set(testbinary ${benchmarkName}Benchmark)
     add_executable(${testbinary} ${testsrc})
-    target_link_libraries(${testbinary} PRIVATE idyntree-icub idyntree-core idyntree-model idyntree-testmodels Eigen3::Eigen)
+    target_link_libraries(${testbinary} PRIVATE idyntree-icub idyntree-core idyntree-model idyntree-testmodels Eigen3::Eigen YARP::YARP_sig)
 endmacro()
 
 add_yarp_benchmark(PseudoInverse)

--- a/src/tests/yarp_benchmark/CMakeLists.txt
+++ b/src/tests/yarp_benchmark/CMakeLists.txt
@@ -10,7 +10,7 @@ macro(add_yarp_benchmark benchmarkName)
     set(testsrc ${benchmarkName}Benchmark.cpp)
     set(testbinary ${benchmarkName}Benchmark)
     add_executable(${testbinary} ${testsrc})
-    target_link_libraries(${testbinary} PRIVATE idyntree-icub idyntree-core idyntree-model idyntree-testmodels Eigen3::Eigen YARP::YARP_sig)
+    target_link_libraries(${testbinary} PRIVATE idyntree-icub idyntree-core idyntree-model idyntree-testmodels Eigen3::Eigen YARP::YARP_sig  YARP::YARP_math)
 endmacro()
 
 add_yarp_benchmark(PseudoInverse)

--- a/src/yarp/CMakeLists.txt
+++ b/src/yarp/CMakeLists.txt
@@ -14,7 +14,7 @@ SET(iDynTree_YARP_header include/iDynTree/yarp/YARPConversions.h
 
 SOURCE_GROUP("Header Files" FILES ${iDynTree_YARP_header})
 
-add_library(idyntree-yarp INTERFACE ${iDynTree_YARP_source} ${iDynTree_YARP_header})
+add_library(idyntree-yarp INTERFACE)
 add_library(iDynTree::idyntree-yarp ALIAS idyntree-yarp)
 
 set_target_properties(idyntree-yarp PROPERTIES PUBLIC_HEADER "${iDynTree_YARP_header}")

--- a/src/yarp/CMakeLists.txt
+++ b/src/yarp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Fondazione Istituto Italiano di Tecnologia
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
 #
 # Licensed under either the GNU Lesser General Public License v3.0 :
 # https://www.gnu.org/licenses/lgpl-3.0.html
@@ -6,39 +6,23 @@
 # https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 # at your option.
 
-project(iDynTree_YARP CXX)
-
-SET(iDynTree_YARP_source src/YARPConversions.cpp
-                         src/YARPConfigurationsLoader.cpp)
-
 SET(iDynTree_YARP_header include/iDynTree/yarp/YARPConversions.h
                          include/iDynTree/yarp/YARPEigenConversions.h
-                         include/iDynTree/yarp/YARPConfigurationsLoader.h)
+                         include/iDynTree/yarp/YARPConfigurationsLoader.h
+                         include/iDynTree/yarp/YARPConversionsImplementation.h
+                         include/iDynTree/yarp/YARPConfigurationsLoaderImplementation.h)
 
-SOURCE_GROUP("Source Files" FILES ${iDynTree_YARP_source})
 SOURCE_GROUP("Header Files" FILES ${iDynTree_YARP_header})
 
-include(AddInstallRPATHSupport)
-add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/bin"
-                          LIB_DIRS "${CMAKE_INSTALL_PREFIX}/lib"
-                          DEPENDS IDYNTREE_ENABLE_RPATH
-                          USE_LINK_PATH)
-
-
-add_library(idyntree-yarp ${iDynTree_YARP_source} ${iDynTree_YARP_header})
+add_library(idyntree-yarp INTERFACE ${iDynTree_YARP_source} ${iDynTree_YARP_header})
 add_library(iDynTree::idyntree-yarp ALIAS idyntree-yarp)
 
 set_target_properties(idyntree-yarp PROPERTIES PUBLIC_HEADER "${iDynTree_YARP_header}")
 
-target_include_directories(idyntree-yarp PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                                                "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_directories(idyntree-yarp INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(idyntree-yarp idyntree-core
-                                    idyntree-model
-                                    YARP::YARP_os
-                                    YARP::YARP_math)
-                                    
-target_compile_options(idyntree-yarp PRIVATE ${IDYNTREE_WARNING_FLAGS})
+target_link_libraries(idyntree-yarp INTERFACE idyntree-core idyntree-model)
 
 install(TARGETS idyntree-yarp
         EXPORT iDynTree

--- a/src/yarp/include/iDynTree/yarp/YARPConfigurationsLoader.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConfigurationsLoader.h
@@ -28,5 +28,6 @@ namespace iDynTree
     bool parseRotationMatrix(const yarp::os::Searchable& rf, const std::string& key, iDynTree::Rotation& rotation);
 }
 
+#include "YARPConfigurationsLoaderImplementation.h"
 
 #endif

--- a/src/yarp/include/iDynTree/yarp/YARPConfigurationsLoaderImplementation.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConfigurationsLoaderImplementation.h
@@ -7,10 +7,13 @@
  * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
  * at your option.
  */
-#include "iDynTree/yarp/YARPConfigurationsLoader.h"
-#include "yarp/os/Value.h"
 
-bool iDynTree::parseRotationMatrix(const yarp::os::Searchable& rf, const std::string& key, iDynTree::Rotation& rotation)
+#ifndef IDYNTREE_YARP_CONFIGURATIONS_LOADER_IMPLEMENTATION_H
+#define IDYNTREE_YARP_CONFIGURATIONS_LOADER_IMPLEMENTATION_H
+
+#include <yarp/os/Value.h>
+
+inline bool iDynTree::parseRotationMatrix(const yarp::os::Searchable& rf, const std::string& key, iDynTree::Rotation& rotation)
 {
     yarp::os::Value ini = rf.find(key);
     if (ini.isNull() || !ini.isList())
@@ -41,3 +44,5 @@ bool iDynTree::parseRotationMatrix(const yarp::os::Searchable& rf, const std::st
     }
     return true;
 }
+
+#endif

--- a/src/yarp/include/iDynTree/yarp/YARPConversions.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConversions.h
@@ -219,4 +219,6 @@ bool toiDynTree(const yarp::sig::Matrix& yarpMatrix, MatrixType& iDynTreeMatrix)
 
 }
 
+#include "YARPConversionsImplementation.h"
+
 #endif

--- a/src/yarp/include/iDynTree/yarp/YARPConversionsImplementation.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConversionsImplementation.h
@@ -8,7 +8,8 @@
  * at your option.
  */
 
-#include <iDynTree/yarp/YARPConversions.h>
+#ifndef IDYNTREE_YARP_CONVERSIONS_IMPLEMENTATION_H
+#define IDYNTREE_YARP_CONVERSIONS_IMPLEMENTATION_H
 
 #include <iDynTree/Core/Direction.h>
 #include <iDynTree/Core/Transform.h>
@@ -22,7 +23,7 @@ using namespace yarp::math;
 namespace iDynTree
 {
 
-bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTreeWrench)
+inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTreeWrench)
 {
     if( yarpVector.size() != 6 )
     {
@@ -35,7 +36,7 @@ bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTre
 }
 
 
-bool toYarp(const iDynTree::Wrench & iDynTreeWrench,yarp::sig::Vector & yarpVector)
+inline bool toYarp(const iDynTree::Wrench & iDynTreeWrench,yarp::sig::Vector & yarpVector)
 {
     if( yarpVector.size() != 6 )
     {
@@ -47,7 +48,7 @@ bool toYarp(const iDynTree::Wrench & iDynTreeWrench,yarp::sig::Vector & yarpVect
     return true;
 }
 
-bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Position& iDynTreePosition)
+inline bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Position& iDynTreePosition)
 {
     if( yarpVector.size() != 3 )
     {
@@ -58,7 +59,7 @@ bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Position& iDynTre
     return true;
 }
 
-bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Vector3& iDynTreeVector3)
+inline bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Vector3& iDynTreeVector3)
 {
     if( yarpVector.size() != 3 )
     {
@@ -69,7 +70,7 @@ bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Vector3& iDynTree
     return true;
 }
 
-bool toYarp(const iDynTree::Position& iDynTreePosition, yarp::sig::Vector& yarpVector)
+inline bool toYarp(const iDynTree::Position& iDynTreePosition, yarp::sig::Vector& yarpVector)
 {
     if( yarpVector.size() != 3 )
     {
@@ -80,7 +81,7 @@ bool toYarp(const iDynTree::Position& iDynTreePosition, yarp::sig::Vector& yarpV
     return true;
 }
 
-bool toiDynTree(const yarp::sig::Vector& yarpVector, Direction& direction)
+inline bool toiDynTree(const yarp::sig::Vector& yarpVector, Direction& direction)
 {
     if( yarpVector.size() != 3 )
     {
@@ -95,7 +96,7 @@ bool toiDynTree(const yarp::sig::Vector& yarpVector, Direction& direction)
     return true;
 }
 
-bool toYarp(const Vector3& iDynTreeVector3, yarp::sig::Vector& yarpVector)
+inline bool toYarp(const Vector3& iDynTreeVector3, yarp::sig::Vector& yarpVector)
 {
     if( yarpVector.size() != 3 )
     {
@@ -106,14 +107,14 @@ bool toYarp(const Vector3& iDynTreeVector3, yarp::sig::Vector& yarpVector)
     return true;
 }
 
-bool toiDynTree(const yarp::sig::Vector& yarpVector, VectorDynSize& iDynTreeVector)
+inline bool toiDynTree(const yarp::sig::Vector& yarpVector, VectorDynSize& iDynTreeVector)
 {
     iDynTreeVector.resize(yarpVector.size());
     memcpy(iDynTreeVector.data(),yarpVector.data(),yarpVector.size()*sizeof(double));
     return true;
 }
 
-bool toiDynTree(const yarp::sig::Matrix& yarpHomogeneousMatrix,
+inline bool toiDynTree(const yarp::sig::Matrix& yarpHomogeneousMatrix,
                 iDynTree::Transform& iDynTreeTransform)
 {
     if( yarpHomogeneousMatrix.rows() != 4 ||
@@ -144,7 +145,7 @@ bool toiDynTree(const yarp::sig::Matrix& yarpHomogeneousMatrix,
     return true;
 }
 
-bool toYarp(const iDynTree::Transform& iDynTreeTransform,
+inline bool toYarp(const iDynTree::Transform& iDynTreeTransform,
             yarp::sig::Matrix& yarpHomogeneousMatrix)
 {
     iDynTree::Matrix4x4 homTrans = iDynTreeTransform.asHomogeneousTransform();
@@ -154,13 +155,6 @@ bool toYarp(const iDynTree::Transform& iDynTreeTransform,
     return true;
 }
 
-
-
-
-
-
 }
 
-
-
-
+#endif


### PR DESCRIPTION
The `idyntree-yarp` and `idyntree-icub` libraries are now header-only, and are always installed even if
`IDYNTREE_USES_YARP` or `IDYNTREE_USES_ICUB_MAIN` are set to `OFF`, to simplify deployment of the library.
The downstream libraries that want to use them need to find and link `YARP` and `ICUB` CMake packages on their own.

The main advantage is that thanks to this change, it does not matter the order in which iDynTree and YARP/ICUB are installed, and they could also be installed in different form and work well together (for example iDynTree could be installed in binary form, and YARP/ICUB installed later in source form, and [`whole-body-estimators`](https://github.com/robotology/whole-body-estimators) will still work fine, avoiding problems such as https://github.com/robotology/whole-body-estimators/issues/46 .

`IDYNTREE_USES_YARP` and `IDYNTREE_USES_ICUB_MAIN` options are still used as they control the compilation of two different outputs: 
* Command line tools that depend on both `idyntree` and `YARP`, such as `yarprobostatepublisher` or `urdf2df`.  Ideally, this tools could be moved to a different repo (`idyntree-yarp-tools`?) but that can be done without breaking anything, while making this libraries header-only needs to be done before iDynTree 3 release as it will break ABI compatibility. 
* Test that use YARP and ICUB. These will always remain here, but they are only relevant for people that want to do iDynTree development, and not relevant at all for iDynTree consumers. 

Fix https://github.com/robotology/idyntree/issues/653 . 