### PR TITLE
Fix KinDynComputationsTutorial.py to work with modern Python and iDynTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The example file `examples/python/KinDynComputationsTutorial.py` has been fixed to work with Python 3 and iDynTree >= 2.0 ().
+
 ## [3.2.0] - 2021-05-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- The example file `examples/python/KinDynComputationsTutorial.py` has been fixed to work with Python 3 and iDynTree >= 2.0 ().
+- The example file `examples/python/KinDynComputationsTutorial.py` has been fixed to work with Python 3 and iDynTree >= 2.0 (https://github.com/robotology/idyntree/pull/873).
 
 ## [3.2.0] - 2021-05-15
 

--- a/examples/python/KinDynComputationsTutorial.py
+++ b/examples/python/KinDynComputationsTutorial.py
@@ -61,7 +61,7 @@ baseAcc.zero();
 links = dynComp.model().getNrOfLinks();
 regr = iDynTree.MatrixDynSize(6+dofs,10*links);
 ok = dynComp.inverseDynamicsInertialParametersRegressor(baseAcc, dds, regr);
-# The Dynamics Regressior is quite big, uncomment if you really want to print it
+# The Dynamics Regressor is quite big, uncomment if you really want to print it
 #if( not ok ):
 #    print("Error in computing the dynamics regressor");
 #else :

--- a/examples/python/KinDynComputationsTutorial.py
+++ b/examples/python/KinDynComputationsTutorial.py
@@ -1,25 +1,26 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Jun 23 11:35:46 2015
+To run this example, first install iDynTree for python,
+then navigate to this directory and run:
+python KinDynComputationsTutorial.py
 
-@author: adelpret
+Otherwise, modify the URDF_FILE parameter to point to an existing
+URDF in your system.
 """
 
-import iDynTree
-from iDynTree import KinDynComputations
-from iDynTree import ModelLoader
+import idyntree.bindings as iDynTree
 
 
-URDF_FILE = '/home/username/path/robot.urdf';
+URDF_FILE = '../../src/tests/data/icub.urdf ';
 
-dynComp = KinDynComputations();
-mdlLoader = ModelLoader();
+dynComp = iDynTree.KinDynComputations();
+mdlLoader = iDynTree.ModelLoader();
 mdlLoader.loadModelFromFile(URDF_FILE);
 
 dynComp.loadRobotModel(mdlLoader.model());
 
-print "The loaded model has", dynComp.model().getNrOfDOFs(), \
-    "internal degrees of freedom and",dynComp.model().getNrOfLinks(),"links."
+print("The loaded model has", dynComp.model().getNrOfDOFs(), \
+    "internal degrees of freedom and",dynComp.model().getNrOfLinks(),"links.")
 
 dofs = dynComp.model().getNrOfDOFs();
 s = iDynTree.VectorDynSize(dofs);
@@ -27,7 +28,7 @@ ds = iDynTree.VectorDynSize(dofs);
 dds = iDynTree.VectorDynSize(dofs);
 for dof in range(dofs):
     # For the sake of the example, we fill the joints vector with gibberish data (remember in any case
-    # that all quantities are expressed in radians-based units 
+    # that all quantities are expressed in radians-based units
     s.setVal(dof, 1.0);
     ds.setVal(dof, 0.4);
     dds.setVal(dof, 0.3);
@@ -40,19 +41,28 @@ gravity.setVal(2, -9.81);
 dynComp.setRobotState(s,ds,gravity);
 
 jac = iDynTree.MatrixDynSize(6,6+dofs);
-ok = dynComp.getFreeFloatingJacobian("lf_foot", jac);
+ok = dynComp.getFrameFreeFloatingJacobian("l_sole", jac);
 if( not ok ):
-    print "Error in computing jacobian of frame " + "lf_foot";
-else: 
-    print "Jacobian of lf_foot is\n" + jac.toString();
+    print("Error in computing jacobian of frame " + "l_sole");
+else:
+    print("Jacobian of lf_foot is\n" + jac.toString());
 
+
+root_H_sole = dynComp.getRelativeTransform("root_link", "l_sole");
+root_R_sole = root_H_sole.getRotation()
+if( not ok ):
+    print("Error in computing jacobian of frame " + "l_sole");
+else:
+    print("Orientation between root_link and l_sole is\n" + str(root_R_sole.toNumPy()));
+    print("In RPY format:\n" + str(root_R_sole.asRPY().toNumPy()))
 
 baseAcc = iDynTree.Vector6();
 baseAcc.zero();
 links = dynComp.model().getNrOfLinks();
 regr = iDynTree.MatrixDynSize(6+dofs,10*links);
 ok = dynComp.inverseDynamicsInertialParametersRegressor(baseAcc, dds, regr);
-if( not ok ):
-    print "Error in computing the dynamics regressor";
-else :
-    print "The dynamics regressor is\n" + regr.toString();
+# The Dynamics Regressior is quite big, uncomment if you really want to print it
+#if( not ok ):
+#    print("Error in computing the dynamics regressor");
+#else :
+#    print("The dynamics regressor is\n" + regr.toString());


### PR DESCRIPTION
The tutorial was not working on Python 3 or iDynTree > 2.

To test the tutorial, it is possible to use iDynTree installed via conda on Windows/Linux/macOS, for example:
~~~
# Install iDynTree
conda create -n idyntreenv -c conda-forge -c robotology idyntree
conda activate idyntreenv
# Run example
git clone https://github.com/robotology/idyntree
cd idyntree/examples/python
git checkout  fix/pythonTutorial
python KinDynComputationsTutorial.py 
~~~

While on Linux iDynTree can also be installed via `pip`.
