### PR TITLE
conda-forge-ci: Switch to use official robotology channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         # Actual dependencies
         mamba install -c conda-forge eigen libxml2 assimp ipopt qt irrlicht
         # robotology dependencies
-        mamba install -c conda-forge -c robotology-staging yarp icub-main osqp-eigen
+        mamba install -c conda-forge -c robotology yarp icub-main osqp-eigen
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]


### PR DESCRIPTION
As https://github.com/robotology/robotology-superbuild/pull/652 has been merged, we now have officially generated packages coming from the robotology-superbuild in the [robotology anaconda channel](https://anaconda.org/robotology), so we can switch to use that instead of the experimental and test-only `robotology-staging`.