### PR TITLE
Fix the visualization of boxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The example file `examples/python/KinDynComputationsTutorial.py` has been fixed to work with Python 3 and iDynTree >= 2.0 (https://github.com/robotology/idyntree/pull/873).
+- Fix of a bug introduced by https://github.com/robotology/idyntree/pull/845 in the visualization of boxes (https://github.com/robotology/idyntree/pull/874)
 
 ## [3.2.0] - 2021-05-15
 

--- a/src/model/src/SolidShapes.cpp
+++ b/src/model/src/SolidShapes.cpp
@@ -42,7 +42,12 @@ namespace iDynTree
         m_texture = texture;
     }
 
-    SolidShape::SolidShape(): nameIsValid(false), m_isMaterialSet(false) {}
+    SolidShape::SolidShape()
+        : nameIsValid(false)
+        , link_H_geometry(iDynTree::Transform::Identity())
+        , m_isMaterialSet(false)
+    {
+    }
 
     SolidShape::~SolidShape()
     {

--- a/src/visualization/src/IrrlichtUtils.h
+++ b/src/visualization/src/IrrlichtUtils.h
@@ -169,10 +169,6 @@ inline irr::scene::ISceneNode * addGeometryToSceneManager(const iDynTree::SolidS
 
         irr::scene::IMesh* boxMesh = smgr->getGeometryCreator()->createCubeMesh(irr::core::vector3df(box->getX(),box->getY(),box->getZ()));
 
-        irr::core::matrix4 irr2idyntree;
-        irr2idyntree.buildRotateFromTo(irr::core::vector3df(0.0,1.0,0.0),irr::core::vector3df(0.0,0.0,1.0));
-        smgr->getMeshManipulator()->transform(boxMesh,irr2idyntree);
-
         geomNode = smgr->addMeshSceneNode(boxMesh,linkNode);
 
         boxMesh->drop();


### PR DESCRIPTION
This fixes a bug in the visualization of boxes introduced by https://github.com/robotology/idyntree/pull/845

The reason why that change was added in the first place was because I tried to add a box in the visualizer. In particular, I used a code like

```
    iDynTree::Box box;

    box.setX(0.1);
    box.setY(0.2);
    box.setZ(1.0);
    addGeometryToSceneManager(&box, nullptr, pimpl->m_irrSmgr);
```

I was expecting a box much bigger on the Z axis, but it was not the case. Indeed, it turned out that the orientation of the box was variable. Finally, by checking with ``valgrind``, I realized that ``link_H_geometry`` was read when adding the mesh to the visualizer, but it was never set. Adding the initialization of ``link_H_geometry`` solved the problem for ``valgrind`` and in the visualization.

