### PR TITLE
Add the possibility to load the reduced model using a generic base frame

### DIFF
--- a/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
+++ b/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
@@ -1,15 +1,15 @@
-function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelName,debugMode)
+function KinDynModel = loadReducedModel(jointList,baseFrameName,modelPath,modelName,debugMode)
 
     % LOADREDUCEDMODEL loads the urdf model of the rigid multi-body system.
-    %                     
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    %
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelName,debugMode)
     %
     % INPUTS:  - jointList: cell array containing the list of joints to be used
     %                       in the reduced model;
-    %          - baseLinkName: a string that specifies link which is considered
+    %          - baseFrameName: a string that specifies frame which is considered
     %                          as the floating base;
     %          - modelPath: a string that specifies the path to the urdf model;
     %          - modelName: a string that specifies the model name;
@@ -25,27 +25,23 @@ function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelNa
 
     %% ------------Initialization----------------
     disp(['[loadReducedModel]: loading the following model: ',[modelPath,modelName]]);
-        
+
     % if DEBUG option is set to TRUE, all the wrappers will be run in debug
     % mode. Wrappers concerning iDyntree simulator have their own debugger
     KinDynModel.DEBUG      = debugMode;
-    
-    % retrieve the link that will be used as the floating base
-    KinDynModel.BASE_LINK  = baseLinkName;
-        
+
     % load the list of joints to be used in the reduced model
     jointList_idyntree     = iDynTree.StringVector();
-    
+
     for k = 1:length(jointList)
-        
         jointList_idyntree.push_back(jointList{k});
     end
 
     % only joints specified in the joint list will be considered in the model
     modelLoader            = iDynTree.ModelLoader();
     reducedModel           = modelLoader.model();
-
     modelLoader.loadReducedModelFromFile([modelPath,modelName], jointList_idyntree);
+
 
     % get the number of degrees of freedom of the reduced model
     KinDynModel.NDOF       = reducedModel.getNrOfDOFs();
@@ -55,9 +51,18 @@ function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelNa
     KinDynModel.kinDynComp = iDynTree.KinDynComputations();
 
     KinDynModel.kinDynComp.loadRobotModel(reducedModel);
-    
+
+    % retrieve the link that will be used as the floating base
+    frameBaseIndex        = reducedModel.getFrameIndex(baseFrameName);
+    linkBaseIndex         = reducedModel.getFrameLink(frameBaseIndex);
+    KinDynModel.BASE_LINK = reducedModel.getLinkName(linkBaseIndex);
+
+    % This is a fixed transform between the link and the frame
+    KinDynModel.baseFixedTransform = KinDynModel.kinDynComp.getRelativeTransform(frameBaseIndex, ...
+                                                                                 linkBaseIndex);
+
     % set the floating base link
     KinDynModel.kinDynComp.setFloatingBase(KinDynModel.BASE_LINK);
-    
+
     disp(['[loadReducedModel]: loaded model: ',[modelPath,modelName],', number of joints: ',num2str(KinDynModel.NDOF)]);
 end


### PR DESCRIPTION
Thanks to this PR the `loadReducedModel` `MATLAB` function can instantiate the a kindynobject even if the base link is set to a generic frame of the robot.

For instance this code works without problems even if `l_sole` is not a link but a frame.

```matlab
debug = false;
base_link = 'l_foot_front';
file_name = 'model.urdf';
resource_finder = yarp.ResourceFinder.getResourceFinderSingleton();
model_path = resource_finder.findFileByName(file_name);
base_frame = 'l_sole'; % <--------- This is just a frame not a link!
model_path = erase(model_path, file_name);
joints = {'torso_pitch', 'torso_roll', 'torso_yaw', ...
              'l_shoulder_pitch', 'l_shoulder_roll', 'l_shoulder_yaw', 'l_elbow', ...
              'r_shoulder_pitch', 'r_shoulder_roll', 'r_shoulder_yaw', 'r_elbow', ...
              'l_hip_pitch', 'l_hip_roll', 'l_hip_yaw', 'l_knee', 'l_ankle_pitch', 'l_ankle_roll', ...
              'r_hip_pitch', 'r_hip_roll', 'r_hip_yaw', 'r_knee', 'r_ankle_pitch', 'r_ankle_roll'};

model = iDynTreeWrappers.loadReducedModel(joints, base_link, ...
                                          model_path, file_name, debug);
```
and `model` is a struct that contains
```matlab
>> model

model = 

  struct with fields:

                 DEBUG: 0
                  NDOF: 23
            kinDynComp: [1×1 iDynTree.KinDynComputations]
             BASE_LINK: 'l_ankle_2'
    baseFixedTransform: [1×1 iDynTree.Transform]
```

where `baseFixedTransform` is a fixed homogeneous transform from `l_sole` and `l_ankle_2` (in this particular case)

The PR does not break the compatibility with the already existing code indeed if `base_frame = 'root_link';` 

```
model.BASE_LINK
model.baseFixedTransform.toString()

ans =

    'root_link'


ans =

    '1 0 0
     0 1 0
     0 0 1
      0 0 0
     '
```


The PR removes also white spaces :smile: 

cc @gabrielenava @Giulero @HosameldinMohamed 
