### PR TITLE
Fix overlinking of MATLAB bindings to MatlabEngine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,13 @@ jobs:
         cd build
         cmake --build . --config ${{ matrix.build_type }}
 
+    - name: Inspect libraries linked by iDynTreeMEX.mexa64 [Conda/Linux]
+      if: contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        cd build
+        ldd ./lib/iDynTreeMEX.mexa64
+
     - name: Test [Conda]
       shell: bash -l {0}
       run: |
@@ -315,6 +322,7 @@ jobs:
         # See https://github.com/robotology/idyntree/issues/569
         export PATH=$PATH:${GITHUB_WORKSPACE}/install/bin:${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin:${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/debug/bin
         cmake --build . --config ${{ matrix.build_type }}
+  
         
     - name: Test
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the `IDYNTREE_USES_ASSIMP` option on Windows if `IDYNTREE_USES_YARP` is also enabled (https://github.com/robotology/idyntree/pull/832).
 - Fixed the ``OBJ`` meshes visualization in the Visualizer library (https://github.com/robotology/idyntree/pull/833).
 - Fixed `ModelVisualization::getWorldLinkTransform()` method (https://github.com/robotology/idyntree/issues/836)
+- Only link required MATLAB libraries when compiling iDynTree MATLAB bindings (https://github.com/robotology/idyntree/pull/840).
 
 ### Deprecated
 - The method `ModelVisualization::getWorldModelTransform()` is deprecated, and will be removed in iDynTree 4.0.

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -76,7 +76,7 @@ macro(GET_LIBRARY_FROM_SWIG_WRAPPER i_main_file i_other_files target_name genera
         PROPERTY SWIG_DEPENDS ${i_other_files})
   else()
       if(${target_name} STREQUAL "iDynTreeMEX") 
-          matlab_add_mex(NAME ${target_name} SRC ${swig_generated_sources})
+          matlab_add_mex(NAME ${target_name} SRC ${swig_generated_sources} NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES)
       else()
           add_library(${target_name} MODULE ${swig_generated_sources})
       endif()
@@ -102,21 +102,7 @@ if(IDYNTREE_USES_MATLAB)
           ${IDYNTREE_GENERATE_MATLAB}
           ${MEX_BINDINGS_SOURCE_DIR})
 
-  set_target_properties(${target_name}
-    PROPERTIES OUTPUT_NAME ${mexname}
-               PREFIX ""
-               SUFFIX .mex)
-
-  target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} idyntree-core ${Matlab_LIBRARIES})
-  target_include_directories(${target_name} PUBLIC ${Matlab_INCLUDE_DIRS})
-  set_target_properties(${target_name} PROPERTIES PREFIX "" SUFFIX .${Matlab_MEX_EXTENSION})
-
-  # entry point in the mex file + taking care of visibility and symbol clashes.
-  if(WIN32)
-    set_target_properties(${target_name}
-        PROPERTIES
-        DEFINE_SYMBOL "DLL_EXPORT_SYM=__declspec(dllexport)")
-  endif()
+  target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} idyntree-core ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY})
 
   # Install the generated front-end to ${CMAKE_INSTALL_PREFIX}/mex
   install(

--- a/cmake/FindMatlab.cmake
+++ b/cmake/FindMatlab.cmake
@@ -251,7 +251,7 @@ cmake_policy(SET CMP0057 NEW) # if IN_LIST
 
 set(_FindMatlab_SELF_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include(FindPackageHandleStandardArgs)
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 

--- a/cmake/FindMatlab.cmake
+++ b/cmake/FindMatlab.cmake
@@ -1,4 +1,4 @@
-# Vendored from https://gitlab.kitware.com/cmake/cmake/-/raw/v3.17.0/Modules/FindMatlab.cmake
+# Vendored from https://gitlab.kitware.com/cmake/cmake/-/raw/v3.20.0-rc3/Modules/FindMatlab.cmake
 # Distributed under the OSI-approved BSD 3-Clause License.  See
 # https://cmake.org/licensing for details.
 
@@ -18,6 +18,9 @@ can also be used:
 * to retrieve various information from Matlab (mex extensions, versions and
   release queries, ...)
 
+.. versionadded:: 3.12
+  Added Matlab Compiler Runtime (MCR) support.
+
 The module supports the following components:
 
 * ``ENG_LIBRARY`` and ``MAT_LIBRARY``: respectively the ``ENG`` and ``MAT``
@@ -28,6 +31,17 @@ The module supports the following components:
 * ``MEX_COMPILER`` the MEX compiler.
 * ``MCC_COMPILER`` the MCC compiler, included with the Matlab Compiler add-on.
 * ``SIMULINK`` the Simulink environment.
+
+.. versionadded:: 3.7
+  Added the ``MAT_LIBRARY`` component.
+
+.. versionadded:: 3.13
+  Added the ``ENGINE_LIBRARY``, ``DATAARRAY_LIBRARY`` and ``MCC_COMPILER``
+  components.
+
+.. versionchanged:: 3.14
+  Removed the ``MX_LIBRARY``, ``ENGINE_LIBRARY`` and ``DATAARRAY_LIBRARY``
+  components.  These libraries are found unconditionally.
 
 .. note::
 
@@ -108,8 +122,12 @@ Result variables
   Matlab matrix library. Available only if the component ``MAT_LIBRARY``
   is requested.
 ``Matlab_ENGINE_LIBRARY``
+  .. versionadded:: 3.13
+
   Matlab C++ engine library, always available for R2018a and newer.
 ``Matlab_DATAARRAY_LIBRARY``
+  .. versionadded:: 3.13
+
   Matlab C++ data array library, always available for R2018a and newer.
 ``Matlab_LIBRARIES``
   the whole set of libraries of Matlab
@@ -117,6 +135,8 @@ Result variables
   the mex compiler of Matlab. Currently not used.
   Available only if the component ``MEX_COMPILER`` is requested.
 ``Matlab_MCC_COMPILER``
+  .. versionadded:: 3.13
+
   the mcc compiler of Matlab. Included with the Matlab Compiler add-on.
   Available only if the component ``MCC_COMPILER`` is requested.
 
@@ -230,7 +250,7 @@ cmake_policy(SET CMP0057 NEW) # if IN_LIST
 
 set(_FindMatlab_SELF_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-include(FindPackageHandleStandardArgs)
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 
@@ -242,6 +262,7 @@ if(NOT MATLAB_ADDITIONAL_VERSIONS)
 endif()
 
 set(MATLAB_VERSIONS_MAPPING
+  "R2020b=9.9"
   "R2020a=9.8"
   "R2019b=9.7"
   "R2019a=9.6"
@@ -389,12 +410,12 @@ function(matlab_extract_all_installed_versions_from_registry win64 matlab_versio
 
   set(matlabs_from_registry)
 
-  foreach(_installation_type IN ITEMS "MATLAB" "MATLAB Runtime")
+  foreach(_installation_type IN ITEMS "MATLAB" "MATLAB Runtime" "MATLAB Compiler Runtime")
 
     # /reg:64 should be added on 64 bits capable OSs in order to enable the
     # redirection of 64 bits applications
     execute_process(
-      COMMAND reg query HKEY_LOCAL_MACHINE\\SOFTWARE\\Mathworks\\${_installation_type} /f * /k ${APPEND_REG}
+      COMMAND reg query "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mathworks\\${_installation_type}" /f * /k ${APPEND_REG}
       RESULT_VARIABLE resultMatlab
       OUTPUT_VARIABLE varMatlab
       ERROR_VARIABLE errMatlab
@@ -405,12 +426,12 @@ function(matlab_extract_all_installed_versions_from_registry win64 matlab_versio
     if(resultMatlab EQUAL 0)
 
       string(
-        REGEX MATCHALL "MATLAB\\\\([0-9]+(\\.[0-9]+)?)"
+        REGEX MATCHALL "${_installation_type}\\\\([0-9]+(\\.[0-9]+)?)"
         matlab_versions_regex ${varMatlab})
 
       foreach(match IN LISTS matlab_versions_regex)
         string(
-          REGEX MATCH "MATLAB\\\\(([0-9]+)(\\.([0-9]+))?)"
+          REGEX MATCH "${_installation_type}\\\\(([0-9]+)(\\.([0-9]+))?)"
           current_match ${match})
 
         set(_matlab_current_version ${CMAKE_MATCH_1})
@@ -517,7 +538,7 @@ function(matlab_get_all_valid_matlab_roots_from_registry matlab_versions matlab_
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MathWorks\\MATLAB\\${_matlab_current_version};MATLABROOT]"
       ABSOLUTE)
 
-    if(EXISTS ${current_MATLAB_ROOT})
+    if(EXISTS "${current_MATLAB_ROOT}")
       list(APPEND _matlab_roots_list "MATLAB" ${_matlab_current_version} ${current_MATLAB_ROOT})
     endif()
 
@@ -533,7 +554,23 @@ function(matlab_get_all_valid_matlab_roots_from_registry matlab_versions matlab_
     # remove the dot
     string(REPLACE "." "" _matlab_current_version_without_dot "${_matlab_current_version}")
 
-    if(EXISTS ${current_MATLAB_ROOT})
+    if(EXISTS "${current_MATLAB_ROOT}")
+      list(APPEND _matlab_roots_list "MCR" ${_matlab_current_version} "${current_MATLAB_ROOT}/v${_matlab_current_version_without_dot}")
+    endif()
+
+  endforeach()
+
+  # Check for old MCR installations
+  foreach(_matlab_current_version ${matlab_versions})
+    get_filename_component(
+      current_MATLAB_ROOT
+      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MathWorks\\MATLAB Compiler Runtime\\${_matlab_current_version};MATLABROOT]"
+      ABSOLUTE)
+
+    # remove the dot
+    string(REPLACE "." "" _matlab_current_version_without_dot "${_matlab_current_version}")
+
+    if(EXISTS "${current_MATLAB_ROOT}")
       list(APPEND _matlab_roots_list "MCR" ${_matlab_current_version} "${current_MATLAB_ROOT}/v${_matlab_current_version_without_dot}")
     endif()
 
@@ -923,14 +960,26 @@ endfunction()
     the same folder without any processing, with the same name as the final
     mex file, and with extension `.m`. In that case, typing ``help <name>``
     in Matlab prints the documentation contained in this file.
-  ``R2017b`` or ``R2018a`` may be given to specify the version of the C API
+  ``R2017b`` or ``R2018a``
+    .. versionadded:: 3.14
+
+    May be given to specify the version of the C API
     to use: ``R2017b`` specifies the traditional (separate complex) C API,
     and corresponds to the ``-R2017b`` flag for the `mex` command. ``R2018a``
     specifies the new interleaved complex C API, and corresponds to the
     ``-R2018a`` flag for the `mex` command. Ignored if MATLAB version prior
     to R2018a. Defaults to ``R2017b``.
-  ``MODULE`` or ``SHARED`` may be given to specify the type of library to be
-    created. ``EXECUTABLE`` may be given to create an executable instead of
+
+  ``MODULE`` or ``SHARED``
+    .. versionadded:: 3.7
+
+    May be given to specify the type of library to be
+    created.
+
+  ``EXECUTABLE``
+    .. versionadded:: 3.7
+
+    May be given to create an executable instead of
     a library. If no type is given explicitly, the type is ``SHARED``.
   ``EXCLUDE_FROM_ALL``
     This option has the same meaning as for :prop_tgt:`EXCLUDE_FROM_ALL` and
@@ -993,7 +1042,10 @@ function(matlab_add_mex)
     endif()
   endif()
 
-  if(NOT Matlab_VERSION_STRING VERSION_LESS "9.4") # For 9.4 (R2018a) and newer, add API macro
+  # For 9.4 (R2018a) and newer, add API macro.
+  # Add it for unknown versions too, just in case.
+  if(NOT Matlab_VERSION_STRING VERSION_LESS "9.4"
+      OR Matlab_VERSION_STRING STREQUAL "unknown")
     if(${${prefix}_R2018a})
       set(MEX_API_MACRO "MATLAB_DEFAULT_RELEASE=R2018a")
     else()
@@ -1032,7 +1084,12 @@ function(matlab_add_mex)
   target_include_directories(${${prefix}_NAME} PRIVATE ${Matlab_INCLUDE_DIRS})
 
   if(Matlab_HAS_CPP_API)
-    target_link_libraries(${${prefix}_NAME} ${Matlab_ENGINE_LIBRARY} ${Matlab_DATAARRAY_LIBRARY})
+    if(Matlab_ENGINE_LIBRARY)
+      target_link_libraries(${${prefix}_NAME} ${Matlab_ENGINE_LIBRARY})
+    endif()
+    if(Matlab_DATAARRAY_LIBRARY)
+      target_link_libraries(${${prefix}_NAME} ${Matlab_DATAARRAY_LIBRARY})
+    endif()
   endif()
 
   target_link_libraries(${${prefix}_NAME} ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} ${${prefix}_LINK_TO})
@@ -1652,32 +1709,34 @@ find_path(
   )
 list(APPEND _matlab_required_variables Matlab_INCLUDE_DIRS)
 
-_Matlab_find_library(
-  ${_matlab_lib_prefix_for_search}
-  Matlab_MEX_LIBRARY
-  mex
-  PATHS ${_matlab_lib_dir_for_search}
-  NO_DEFAULT_PATH
-)
-list(APPEND _matlab_required_variables Matlab_MEX_LIBRARY)
+if(Matlab_Or_MCR STREQUAL "MATLAB" OR Matlab_Or_MCR STREQUAL "UNKNOWN")
+  _Matlab_find_library(
+    ${_matlab_lib_prefix_for_search}
+    Matlab_MEX_LIBRARY
+    mex
+    PATHS ${_matlab_lib_dir_for_search}
+    NO_DEFAULT_PATH
+  )
+  list(APPEND _matlab_required_variables Matlab_MEX_LIBRARY)
 
-# the MEX extension is required
-list(APPEND _matlab_required_variables Matlab_MEX_EXTENSION)
+  # the MEX extension is required
+  list(APPEND _matlab_required_variables Matlab_MEX_EXTENSION)
 
-# the matlab root is required
-list(APPEND _matlab_required_variables Matlab_ROOT_DIR)
+  # the matlab root is required
+  list(APPEND _matlab_required_variables Matlab_ROOT_DIR)
 
-# The MX library is required
-_Matlab_find_library(
-  ${_matlab_lib_prefix_for_search}
-  Matlab_MX_LIBRARY
-  mx
-  PATHS ${_matlab_lib_dir_for_search}
-  NO_DEFAULT_PATH
-)
-list(APPEND _matlab_required_variables Matlab_MX_LIBRARY)
-if(Matlab_MX_LIBRARY)
-  set(Matlab_MX_LIBRARY_FOUND TRUE)
+  # The MX library is required
+  _Matlab_find_library(
+    ${_matlab_lib_prefix_for_search}
+    Matlab_MX_LIBRARY
+    mx
+    PATHS ${_matlab_lib_dir_for_search}
+    NO_DEFAULT_PATH
+  )
+  list(APPEND _matlab_required_variables Matlab_MX_LIBRARY)
+  if(Matlab_MX_LIBRARY)
+    set(Matlab_MX_LIBRARY_FOUND TRUE)
+  endif()
 endif()
 
 if(Matlab_HAS_CPP_API)
@@ -1691,7 +1750,6 @@ if(Matlab_HAS_CPP_API)
     DOC "MatlabEngine Library"
     NO_DEFAULT_PATH
   )
-  list(APPEND _matlab_required_variables Matlab_ENGINE_LIBRARY)
   if(Matlab_ENGINE_LIBRARY)
     set(Matlab_ENGINE_LIBRARY_FOUND TRUE)
   endif()
@@ -1705,7 +1763,6 @@ if(Matlab_HAS_CPP_API)
     DOC "MatlabDataArray Library"
     NO_DEFAULT_PATH
   )
-  list(APPEND _matlab_required_variables Matlab_DATAARRAY_LIBRARY)
   if(Matlab_DATAARRAY_LIBRARY)
     set(Matlab_DATAARRAY_LIBRARY_FOUND TRUE)
   endif()


### PR DESCRIPTION
This PR fixes the problem described in https://github.com/robotology/robotology-superbuild/issues/653 for iDynTree, by locally implementing the CMake fix proposed in https://gitlab.kitware.com/cmake/cmake/-/issues/21912 .

Before (the library links `libMatlabEngine.so` and `libMatlabDataArray.so`):
~~~
ldd ./build/iDynTreeMEX.mexa64
linux-vdso.so.1 (0x00007fff9bf9a000)
	libMatlabEngine.so => /home/runner/work/idyntree/idyntree/msdk_R2020b_mexa64/extern/bin/glnxa64/libMatlabEngine.so (0x00007fde698a1000)
	libMatlabDataArray.so => /home/runner/work/idyntree/idyntree/msdk_R2020b_mexa64/bin/glnxa64/libMatlabDataArray.so (0x00007fde6987c000)
	libmex.so => /home/runner/work/idyntree/idyntree/msdk_R2020b_mexa64/bin/glnxa64/libmex.so (0x00007fde69763000)
	libmx.so => /home/runner/work/idyntree/idyntree/msdk_R2020b_mexa64/bin/glnxa64/libmx.so (0x00007fde6950d000)
	libidyntree-solid-shapes.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-solid-shapes.so (0x00007fde694ff000)
	libidyntree-inverse-kinematics.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-inverse-kinematics.so (0x00007fde694c0000)
	libidyntree-visualization.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-visualization.so (0x00007fde69478000)
	libidyntree-high-level.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-high-level.so (0x00007fde69455000)
	libidyntree-estimation.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-estimation.so (0x00007fde693c7000)
	libidyntree-modelio-urdf.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-modelio-urdf.so (0x00007fde6937b000)
	libidyntree-sensors.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-sensors.so (0x00007fde69355000)
	libidyntree-model.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-model.so (0x00007fde692de000)
	libidyntree-core.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-core.so (0x00007fde69266000)
	libstdc++.so.6 => /usr/share/miniconda/envs/test/lib/libstdc++.so.6 (0x00007fde690f1000)
	libgcc_s.so.1 => /usr/share/miniconda/envs/test/lib/libgcc_s.so.1 (0x00007fde690dd000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fde68edc000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fde68ed4000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fde68eb1000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fde69b6e000)
	libmwfl.so => not found
	libut.so => not found
	libmwservices.so => not found
	libmwfoundation_matlabdata_matlab.so => not found
	libmwfoundation_matlabdata.so => not found
	libmwmvm.so => not found
	libmwm_dispatcher_interfaces.so => not found
	libmwm_dispatcher.so => not found
	libmwi18n.so => not found
	libmwfoundation_filesystem.so => not found
	libmwmlutil.so => not found
	libmwfoundation_usm.so => not found
	libmwgenerate_diag_message.so => not found
	libmwmcos.so => not found
	libmwcpp11compat.so => not found
	libmwboost_date_time.so.1.70.0 => not found
	libmwboost_log.so.1.70.0 => not found
	libmwboost_thread.so.1.70.0 => not found
	libmwi18n.so => not found
	libmwmfl_permute.so => not found
	libut.so => not found
	libmwfl.so => not found
	libmwfoundation_usm.so => not found
	libmwindexingapimethods.so => not found
	libmwcpp11compat.so => not found
	libmwboost_log.so.1.70.0 => not found
	libmwboost_thread.so.1.70.0 => not found
	libicuuc.so.64 => not found
	libtbbmalloc.so.2 => /lib/x86_64-linux-gnu/libtbbmalloc.so.2 (0x00007fde68e65000)
	libz.so.1 => /usr/share/miniconda/envs/test/lib/libz.so.1 (0x00007fde68e4b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fde68cfa000)
	libassimp.so.5 => /usr/share/miniconda/envs/test/lib/libassimp.so.5 (0x00007fde6809e000)
	libipopt.so.3 => /usr/share/miniconda/envs/test/lib/libipopt.so.3 (0x00007fde67e3e000)
	libIrrlicht.so => /usr/share/miniconda/envs/test/lib/libIrrlicht.so (0x00007fde678f7000)
	libidyntree-modelio-xml.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-modelio-xml.so (0x00007fde678e2000)
	libxml2.so.2 => /usr/share/miniconda/envs/test/lib/libxml2.so.2 (0x00007fde67778000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fde6776d000)
	liblapack.so.3 => /usr/share/miniconda/envs/test/lib/./liblapack.so.3 (0x00007fde657a8000)
	libdmumps_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libdmumps_seq-5.2.1.so (0x00007fde65582000)
	libmumps_common_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libmumps_common_seq-5.2.1.so (0x00007fde65521000)
	libpord_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libpord_seq-5.2.1.so (0x00007fde65508000)
	libmpiseq_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libmpiseq_seq-5.2.1.so (0x00007fde654fa000)
	libesmumps-6.so => /usr/share/miniconda/envs/test/lib/./libesmumps-6.so (0x00007fde654f3000)
	libscotch-6.so => /usr/share/miniconda/envs/test/lib/./libscotch-6.so (0x00007fde6544e000)
	libscotcherr-6.so => /usr/share/miniconda/envs/test/lib/./libscotcherr-6.so (0x00007fde65449000)
	libmetis.so => /usr/share/miniconda/envs/test/lib/./libmetis.so (0x00007fde653d4000)
	libgfortran.so.5 => /usr/share/miniconda/envs/test/lib/./libgfortran.so.5 (0x00007fde65234000)
	libpng16.so.16 => /usr/share/miniconda/envs/test/lib/./libpng16.so.16 (0x00007fde651f9000)
	libjpeg.so.8 => /usr/share/miniconda/envs/test/lib/./libjpeg.so.8 (0x00007fde6515f000)
	libbz2.so.1.0 => /usr/share/miniconda/envs/test/lib/./libbz2.so.1.0 (0x00007fde6514b000)
	libX11.so.6 => /usr/share/miniconda/envs/test/lib/./libX11.so.6 (0x00007fde65008000)
	libGL.so.1 => /lib/x86_64-linux-gnu/libGL.so.1 (0x00007fde64f80000)
	libXxf86vm.so.1 => /lib/x86_64-linux-gnu/libXxf86vm.so.1 (0x00007fde64f77000)
	libicuuc.so.68 => /usr/share/miniconda/envs/test/lib/./libicuuc.so.68 (0x00007fde64d8d000)
	liblzma.so.5 => /usr/share/miniconda/envs/test/lib/./liblzma.so.5 (0x00007fde64d64000)
	libiconv.so.2 => /usr/share/miniconda/envs/test/lib/./libiconv.so.2 (0x00007fde64c7e000)
	libgomp.so.1 => /usr/share/miniconda/envs/test/lib/././libgomp.so.1 (0x00007fde64c51000)
	libquadmath.so.0 => /usr/share/miniconda/envs/test/lib/./libquadmath.so.0 (0x00007fde64c15000)
	libxcb.so.1 => /usr/share/miniconda/envs/test/lib/././libxcb.so.1 (0x00007fde64be9000)
	libGLdispatch.so.0 => /lib/x86_64-linux-gnu/libGLdispatch.so.0 (0x00007fde64b31000)
	libGLX.so.0 => /lib/x86_64-linux-gnu/libGLX.so.0 (0x00007fde64afd000)
	libXext.so.6 => /usr/share/miniconda/envs/test/lib/./libXext.so.6 (0x00007fde64ae8000)
	libicudata.so.68 => /usr/share/miniconda/envs/test/lib/././libicudata.so.68 (0x00007fde62fa5000)
	libXau.so.6 => /usr/share/miniconda/envs/test/lib/./././libXau.so.6 (0x00007fde62fa0000)
~~~

After (for MATLAB only `libmex` and `libmx` are linked):
~~~
ldd ./build/iDynTreeMEX.mexa64
	linux-vdso.so.1 (0x00007ffc351b4000)
	libidyntree-solid-shapes.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-solid-shapes.so (0x00007fca144f6000)
	libidyntree-inverse-kinematics.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-inverse-kinematics.so (0x00007fca144b9000)
	libidyntree-visualization.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-visualization.so (0x00007fca14471000)
	libmex.so => /home/runner/work/idyntree/idyntree/msdk_R2020b_mexa64/bin/glnxa64/libmex.so (0x00007fca14358000)
	libmx.so => /home/runner/work/idyntree/idyntree/msdk_R2020b_mexa64/bin/glnxa64/libmx.so (0x00007fca14102000)
	libidyntree-high-level.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-high-level.so (0x00007fca140dd000)
	libidyntree-estimation.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-estimation.so (0x00007fca1404f000)
	libidyntree-modelio-urdf.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-modelio-urdf.so (0x00007fca14003000)
	libidyntree-sensors.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-sensors.so (0x00007fca13fdd000)
	libidyntree-model.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-model.so (0x00007fca13f68000)
	libidyntree-core.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-core.so (0x00007fca13ef0000)
	libstdc++.so.6 => /usr/share/miniconda/envs/test/lib/libstdc++.so.6 (0x00007fca13d79000)
	libgcc_s.so.1 => /usr/share/miniconda/envs/test/lib/libgcc_s.so.1 (0x00007fca13d65000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fca13b64000)
	libassimp.so.5 => /usr/share/miniconda/envs/test/lib/libassimp.so.5 (0x00007fca12f08000)
	libipopt.so.3 => /usr/share/miniconda/envs/test/lib/libipopt.so.3 (0x00007fca12ca8000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fca12b57000)
	libIrrlicht.so => /usr/share/miniconda/envs/test/lib/libIrrlicht.so (0x00007fca12610000)
	libmwfl.so => not found
	libut.so => not found
	libmwservices.so => not found
	libmwfoundation_matlabdata_matlab.so => not found
	libmwfoundation_matlabdata.so => not found
	libmwmvm.so => not found
	libmwm_dispatcher_interfaces.so => not found
	libmwm_dispatcher.so => not found
	libmwi18n.so => not found
	libmwfoundation_filesystem.so => not found
	libmwmlutil.so => not found
	libmwfoundation_usm.so => not found
	libmwgenerate_diag_message.so => not found
	libmwmcos.so => not found
	libmwcpp11compat.so => not found
	libmwboost_date_time.so.1.70.0 => not found
	libmwboost_log.so.1.70.0 => not found
	libmwboost_thread.so.1.70.0 => not found
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fca125e7000)
	libmwi18n.so => not found
	libmwmfl_permute.so => not found
	libut.so => not found
	libmwfl.so => not found
	libmwfoundation_usm.so => not found
	libmwindexingapimethods.so => not found
	libmwcpp11compat.so => not found
	libmwboost_log.so.1.70.0 => not found
	libmwboost_thread.so.1.70.0 => not found
	libicuuc.so.64 => not found
	libtbbmalloc.so.2 => /lib/x86_64-linux-gnu/libtbbmalloc.so.2 (0x00007fca125a1000)
	libz.so.1 => /usr/share/miniconda/envs/test/lib/libz.so.1 (0x00007fca12587000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fca147c5000)
	libidyntree-modelio-xml.so => /home/runner/work/idyntree/idyntree/build/lib/libidyntree-modelio-xml.so (0x00007fca12570000)
	libxml2.so.2 => /usr/share/miniconda/envs/test/lib/libxml2.so.2 (0x00007fca12408000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fca123fd000)
	liblapack.so.3 => /usr/share/miniconda/envs/test/lib/./liblapack.so.3 (0x00007fca10438000)
	libdmumps_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libdmumps_seq-5.2.1.so (0x00007fca10212000)
	libmumps_common_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libmumps_common_seq-5.2.1.so (0x00007fca101af000)
	libpord_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libpord_seq-5.2.1.so (0x00007fca10196000)
	libmpiseq_seq-5.2.1.so => /usr/share/miniconda/envs/test/lib/./libmpiseq_seq-5.2.1.so (0x00007fca1018a000)
	libesmumps-6.so => /usr/share/miniconda/envs/test/lib/./libesmumps-6.so (0x00007fca10183000)
	libscotch-6.so => /usr/share/miniconda/envs/test/lib/./libscotch-6.so (0x00007fca100de000)
	libscotcherr-6.so => /usr/share/miniconda/envs/test/lib/./libscotcherr-6.so (0x00007fca100d9000)
	libmetis.so => /usr/share/miniconda/envs/test/lib/./libmetis.so (0x00007fca10062000)
	libgfortran.so.5 => /usr/share/miniconda/envs/test/lib/./libgfortran.so.5 (0x00007fca0fec2000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fca0febc000)
	libpng16.so.16 => /usr/share/miniconda/envs/test/lib/./libpng16.so.16 (0x00007fca0fe83000)
	libjpeg.so.8 => /usr/share/miniconda/envs/test/lib/./libjpeg.so.8 (0x00007fca0fde9000)
	libbz2.so.1.0 => /usr/share/miniconda/envs/test/lib/./libbz2.so.1.0 (0x00007fca0fdd3000)
	libX11.so.6 => /usr/share/miniconda/envs/test/lib/./libX11.so.6 (0x00007fca0fc90000)
	libGL.so.1 => /lib/x86_64-linux-gnu/libGL.so.1 (0x00007fca0fc08000)
	libXxf86vm.so.1 => /lib/x86_64-linux-gnu/libXxf86vm.so.1 (0x00007fca0fc01000)
	libicuuc.so.68 => /usr/share/miniconda/envs/test/lib/./libicuuc.so.68 (0x00007fca0fa17000)
	liblzma.so.5 => /usr/share/miniconda/envs/test/lib/./liblzma.so.5 (0x00007fca0f9ec000)
	libiconv.so.2 => /usr/share/miniconda/envs/test/lib/./libiconv.so.2 (0x00007fca0f906000)
	libgomp.so.1 => /usr/share/miniconda/envs/test/lib/././libgomp.so.1 (0x00007fca0f8d9000)
	libquadmath.so.0 => /usr/share/miniconda/envs/test/lib/./libquadmath.so.0 (0x00007fca0f89f000)
	libxcb.so.1 => /usr/share/miniconda/envs/test/lib/././libxcb.so.1 (0x00007fca0f871000)
	libGLdispatch.so.0 => /lib/x86_64-linux-gnu/libGLdispatch.so.0 (0x00007fca0f7b9000)
	libGLX.so.0 => /lib/x86_64-linux-gnu/libGLX.so.0 (0x00007fca0f785000)
	libXext.so.6 => /usr/share/miniconda/envs/test/lib/./libXext.so.6 (0x00007fca0f770000)
	libicudata.so.68 => /usr/share/miniconda/envs/test/lib/././libicudata.so.68 (0x00007fca0dc2f000)
	libXau.so.6 => /usr/share/miniconda/envs/test/lib/./././libXau.so.6 (0x00007fca0dc28000)
~~~