### PR TITLE
Introduce color palette in the Visualizer

### DIFF
--- a/src/tools/idyntree-model-view.cpp
+++ b/src/tools/idyntree-model-view.cpp
@@ -26,6 +26,10 @@ void addOptions(cmdline::parser &cmd)
     cmd.add<std::string>("model", 'm',
                          "Model to load.",
                          true);
+
+    cmd.add<std::string>("color-palette", 'c',
+                         "Color palette.",
+                         false);
 }
 
 int main(int argc, char** argv)
@@ -35,7 +39,7 @@ int main(int argc, char** argv)
     cmd.parse_check(argc, argv);
 
     // Read model
-    std::string modelPath = cmd.get<std::string>("model");
+    const std::string& modelPath = cmd.get<std::string>("model");
     iDynTree::ModelLoader mdlLoader;
     bool ok = mdlLoader.loadModelFromFile(modelPath);
 
@@ -48,6 +52,17 @@ int main(int argc, char** argv)
     // Visualize the model
     iDynTree::Visualizer visualizer;
     ok = visualizer.addModel(mdlLoader.model(),"model");
+    const std::string& palette = cmd.get<std::string>("color-palette");
+    if(!palette.empty())
+    {
+        ok = visualizer.setColorPalette(palette);
+        if( !ok )
+        {
+            std::cerr << "Impossible to set the color palette." << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
     visualizer.camera().animator()->enableMouseControl();
 
     if( !ok )
@@ -64,5 +79,3 @@ int main(int argc, char** argv)
 
     return EXIT_SUCCESS;
 }
-
-

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -438,6 +438,16 @@ public:
     virtual bool setVectorColor(size_t vectorIndex, const ColorViz & vectorColor) = 0;
 
     /**
+     * Set the default color for the vector.
+     */
+    virtual void setVectorsDefaultColor(const ColorViz &vectorColor) = 0;
+
+    /**
+     * Set the color for all the existing vectors.
+     */
+    virtual void setVectorsColor(const ColorViz &vectorColor) = 0;
+
+    /**
      * @brief Determines the dimension of the visualized arrows
      * @param zeroModulusRadius Constant offset for the arrow radius.
      * @param modulusMultiplier Multiplies the modulus and adds up to the zeroModulusRadius to get the total arrow radius.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -824,6 +824,12 @@ public:
      */
     bool isWindowActive() const;
 
+    /**
+     * @brief Set the color palette.
+     * @param name name of the color palette. Currently only vanilla and meshcat are supported.
+     * @return true if all went ok, false otherwise.
+     */
+    bool setColorPalette(const std::string& name);
 };
 
 }

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -105,6 +105,8 @@ public:
     virtual bool updateVector(size_t, const Position &, const Vector3&) override { return false; }
     virtual bool setVectorColor(size_t , const ColorViz &) override { return false; }
     virtual bool setVectorsAspect(double, double, double) override { return false; }
+    virtual void setVectorsColor(const ColorViz &) override { return; }
+    virtual void setVectorsDefaultColor(const ColorViz &) override { return; }
 };
 
 class DummyFrameVisualization : public IFrameVisualization

--- a/src/visualization/src/IrrlichtUtils.h
+++ b/src/visualization/src/IrrlichtUtils.h
@@ -262,28 +262,22 @@ inline irr::scene::ISceneNode * addGeometryToSceneManager(const iDynTree::SolidS
 
 inline irr::scene::ISceneNode * addFrameAxes(irr::scene::ISceneManager* smgr,
                                              irr::scene::ISceneNode * parentNode=0,
-                                             irr::f32 arrowLength=1.0)
+                                             irr::f32 arrowLength=1.0,
+                                             const irr::video::SColor& red = irr::video::SColor(20, 255, 0, 0),
+                                             const irr::video::SColor& green = irr::video::SColor(20, 0, 255, 0),
+                                             const irr::video::SColor& blue = irr::video::SColor(20, 0, 0, 255))
 {
-    irr::u32 alphaLev = 20;
     irr::video::SMaterial transRed;
-    transRed.AmbientColor = irr::video::SColor(alphaLev,255,0,0);
-    transRed.DiffuseColor = irr::video::SColor(alphaLev,255,0,0);
+    transRed.AmbientColor = red;
+    transRed.DiffuseColor = red;
 
     irr::video::SMaterial transGreen;
-    transGreen.AmbientColor = irr::video::SColor(alphaLev,0,255,0);
-    transGreen.DiffuseColor = irr::video::SColor(alphaLev,0,255,0);
+    transGreen.AmbientColor = green;
+    transGreen.DiffuseColor = green;
 
     irr::video::SMaterial transBlue;
-    transBlue.AmbientColor = irr::video::SColor(alphaLev,0,0,255);
-    transBlue.DiffuseColor = irr::video::SColor(alphaLev,0,0,255);
-
-    irr::video::SMaterial transYellow;
-    transYellow.AmbientColor = irr::video::SColor(alphaLev,255,255,0);
-    transYellow.DiffuseColor = irr::video::SColor(alphaLev,255,255,0);
-
-    irr::video::SMaterial transGray;
-    transYellow.AmbientColor = irr::video::SColor(alphaLev,100,100,100);
-    transYellow.DiffuseColor = irr::video::SColor(alphaLev,100,100,100);
+    transBlue.AmbientColor = blue;
+    transBlue.DiffuseColor = blue;
 
     irr::scene::ISceneNode * frameNode = smgr->addEmptySceneNode(parentNode);
 

--- a/src/visualization/src/VectorsVisualization.cpp
+++ b/src/visualization/src/VectorsVisualization.cpp
@@ -123,6 +123,7 @@ size_t VectorsVisualization::addVector(const Position &origin, const Direction &
     newVector.origin = origin;
     newVector.direction = direction;
     newVector.modulus = modulus;
+    newVector.color = m_vectorsDefaultColor;
 
     m_vectors.push_back(newVector);
 
@@ -187,6 +188,20 @@ bool VectorsVisualization::updateVector(size_t vectorIndex, const Position &orig
 bool VectorsVisualization::updateVector(size_t vectorIndex, const Position &origin, const Vector3 &components)
 {
     return updateVector(vectorIndex, origin, Direction(components(0), components(1), components(2)), toEigen(components).norm());
+}
+
+void VectorsVisualization::setVectorsDefaultColor(const ColorViz &vectorColor)
+{
+    m_vectorsDefaultColor = vectorColor;
+}
+
+void VectorsVisualization::setVectorsColor(const ColorViz &vectorColor)
+{
+    for(auto & vector : m_vectors) {
+        vector.color = vectorColor;
+    }
+
+    drawAll();
 }
 
 bool VectorsVisualization::setVectorColor(size_t vectorIndex, const ColorViz &vectorColor)

--- a/src/visualization/src/VectorsVisualization.h
+++ b/src/visualization/src/VectorsVisualization.h
@@ -27,6 +27,8 @@ namespace iDynTree {
             irr::scene::ISceneNode * visualizationNode = nullptr;
         } VectorsProperties;
 
+        ColorViz m_vectorsDefaultColor{ColorViz(1.0, 0.0, 0.0, 1.0)};
+
         std::vector<VectorsProperties> m_vectors;
 
         irr::scene::ISceneManager* m_smgr;
@@ -67,6 +69,10 @@ namespace iDynTree {
         virtual bool updateVector(size_t vectorIndex, const Position & origin, const Vector3& components) override;
 
         virtual bool setVectorColor(size_t vectorIndex, const ColorViz & vectorColor) override;
+
+        virtual void setVectorsDefaultColor(const ColorViz &vectorColor) override;
+
+        virtual void setVectorsColor(const ColorViz &vectorColor) override;
 
         virtual bool setVectorsAspect(double zeroModulusRadius, double modulusMultiplier, double heightScale) override;
 

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -148,6 +148,34 @@ struct Visualizer::VisualizerPimpl
      */
     TexturesHandler m_textures;
 
+    double rootFrameArrowsDimension;
+    struct ColorPalette
+    {
+        irr::video::SColorf background;
+        irr::video::SColor  gridColor;
+
+        irr::video::SColor xAxis;
+        irr::video::SColor yAxis;
+        irr::video::SColor zAxis;
+    };
+    std::unordered_map<std::string, ColorPalette> m_palette;
+
+    void initializePalette()
+    {
+        irr::u32 alphaLev = 20;
+        // vanilla palette (This is the original palette of the visualizer)
+        m_palette["vanilla"].background = irr::video::SColorf(0.0,0.4,0.4,1.0);
+        m_palette["vanilla"].gridColor = irr::video::SColor(100,0,0,255);
+        m_palette["vanilla"].xAxis = irr::video::SColor(alphaLev,255,0,0);
+        m_palette["vanilla"].yAxis = irr::video::SColor(alphaLev,0,255,0);
+        m_palette["vanilla"].zAxis = irr::video::SColor(alphaLev,0,0,255);
+
+        m_palette["meshcat"].background = irr::video::SColorf(0.42,0.63,0.85,1.0);
+        m_palette["meshcat"].gridColor =  irr::video::SColor(128,128,128,100);
+        m_palette["meshcat"].xAxis = irr::video::SColor(alphaLev,234, 67, 53);
+        m_palette["meshcat"].yAxis = irr::video::SColor(alphaLev,52, 168, 83);
+        m_palette["meshcat"].zAxis = irr::video::SColor(alphaLev,66,133,244);
+    }
 #else
     DummyCamera m_camera;
     DummyEnvironment m_environment;
@@ -204,6 +232,9 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
         return false;
     }
 
+    // initialize the color palette
+    pimpl->initializePalette();
+
     irr::SIrrlichtCreationParameters irrDevParams;
 
     irrDevParams.DriverType = irr::video::EDT_OPENGL;
@@ -243,7 +274,8 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
     pimpl->m_irrDevice->getCursorControl()->setVisible(true);
 
     // Add environment
-    pimpl->m_environment.init(pimpl->m_irrSmgr, visualizerOptions.rootFrameArrowsDimension);
+    pimpl->rootFrameArrowsDimension = visualizerOptions.rootFrameArrowsDimension;
+    pimpl->m_environment.init(pimpl->m_irrSmgr, pimpl->rootFrameArrowsDimension);
 
     pimpl->m_camera.setIrrlichtCamera(addVizCamera(pimpl->m_irrSmgr));
     pimpl->m_camera.setCameraAnimator(new CameraAnimator(pimpl->m_irrDevice->getCursorControl(),
@@ -552,4 +584,49 @@ bool Visualizer::isWindowActive() const
 #endif
 }
 
+
+bool Visualizer::setColorPalette(const std::string &name)
+{
+#ifdef IDYNTREE_USES_IRRLICHT
+
+    if( !pimpl->m_isInitialized )
+    {
+        reportError("Visualizer",
+                    "setColorPalette",
+                    "Impossible to set the color palette. Please initialize the visualizer");
+        return false;
+    }
+
+    const auto colors = pimpl->m_palette.find(name);
+
+    if(colors == pimpl->m_palette.end())
+    {
+        std::string paletteName;
+        for (const auto& tmp: pimpl->m_palette)
+            paletteName += " " + tmp.first;
+
+        const std::string error = "The palette named " + name
+                                + " does not exist. The following palette are available"
+                                + paletteName + ".";
+
+        reportError("Visualizer","setColorPalette", error.c_str());
+        return false;
+    }
+
+    this->enviroment().setBackgroundColor(irrlicht2idyntree(colors->second.background));
+    this->enviroment().setFloorGridColor(irrlicht2idyntree(colors->second.gridColor));
+
+    // delete the frame in the origin and create a new one
+    pimpl->m_environment.m_rootFrameNode->drop();
+    pimpl->m_environment.m_rootFrameNode = addFrameAxes(pimpl->m_irrSmgr,
+                                                        pimpl->m_environment.m_envNode,
+                                                        pimpl->rootFrameArrowsDimension);
+    return true;
+
+#else
+    reportError("Visualizer","setColorPalette",
+                "Impossible to use iDynTree::Visualizer, as iDynTree has been compiled without Irrlicht.");
+    return false;
+#endif
+}
 }

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -617,7 +617,7 @@ bool Visualizer::setColorPalette(const std::string &name)
     this->enviroment().setFloorGridColor(irrlicht2idyntree(colors->second.gridColor));
 
     // delete the frame in the origin and create a new one
-    pimpl->m_environment.m_rootFrameNode->drop();
+    pimpl->m_environment.m_rootFrameNode->remove();
     pimpl->m_environment.m_rootFrameNode = addFrameAxes(pimpl->m_irrSmgr,
                                                         pimpl->m_environment.m_envNode,
                                                         pimpl->rootFrameArrowsDimension,

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -151,12 +151,14 @@ struct Visualizer::VisualizerPimpl
     double rootFrameArrowsDimension;
     struct ColorPalette
     {
-        irr::video::SColorf background;
-        irr::video::SColor  gridColor;
+        irr::video::SColorf background = irr::video::SColorf(0.0,0.4,0.4,1.0);
+        irr::video::SColor  gridColor = irr::video::SColor(100,0,0,255);
 
-        irr::video::SColor xAxis;
-        irr::video::SColor yAxis;
-        irr::video::SColor zAxis;
+        irr::video::SColor xAxis = irr::video::SColor(20,255,0,0);
+        irr::video::SColor yAxis = irr::video::SColor(20,0,255,0);
+        irr::video::SColor zAxis = irr::video::SColor(20,0,0,255);
+
+        irr::video::SColor vector = irr::video::SColor(1,1,0,0);
     };
     std::unordered_map<std::string, ColorPalette> m_palette;
 
@@ -169,12 +171,14 @@ struct Visualizer::VisualizerPimpl
         m_palette["vanilla"].xAxis = irr::video::SColor(alphaLev,255,0,0);
         m_palette["vanilla"].yAxis = irr::video::SColor(alphaLev,0,255,0);
         m_palette["vanilla"].zAxis = irr::video::SColor(alphaLev,0,0,255);
+        m_palette["vanilla"].vector = irr::video::SColor(255,255,0,0);
 
         m_palette["meshcat"].background = irr::video::SColorf(0.42,0.63,0.85,1.0);
         m_palette["meshcat"].gridColor =  irr::video::SColor(128,128,128,100);
         m_palette["meshcat"].xAxis = irr::video::SColor(alphaLev,234, 67, 53);
         m_palette["meshcat"].yAxis = irr::video::SColor(alphaLev,52, 168, 83);
         m_palette["meshcat"].zAxis = irr::video::SColor(alphaLev,66,133,244);
+        m_palette["meshcat"].vector = irr::video::SColor(255,253,98,2);
     }
 #else
     DummyCamera m_camera;
@@ -615,6 +619,9 @@ bool Visualizer::setColorPalette(const std::string &name)
 
     this->enviroment().setBackgroundColor(irrlicht2idyntree(colors->second.background));
     this->enviroment().setFloorGridColor(irrlicht2idyntree(colors->second.gridColor));
+
+    this->vectors().setVectorsColor(irrlicht2idyntree(colors->second.vector));
+    this->vectors().setVectorsDefaultColor(irrlicht2idyntree(colors->second.vector));
 
     // delete the frame in the origin and create a new one
     pimpl->m_environment.m_rootFrameNode->remove();

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -620,7 +620,10 @@ bool Visualizer::setColorPalette(const std::string &name)
     pimpl->m_environment.m_rootFrameNode->drop();
     pimpl->m_environment.m_rootFrameNode = addFrameAxes(pimpl->m_irrSmgr,
                                                         pimpl->m_environment.m_envNode,
-                                                        pimpl->rootFrameArrowsDimension);
+                                                        pimpl->rootFrameArrowsDimension,
+                                                        colors->second.xAxis,
+                                                        colors->second.yAxis,
+                                                        colors->second.zAxis);
     return true;
 
 #else


### PR DESCRIPTION
This PR introduces the color palette in the visualizer.
I implemented only two palettes `vanilla` and `meshcat`. The `vanilla` palette is the original one and it is loaded by default. 

I also modified the `idyntree-model-view` application to load different palettes (you can pass the argument with `-c`)

https://user-images.githubusercontent.com/16744101/107950983-d89f5e80-6f97-11eb-8f05-2b0fcbecdc23.mp4


The only two problems that we have right now are:
1. the model is really dark (is the sun correctly placed?) 
2. the camera is not well oriented at the startup (at least for `iCubGazeboV2_5` model)

cc @S-Dafarra @traversaro @Giulero 