### PR TITLE
Build `manylinux_2_24` compliant wheels

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
 
+  # sdist can be built from any os and against any python version
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:
@@ -33,13 +34,14 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
             coinor-libipopt-dev \
-            libeigen3-dev swig \
+            libeigen3-dev \
+            swig \
             libxml2-dev \
             libassimp-dev
 
@@ -53,16 +55,18 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  build_linux_wheels:
-
-    name: Build wheels on ubuntu-latest
-    runs-on: ubuntu-20.04
+  build_wheels:
+    name: Build wheels [${{ matrix.os }}]
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version:
           - 3.8
-          # - 3.9
+        os:
+          - ubuntu-20.04
+          #- macos-latest
+          #- windows-latest
 
     steps:
 
@@ -74,28 +78,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            coinor-libipopt-dev \
-            libeigen3-dev swig \
-            libxml2-dev \
-            libassimp-dev
+      - name: Install cibuildwheel
+        run: pip install cibuildwheel
 
-      - name: '[Linux] Build wheel'
-        run: pip wheel -w wheelhouse .
-
-      - name: Remove other wheels
-        run: find wheelhouse/ -type f -not -name 'idyntree-*' -delete
-
-      # Rename the wheel to manylinux2014 (even if it is not) so that it can be uploaded to PyPI
-      - name: Rename wheels
-        run: |
-          ls wheelhouse/
-          find wheelhouse/ -type f -name "*.whl" -exec rename.ul linux manylinux2014 {} +
-          ls wheelhouse/
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: cp37-*_x86_64 cp38-*_x86_64 cp39-*_x86_64
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+          CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_24_x86_64
+          CIBW_BEFORE_BUILD_LINUX: "apt-get update && apt-get install -y libeigen3-dev libassimp-dev libxml2-dev coinor-libipopt-dev"
+          CIBW_TEST_COMMAND: "python -c 'import idyntree.bindings'"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -104,7 +98,7 @@ jobs:
   upload_pypi:
     needs:
       - build_sdist
-      - build_linux_wheels
+      - build_wheels
     runs-on: ubuntu-latest
     # Devel branch produces pre-releases
     # Master branch produces stable releases linked to GitHub releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add the possibility to use `MatrixView` and `Span` as input/output objects for `InverseKinematics` class (https://github.com/robotology/idyntree/pull/822).
 ### Changed
+- The wheels uploaded to PyPI are now `manylinux_2_24` compliant (https://github.com/robotology/idyntree/pull/844)
 
 ## [3.0.0] - 2020-02-03
 


### PR DESCRIPTION
This is take 2, after https://github.com/robotology/idyntree/pull/774, https://github.com/robotology/idyntree/issues/776 and https://github.com/robotology/idyntree/pull/777.

Finally, all the tooling necessary to build `manylinux_2_24` is ready :tada: It requires a modern `pip>=21.0` version.

In theory, this PR could also enable the macOS and windows support, but let's do things progressively.