### PR TITLE
 KinDynComputations: Add inverseDynamicsWithInternalJointForceTorques method  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the possibility to use `MatrixView` and `Span` as input/output objects for `InverseKinematics` class (https://github.com/robotology/idyntree/pull/822).
 - Add the possibility to get frame trasform from the visualizer, and to use frame/link name in place of indices (https://github.com/robotology/idyntree/pull/849).
 - Add `IDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES` CMake option (default value: OFF) to detect and install in the active site-package directory the Python bindings (https://github.com/robotology/idyntree/pull/852).
+- Add inverseDynamicsWithInternalJointForceTorques method to KinDynComputations, this method permits to compute the inverse dynamics, but providing as an output the internal joint 6D force/torque for each joint (https://github.com/robotology/idyntree/pull/857).
 
 ### Changed
 - The wheels uploaded to PyPI are now `manylinux_2_24` compliant (https://github.com/robotology/idyntree/pull/844)
+
+### Fixed 
+- Dynamics: In RNEA Dynamic Loop, return zero for wrench corresponding to non-existing parent joint of base link (https://github.com/robotology/idyntree/pull/857).
 
 
 ## [3.0.2] - 2020-04-11

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,40 +7,40 @@ classdef ColorViz < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1808, self);
+        varargout{1} = iDynTreeMEX(1809, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1809, self, varargin{1});
+        iDynTreeMEX(1810, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1810, self);
+        varargout{1} = iDynTreeMEX(1811, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1811, self, varargin{1});
+        iDynTreeMEX(1812, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1812, self);
+        varargout{1} = iDynTreeMEX(1813, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1813, self, varargin{1});
+        iDynTreeMEX(1814, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1814, self);
+        varargout{1} = iDynTreeMEX(1815, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1815, self, varargin{1});
+        iDynTreeMEX(1816, self, varargin{1});
       end
     end
     function self = ColorViz(varargin)
@@ -49,14 +49,14 @@ classdef ColorViz < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1816, varargin{:});
+        tmp = iDynTreeMEX(1817, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1817, self);
+        iDynTreeMEX(1818, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
@@ -4,118 +4,118 @@ classdef ConvexHullProjectionConstraint < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = setActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
-    end
-    function varargout = isActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
     end
-    function varargout = getNrOfConstraints(self,varargin)
+    function varargout = isActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
+    end
+    function varargout = getNrOfConstraints(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
     end
     function varargout = projectedConvexHull(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1946, self);
+        varargout{1} = iDynTreeMEX(1947, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1947, self, varargin{1});
+        iDynTreeMEX(1948, self, varargin{1});
       end
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1948, self);
+        varargout{1} = iDynTreeMEX(1949, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1949, self, varargin{1});
+        iDynTreeMEX(1950, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1950, self);
+        varargout{1} = iDynTreeMEX(1951, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1951, self, varargin{1});
+        iDynTreeMEX(1952, self, varargin{1});
       end
     end
     function varargout = P(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1952, self);
+        varargout{1} = iDynTreeMEX(1953, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1953, self, varargin{1});
+        iDynTreeMEX(1954, self, varargin{1});
       end
     end
     function varargout = Pdirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1954, self);
+        varargout{1} = iDynTreeMEX(1955, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1955, self, varargin{1});
+        iDynTreeMEX(1956, self, varargin{1});
       end
     end
     function varargout = AtimesP(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1956, self);
+        varargout{1} = iDynTreeMEX(1957, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1957, self, varargin{1});
+        iDynTreeMEX(1958, self, varargin{1});
       end
     end
     function varargout = o(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1958, self);
+        varargout{1} = iDynTreeMEX(1959, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1959, self, varargin{1});
+        iDynTreeMEX(1960, self, varargin{1});
       end
     end
     function varargout = buildConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1960, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1961, self, varargin{:});
     end
     function varargout = supportFrameIndices(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1961, self);
+        varargout{1} = iDynTreeMEX(1962, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1962, self, varargin{1});
+        iDynTreeMEX(1963, self, varargin{1});
       end
     end
     function varargout = absoluteFrame_X_supportFrame(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1963, self);
+        varargout{1} = iDynTreeMEX(1964, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1964, self, varargin{1});
+        iDynTreeMEX(1965, self, varargin{1});
       end
     end
     function varargout = project(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1965, self, varargin{:});
-    end
-    function varargout = computeMargin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1966, self, varargin{:});
     end
-    function varargout = setProjectionAlongDirection(self,varargin)
+    function varargout = computeMargin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
     end
-    function varargout = projectAlongDirection(self,varargin)
+    function varargout = setProjectionAlongDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
+    end
+    function varargout = projectAlongDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
     end
     function self = ConvexHullProjectionConstraint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -123,14 +123,14 @@ classdef ConvexHullProjectionConstraint < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1969, varargin{:});
+        tmp = iDynTreeMEX(1970, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1970, self);
+        iDynTreeMEX(1971, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,27 +5,27 @@ classdef ICamera < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1801, self);
+        iDynTreeMEX(1802, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
-    end
-    function varargout = setTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
     end
-    function varargout = getPosition(self,varargin)
+    function varargout = setTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
     end
-    function varargout = getTarget(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
     end
-    function varargout = setUpVector(self,varargin)
+    function varargout = getTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
     end
-    function varargout = animator(self,varargin)
+    function varargout = setUpVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
+    end
+    function varargout = animator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICameraAnimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICameraAnimator.m
@@ -4,29 +4,29 @@ classdef ICameraAnimator < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = enableMouseControl(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
-    end
-    function varargout = getMoveSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
     end
-    function varargout = setMoveSpeed(self,varargin)
+    function varargout = getMoveSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
     end
-    function varargout = getRotateSpeed(self,varargin)
+    function varargout = setMoveSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
     end
-    function varargout = setRotateSpeed(self,varargin)
+    function varargout = getRotateSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
     end
-    function varargout = getZoomSpeed(self,varargin)
+    function varargout = setRotateSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
     end
-    function varargout = setZoomSpeed(self,varargin)
+    function varargout = getZoomSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
+    end
+    function varargout = setZoomSpeed(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1800, self);
+        iDynTreeMEX(1801, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,36 +5,36 @@ classdef IEnvironment < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1838, self);
+        iDynTreeMEX(1839, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
-    end
-    function varargout = setElementVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
-    function varargout = setBackgroundColor(self,varargin)
+    function varargout = setElementVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
     end
-    function varargout = setFloorGridColor(self,varargin)
+    function varargout = setBackgroundColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
-    function varargout = setAmbientLight(self,varargin)
+    function varargout = setFloorGridColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
     end
-    function varargout = getLights(self,varargin)
+    function varargout = setAmbientLight(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
     end
-    function varargout = addLight(self,varargin)
+    function varargout = getLights(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
     end
-    function varargout = lightViz(self,varargin)
+    function varargout = addLight(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
     end
-    function varargout = removeLight(self,varargin)
+    function varargout = lightViz(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
+    end
+    function varargout = removeLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IFrameVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IFrameVisualization.m
@@ -5,24 +5,24 @@ classdef IFrameVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1865, self);
+        iDynTreeMEX(1866, self);
         self.SwigClear();
       end
     end
     function varargout = addFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1866, self, varargin{:});
-    end
-    function varargout = setVisible(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1867, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = setVisible(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1868, self, varargin{:});
     end
-    function varargout = getFrameTransform(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
     end
-    function varargout = updateFrame(self,varargin)
+    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
+    end
+    function varargout = updateFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
     end
     function self = IFrameVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1848, self);
+        iDynTreeMEX(1849, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
-    end
-    function varargout = getNrOfJets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
     end
-    function varargout = getJetDirection(self,varargin)
+    function varargout = getNrOfJets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
     end
-    function varargout = setJetDirection(self,varargin)
+    function varargout = getJetDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
     end
-    function varargout = setJetColor(self,varargin)
+    function varargout = setJetDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
     end
-    function varargout = setJetsDimensions(self,varargin)
+    function varargout = setJetColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
     end
-    function varargout = setJetsIntensity(self,varargin)
+    function varargout = setJetsDimensions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1855, self, varargin{:});
+    end
+    function varargout = setJetsIntensity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1856, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1824, self);
+        iDynTreeMEX(1825, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
-    end
-    function varargout = setType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
     end
-    function varargout = getType(self,varargin)
+    function varargout = setType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
     end
-    function varargout = setPosition(self,varargin)
+    function varargout = getType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
     end
-    function varargout = getPosition(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
     end
-    function varargout = setDirection(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
     end
-    function varargout = getDirection(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
     end
-    function varargout = setAmbientColor(self,varargin)
+    function varargout = getDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
     end
-    function varargout = getAmbientColor(self,varargin)
+    function varargout = setAmbientColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
     end
-    function varargout = setSpecularColor(self,varargin)
+    function varargout = getAmbientColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
     end
-    function varargout = getSpecularColor(self,varargin)
+    function varargout = setSpecularColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
     end
-    function varargout = setDiffuseColor(self,varargin)
+    function varargout = getSpecularColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
     end
-    function varargout = getDiffuseColor(self,varargin)
+    function varargout = setDiffuseColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
+    end
+    function varargout = getDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,60 +5,60 @@ classdef IModelVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1871, self);
+        iDynTreeMEX(1872, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
-    end
-    function varargout = setLinkPositions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = setLinkPositions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
     end
-    function varargout = getInstanceName(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
     end
-    function varargout = setModelVisibility(self,varargin)
+    function varargout = getInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
-    function varargout = setModelColor(self,varargin)
+    function varargout = setModelVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
     end
-    function varargout = resetModelColor(self,varargin)
+    function varargout = setModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
     end
-    function varargout = setLinkColor(self,varargin)
+    function varargout = resetModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
     end
-    function varargout = resetLinkColor(self,varargin)
+    function varargout = setLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
     end
-    function varargout = getLinkNames(self,varargin)
+    function varargout = resetLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
     end
-    function varargout = setLinkVisibility(self,varargin)
+    function varargout = getLinkNames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
     end
-    function varargout = getFeatures(self,varargin)
+    function varargout = setLinkVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
     end
-    function varargout = setFeatureVisibility(self,varargin)
+    function varargout = getFeatures(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
     end
-    function varargout = jets(self,varargin)
+    function varargout = setFeatureVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
     end
-    function varargout = getWorldModelTransform(self,varargin)
+    function varargout = jets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = getWorldModelTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
     end
-    function varargout = getWorldFrameTransform(self,varargin)
+    function varargout = getWorldLinkTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
+    end
+    function varargout = getWorldFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ITexture.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ITexture.m
@@ -5,18 +5,18 @@ classdef ITexture < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1889, self);
+        iDynTreeMEX(1890, self);
         self.SwigClear();
       end
     end
     function varargout = environment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
-    end
-    function varargout = getPixelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
     end
-    function varargout = getPixels(self,varargin)
+    function varargout = getPixelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
+    end
+    function varargout = getPixels(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
     end
     function self = ITexture(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ITexturesHandler.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ITexturesHandler.m
@@ -5,15 +5,15 @@ classdef ITexturesHandler < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1903, self);
+        iDynTreeMEX(1904, self);
         self.SwigClear();
       end
     end
     function varargout = add(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
     end
     function varargout = get(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
     end
     function self = ITexturesHandler(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,33 +5,33 @@ classdef IVectorsVisualization < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1856, self);
+        iDynTreeMEX(1857, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1857, self, varargin{:});
-    end
-    function varargout = getNrOfVectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1858, self, varargin{:});
     end
-    function varargout = getVector(self,varargin)
+    function varargout = getNrOfVectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1859, self, varargin{:});
     end
-    function varargout = updateVector(self,varargin)
+    function varargout = getVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1860, self, varargin{:});
     end
-    function varargout = setVectorColor(self,varargin)
+    function varargout = updateVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1861, self, varargin{:});
     end
-    function varargout = setVectorsDefaultColor(self,varargin)
+    function varargout = setVectorColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1862, self, varargin{:});
     end
-    function varargout = setVectorsColor(self,varargin)
+    function varargout = setVectorsDefaultColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1863, self, varargin{:});
     end
-    function varargout = setVectorsAspect(self,varargin)
+    function varargout = setVectorsColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1864, self, varargin{:});
+    end
+    function varargout = setVectorsAspect(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1865, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
@@ -9,187 +9,187 @@ classdef InverseKinematics < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1972, varargin{:});
+        tmp = iDynTreeMEX(1973, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1973, self);
+        iDynTreeMEX(1974, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
-    end
-    function varargout = setModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
     end
-    function varargout = setJointLimits(self,varargin)
+    function varargout = setModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
     end
-    function varargout = getJointLimits(self,varargin)
+    function varargout = setJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
     end
-    function varargout = clearProblem(self,varargin)
+    function varargout = getJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
     end
-    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
+    function varargout = clearProblem(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
     end
-    function varargout = setCurrentRobotConfiguration(self,varargin)
+    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
     end
-    function varargout = setJointConfiguration(self,varargin)
+    function varargout = setCurrentRobotConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
     end
-    function varargout = setRotationParametrization(self,varargin)
+    function varargout = setJointConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
     end
-    function varargout = rotationParametrization(self,varargin)
+    function varargout = setRotationParametrization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
     end
-    function varargout = setMaxIterations(self,varargin)
+    function varargout = rotationParametrization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
     end
-    function varargout = maxIterations(self,varargin)
+    function varargout = setMaxIterations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
     end
-    function varargout = setMaxCPUTime(self,varargin)
+    function varargout = maxIterations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
     end
-    function varargout = maxCPUTime(self,varargin)
+    function varargout = setMaxCPUTime(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
     end
-    function varargout = setCostTolerance(self,varargin)
+    function varargout = maxCPUTime(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
     end
-    function varargout = costTolerance(self,varargin)
+    function varargout = setCostTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
     end
-    function varargout = setConstraintsTolerance(self,varargin)
+    function varargout = costTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
     end
-    function varargout = constraintsTolerance(self,varargin)
+    function varargout = setConstraintsTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
     end
-    function varargout = setVerbosity(self,varargin)
+    function varargout = constraintsTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
     end
-    function varargout = linearSolverName(self,varargin)
+    function varargout = setVerbosity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
     end
-    function varargout = setLinearSolverName(self,varargin)
+    function varargout = linearSolverName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1994, self, varargin{:});
     end
-    function varargout = addFrameConstraint(self,varargin)
+    function varargout = setLinearSolverName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1995, self, varargin{:});
     end
-    function varargout = addFramePositionConstraint(self,varargin)
+    function varargout = addFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1996, self, varargin{:});
     end
-    function varargout = addFrameRotationConstraint(self,varargin)
+    function varargout = addFramePositionConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1997, self, varargin{:});
     end
-    function varargout = activateFrameConstraint(self,varargin)
+    function varargout = addFrameRotationConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
     end
-    function varargout = deactivateFrameConstraint(self,varargin)
+    function varargout = activateFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
     end
-    function varargout = isFrameConstraintActive(self,varargin)
+    function varargout = deactivateFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
     end
-    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
+    function varargout = isFrameConstraintActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
     end
-    function varargout = getCenterOfMassProjectionMargin(self,varargin)
+    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
     end
-    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
+    function varargout = getCenterOfMassProjectionMargin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2003, self, varargin{:});
     end
-    function varargout = addTarget(self,varargin)
+    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2004, self, varargin{:});
     end
-    function varargout = addPositionTarget(self,varargin)
+    function varargout = addTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
     end
-    function varargout = addRotationTarget(self,varargin)
+    function varargout = addPositionTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
     end
-    function varargout = updateTarget(self,varargin)
+    function varargout = addRotationTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2007, self, varargin{:});
     end
-    function varargout = updatePositionTarget(self,varargin)
+    function varargout = updateTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
     end
-    function varargout = updateRotationTarget(self,varargin)
+    function varargout = updatePositionTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2009, self, varargin{:});
     end
-    function varargout = setDefaultTargetResolutionMode(self,varargin)
+    function varargout = updateRotationTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2010, self, varargin{:});
     end
-    function varargout = defaultTargetResolutionMode(self,varargin)
+    function varargout = setDefaultTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2011, self, varargin{:});
     end
-    function varargout = setTargetResolutionMode(self,varargin)
+    function varargout = defaultTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2012, self, varargin{:});
     end
-    function varargout = targetResolutionMode(self,varargin)
+    function varargout = setTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2013, self, varargin{:});
     end
-    function varargout = setDesiredFullJointsConfiguration(self,varargin)
+    function varargout = targetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2014, self, varargin{:});
     end
-    function varargout = setDesiredReducedJointConfiguration(self,varargin)
+    function varargout = setDesiredFullJointsConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2015, self, varargin{:});
     end
-    function varargout = setFullJointsInitialCondition(self,varargin)
+    function varargout = setDesiredReducedJointConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2016, self, varargin{:});
     end
-    function varargout = setReducedInitialCondition(self,varargin)
+    function varargout = setFullJointsInitialCondition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2017, self, varargin{:});
     end
-    function varargout = solve(self,varargin)
+    function varargout = setReducedInitialCondition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2018, self, varargin{:});
     end
-    function varargout = getFullJointsSolution(self,varargin)
+    function varargout = solve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2019, self, varargin{:});
     end
-    function varargout = getReducedSolution(self,varargin)
+    function varargout = getFullJointsSolution(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2020, self, varargin{:});
     end
-    function varargout = getPoseForFrame(self,varargin)
+    function varargout = getReducedSolution(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2021, self, varargin{:});
     end
-    function varargout = fullModel(self,varargin)
+    function varargout = getPoseForFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2022, self, varargin{:});
     end
-    function varargout = reducedModel(self,varargin)
+    function varargout = fullModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2023, self, varargin{:});
     end
-    function varargout = setCOMTarget(self,varargin)
+    function varargout = reducedModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2024, self, varargin{:});
     end
-    function varargout = setCOMAsConstraint(self,varargin)
+    function varargout = setCOMTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2025, self, varargin{:});
     end
-    function varargout = setCOMAsConstraintTolerance(self,varargin)
+    function varargout = setCOMAsConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2026, self, varargin{:});
     end
-    function varargout = isCOMAConstraint(self,varargin)
+    function varargout = setCOMAsConstraintTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2027, self, varargin{:});
     end
-    function varargout = isCOMTargetActive(self,varargin)
+    function varargout = isCOMAConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2028, self, varargin{:});
     end
-    function varargout = deactivateCOMTarget(self,varargin)
+    function varargout = isCOMTargetActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2029, self, varargin{:});
     end
-    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+    function varargout = deactivateCOMTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2030, self, varargin{:});
+    end
+    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2031, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -167,17 +167,20 @@ classdef KinDynComputations < SwigRef
     function varargout = inverseDynamics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
     end
-    function varargout = generalizedBiasForces(self,varargin)
+    function varargout = inverseDynamicsWithInternalJointForceTorques(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
     end
-    function varargout = generalizedGravityForces(self,varargin)
+    function varargout = generalizedBiasForces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
     end
-    function varargout = generalizedExternalForces(self,varargin)
+    function varargout = generalizedGravityForces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
     end
-    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+    function varargout = generalizedExternalForces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
+    end
+    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
@@ -4,49 +4,49 @@ classdef Matrix4x4Vector < SwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = pop(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
     end
-    function varargout = setbrace(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
     end
-    function varargout = append(self,varargin)
+    function varargout = setbrace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
     end
-    function varargout = empty(self,varargin)
+    function varargout = append(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
     end
-    function varargout = swap(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = swap(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = rbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
     end
-    function varargout = clear(self,varargin)
+    function varargout = rend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
     end
-    function varargout = get_allocator(self,varargin)
+    function varargout = clear(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
     end
-    function varargout = pop_back(self,varargin)
+    function varargout = get_allocator(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
     end
-    function varargout = erase(self,varargin)
+    function varargout = pop_back(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
     end
     function self = Matrix4x4Vector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -54,41 +54,41 @@ classdef Matrix4x4Vector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1782, varargin{:});
+        tmp = iDynTreeMEX(1783, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = push_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
-    end
-    function varargout = front(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
     end
-    function varargout = back(self,varargin)
+    function varargout = front(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
     end
-    function varargout = assign(self,varargin)
+    function varargout = back(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = assign(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
     end
-    function varargout = insert(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = insert(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = reserve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = capacity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1792, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1792, self);
+        iDynTreeMEX(1793, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/PixelViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PixelViz.m
@@ -4,20 +4,20 @@ classdef PixelViz < iDynTree.ColorViz
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1818, self);
+        varargout{1} = iDynTreeMEX(1819, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1819, self, varargin{1});
+        iDynTreeMEX(1820, self, varargin{1});
       end
     end
     function varargout = height(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1820, self);
+        varargout{1} = iDynTreeMEX(1821, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1821, self, varargin{1});
+        iDynTreeMEX(1822, self, varargin{1});
       end
     end
     function self = PixelViz(varargin)
@@ -27,14 +27,14 @@ classdef PixelViz < iDynTree.ColorViz
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1822, varargin{:});
+        tmp = iDynTreeMEX(1823, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1823, self);
+        iDynTreeMEX(1824, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon.m
@@ -7,10 +7,10 @@ classdef Polygon < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1925, self);
+        varargout{1} = iDynTreeMEX(1926, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1926, self, varargin{1});
+        iDynTreeMEX(1927, self, varargin{1});
       end
     end
     function self = Polygon(varargin)
@@ -19,36 +19,36 @@ classdef Polygon < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1927, varargin{:});
+        tmp = iDynTreeMEX(1928, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
-    end
-    function varargout = getNrOfVertices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getNrOfVertices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
     end
-    function varargout = applyTransform(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = applyTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1934, self);
+        iDynTreeMEX(1935, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = XYRectangleFromOffsets(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(1933, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(1934, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
@@ -7,10 +7,10 @@ classdef Polygon2D < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1935, self);
+        varargout{1} = iDynTreeMEX(1936, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1936, self, varargin{1});
+        iDynTreeMEX(1937, self, varargin{1});
       end
     end
     function self = Polygon2D(varargin)
@@ -19,26 +19,26 @@ classdef Polygon2D < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1937, varargin{:});
+        tmp = iDynTreeMEX(1938, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
-    end
-    function varargout = getNrOfVertices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = getNrOfVertices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1942, self);
+        iDynTreeMEX(1943, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,67 +9,67 @@ classdef Visualizer < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1906, varargin{:});
+        tmp = iDynTreeMEX(1907, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1907, self);
+        iDynTreeMEX(1908, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
-    end
-    function varargout = getNrOfVisualizedModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
     end
-    function varargout = getModelInstanceName(self,varargin)
+    function varargout = getNrOfVisualizedModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
     end
-    function varargout = getModelInstanceIndex(self,varargin)
+    function varargout = getModelInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
     end
-    function varargout = addModel(self,varargin)
+    function varargout = getModelInstanceIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
     end
-    function varargout = modelViz(self,varargin)
+    function varargout = addModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
     end
-    function varargout = camera(self,varargin)
+    function varargout = modelViz(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
     end
-    function varargout = enviroment(self,varargin)
+    function varargout = camera(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
     end
-    function varargout = vectors(self,varargin)
+    function varargout = enviroment(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
     end
-    function varargout = frames(self,varargin)
+    function varargout = vectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
     end
-    function varargout = textures(self,varargin)
+    function varargout = frames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
     end
-    function varargout = run(self,varargin)
+    function varargout = textures(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
     end
-    function varargout = draw(self,varargin)
+    function varargout = run(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
     end
-    function varargout = drawToFile(self,varargin)
+    function varargout = draw(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
     end
-    function varargout = close(self,varargin)
+    function varargout = drawToFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
     end
-    function varargout = isWindowActive(self,varargin)
+    function varargout = close(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
     end
-    function varargout = setColorPalette(self,varargin)
+    function varargout = isWindowActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
+    end
+    function varargout = setColorPalette(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,40 +7,40 @@ classdef VisualizerOptions < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1893, self);
+        varargout{1} = iDynTreeMEX(1894, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1894, self, varargin{1});
+        iDynTreeMEX(1895, self, varargin{1});
       end
     end
     function varargout = winWidth(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1895, self);
+        varargout{1} = iDynTreeMEX(1896, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1896, self, varargin{1});
+        iDynTreeMEX(1897, self, varargin{1});
       end
     end
     function varargout = winHeight(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1897, self);
+        varargout{1} = iDynTreeMEX(1898, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1898, self, varargin{1});
+        iDynTreeMEX(1899, self, varargin{1});
       end
     end
     function varargout = rootFrameArrowsDimension(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1899, self);
+        varargout{1} = iDynTreeMEX(1900, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1900, self, varargin{1});
+        iDynTreeMEX(1901, self, varargin{1});
       end
     end
     function self = VisualizerOptions(varargin)
@@ -49,14 +49,14 @@ classdef VisualizerOptions < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1901, varargin{:});
+        tmp = iDynTreeMEX(1902, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1902, self);
+        iDynTreeMEX(1903, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
@@ -1,3 +1,3 @@
 function varargout = sizeOfRotationParametrization(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1971, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1972, varargin{:});
 end

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -1179,6 +1179,42 @@ public:
                                FreeFloatingGeneralizedTorques & baseForceAndJointTorques);
 
     /**
+     * This method is similar to inverseDynamics, but provides as an additional output the internal 6D force/torques (aka wrenches)
+     * excerted by the two links connected to each joint, in the linkInternalWrenches argument.
+     *
+     * The `linkInternalWrenches` is a container of \f$n_{L}\f$ (number of links) 6D Force/Torques, one associated to each link.
+     * In particular, if the link \f$L\f$ is the link with index \f$L\f$ the element linkInternalWrenches(i) contains, depending on the
+     * choice of `FrameVelocityRepresentation`:
+     *
+     * |`FrameVelocityRepresentation` |  `linkInternalWrenches(i)` |
+     * |:----------------------------:|:--------------------------:|
+     * | `MIXED_REPRESENTATION` (default) | \f$ {}_{L[A]} \mathrm{f}_{\lambda(L), L} \f$ |
+     * | `BODY_FIXED_REPRESENTATION` | f$ {}_{L} \mathrm{f}_{\lambda(L), L} \f$ |
+     * | `INERTIAL_FIXED_REPRESENTATION` | \f$ {}_{A} \mathrm{f}_{\lambda(L), L} \f$ |
+     *
+     * Where if $C$ is a given frame, \f$ {}_{C} \mathrm{f}_{\lambda(L), L} \f$ is the 6D force/torque that the
+     * parent link \f$\lambda(L)\f$ excerts on its child \f$L\f$.
+     *
+     * \warning Note that this definition strictly depends on the floating base specified in the KinDynComputations instances,
+     *          as given a link \f$L\f$, its parent \lambda(L) depends on the choosen base link.
+     */
+    bool inverseDynamicsWithInternalJointForceTorques(const Vector6& baseAcc,
+                                                      const VectorDynSize& s_ddot,
+                                                      const LinkNetExternalWrenches & linkExtForces,
+                                                            FreeFloatingGeneralizedTorques & baseForceAndJointTorques,
+                                                            LinkInternalWrenches& linkInternalWrenches
+                                                            );
+    /**
+     * Variant of inverseDynamicsWithInternalJointForceTorques that takes iDynTree::Span objects that point to already allocated memory as inputs.
+     * See inverseDynamicsWithInternalJointForceTorques for the description of the input and output parameters.
+     */
+    bool inverseDynamicsWithInternalJointForceTorques(iDynTree::Span<const double> baseAcc,
+                                                      iDynTree::Span<const double> s_ddot,
+                                                      const LinkNetExternalWrenches & linkExtForces,
+                                                            FreeFloatingGeneralizedTorques & baseForceAndJointTorques,
+                                                            LinkInternalWrenches& linkInternalWrenches);
+
+    /**
      * @brief Compute the getNrOfDOFS()+6 vector of generalized bias (gravity+coriolis) forces.
      *
      * This method computes \f$C(q, \nu) \nu + G(q) \in \mathbb{R}^{6+n_{DOF}}\f$.

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -347,10 +347,6 @@ void testInverseDynamics(KinDynComputations & dynComp)
             }
             inertialWrenches(lnkIdx) = I*a + v*(I*v) - gravitationalWrench;
 
-
-
-            inertialWrenches(lnkIdx) = inertialWrenches(lnkIdx) ;
-
             // Compute external wrenches (it was already an input of inverseDynamics)
             externalWrenches(lnkIdx) = netExternalWrenches(lnkIdx);
 

--- a/src/model/src/Dynamics.cpp
+++ b/src/model/src/Dynamics.cpp
@@ -128,6 +128,10 @@ bool RNEADynamicPhase(const Model& model, const Traversal& traversal,
             // are coherent, should be zero. This because any external wrench on the base should
             // be present also in the fExt vector .
             baseWrenchJntTorques.baseWrench() = f(visitedLinkIndex);
+
+            // As the the base link has no parent link and the residual force/torque is reported as the base wrench in
+            // the generalized torques, set the related internal joint force/torque to zero
+            f(visitedLinkIndex) = iDynTree::Wrench::Zero();
         }
         else
         {


### PR DESCRIPTION
This additional method permits to compute the inverse dynamics, but providing as an output the internal joint wrenches for each joint.

This quantity was already computed inside the Recursive Newton-Euler Algorithm dynamic loop, but for each link $L$ it was expressed in the frame $L$, while when the KinDynComputations `FrameVelocityRepresentation` is set to `MIXED_REPRESENTATION` (the default value) for coerence with the rest of quantities we want it to be expressed in the frame $L[A]$, i.e. with the origin of frame $L$ and the orientation of the Absolute/World frame $A$, so most of the additional logic is to perform this conversion (and similar conversions or lack of conversion if other less-used `FrameVelocityRepresentation`  are selected by the user).

Tests have been added in `KinDynComputationsUnitTest` to cover the logic of this new methods. 

To review the PR, you can check the individual commits, skipping the commit related to the re-generation of MATLAB bindings, that do not contain any relevant change, as those changes are automatic.

@VenusPasandi in particular can yo review if the documentation of the new methods is understandable enough? Thanks! 

Fix https://github.com/robotology/idyntree/issues/853 .
