### PR TITLE
CI: Add irrlicht to conda-forge build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        ctest --output-on-failure -C ${{ matrix.build_type }} . 
+        # Visualizer tests excluded as a workaround for https://github.com/robotology/idyntree/issues/808
+        ctest --output-on-failure -C ${{ matrix.build_type }} -E "Visualizer" . 
 
   build-with-system-dependencies:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         # Compilation related dependencies 
         mamba install -c conda-forge cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge eigen libxml2 assimp ipopt qt
+        mamba install -c conda-forge eigen libxml2 assimp ipopt qt irrlicht
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]
@@ -58,7 +58,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON -DIDYNTREE_USES_ASSIMP:BOOL=ON -DIDYNTREE_USES_IPOPT:BOOL=ON ..
+        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON -DIDYNTREE_USES_ASSIMP:BOOL=ON -DIDYNTREE_USES_IPOPT:BOOL=ON -DIDYNTREE_USES_IRRLICHT:BOOL=ON ..
 
     - name: Configure [Conda/Windows]
       if: contains(matrix.os, 'windows')
@@ -66,7 +66,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G"Visual Studio 16 2019"  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON -DIDYNTREE_USES_ASSIMP:BOOL=ON -DIDYNTREE_USES_IPOPT:BOOL=ON ..
+        cmake -G"Visual Studio 16 2019"  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_Qt5:BOOL=ON -DIDYNTREE_USES_ASSIMP:BOOL=ON -DIDYNTREE_USES_IPOPT:BOOL=ON -DIDYNTREE_USES_IRRLICHT:BOOL=ON ..
 
     - name: Build [Conda]
       shell: bash -l {0}


### PR DESCRIPTION
Irrlicht is now available in conda-forge (https://github.com/conda-forge/staged-recipes/pull/13900) so we can enabled it also in conda CI.