### PR TITLE
Allow the visualization of labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add the visualization of labels in the visualizer (https://github.com/robotology/idyntree/pull/879)
 
 ## [3.2.1] - 2021-06-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 3.2.1
+project(iDynTree VERSION 3.3.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 3.3.0
+project(iDynTree VERSION 4.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -21,6 +21,7 @@ if(IDYNTREE_USES_IRRLICHT)
                                                src/Texture.h
                                                src/TexturesHandler.h
                                                src/Light.h
+                                               src/Label.h
                                                src/FloorGridSceneNode.h)
     set(iDynTree_visualization_private_source  src/Camera.cpp
                                                src/CameraAnimator.cpp
@@ -32,6 +33,7 @@ if(IDYNTREE_USES_IRRLICHT)
                                                src/Texture.cpp
                                                src/TexturesHandler.cpp
                                                src/Light.cpp
+                                               src/Label.cpp
                                                src/FloorGridSceneNode.cpp)
 endif()
 

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -714,6 +714,11 @@ public:
      * Get the transformation of given frame with respect to visualizer world \f$ w_H_{frame}\f$
      */
     virtual Transform getWorldFrameTransform(const std::string& frameName) = 0;
+
+    /**
+     * Get the label for the model.
+     */
+    virtual ILabel& label() = 0;
 };
 
 /**

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -531,6 +531,14 @@ public:
     virtual bool setVectorsAspect(double zeroModulusRadius, double modulusMultiplier, double heightScale) = 0;
 
     /**
+     * @brief Set the visibility of a given vector
+     * @param The index of the vector to change the visibility
+     * @param visible The visibility of the vector
+     * @return true if successfull, false if the index is out of bounds
+     */
+    virtual bool setVisible(size_t vectorIndex, bool visible = true) = 0;
+
+    /**
      * @brief Get the label associated to a vector
      * @param vectorIndex The index of the vector to get the label
      * @return The label associated to the vector. nullptr if the vectorIndex is out of bounds.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -383,6 +383,81 @@ public:
 };
 
 /**
+ * The interface to add a label in the visualizer.
+ */
+
+class ILabel
+{
+public:
+
+    /**
+     * Destructor
+     */
+    virtual ~ILabel() = 0;
+
+    /**
+     * @brief Set the text of the label
+     * @param text The text to be displayed
+     */
+    virtual void setText(const std::string& text) = 0;
+
+    /**
+     * @brief Get the label text
+     * @return The text shown in the label.
+     */
+    virtual std::string getText() const = 0;
+
+    /**
+     * @brief Set the height of the label. The width is computed automatically
+     * @param height The height to be set
+     */
+    virtual void setSize(float height) = 0;
+
+    /**
+     * @brief Set the width and the height of the label
+     * @param width The width of the label
+     * @param height The height of the label
+     */
+    virtual void setSize(float width, float height) = 0;
+
+    /**
+     * @brief Get the width of the label
+     * @return The width of the label
+     */
+    virtual float width() const = 0;
+
+    /**
+     * @brief Get the height of the label
+     * @return The height of the label
+     */
+    virtual float height() const = 0;
+
+    /**
+     * @brief Set the position of the label
+     * @param position The position of the label
+     */
+    virtual void setPosition(const iDynTree::Position& position) = 0;
+
+    /**
+     * @brief Get the position of the label
+     * @return The position of the label
+     */
+    virtual iDynTree::Position getPosition() const = 0;
+
+    /**
+     * @brief Set the color of the label
+     * @param color The color of the label
+     */
+    virtual void setColor(const iDynTree::ColorViz& color) = 0;
+
+    /**
+     * @brief Set the visibility of the label
+     * @param visible The visibility of the label
+     */
+    virtual void setVisible(bool visible = true) = 0;
+};
+
+/**
  * Interface to the visualization of vectors.
  */
 class IVectorsVisualization
@@ -454,6 +529,13 @@ public:
      * @return true if successfull, false in case of negative numbers.
      */
     virtual bool setVectorsAspect(double zeroModulusRadius, double modulusMultiplier, double heightScale) = 0;
+
+    /**
+     * @brief Get the label associated to a vector
+     * @param vectorIndex The index of the vector to get the label
+     * @return The label associated to the vector. nullptr if the vectorIndex is out of bounds.
+     */
+    virtual ILabel* getVectorLabel(size_t vectorIndex) = 0;
 };
 
 /**
@@ -617,81 +699,6 @@ public:
      * Get the transformation of given frame with respect to visualizer world \f$ w_H_{frame}\f$
      */
     virtual Transform getWorldFrameTransform(const std::string& frameName) = 0;
-};
-
-/**
- * The interface to add a label in the visualizer.
- */
-
-class ILabel
-{
-public:
-
-    /**
-     * Destructor
-     */
-    virtual ~ILabel() = 0;
-
-    /**
-     * @brief Set the text of the label
-     * @param text The text to be displayed
-     */
-    virtual void setText(const std::string& text) = 0;
-
-    /**
-     * @brief Get the label text
-     * @return The text shown in the label.
-     */
-    virtual std::string getText() const = 0;
-
-    /**
-     * @brief Set the height of the label. The width is computed automatically
-     * @param height The height to be set
-     */
-    virtual void setSize(float height) = 0;
-
-    /**
-     * @brief Set the width and the height of the label
-     * @param width The width of the label
-     * @param height The height of the label
-     */
-    virtual void setSize(float width, float height) = 0;
-
-    /**
-     * @brief Get the width of the label
-     * @return The width of the label
-     */
-    virtual float width() const = 0;
-
-    /**
-     * @brief Get the height of the label
-     * @return The height of the label
-     */
-    virtual float height() const = 0;
-
-    /**
-     * @brief Set the position of the label
-     * @param position The position of the label
-     */
-    virtual void setPosition(const iDynTree::Position& position) = 0;
-
-    /**
-     * @brief Get the position of the label
-     * @return The position of the label
-     */
-    virtual iDynTree::Position getPosition() const = 0;
-
-    /**
-     * @brief Set the color of the label
-     * @param color The color of the label
-     */
-    virtual void setColor(const iDynTree::ColorViz& color) = 0;
-
-    /**
-     * @brief Set the visibility of the label
-     * @param visible The visibility of the label
-     */
-    virtual void setVisible(bool visible = true) = 0;
 };
 
 /**
@@ -889,6 +896,11 @@ public:
      * Get a reference to the internal ITexturesHandler interface.
      */
     ITexturesHandler& textures();
+
+    /**
+     * Get a label given a name. Note: this does not set the text in the label.
+     */
+    ILabel& getLabel(const std::string& labelName);
 
     /**
      * Wrap the run method of the Irrlicht device.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -585,6 +585,13 @@ public:
      * Update Frame
      */
     virtual bool updateFrame(size_t frameIndex, const Transform& transformation) = 0;
+
+    /**
+     * Get the label of a frame.
+     *
+     * Returns nullptr of the frame index is out of bounds.
+     */
+    virtual ILabel* getFrameLabel(size_t frameIndex) = 0;
 };
 
 

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -620,6 +620,81 @@ public:
 };
 
 /**
+ * The interface to add a label in the visualizer.
+ */
+
+class ILabel
+{
+public:
+
+    /**
+     * Destructor
+     */
+    virtual ~ILabel() = 0;
+
+    /**
+     * @brief Set the text of the label
+     * @param text The text to be displayed
+     */
+    virtual void setText(const std::string& text) = 0;
+
+    /**
+     * @brief Get the label text
+     * @return The text shown in the label.
+     */
+    virtual std::string getText() const = 0;
+
+    /**
+     * @brief Set the height of the label. The width is computed automatically
+     * @param height The height to be set
+     */
+    virtual void setSize(float height) = 0;
+
+    /**
+     * @brief Set the width and the height of the label
+     * @param width The width of the label
+     * @param height The height of the label
+     */
+    virtual void setSize(float width, float height) = 0;
+
+    /**
+     * @brief Get the width of the label
+     * @return The width of the label
+     */
+    virtual float width() const = 0;
+
+    /**
+     * @brief Get the height of the label
+     * @return The height of the label
+     */
+    virtual float height() const = 0;
+
+    /**
+     * @brief Set the position of the label
+     * @param position The position of the label
+     */
+    virtual void setPosition(const iDynTree::Position& position) = 0;
+
+    /**
+     * @brief Get the position of the label
+     * @return The position of the label
+     */
+    virtual iDynTree::Position getPosition() const = 0;
+
+    /**
+     * @brief Set the color of the label
+     * @param color The color of the label
+     */
+    virtual void setColor(const iDynTree::ColorViz& color) = 0;
+
+    /**
+     * @brief Set the visibility of the label
+     * @param visible The visibility of the label
+     */
+    virtual void setVisible(bool visible = true) = 0;
+};
+
+/**
  * The interface for an object that can be used as an additional target for the renderer.
  * This allows rendering the scene using dimensions and environment that are different from
  * the main window. The camera is in common. Any camera change in the main window is also

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -137,6 +137,7 @@ public:
     virtual size_t getNrOfFrames() const override {return 0; };
     virtual bool getFrameTransform(size_t , Transform& ) const override {return false;};
     virtual bool updateFrame(size_t, const Transform&) override {return false;};
+    virtual ILabel* getFrameLabel(size_t) override {return nullptr;};
 };
 
 /**

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -147,6 +147,7 @@ class DummyModelVisualization : public IModelVisualization
 {
     Model m_dummyModel;
     DummyJetsVisualization m_dummyJets;
+    DummyLabel m_dummyLabel;
 public:
     virtual ~DummyModelVisualization() {};
     virtual bool init(const Model& , const std::string , Visualizer &) { return false; }
@@ -170,6 +171,7 @@ public:
     virtual Transform getWorldFrameTransform(const FrameIndex &) { return iDynTree::Transform::Identity(); }
     virtual Transform getWorldLinkTransform(const std::string &) { return iDynTree::Transform::Identity(); }
     virtual Transform getWorldFrameTransform(const std::string &) { return iDynTree::Transform::Identity(); }
+    virtual ILabel& label() { return m_dummyLabel; };
 };
 
 class DummyTexturesHandler : public ITexturesHandler

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -93,6 +93,22 @@ public:
     virtual bool setJetsIntensity(const VectorDynSize & ) { return false; };
 };
 
+class DummyLabel : public iDynTree::ILabel
+{
+public:
+    virtual ~DummyLabel() override {};
+    virtual void setText(const std::string& ) override {};
+    virtual std::string getText() const override {return "";};
+    virtual void setSize(float ) override {};
+    virtual void setSize(float , float ) override {};
+    virtual float width() const override {return 0.0;};
+    virtual float height() const override {return 0.0;};
+    virtual void setPosition(const iDynTree::Position& ) override {};
+    virtual iDynTree::Position getPosition() const override {return iDynTree::Position::Zero();};
+    virtual void setColor(const iDynTree::ColorViz& ) override {};
+    virtual void setVisible(bool ) override {};
+};
+
 class DummyVectorsVisualization : public IVectorsVisualization {
 public:
     virtual ~DummyVectorsVisualization() override { }
@@ -107,6 +123,7 @@ public:
     virtual bool setVectorsAspect(double, double, double) override { return false; }
     virtual void setVectorsColor(const ColorViz &) override { return; }
     virtual void setVectorsDefaultColor(const ColorViz &) override { return; }
+    virtual ILabel* getVectorLabel(size_t ) override {return nullptr;}
 };
 
 class DummyFrameVisualization : public IFrameVisualization

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -123,6 +123,7 @@ public:
     virtual bool setVectorsAspect(double, double, double) override { return false; }
     virtual void setVectorsColor(const ColorViz &) override { return; }
     virtual void setVectorsDefaultColor(const ColorViz &) override { return; }
+    virtual bool setVisible(size_t , bool ) override { return false; }
     virtual ILabel* getVectorLabel(size_t ) override {return nullptr;}
 };
 

--- a/src/visualization/src/FrameVisualization.cpp
+++ b/src/visualization/src/FrameVisualization.cpp
@@ -31,6 +31,7 @@ size_t iDynTree::FrameVisualization::addFrame(const iDynTree::Transform &transfo
 
     m_frames.back().visualizationNode = addFrameAxes(m_smgr, 0, arrowLength);
     setFrameTransform(m_frames.size() - 1, transformation);
+    m_frames.back().label.init(m_smgr, m_frames.back().visualizationNode);
 
     return m_frames.size() - 1;
 }
@@ -74,6 +75,16 @@ bool iDynTree::FrameVisualization::updateFrame(size_t frameIndex, const iDynTree
     }
     setFrameTransform(frameIndex, transformation);
     return true;
+}
+
+iDynTree::ILabel *iDynTree::FrameVisualization::getFrameLabel(size_t frameIndex)
+{
+    if (frameIndex >= m_frames.size()) {
+        reportError("FrameVisualization","getFrameLabel","frameIndex out of bounds.");
+        return nullptr;
+    }
+
+    return &m_frames[frameIndex].label;
 }
 
 iDynTree::FrameVisualization::~FrameVisualization()

--- a/src/visualization/src/FrameVisualization.h
+++ b/src/visualization/src/FrameVisualization.h
@@ -11,6 +11,7 @@
 #define IDYNTREE_FRAMEVISUALIZATION_H
 
 #include <iDynTree/Visualizer.h>
+#include "Label.h"
 
 #include <vector>
 #include <irrlicht.h>
@@ -22,6 +23,7 @@ namespace iDynTree
         struct Frame
         {
             irr::scene::ISceneNode * visualizationNode = nullptr;
+            Label label;
         };
 
         std::vector<Frame> m_frames;
@@ -52,6 +54,8 @@ namespace iDynTree
         virtual bool getFrameTransform(size_t frameIndex, Transform& currentTransform) const final;
 
         virtual bool updateFrame(size_t frameIndex, const Transform& transformation) final;
+
+        virtual ILabel* getFrameLabel(size_t frameIndex) final;
 
     };
 }

--- a/src/visualization/src/Label.cpp
+++ b/src/visualization/src/Label.cpp
@@ -16,6 +16,48 @@
 #include "IrrlichtUtils.h"
 
 
+Label::Label()
+{
+
+}
+
+Label::Label(const Label &other)
+{
+    operator=(other);
+}
+
+Label::Label(Label &&other)
+{
+    operator=(other);
+}
+
+Label &Label::operator=(const Label &other)
+{
+    m_font = other.m_font;
+    if (m_font)
+    {
+        m_font->grab();
+    }
+
+    m_label = other.m_label;
+    if (m_label)
+    {
+        m_label->grab();
+    }
+    return *this;
+}
+
+Label &Label::operator=(Label &&other)
+{
+    m_font = other.m_font;
+    other.m_font = nullptr;
+
+    m_label = other.m_label;
+    other.m_label = nullptr;
+
+    return *this;
+}
+
 Label::~Label()
 {
     if (m_font)
@@ -39,6 +81,11 @@ void Label::init(irr::scene::ISceneManager *smgr, irr::scene::ISceneNode *parent
 
     m_label = smgr->addBillboardTextSceneNode(m_font, L"", parent);
     m_label->grab();
+}
+
+bool Label::initialized() const
+{
+    return m_font && m_label;
 }
 
 void Label::setText(const std::string &text)

--- a/src/visualization/src/Label.cpp
+++ b/src/visualization/src/Label.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#include "Label.h"
+#include <cassert>
+#include <string>
+#include <codecvt>
+#include <locale>
+#include "IrrlichtUtils.h"
+
+
+Label::~Label()
+{
+    if (m_font)
+    {
+        m_font->drop();
+        m_font = nullptr;
+    }
+
+    if (m_label)
+    {
+        m_label->drop();
+        m_label = nullptr;
+    }
+}
+
+void Label::init(irr::scene::ISceneManager *smgr, irr::scene::ISceneNode *parent)
+{
+    assert(smgr);
+    m_font = smgr->getGUIEnvironment()->getBuiltInFont();
+    m_font->grab();
+
+    m_label = smgr->addBillboardTextSceneNode(m_font, L"", parent);
+    m_label->grab();
+}
+
+void Label::setText(const std::string &text)
+{
+    assert(m_font);
+    assert(m_label);
+    using convert_typeX = std::codecvt_utf8<wchar_t>;
+    std::wstring_convert<convert_typeX, wchar_t> converterX;
+    m_wtext = converterX.from_bytes(text).c_str(); //See https://stackoverflow.com/a/18374698
+    m_label->setText(m_wtext.c_str());
+    m_text = text;
+    if (m_ratio >= 0)
+    {
+        auto dims = m_font->getDimension(m_wtext.c_str());
+        if (dims.Height)
+        {
+            m_ratio = dims.Width / (float) dims.Height;
+            m_width = m_ratio * m_height;
+            m_label->setSize({m_width, m_height});
+        }
+    }
+    setColor(m_color);
+}
+
+std::string Label::getText() const
+{
+    return m_text;
+}
+
+void Label::setSize(float height)
+{
+    assert(m_font);
+    assert(m_label);
+
+    m_height = -height;
+    auto dims = m_font->getDimension(m_wtext.c_str());
+    if (dims.Height)
+    {
+        m_ratio = dims.Width / (float) dims.Height;
+        m_width = m_ratio * m_height;
+        m_label->setSize({m_width, m_height});
+    }
+
+}
+
+void Label::setSize(float width, float height)
+{
+    m_height = -height;
+    m_width = -width;
+    m_ratio = -1.0;
+    m_label->setSize({m_width, m_height});
+}
+
+float Label::width() const
+{
+    return m_width;
+}
+
+float Label::height() const
+{
+    return m_height;
+}
+
+void Label::setPosition(const iDynTree::Position &position)
+{
+    assert(m_label);
+    m_label->setPosition(iDynTree::idyntree2irr_pos(position));
+}
+
+iDynTree::Position Label::getPosition() const
+{
+    assert(m_label);
+    return iDynTree::irr2idyntree_pos(m_label->getPosition());
+}
+
+void Label::setColor(const iDynTree::ColorViz &color)
+{
+    assert(m_label);
+    m_color = color;
+    m_label->setTextColor(iDynTree::idyntree2irrlicht(color).toSColor());
+    m_label->setColor(iDynTree::idyntree2irrlicht(color).toSColor());
+}
+
+void Label::setVisible(bool visible)
+{
+    assert(m_label);
+    m_label->setVisible(visible);
+}

--- a/src/visualization/src/Label.cpp
+++ b/src/visualization/src/Label.cpp
@@ -141,12 +141,12 @@ void Label::setSize(float width, float height)
 
 float Label::width() const
 {
-    return m_width;
+    return -m_width;
 }
 
 float Label::height() const
 {
-    return m_height;
+    return -m_height;
 }
 
 void Label::setPosition(const iDynTree::Position &position)

--- a/src/visualization/src/Label.h
+++ b/src/visualization/src/Label.h
@@ -27,9 +27,21 @@ class Label : public iDynTree::ILabel
 
 public:
 
+    Label();
+
+    Label(const Label& other);
+
+    Label(Label&& other);
+
+    Label& operator=(const Label& other);
+
+    Label& operator=(Label&& other);
+
     virtual ~Label();
 
     void init(irr::scene::ISceneManager* smgr, irr::scene::ISceneNode* parent = nullptr);
+
+    bool initialized() const;
 
     virtual void setText(const std::string& text) final;
 
@@ -49,7 +61,7 @@ public:
 
     virtual void setColor(const iDynTree::ColorViz& color) final;
 
-    virtual void setVisible(bool visible = true) final;
+    virtual void setVisible(bool visible) final;
 };
 
 #endif // LABEL_H

--- a/src/visualization/src/Label.h
+++ b/src/visualization/src/Label.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#ifndef IDYNTREE_LABEL_H
+#define IDYNTREE_LABEL_H
+
+#include <iDynTree/Visualizer.h>
+#include <irrlicht.h>
+
+class Label : public iDynTree::ILabel
+{
+    irr::gui::IGUIFont* m_font{nullptr};
+    irr::scene::IBillboardTextSceneNode* m_label{nullptr};
+    float m_ratio{1.0};
+    float m_width{0.0};
+    float m_height{-0.1};
+    std::string m_text;
+    std::wstring m_wtext;
+    iDynTree::ColorViz m_color{0.0, 0.0, 0.0, 1.0};
+
+public:
+
+    virtual ~Label();
+
+    void init(irr::scene::ISceneManager* smgr, irr::scene::ISceneNode* parent = nullptr);
+
+    virtual void setText(const std::string& text) final;
+
+    virtual std::string getText() const final;
+
+    virtual void setSize(float height) final;
+
+    virtual void setSize(float width, float height) final;
+
+    virtual float width() const final;
+
+    virtual float height() const final;
+
+    virtual void setPosition(const iDynTree::Position& position) final;
+
+    virtual iDynTree::Position getPosition() const final;
+
+    virtual void setColor(const iDynTree::ColorViz& color) final;
+
+    virtual void setVisible(bool visible = true) final;
+};
+
+#endif // LABEL_H

--- a/src/visualization/src/ModelVisualization.cpp
+++ b/src/visualization/src/ModelVisualization.cpp
@@ -11,6 +11,7 @@
 #include "ModelVisualization.h"
 #include "JetsVisualization.h"
 #include "IrrlichtUtils.h"
+#include "Label.h"
 
 #include <iDynTree/Model/ForwardKinematics.h>
 #include <iDynTree/Model/Model.h>
@@ -71,6 +72,11 @@ struct ModelVisualization::ModelVisualizationPimpl
      * JetsVisualization helper class
      */
     JetsVisualization m_jets;
+
+    /**
+     * The label of the model
+     */
+    Label m_label;
 
 
     ModelVisualizationPimpl()
@@ -202,6 +208,13 @@ bool ModelVisualization::init(const Model& model,
     // Initialize the jets visualizer
     this->pimpl->m_jets.init(this->pimpl->m_irrSmgr,this,&(this->pimpl->frameNodes));
 
+    irr::scene::ISceneNode* labelParent = this->pimpl->modelNode;
+    if (this->pimpl->linkNodes.size() > 0)
+    {
+        labelParent = this->pimpl->linkNodes.front();
+    }
+    this->pimpl->m_label.init(this->pimpl->m_irrSmgr, labelParent);
+
     pimpl->m_isValid = true;
 
     return true;
@@ -272,6 +285,11 @@ Transform ModelVisualization::getWorldFrameTransform(const std::string& frameNam
     }
 
     return getWorldFrameTransform(frameIndex);
+}
+
+ILabel &ModelVisualization::label()
+{
+    return pimpl->m_label;
 }
 
 

--- a/src/visualization/src/ModelVisualization.h
+++ b/src/visualization/src/ModelVisualization.h
@@ -41,7 +41,7 @@ public:
     virtual void setModelColor(const ColorViz & modelColor);
     virtual void resetModelColor();
     virtual bool setLinkColor(const LinkIndex& linkIndex, const ColorViz& linkColor);
-    virtual bool resetLinkColor(const LinkIndex& linkIndex); 
+    virtual bool resetLinkColor(const LinkIndex& linkIndex);
     virtual std::vector< std::string > getLinkNames();
     virtual bool setLinkVisibility(const std::string & linkName, bool isVisible);
     virtual std::vector<std::string> getFeatures();
@@ -54,6 +54,7 @@ public:
     virtual Transform getWorldFrameTransform(const FrameIndex& frameIndex);
     virtual Transform getWorldLinkTransform(const std::string& linkName);
     virtual Transform getWorldFrameTransform(const std::string& frameName);
+    virtual ILabel& label();
 };
 
 }

--- a/src/visualization/src/VectorsVisualization.cpp
+++ b/src/visualization/src/VectorsVisualization.cpp
@@ -245,6 +245,18 @@ bool VectorsVisualization::setVectorsAspect(double zeroModulusRadius, double mod
     return true;
 }
 
+bool VectorsVisualization::setVisible(size_t vectorIndex, bool visible)
+{
+    if (vectorIndex >= m_vectors.size()) {
+        reportError("VectorsVisualization","setVisible","vectorIndex out of bounds.");
+        return false;
+    }
+
+    m_vectors[vectorIndex].visualizationNode->setVisible(visible);
+
+    return true;
+}
+
 ILabel *VectorsVisualization::getVectorLabel(size_t vectorIndex)
 {
     if (vectorIndex >= m_vectors.size()) {

--- a/src/visualization/src/VectorsVisualization.cpp
+++ b/src/visualization/src/VectorsVisualization.cpp
@@ -22,13 +22,6 @@ using namespace iDynTree;
 
 void VectorsVisualization::drawVector(size_t vectorIndex)
 {
-    // Delete existing node
-    if (m_vectors[vectorIndex].visualizationNode)
-    {
-        m_vectors[vectorIndex].visualizationNode->remove();
-        m_vectors[vectorIndex].visualizationNode = nullptr;
-    }
-
     float arrowHeight = static_cast<float>(std::abs(m_vectors[vectorIndex].modulus) * m_heightScale);
     float arrowWidth = static_cast<float>(m_radiusOffset +
                                           m_radiusMultiplier * std::abs(m_vectors[vectorIndex].modulus) * m_heightScale);
@@ -58,7 +51,14 @@ void VectorsVisualization::drawVector(size_t vectorIndex)
     irr::scene::IMesh* arrowMesh = m_smgr->getGeometryCreator()->createArrowMesh(4, 8, arrowHeight, 0.9f * arrowHeight,
                                                                                  arrowWidth, 2.0f * arrowWidth);
 
-    m_vectors[vectorIndex].visualizationNode = m_smgr->addMeshSceneNode(arrowMesh,frameNode);
+    if (m_vectors[vectorIndex].visualizationNode)
+    {
+        m_vectors[vectorIndex].visualizationNode->setMesh(arrowMesh);
+    }
+    else
+    {
+        m_vectors[vectorIndex].visualizationNode = m_smgr->addMeshSceneNode(arrowMesh,frameNode);
+    }
     m_vectors[vectorIndex].visualizationNode->setPosition(arrowPosition);
     m_vectors[vectorIndex].visualizationNode->setRotation(arrowRotation);
     irr::video::SMaterial arrowColor;
@@ -128,6 +128,7 @@ size_t VectorsVisualization::addVector(const Position &origin, const Direction &
     m_vectors.push_back(newVector);
 
     drawVector(m_vectors.size()-1);
+    m_vectors.back().label.init(m_smgr, m_vectors.back().visualizationNode);
 
     return m_vectors.size() - 1;
 }
@@ -242,4 +243,14 @@ bool VectorsVisualization::setVectorsAspect(double zeroModulusRadius, double mod
     drawAll();
 
     return true;
+}
+
+ILabel *VectorsVisualization::getVectorLabel(size_t vectorIndex)
+{
+    if (vectorIndex >= m_vectors.size()) {
+        reportError("VectorsVisualization","getVectorLabel","vectorIndex out of bounds.");
+        return nullptr;
+    }
+
+    return &m_vectors[vectorIndex].label;
 }

--- a/src/visualization/src/VectorsVisualization.h
+++ b/src/visualization/src/VectorsVisualization.h
@@ -11,6 +11,7 @@
 #define IDYNTREE_VECTORS_VISUALIZATION_H
 
 #include <iDynTree/Visualizer.h>
+#include "Label.h"
 
 #include <vector>
 #include <irrlicht.h>
@@ -24,7 +25,8 @@ namespace iDynTree {
             Direction direction;
             double modulus;
             ColorViz color = ColorViz(1.0, 0.0, 0.0, 1.0);
-            irr::scene::ISceneNode * visualizationNode = nullptr;
+            Label label;
+            irr::scene::IMeshSceneNode * visualizationNode = nullptr;
         } VectorsProperties;
 
         ColorViz m_vectorsDefaultColor{ColorViz(1.0, 0.0, 0.0, 1.0)};
@@ -75,6 +77,8 @@ namespace iDynTree {
         virtual void setVectorsColor(const ColorViz &vectorColor) override;
 
         virtual bool setVectorsAspect(double zeroModulusRadius, double modulusMultiplier, double heightScale) override;
+
+        virtual ILabel* getVectorLabel(size_t vectorIndex) override;
 
     };
 

--- a/src/visualization/src/VectorsVisualization.h
+++ b/src/visualization/src/VectorsVisualization.h
@@ -78,6 +78,8 @@ namespace iDynTree {
 
         virtual bool setVectorsAspect(double zeroModulusRadius, double modulusMultiplier, double heightScale) override;
 
+        virtual bool setVisible(size_t vectorIndex, bool visible) override;
+
         virtual ILabel* getVectorLabel(size_t vectorIndex) override;
 
     };

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -551,6 +551,10 @@ ITexturesHandler &Visualizer::textures()
 ILabel &Visualizer::getLabel(const std::string &labelName)
 {
 #ifdef IDYNTREE_USES_IRRLICHT
+    if( !this->pimpl->m_isInitialized )
+    {
+        init();
+    }
     Label& requestedLabel =  this->pimpl->m_labels[labelName];
     if (!requestedLabel.initialized())
     {

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -22,10 +22,12 @@
 #include "FrameVisualization.h"
 #include "TexturesHandler.h"
 #include "CameraAnimator.h"
+#include "Label.h"
 #endif
 
 #include "DummyImplementations.h"
 
+#include <unordered_map>
 #include <cassert>
 
 namespace iDynTree
@@ -152,7 +154,16 @@ struct Visualizer::VisualizerPimpl
      */
     TexturesHandler m_textures;
 
+    /**
+     * Dimension of the root frame arrows
+     */
     double rootFrameArrowsDimension;
+
+    /**
+     * Set of labels
+     */
+    std::unordered_map<std::string, Label> m_labels;
+
     struct ColorPalette
     {
         irr::video::SColorf background = irr::video::SColorf(0.0,0.4,0.4,1.0);
@@ -190,6 +201,7 @@ struct Visualizer::VisualizerPimpl
     DummyVectorsVisualization m_invalidVectors;
     DummyFrameVisualization m_invalidFrames;
     DummyTexturesHandler m_invalidTextures;
+    DummyLabel m_invalidLabel;
 #endif
 
     VisualizerPimpl()
@@ -533,6 +545,20 @@ ITexturesHandler &Visualizer::textures()
     return this->pimpl->m_textures;
 #else
     return this->pimpl->m_invalidTextures;
+#endif
+}
+
+ILabel &Visualizer::getLabel(const std::string &labelName)
+{
+#ifdef IDYNTREE_USES_IRRLICHT
+    Label& requestedLabel =  this->pimpl->m_labels[labelName];
+    if (!requestedLabel.initialized())
+    {
+        requestedLabel.init(this->pimpl->m_irrSmgr);
+    }
+    return requestedLabel;
+#else
+    return this->pimpl->m_invalidLabel;
 #endif
 }
 

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -56,6 +56,10 @@ IModelVisualization::~IModelVisualization()
 {
 }
 
+ILabel::~ILabel()
+{
+}
+
 ILight::~ILight()
 {
 }

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -76,7 +76,7 @@ void checkArrowsVisualization() {
     ok = vectors.updateVector(index, iDynTree::Position(0.2, 0.1, 0.1), components);
     ASSERT_IS_TRUE(ok);
 
-
+    vectors.getVectorLabel(0)->setText("Vector0");
 
     for(int i=0; i < 5; i++)
     {

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -23,6 +23,11 @@ void checkVizLoading(const iDynTree::Model & model)
     bool ok = viz.addModel(model,"model");
     ASSERT_IS_TRUE(ok);
 
+    iDynTree::ILabel& label = viz.modelViz("model").label();
+    label.setText("TEST MODEL");
+    label.setSize(1.0);
+    label.setPosition(iDynTree::Position(-1.0, -1.0, 0.3));
+
     for(int i=0; i < 5; i++)
     {
         viz.draw();

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -186,12 +186,29 @@ void checkFrameVisualization() {
 
 }
 
+void checkLabelVisualization()
+{
+    iDynTree::Visualizer viz;
+
+    iDynTree::ILabel& label = viz.getLabel("dummy");
+    label.setText("Label test");
+    label.setSize(1.0);
+    label.setPosition(iDynTree::Position(-1.0, -1.0, 0.1));
+    label.setColor(iDynTree::ColorViz(1.0, 0.0, 0.0, 0.0));
+
+    for(int i=0; i < 5; i++)
+    {
+        viz.draw();
+    }
+}
+
 int main()
 {
     threeLinksReducedTest();
     checkArrowsVisualization();
     checkAdditionalTexture();
     checkFrameVisualization();
+    checkLabelVisualization();
 
     return EXIT_SUCCESS;
 }

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -141,6 +141,7 @@ void checkFrameVisualization() {
 
     size_t index = frames.addFrame(firstTransform);
     ASSERT_IS_TRUE(index == 0);
+    frames.getFrameLabel(0)->setText("First");
 
     iDynTree::Transform secondTransform;
     secondTransform.setRotation(iDynTree::Rotation::RPY(-1.57, 0,0));
@@ -148,6 +149,7 @@ void checkFrameVisualization() {
 
     index = frames.addFrame(secondTransform);
     ASSERT_IS_TRUE(index == 1);
+    frames.getFrameLabel(1)->setText("Second");
 
     for(int i=0; i < 5; i++)
     {

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -83,6 +83,14 @@ void checkArrowsVisualization() {
         viz.draw();
     }
 
+    ok = vectors.setVisible(0, false);
+    ASSERT_IS_TRUE(ok);
+
+    for(int i=0; i < 5; i++)
+    {
+        viz.draw();
+    }
+
     viz.close();
 }
 


### PR DESCRIPTION
This PR adds the visualization of labels.

The labels can be free objects or attached to vectors, frames or models. Thus, if the corresponding parent object moves, also the label moves.

The font quality is not the best, but it is a start.

The label is always facing the camera, as in the video

https://user-images.githubusercontent.com/18591940/121932696-725bfa00-cd45-11eb-8a3c-d48334d8422b.mp4
