### PR TITLE
Fix obj visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the `IDYNTREE_USES_ASSIMP` option on Windows if `IDYNTREE_USES_YARP` is also enabled (https://github.com/robotology/idyntree/pull/832).
-
+- Fixed the ``OBJ`` meshes visualization in the Visualizer library (https://github.com/robotology/idyntree/pull/833).
 ## [3.0.0] - 2020-02-03
 
 ### Added
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1] - 2020-11-24
 
 ### Fixed
-- Fixed problem in pybind11-based Python bindings (https://github.com/robotology/idyntree/pull/781). 
+- Fixed problem in pybind11-based Python bindings (https://github.com/robotology/idyntree/pull/781).
 
 ## [2.0.0] - 2020-11-22
 

--- a/src/visualization/src/IrrlichtUtils.h
+++ b/src/visualization/src/IrrlichtUtils.h
@@ -228,9 +228,9 @@ inline irr::scene::ISceneNode * addGeometryToSceneManager(const iDynTree::SolidS
         iDynTree::Vector3 scale = externalMesh->getScale();
 
         // If multiple mesh are loaded, add them
-        if (getFileExt(externalMesh->getFilename()) == "stl")
+        if (getFileExt(externalMesh->getFilename()) == "stl" || getFileExt(externalMesh->getFilename()) == "obj")
         {
-            scale(0) = -scale(0); //STL meshes are interpreted as left handed by irrlicht
+            scale(0) = -scale(0); //STL and OBJ meshes are interpreted as left handed by irrlicht
         }
 
         geomNode = smgr->addMeshSceneNode(loadedAnimatedMesh->getMesh(0),linkNode);


### PR DESCRIPTION
This PR applies the same fix proposed in https://github.com/robotology/idyntree/pull/802 for `stl` meshes visualization to `obj` ones.  