### PR TITLE
CI: Avoid to use JamesIves/github-pages-deploy-action@master

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Deploy
       if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel')
-      uses: JamesIves/github-pages-deploy-action@master
+      uses: JamesIves/github-pages-deploy-action@4.1.1
       env:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         BRANCH: gh-pages


### PR DESCRIPTION
The master branch on JamesIves/github-pages-deploy-action disappeared and in any case it is more reproducible to use a released version.