### PR TITLE
Remove direct indices in iDynTreeWrappers visualizer example

### DIFF
--- a/examples/matlab/iDynTreeWrappers/visualizeRobot.m
+++ b/examples/matlab/iDynTreeWrappers/visualizeRobot.m
@@ -31,7 +31,7 @@ robotName='iCubGenova04';
  modelPath = [icubModelsInstallPrefix '/share/iCub/robots/' robotName '/'];
  fileName='model.urdf';
 
- jointOrder={
+ consideredJoints={
     'r_hip_pitch';
     'r_hip_roll';
     'r_hip_yaw';
@@ -68,7 +68,7 @@ robotName='iCubGenova04';
 
 % Main variable of iDyntreeWrappers used for many things including updating
 % robot position and getting world to frame transforms
-KinDynModel = iDynTreeWrappers.loadReducedModel(jointOrder,'root_link',modelPath,fileName,false);
+KinDynModel = iDynTreeWrappers.loadReducedModel(consideredJoints,'root_link',modelPath,fileName,false);
 
 % create vector of positions
 joints_positions=zeros(KinDynModel.NDOF,1);
@@ -90,7 +90,12 @@ iDynTreeWrappers.setRobotState(KinDynModel,world_H_base,joints_positions,zeros(6
 pause(1);
 % generate decent position
 joints_positions=zeros(KinDynModel.NDOF,1);
-joints_positions([16 17 19 23 24 26])=pi/10;
+joints_positions(KinDynModel.kinDynComp.model.getJointIndex('r_shoulder_roll')) = pi/10;
+joints_positions(KinDynModel.kinDynComp.model.getJointIndex('r_shoulder_yaw')) = pi/10;
+joints_positions(KinDynModel.kinDynComp.model.getJointIndex('r_elbow')) = pi/10;
+joints_positions(KinDynModel.kinDynComp.model.getJointIndex('l_shoulder_roll')) = pi/10;
+joints_positions(KinDynModel.kinDynComp.model.getJointIndex('l_shoulder_yaw')) = pi/10;
+joints_positions(KinDynModel.kinDynComp.model.getJointIndex('l_elbow')) = pi/10;
 
 %% Update robot position
 % update kinematics
@@ -106,15 +111,16 @@ axis tight
 iDynTreeWrappers.modifyLinksVisualization(visualizer,'useDefault',true);
 
 % Modify using link indices
-indecesToModify= 23;
-iDynTreeWrappers.modifyLinksVisualization(visualizer,'linksIndices',indecesToModify,'color',[1,1,1]);
+indecesToModify = find(contains(visualizer.linkNames,'head'));
+iDynTreeWrappers.modifyLinksVisualization(visualizer,'linksIndices',indecesToModify,'color',[1,0,0]);
 
-indecesToModify=[28,33];
+indecesToModify=[find(contains(visualizer.linkNames,'l_forearm')), ...
+                 find(contains(visualizer.linkNames,'l_hand'))];
 iDynTreeWrappers.modifyLinksVisualization(visualizer,'linksIndices',indecesToModify,'color',[0,0,0],'transparency',1,'material','metal');
 
 % Modify using link names
 % Select link names to modify
-linkstoModify=visualizer.linkNames([1,6,13,19]);
+linkstoModify = [{'r_upper_leg'}, {'r_lower_leg'}, {'r_ankle_1'}, {'r_ankle_2'}];
 
 iDynTreeWrappers.modifyLinksVisualization(visualizer,'linksToModify',linkstoModify,'style','wireframe');
 pause(1);


### PR DESCRIPTION
This PR address the changes requested in https://github.com/robotology/idyntree/issues/805.

Implementing this feature I noticed that we currently can not use the indices returned by `getLinkIndex()` because of https://github.com/robotology/idyntree/issues/809, so I was getting those indices directly from the `visualizer.linkNames` vector.


After loading the model, the example does the following:
- joints `r_shoulder_roll` `r_shoulder_yaw` `r_elbow` `l_shoulder_roll` `l_shoulder_yaw` `l_elbow` are changed to pi/10
- link `head` color is set to red
- links `l_forearm` and `l_hand` transparency is changed to 1
- links 'r_upper_leg' 'r_lower_leg' 'r_ankle_1' 'r_ankle_2' style is set to `wireframe`

here is the output
![output](https://user-images.githubusercontent.com/35487806/105867170-104c6380-5ff5-11eb-993c-d0d5f525e87a.jpg)
