### PR TITLE
Do not call find_package(pybind11 QUIET) if IDYNTREE_USES_PYTHON_PYBIND11 is OFF

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -97,13 +97,9 @@ endif()
 
 
 option(IDYNTREE_USES_PYTHON_PYBIND11 "Create iDynTree Python bindings using pybind11" FALSE)
-find_package(pybind11 QUIET)
 if (IDYNTREE_USES_PYTHON_PYBIND11)
-    if (${pybind11_FOUND})
-        add_subdirectory(pybind11)
-    else()
-       MESSAGE(FATAL_ERROR "pybind11 not found, impossible to generate iDynTree pybind11 bindings.")
-    endif()
+    find_package(pybind11 REQUIRED)
+    add_subdirectory(pybind11)
 endif()
 
 # Install main __init__.py file.


### PR DESCRIPTION
Calling find_package(pybind11) can create configuration failures even if the QUIET option is passed (see https://github.com/robotology/idyntree/issues/876). 

As at the moment there is not automatic detection of pybind11 to enable the pybind11 bindings, it is just easier to properly search for pybind11 if IDYNTREE_USES_PYTHON_PYBIND11 is ON, and do not do anything otherwise.

Fix related to https://github.com/robotology/idyntree/issues/876 .