### PR TITLE
Added some antialiasing to the visualizer

### DIFF
--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -244,6 +244,7 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
     irrDevParams.DriverType = irr::video::EDT_OPENGL;
     irrDevParams.WindowSize = irr::core::dimension2d<irr::u32>(visualizerOptions.winWidth, visualizerOptions.winHeight);
     irrDevParams.WithAlphaChannel = true;
+    irrDevParams.AntiAlias = 4;
 
     if( visualizerOptions.verbose )
     {


### PR DESCRIPTION
This is to reduce the so-called "jaggies" that are due to the aliasing problem. This increases a bit the computational load, but straight lines appear smoother. The number refers to multisampling value (see https://vulkan-tutorial.com/Multisampling)

| Antialiasing = 0 (default) | Antialiasing = 4 |
:---------------------------------:|:----------------------: 
|![Screenshot from 2021-05-03 09-12-26](https://user-images.githubusercontent.com/18591940/116851022-f45aee00-abf1-11eb-88be-7c06762f6386.png) |  ![Screenshot from 2021-05-03 09-13-25](https://user-images.githubusercontent.com/18591940/116851039-fc1a9280-abf1-11eb-8388-00426a15c28d.png) | 

Notice the appearance of the red arrows below the feet.

