### PR TITLE
Fix use of inline in idyntree-yarp and idyntree-icub compatibility header-only libraries

### DIFF
--- a/src/icub/include/iDynTree/iKinConversions.h
+++ b/src/icub/include/iDynTree/iKinConversions.h
@@ -29,8 +29,8 @@ class DHChain;
  *
  * \ingroup iDynTreeICUB
  */
-bool DHChainFromiKinChain(iCub::iKin::iKinChain & ikinChain,
-                          DHChain & out);
+inline bool DHChainFromiKinChain(iCub::iKin::iKinChain & ikinChain,
+                                 DHChain & out);
 
 /**
  * \brief Load a iDynTree::Model object from a iCub::iKin::iKinChain .
@@ -39,8 +39,8 @@ bool DHChainFromiKinChain(iCub::iKin::iKinChain & ikinChain,
  *
  * \ingroup iDynTreeICUB
  */
-bool modelFromiKinChain(iCub::iKin::iKinChain & ikinChain,
-                        Model & output);
+inline bool modelFromiKinChain(iCub::iKin::iKinChain & ikinChain,
+                               Model & output);
 
 /**
  * \brief iKinLimb class to extract a iKinLimb from iDynTree structures.
@@ -53,24 +53,24 @@ public:
     /**
      * Default constructor.
      */
-    iKinLimbImported();
+    inline iKinLimbImported();
 
     /**
      * Default destructor.
      */
-    virtual ~iKinLimbImported();
+    inline virtual ~iKinLimbImported();
 
     /**
      * Initialize the limb properties from a chain in a iDynTree::Model
      */
-    bool fromModel(const Model & model,
-                   const std::string& baseFrame,
-                   const std::string& distalFrame);
+    inline bool fromModel(const Model & model,
+                          const std::string& baseFrame,
+                          const std::string& distalFrame);
 
     /**
      * Initialize the limb properties from a iDynTree::DHChain
      */
-    bool fromDHChain(const DHChain & dhChain);
+    inline bool fromDHChain(const DHChain & dhChain);
 };
 
 /**
@@ -80,18 +80,18 @@ public:
  *
  * \ingroup iDynTreeICUB
  */
-bool iKinLimbFromModel(const Model & model,
-                        const std::string& baseFrame,
-                        const std::string& distalFrame,
-                        iCub::iKin::iKinLimb & ikinLimb);
+inline bool iKinLimbFromModel(const Model & model,
+                              const std::string& baseFrame,
+                              const std::string& distalFrame,
+                              iCub::iKin::iKinLimb & ikinLimb);
 
 /**
  * \brief Create a iCub::iKin::iKinLimb from an iDynTree::DHChain
  *
  * \ingroup iDynTreeICUB
  */
-bool iKinLimbFromDHChain(const DHChain & dhChain,
-                         iCub::iKin::iKinLimb& ikinLimb);
+inline bool iKinLimbFromDHChain(const DHChain & dhChain,
+                                iCub::iKin::iKinLimb& ikinLimb);
 
 }
 

--- a/src/icub/include/iDynTree/iKinConversionsImplementation.h
+++ b/src/icub/include/iDynTree/iKinConversionsImplementation.h
@@ -23,7 +23,7 @@
 namespace iDynTree
 {
 
-inline DHLink iKinLink2DHLink(const iCub::iKin::iKinLink & ikinlink)
+DHLink iKinLink2DHLink(const iCub::iKin::iKinLink & ikinlink)
 {
     DHLink ret;
 
@@ -37,14 +37,14 @@ inline DHLink iKinLink2DHLink(const iCub::iKin::iKinLink & ikinlink)
     return ret;
 }
 
-inline iCub::iKin::iKinLink DHLink2iKinLink(const DHLink & dhLink)
+iCub::iKin::iKinLink DHLink2iKinLink(const DHLink & dhLink)
 {
     return iCub::iKin::iKinLink(dhLink.A,dhLink.D,
                                 dhLink.Alpha,dhLink.Offset,
                                 dhLink.Min,dhLink.Max);
 }
 
-inline bool DHChainFromiKinChain(iCub::iKin::iKinChain& ikinChain,
+bool DHChainFromiKinChain(iCub::iKin::iKinChain& ikinChain,
                                 DHChain& dhChain)
 {
     assert(ikinChain.getN() == ikinChain.getDOF());
@@ -69,7 +69,7 @@ inline bool DHChainFromiKinChain(iCub::iKin::iKinChain& ikinChain,
     return true;
 }
 
-inline bool modelFromiKinChain(iCub::iKin::iKinChain& ikinChain, Model& output)
+bool modelFromiKinChain(iCub::iKin::iKinChain& ikinChain, Model& output)
 {
     DHChain chain;
     bool ok = DHChainFromiKinChain(ikinChain, chain);
@@ -84,14 +84,14 @@ inline bool modelFromiKinChain(iCub::iKin::iKinChain& ikinChain, Model& output)
     return ok;
 }
 
-inline iKinLimbImported::iKinLimbImported(): iCub::iKin::iKinLimb()
+iKinLimbImported::iKinLimbImported(): iCub::iKin::iKinLimb()
 {
 }
 
-inline iKinLimbImported::~iKinLimbImported()
+iKinLimbImported::~iKinLimbImported()
 {}
 
-inline bool iKinLimbImported::fromDHChain(const DHChain &dhChain)
+bool iKinLimbImported::fromDHChain(const DHChain &dhChain)
 {
     // Cleanup existing data
     dispose();
@@ -113,7 +113,7 @@ inline bool iKinLimbImported::fromDHChain(const DHChain &dhChain)
     return true;
 }
 
-inline bool iKinLimbImported::fromModel(const Model &model,
+bool iKinLimbImported::fromModel(const Model &model,
                                  const std::string &baseFrame,
                                  const std::string &distalFrame)
 {
@@ -123,7 +123,7 @@ inline bool iKinLimbImported::fromModel(const Model &model,
     return conversionSuccessful;
 }
 
-inline bool iKinLimbFromDHChain(const DHChain & dhChain,
+bool iKinLimbFromDHChain(const DHChain & dhChain,
                          iCub::iKin::iKinLimb& ikinLimb)
 {
     iKinLimbImported ikinLimbImported;
@@ -135,7 +135,7 @@ inline bool iKinLimbFromDHChain(const DHChain & dhChain,
     return ok;
 }
 
-inline bool iKinLimbFromModel(const Model & model,
+bool iKinLimbFromModel(const Model & model,
                        const std::string& baseFrame,
                        const std::string& distalFrame,
                        iCub::iKin::iKinLimb & ikinLimb)

--- a/src/icub/include/iDynTree/skinDynLibConversions.h
+++ b/src/icub/include/iDynTree/skinDynLibConversions.h
@@ -36,7 +36,7 @@ public:
     int body_part;
     int local_link_index;
 
-    bool operator<(const skinDynLibLinkID& k) const
+    inline bool operator<(const skinDynLibLinkID& k) const
     {
         if(this->body_part < k.body_part)
         {
@@ -52,7 +52,7 @@ public:
         }
     }
 
-    bool operator==(const skinDynLibLinkID& k) const
+    inline bool operator==(const skinDynLibLinkID& k) const
     {
         return (this->body_part == k.body_part &&
                 this->local_link_index == k.local_link_index);
@@ -110,39 +110,39 @@ public:
      *          must be rigidly attached to the considered link.
      *
      */
-    bool addSkinDynLibAlias(const Model& model,
-                            const std::string iDynTree_link_name, const std::string iDynTree_frame_name,
-                            const int skinDynLib_body_part, const int skinDynLib_link_index);
+    inline bool addSkinDynLibAlias(const Model& model,
+                                   const std::string iDynTree_link_name, const std::string iDynTree_frame_name,
+                                   const int skinDynLib_body_part, const int skinDynLib_link_index);
 
     /**
      * Retrieve the skinDynLib alias of a link, added to the class using the addSkinDynLibAlias method.
      */
-    bool getSkinDynLibAlias(const Model & model,
-                            const std::string iDynTree_link_name,
-                                  std::string & iDynTree_frame_name,
-                                  int & skinDynLib_body_part,
-                                  int & skinDynLib_link_index) const;
+    inline bool getSkinDynLibAlias(const Model & model,
+                                   const std::string iDynTree_link_name,
+                                   std::string & iDynTree_frame_name,
+                                   int & skinDynLib_body_part,
+                                   int & skinDynLib_link_index) const;
 
     /**
      * Retrieve the skinDynLib alias of a link, added to the class using the addSkinDynLibAlias method.
      */
-    bool getSkinDynLibAlias(const Model & model,
-                            const LinkIndex iDynTree_link_index,
-                                  FrameIndex & iDynTree_frame_index,
-                             int & skinDynLib_body_part,
-                             int & skinDynLib_link_index) const;
+    inline bool getSkinDynLibAlias(const Model & model,
+                                   const LinkIndex iDynTree_link_index,
+                                   FrameIndex & iDynTree_frame_index,
+                                   int & skinDynLib_body_part,
+                                   int & skinDynLib_link_index) const;
 
     /**
      * Convert a skinDynLib identifier to a iDynTree link/frame identifier.
      */
-    bool skinDynLib2iDynTree(const int skinDynLib_body_part,
-                             const int skinDynLib_link_index,
-                             LinkIndex & iDynTree_link_index,
-                             FrameIndex & iDynTree_frame_index) const;
+    inline bool skinDynLib2iDynTree(const int skinDynLib_body_part,
+                                    const int skinDynLib_link_index,
+                                    LinkIndex & iDynTree_link_index,
+                                    FrameIndex & iDynTree_frame_index) const;
     /**
      * Remove a alias in the form (body_part, link_index) for a link
      */
-    bool removeSkinDynLibAlias(const Model & model, const std::string linkName);
+    inline bool removeSkinDynLibAlias(const Model & model, const std::string linkName);
 
     /**
      * Convert a dynContactList to a LinkUnknownWrenchContacts.
@@ -150,9 +150,9 @@ public:
      * The contactId contained in the dynContactList is preserved and saved
      * in the appropriate attribute in the LinkUnknownWrenchContacts class.
      */
-    bool fromSkinDynLibToiDynTree(const Model& model,
-                                  const iCub::skinDynLib::dynContactList & dynList,
-                                        LinkUnknownWrenchContacts & unknowns);
+    inline bool fromSkinDynLibToiDynTree(const Model& model,
+                                         const iCub::skinDynLib::dynContactList & dynList,
+                                         LinkUnknownWrenchContacts & unknowns);
 
     /**
      * Convert a skinContactList to a LinkUnknownWrenchContacts.
@@ -160,9 +160,9 @@ public:
      * The contactId contained in the skinContactList is preserved and saved
      * in the appropriate attribute in the LinkUnknownWrenchContacts class.
      */
-    bool fromSkinDynLibToiDynTree(const Model& model,
-                                  const iCub::skinDynLib::skinContactList & skinList,
-                                        LinkUnknownWrenchContacts & unknowns);
+    inline bool fromSkinDynLibToiDynTree(const Model& model,
+                                         const iCub::skinDynLib::skinContactList & skinList,
+                                         LinkUnknownWrenchContacts & unknowns);
 
     /**
      * Convert a LinkContactWrenches to a iCub::skinDynLib::dynContactList.
@@ -170,9 +170,9 @@ public:
      * This function creates a new dynContactList.
      *
      */
-    bool fromiDynTreeToSkinDynLib(const Model& model,
-                                  const LinkContactWrenches & contactWrenches,
-                                        iCub::skinDynLib::dynContactList & dynList);
+    inline bool fromiDynTreeToSkinDynLib(const Model& model,
+                                         const LinkContactWrenches & contactWrenches,
+                                         iCub::skinDynLib::dynContactList & dynList);
 
     /**
      * Update an existing skinContactList in which some forces and torque are
@@ -181,9 +181,9 @@ public:
      * the LinkContactWrenches contacts is done through the contactId, that then
      * should be consistent between the two functions.
      */
-    bool updateSkinContactListFromLinkContactWrenches(const Model& model,
-                                                      const LinkContactWrenches & contactWrenches,
-                                                            iCub::skinDynLib::skinContactList & skinContactListToUpdate);
+    inline bool updateSkinContactListFromLinkContactWrenches(const Model& model,
+                                                             const LinkContactWrenches & contactWrenches,
+                                                             iCub::skinDynLib::skinContactList & skinContactListToUpdate);
 };
 
 }

--- a/src/yarp/include/iDynTree/yarp/YARPConfigurationsLoader.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConfigurationsLoader.h
@@ -25,7 +25,7 @@ namespace iDynTree
     * @param rotation The output rotation
     * @return true if successfull
     */
-    bool parseRotationMatrix(const yarp::os::Searchable& rf, const std::string& key, iDynTree::Rotation& rotation);
+    inline bool parseRotationMatrix(const yarp::os::Searchable& rf, const std::string& key, iDynTree::Rotation& rotation);
 }
 
 #include "YARPConfigurationsLoaderImplementation.h"

--- a/src/yarp/include/iDynTree/yarp/YARPConversions.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConversions.h
@@ -30,7 +30,7 @@ class Transform;
  * @return true if conversion was successful, false otherwise
  * \ingroup iDynTreeYARP
  */
-bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTreeWrench);
+inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTreeWrench);
 
 /**
  * Convert a iDynTree::Wrench to a yarp::sig::Vector
@@ -39,7 +39,7 @@ bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTre
  * @return true if conversion was successful, false otherwise
  * \ingroup iDynTreeYARP
  */
-bool toYarp(const iDynTree::Wrench & iDynTreeWrench, yarp::sig::Vector & yarpVector);
+inline bool toYarp(const iDynTree::Wrench & iDynTreeWrench, yarp::sig::Vector & yarpVector);
 
 /**
  * Convert a yarp::sig::Vector to a iDynTree::Position
@@ -48,7 +48,7 @@ bool toYarp(const iDynTree::Wrench & iDynTreeWrench, yarp::sig::Vector & yarpVec
  * @return true if conversion was successful, false otherwise (if the input yarpVector has size different from 3)
  * \ingroup iDynTreeYARP
  */
-bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Position & iDynTreePosition);
+inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Position & iDynTreePosition);
 
 /**
  * Convert a yarp::sig::Vector to a iDynTree::Vector3
@@ -57,7 +57,7 @@ bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Position & iDynT
  * @return true if conversion was successful, false otherwise (if the input yarpVector has size different from 3)
  * \ingroup iDynTreeYARP
  */
-bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Vector3 & iDynTreeVector3);
+inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Vector3 & iDynTreeVector3);
 
 /**
  * Convert a iDynTree::Position to a yarp::sig::Vector of 3 elements.
@@ -66,7 +66,7 @@ bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Vector3 & iDynTr
  * @return true if conversion was sucessful, false otherwise
  * \ingroup iDynTreeYARP
  */
-bool toYarp(const iDynTree::Position & iDynTreePosition, yarp::sig::Vector & yarpVector);
+inline bool toYarp(const iDynTree::Position & iDynTreePosition, yarp::sig::Vector & yarpVector);
 
 /**
  * Convert a yarp::sig::Vector of 3 elements to a iDynTree::Direction
@@ -78,7 +78,7 @@ bool toYarp(const iDynTree::Position & iDynTreePosition, yarp::sig::Vector & yar
  *
  * \ingroup iDynTreeYARP
  */
-bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Direction & iDynTreeDirection);
+inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Direction & iDynTreeDirection);
 
 /**
  * Convert a iDynTree::Direction to a yarp::sig::Vector of 3 elements.
@@ -88,7 +88,7 @@ bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Direction & iDyn
  *
  * \ingroup iDynTreeYARP
  */
-bool toYarp(const iDynTree::Vector3 & iDynTreeDirection, yarp::sig::Vector & yarpVector);
+inline bool toYarp(const iDynTree::Vector3 & iDynTreeDirection, yarp::sig::Vector & yarpVector);
 
 /**
  * Convert a 4x4 yarp::sig::Matrix representing an homegeneous matrix to a iDynTree::Transform
@@ -98,7 +98,7 @@ bool toYarp(const iDynTree::Vector3 & iDynTreeDirection, yarp::sig::Vector & yar
  *
  * \ingroup iDynTreeYARP
  */
-bool toiDynTree(const yarp::sig::Matrix & yarpHomogeneousMatrix, iDynTree::Transform & iDynTreeTransform);
+inline bool toiDynTree(const yarp::sig::Matrix & yarpHomogeneousMatrix, iDynTree::Transform & iDynTreeTransform);
 
 /**
  * Convert a iDynTree::Transform to a 4x4 yarp::sig::Matrix representing an homegeneous matrix
@@ -108,7 +108,7 @@ bool toiDynTree(const yarp::sig::Matrix & yarpHomogeneousMatrix, iDynTree::Trans
  *
  * \ingroup iDynTreeYARP
  */
-bool toYarp(const iDynTree::Transform & iDynTreeTransform,  yarp::sig::Matrix & yarpHomogeneousMatrix);
+inline bool toYarp(const iDynTree::Transform & iDynTreeTransform,  yarp::sig::Matrix & yarpHomogeneousMatrix);
 
 /**
  * Convert a yarp::sig::Vector to a iDynTree::VectorDynSize
@@ -119,7 +119,7 @@ bool toYarp(const iDynTree::Transform & iDynTreeTransform,  yarp::sig::Matrix & 
  *
  * \ingroup iDynTreeYARP
  */
-bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::VectorDynSize & iDynTreeVector);
+inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::VectorDynSize & iDynTreeVector);
 
 /**
  * Convert a iDynTree::VectorFixSize to a yarp::sig::Vector

--- a/src/yarp/include/iDynTree/yarp/YARPConversionsImplementation.h
+++ b/src/yarp/include/iDynTree/yarp/YARPConversionsImplementation.h
@@ -23,7 +23,7 @@ using namespace yarp::math;
 namespace iDynTree
 {
 
-inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTreeWrench)
+bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & iDynTreeWrench)
 {
     if( yarpVector.size() != 6 )
     {
@@ -36,7 +36,7 @@ inline bool toiDynTree(const yarp::sig::Vector & yarpVector, iDynTree::Wrench & 
 }
 
 
-inline bool toYarp(const iDynTree::Wrench & iDynTreeWrench,yarp::sig::Vector & yarpVector)
+bool toYarp(const iDynTree::Wrench & iDynTreeWrench,yarp::sig::Vector & yarpVector)
 {
     if( yarpVector.size() != 6 )
     {
@@ -48,7 +48,7 @@ inline bool toYarp(const iDynTree::Wrench & iDynTreeWrench,yarp::sig::Vector & y
     return true;
 }
 
-inline bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Position& iDynTreePosition)
+bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Position& iDynTreePosition)
 {
     if( yarpVector.size() != 3 )
     {
@@ -59,7 +59,7 @@ inline bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Position& 
     return true;
 }
 
-inline bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Vector3& iDynTreeVector3)
+bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Vector3& iDynTreeVector3)
 {
     if( yarpVector.size() != 3 )
     {
@@ -70,7 +70,7 @@ inline bool toiDynTree(const yarp::sig::Vector& yarpVector, iDynTree::Vector3& i
     return true;
 }
 
-inline bool toYarp(const iDynTree::Position& iDynTreePosition, yarp::sig::Vector& yarpVector)
+bool toYarp(const iDynTree::Position& iDynTreePosition, yarp::sig::Vector& yarpVector)
 {
     if( yarpVector.size() != 3 )
     {
@@ -81,7 +81,7 @@ inline bool toYarp(const iDynTree::Position& iDynTreePosition, yarp::sig::Vector
     return true;
 }
 
-inline bool toiDynTree(const yarp::sig::Vector& yarpVector, Direction& direction)
+bool toiDynTree(const yarp::sig::Vector& yarpVector, Direction& direction)
 {
     if( yarpVector.size() != 3 )
     {
@@ -96,7 +96,7 @@ inline bool toiDynTree(const yarp::sig::Vector& yarpVector, Direction& direction
     return true;
 }
 
-inline bool toYarp(const Vector3& iDynTreeVector3, yarp::sig::Vector& yarpVector)
+bool toYarp(const Vector3& iDynTreeVector3, yarp::sig::Vector& yarpVector)
 {
     if( yarpVector.size() != 3 )
     {
@@ -107,14 +107,14 @@ inline bool toYarp(const Vector3& iDynTreeVector3, yarp::sig::Vector& yarpVector
     return true;
 }
 
-inline bool toiDynTree(const yarp::sig::Vector& yarpVector, VectorDynSize& iDynTreeVector)
+bool toiDynTree(const yarp::sig::Vector& yarpVector, VectorDynSize& iDynTreeVector)
 {
     iDynTreeVector.resize(yarpVector.size());
     memcpy(iDynTreeVector.data(),yarpVector.data(),yarpVector.size()*sizeof(double));
     return true;
 }
 
-inline bool toiDynTree(const yarp::sig::Matrix& yarpHomogeneousMatrix,
+bool toiDynTree(const yarp::sig::Matrix& yarpHomogeneousMatrix,
                 iDynTree::Transform& iDynTreeTransform)
 {
     if( yarpHomogeneousMatrix.rows() != 4 ||
@@ -145,7 +145,7 @@ inline bool toiDynTree(const yarp::sig::Matrix& yarpHomogeneousMatrix,
     return true;
 }
 
-inline bool toYarp(const iDynTree::Transform& iDynTreeTransform,
+bool toYarp(const iDynTree::Transform& iDynTreeTransform,
             yarp::sig::Matrix& yarpHomogeneousMatrix)
 {
     iDynTree::Matrix4x4 homTrans = iDynTreeTransform.asHomogeneousTransform();


### PR DESCRIPTION
Fix the problem introduced and described in https://github.com/robotology/idyntree/pull/807#issuecomment-770832239 .