### PR TITLE
Fix compilation of Python bindings on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed compilation of Python bindings on Windows (https://github.com/robotology/idyntree/pull/843).
+
 ## [3.0.1] - 2020-03-11
 
 ### Fixed

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -31,13 +31,15 @@ set_property(
     TARGET ${target_name}
     PROPERTY SWIG_DEPENDS python.i numpy.i)
 
-set_property(
-    TARGET ${target_name}
-    PROPERTY SWIG_COMPILE_OPTIONS -Wextra -threads)
+if(NOT MSVC)
+    set_property(
+        TARGET ${target_name}
+        PROPERTY SWIG_COMPILE_OPTIONS -Wextra -threads)
 
-set_property(
-    TARGET ${target_name}
-    PROPERTY SWIG_GENERATED_COMPILE_OPTIONS -Wextra)
+    set_property(
+        TARGET ${target_name}
+        PROPERTY SWIG_GENERATED_COMPILE_OPTIONS -Wextra)
+endif()
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/idyntree/swig.py


### PR DESCRIPTION
Catched in https://github.com/robotology/robotology-superbuild/pull/663 .