### PR TITLE
Fix github-pages-deploy-action (part 2)

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -39,8 +39,7 @@ jobs:
     - name: Deploy
       if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel')
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      env:
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: deploy
-        
+      with:
+        branch: gh-pages
+        folder: deploy
+        token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Sequel to https://github.com/robotology/idyntree/pull/856 . I forgot to update how the parameter are passed.