### PR TITLE
Add IDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES CMake option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add the possibility to use `MatrixView` and `Span` as input/output objects for `InverseKinematics` class (https://github.com/robotology/idyntree/pull/822).
 - Add the possibility to get frame trasform from the visualizer, and to use frame/link name in place of indices (https://github.com/robotology/idyntree/pull/849).
+- Add `IDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES` CMake option (default value: OFF) to detect and install in the active site-package directory the Python bindings (https://github.com/robotology/idyntree/pull/852).
 
 ### Changed
 - The wheels uploaded to PyPI are now `manylinux_2_24` compliant (https://github.com/robotology/idyntree/pull/844)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -9,14 +9,27 @@ option(IDYNTREE_USES_LUA "Do you want to create the Lua bindings" FALSE)
 option(IDYNTREE_USES_MATLAB "Do you want to create the MATLAB bindings" FALSE)
 option(IDYNTREE_USES_OCTAVE "Do you want to create the OCTAVE bindings" FALSE)
 option(IDYNTREE_GENERATE_MATLAB "Enable if you have the experimental version of SWIG necessary for generating the Matlab wrapper" FALSE)
+option(IDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES "Do you want iDynTree to detect and install in the active site-package directory? (it could be a system dir)" FALSE)
 
 find_package(SWIG)
 
-# Setup installation directory for Python bindings.
-if (IDYNTREE_USES_PYTHON_PYBIND11 OR IDYNTREE_USES_PYTHON)
-    if(IDYNTREE_PACKAGE_FOR_PYPI)
-        set(PYTHON_INSTDIR ${CMAKE_INSTALL_PREFIX})
+if(IDYNTREE_USES_PYTHON OR IDYNTREE_USES_PYTHON_PYBIND11)
+    if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
+        set(IDYNTREE_SEARCHED_Python_Development_Component "Development")
     else()
+        set(IDYNTREE_SEARCHED_Python_Development_Component "Development.Module")
+    endif()
+    find_package(Python3 COMPONENTS Interpreter ${IDYNTREE_SEARCHED_Python_Development_Component} NumPy REQUIRED)
+
+    if (IDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES)
+       set(PYTHON_INSTDIR ${Python3_SITELIB}/idyntree)
+    elseif(IDYNTREE_PACKAGE_FOR_PYPI)
+       set(PYTHON_INSTDIR ${CMAKE_INSTALL_PREFIX})
+    else()
+        execute_process(COMMAND ${Python3_EXECUTABLE}
+                        -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+                        OUTPUT_VARIABLE _PYTHON_INSTDIR)
+        string(STRIP ${_PYTHON_INSTDIR} IDYNTREE_PYTHON_INSTALL_DIR)
         set(PYTHON_INSTDIR ${IDYNTREE_PYTHON_INSTALL_DIR}/idyntree)
     endif()
 endif()

--- a/bindings/pybind11/CMakeLists.txt
+++ b/bindings/pybind11/CMakeLists.txt
@@ -1,9 +1,3 @@
-if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
-    find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
-else()
-    find_package(Python3 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
-endif()
-
 pybind11_add_module(pybind11_idyntree SYSTEM idyntree.cpp
                                     error_utilities.h error_utilities.cpp
                                     idyntree_core.h idyntree_core.cpp

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,11 +1,3 @@
-if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
-    find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
-else()
-    find_package(Python3 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
-endif()
-
-message(STATUS "Using Python: ${Python3_EXECUTABLE}")
-
 cmake_policy(SET CMP0078 NEW)
 cmake_policy(SET CMP0086 NEW)
 

--- a/cmake/iDynTreeOptions.cmake
+++ b/cmake/iDynTreeOptions.cmake
@@ -73,17 +73,7 @@ if(IDYNTREE_COMPILE_BINDINGS)
     add_definitions(-DIDYNTREE_COMPILE_BINDINGS)
 endif(IDYNTREE_COMPILE_BINDINGS)
 
-if(IDYNTREE_USES_PYTHON OR IDYNTREE_USES_PYTHON_PYBIND11)
-    find_package(Python3 COMPONENTS Interpreter QUIET)
-    if (Python3_FOUND)
-        execute_process(COMMAND ${Python3_EXECUTABLE}
-            -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
-            OUTPUT_VARIABLE _PYTHON_INSTDIR)
-        string(STRIP ${_PYTHON_INSTDIR} IDYNTREE_PYTHON_INSTALL_DIR)
-        # Bindings are installed in `idyntree` subdirectory.
-        list(APPEND IDYNTREE_BINARY_DIRS "${IDYNTREE_PYTHON_INSTALL_DIR}/idyntree")
-    endif()
-endif()
+
 
 #set default build type to "Release" in single-config generators
 if(NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
This option (OFF by default) can be used to automatically install the Python bindings in the current active site location. 

This is convenient for example on system in which the site location is not part of the same prefix in which C++ libraries are installed, for example in Conda in Windows where: CMAKE_INSTALL_PREFIX is %CONDA_PREFIX%/Library and Python3_SITELIB is %CONDA_PREFIX%/Lib/site-packages . 

With this option, it is now possible to compile iDynTree on Conda on **Windows** in a way such that both C++ libraries and Python packages are automatically found:
~~~
conda create -n idynpy -c conda-forge cmake compilers pkg-config irrlicht assimp libxml2 ipopt swig python numpy
conda activate idynpy 
git clone https://github.com/robotology/idyntree
cd idyntree
md build
cd build
cmake -DCMAKE_INSTALL_PREFIX:PATH=%CONDA_PREFIX%\Library -DIDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES:BOOL=ON -DIDYNTREE_USES_PYTHON:BOOL=ON -DCMAKE_BUILD_TYPE=Release ..
cmake --build . --config Release
cmake --install . --config Release
~~~ 

The same script on Linux/macOS (the only difference is that `DCMAKE_INSTALL_PREFIX` is `CONDA_PREFIX`  instead of `<CONDA_PREFIX>\Library` : 
~~~
conda create -n idynpy -c conda-forge cmake compilers pkg-config irrlicht assimp libxml2 ipopt swig python numpy
conda activate idynpy 
git clone https://github.com/robotology/idyntree
cd idyntree
md build
cd build
cmake -DCMAKE_INSTALL_PREFIX:PATH=$CONDA_PREFIX -DIDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES:BOOL=ON -DIDYNTREE_USES_PYTHON:BOOL=ON -DCMAKE_BUILD_TYPE=Release ..
cmake --build . --config Release
cmake --install . --config Release
~~~

I also cleanup a bit the Python logic on where to install the files that was quite spread and difficult to understand.

Fix https://github.com/robotology/idyntree/issues/834 .
Related to https://github.com/robotology/robotology-superbuild/issues/641 .
