### PR TITLE
Modify MATLAB visualizer to also support the case in which the mesh package:// URI is resolved in a ROS-compatible way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the possibility to plot and update frames in the Matlab visualizer.
 - Added ``getFileLocationOnLocalFileSystem`` method in ``ExternalMesh`` that attempts to find the mesh location in the local file system. This is now used by the ``Visualizer`` when loading the robot model (https://github.com/robotology/idyntree/pull/798). This can also be used by the `iDynTreeWrapper.prepareVisualization` MATLAB function, if `meshFilePrefix` is explicitly set to `""` (https://github.com/robotology/idyntree/pull/817).
 - Add the possibility to extract submatrix with MatrixView (https://github.com/robotology/idyntree/pull/800)
-- Improved the Visualizer library: camera animations and corrections, interface for frames and texture, fix of ``STL`` visualization. This improvements also include mource control supprot for the camera, also in the `idyntree-model-view` application (https://github.com/robotology/idyntree/pull/802).
+- Improved the Visualizer library: camera animations and corrections, interface for frames and texture, fix of ``STL`` visualization. These improvements also include mouse control support for the camera, also in the `idyntree-model-view` application (https://github.com/robotology/idyntree/pull/802).
 
 ### Changed
 - Promoted the functions `computeBoundingBoxFromShape` and `computeBoxVertices` to public in the `idyntree-solid-shapes` library (https://github.com/robotology/idyntree/pull/801).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add the possibility to plot and update frames in the Matlab visualizer.
-- Added ``getFileLocationOnLocalFileSystem`` method in ``ExternalMesh`` that attempts to find the mesh location in the local file system. This is now used by the ``Visualizer`` when loading the robot model (https://github.com/robotology/idyntree/pull/798)
+- Added ``getFileLocationOnLocalFileSystem`` method in ``ExternalMesh`` that attempts to find the mesh location in the local file system. This is now used by the ``Visualizer`` when loading the robot model (https://github.com/robotology/idyntree/pull/798). This can also be used by the `iDynTreeWrapper.prepareVisualization` MATLAB function, if `meshFilePrefix` is explicitly set to `""` (https://github.com/robotology/idyntree/pull/817).
 - Add the possibility to extract submatrix with MatrixView (https://github.com/robotology/idyntree/pull/800)
-- Improved the Visualizer library: camera animations and corrections, interface for frames and texture, fix of ``STL`` visualization. (https://github.com/robotology/idyntree/pull/802)
+- Improved the Visualizer library: camera animations and corrections, interface for frames and texture, fix of ``STL`` visualization. This improvements also include mource control supprot for the camera, also in the `idyntree-model-view` application (https://github.com/robotology/idyntree/pull/802).
 
 ### Changed
 - Promoted the functions `computeBoundingBoxFromShape` and `computeBoxVertices` to public in the `idyntree-solid-shapes` library (https://github.com/robotology/idyntree/pull/801).

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -5,7 +5,7 @@ function [linkMeshInfo,map]=getMeshes(model,meshFilePrefix)
 %     - Iputs:
 %         - `model` : iDyntree model loaded from a URDF.
 %         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-% `. `meshFilePrefix` should replace package to allow to find the rest of the path.
+% `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
 %     - Outputs:
 %         - `map`        : Cell array having both the names of the meshes and the associated link
 %         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
@@ -41,13 +41,18 @@ for links=1:numberOfLinks
         if solidarray{solids}.isExternalMesh
             externalMesh=solidarray{solids}.asExternalMesh;
             scale=externalMesh.getScale.toMatlab;
-            meshName=split(externalMesh.getFilename,':');
-            meshFile=meshName{2};
-            % Import an STL mesh, returning a PATCH-compatible face-vertex structure
-            if strcmp('package',meshName{1})
-                mesh_triangles = stlread([meshFilePrefix meshFile]);
+            if(meshFilePrefix == "")
+               meshFile = externalMesh.getFilename;
+               mesh_triangles = stlread(externalMesh.getFileLocationOnLocalFileSystem);
             else
-                mesh_triangles = stlread(meshFile);
+                meshName=split(externalMesh.getFilename,':');
+                meshFile=meshName{2};
+                % Import an STL mesh, returning a PATCH-compatible face-vertex structure
+                if strcmp('package',meshName{1})
+                    mesh_triangles = stlread([meshFilePrefix meshFile]);
+                else
+                    mesh_triangles = stlread(meshFile);
+                end
             end
             meshInfo(solids).meshFile=meshFile;
             meshInfo(solids).scale=scale';

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -5,7 +5,7 @@ function [linkMeshInfo,map]=getMeshes(model,meshFilePrefix)
 %     - Iputs:
 %         - `model` : iDyntree model loaded from a URDF.
 %         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-% `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
+% `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
 %     - Outputs:
 %         - `map`        : Cell array having both the names of the meshes and the associated link
 %         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -3,7 +3,7 @@ function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,va
 % - Inputs:
 %   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
 %   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-%   `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
+%   `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
 % - Optional Inputs:
 %     - `view` : Selects the angle in which the figure is seen.
 %     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -3,7 +3,7 @@ function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,va
 % - Inputs:
 %   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
 %   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-%   `. `meshFilePrefix` should replace package to allow to find the rest of the path.
+%   `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
 % - Optional Inputs:
 %     - `view` : Selects the angle in which the figure is seen.
 %     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';

--- a/doc/matlab_visualization.md
+++ b/doc/matlab_visualization.md
@@ -60,7 +60,7 @@ It uses the [iDynTreeWrappers](../bindings/matlab/%2BiDynTreeWrappers) to handle
     - Inputs:
         - `model` : iDynTree model loaded form a URDF.
         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl' 
-`. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
+`. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
     - Outputs:
         - `map`        : Cell array having both the names of the meshes and the associated link
         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.

--- a/doc/matlab_visualization.md
+++ b/doc/matlab_visualization.md
@@ -12,7 +12,7 @@ It uses the [iDynTreeWrappers](../bindings/matlab/%2BiDynTreeWrappers) to handle
     - Inputs:
         - `KinDynModel` : iDynTreeWrappers main variable. Contains the model.
         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-`. `meshFilePrefix` should replace package to allow to find the rest of the path.
+`. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
         - `varargin`  : Variable that allows to add option configuration parameters. Admitted options are:
             - `view` : Selects the angle in which the figure is seen.
             - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';            
@@ -59,8 +59,8 @@ It uses the [iDynTreeWrappers](../bindings/matlab/%2BiDynTreeWrappers) to handle
 - `getMeshes` : Gets the mesh information for each link in the model.
     - Inputs:
         - `model` : iDynTree model loaded form a URDF.
-        - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-`. `meshFilePrefix` should replace package to allow to find the rest of the path.
+        - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl' 
+`. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
     - Outputs:
         - `map`        : Cell array having both the names of the meshes and the associated link
         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.

--- a/doc/matlab_visualization.md
+++ b/doc/matlab_visualization.md
@@ -12,7 +12,7 @@ It uses the [iDynTreeWrappers](../bindings/matlab/%2BiDynTreeWrappers) to handle
     - Inputs:
         - `KinDynModel` : iDynTreeWrappers main variable. Contains the model.
         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-`. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method.
+`. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
         - `varargin`  : Variable that allows to add option configuration parameters. Admitted options are:
             - `view` : Selects the angle in which the figure is seen.
             - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';            

--- a/examples/matlab/iDynTreeWrappers/visualizeRobot.m
+++ b/examples/matlab/iDynTreeWrappers/visualizeRobot.m
@@ -3,13 +3,6 @@
 % to complete the path inside the urdf visual mesh field.
 
 % Example:
-% If a test model has the following mesh file in the URDF
-% 'package://stl/sim_sea_2-5_root_link_prt-binary.stl'
-% The required path is what it takes to reach the stl folder.
-% meshFilePrefix=<path_to_stl_folder>;
-% It basically replaces the functionality of find Package by inserting the
-% path manually.
-% The path to the model is also required:
 % modelPath=<path_to_urdf_folder>;
 
 % REMARK : If you have installed the URDF models by https://github.com/robotology/icub-models
@@ -19,9 +12,6 @@ icubModelsInstallPrefix = '';
 
 % if installed with robotology superbuild you can directly use
 icubModelsInstallPrefix = getenv('ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX');
-
-
- meshFilePrefix = [icubModelsInstallPrefix '/share'];
 % Select the robot using the folder name
 robotName='';
 
@@ -81,6 +71,8 @@ iDynTreeWrappers.setRobotState(KinDynModel,world_H_base,joints_positions,zeros(6
 
 % Prepare figure, handles and variables required for the update, some extra
 % options are commented.
+% This is necessary to avoid to rely on the manual specification of meshFilePrefix used in iDynTree < 3
+meshFilePrefix=""
 [visualizer,objects]=iDynTreeWrappers.prepareVisualization(KinDynModel,meshFilePrefix,...
     'color',[0,0,1],'material','metal','transparency',1,'debug',true,'view',[-92.9356   22.4635],...
     'groundOn',true,'groundColor',[0.5 0.5 0.5], 'groundTransparency',0.5,'groundFrame','l_sole');%,... % optional inputs


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/799 . In particular, if the `meshFilePrefix` is an empty string, the default behaviour of iDynTree will be used.