### PR TITLE
Remove deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Remove headers `iDynTree/Core/AngularForceVector3.h`, `iDynTree/Core/AngularMotionVector3.h`, `include/iDynTree/Core/ForceVector3.h`, `iDynTree/Core/LinearForceVector3.h`, `include/iDynTree/Core/LinearMotionVector3.h`, `include/iDynTree/Core/MotionVector3.h`. They were deprecated in iDynTree 2.0 (https://github.com/robotology/idyntree/pull/708, https://github.com/robotology/idyntree/pull/885).
+- The method `ModelVisualization::getWorldModelTransform()` was removed, it was deprecated in iDynTree 3.0.1 .
 
 ## [Unreleased]
 
 ### Added
 - Add the `is/asPrismaticJoint` methods in the bindings (https://github.com/robotology/idyntree/issues/881, https://github.com/robotology/idyntree/pull/882)
->>>>>>> master
 
 ## [3.2.1] - 2021-06-07
 

--- a/src/sensors/include/iDynTree/Sensors/Sensors.h
+++ b/src/sensors/include/iDynTree/Sensors/Sensors.h
@@ -331,15 +331,6 @@ namespace iDynTree {
             bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, std::ptrdiff_t & sensor_index) const;
 
             /**
-             * Get the index of a sensor of type sensor_type in this SensorList
-             *
-             * @return true if the sensor name is found, false otherwise.
-             *
-             * @deprecated Use the version that takes in input a  std::ptrdiff_t sensor_index 
-             */
-            IDYNTREE_DEPRECATED_WITH_MSG("Use std::ptrdiff_t for representing the SensorIndex.") bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, unsigned int & sensor_index) const;
-
-            /**
              * Get the index of a sensor of type sensor_type and with name sensor_name
              *
              * @return the sensor index if the sensor_name is found, -1 otherwise.

--- a/src/sensors/src/Sensors.cpp
+++ b/src/sensors/src/Sensors.cpp
@@ -202,18 +202,6 @@ bool SensorsList::getSensorIndex(const SensorType & sensor_type, const std::stri
     }
 }
 
-bool SensorsList::getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, unsigned int & sensor_index) const
-{
-    std::ptrdiff_t sensor_index_full ;
-    bool ret = this->getSensorIndex(sensor_type, _sensor_name, sensor_index_full);
-    if (ret) 
-    {
-        sensor_index = static_cast<unsigned int>(sensor_index_full);
-    }
-    return ret;
-}
-
-
 std::ptrdiff_t SensorsList::getSensorIndex(const SensorType& sensor_type, const std::string& _sensor_name) const
 {
     std::ptrdiff_t retVal;

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -688,14 +688,6 @@ public:
     virtual IJetsVisualization& jets() = 0;
 
     /**
-     * Get the transformation of the model (root link) with respect to visualizer world \f$ w_H_{root}\f$
-     * The obtained transformation matrix can be used to map any homogeneous vector from the
-     * model's root link frame to the visualizer world frame.
-     */
-    IDYNTREE_DEPRECATED_WITH_MSG("This method is simply returning the identity. If you need the root link transformation matrix, please use the getWorldLinkTransform(<root link frame index>) method.")
-    virtual Transform getWorldModelTransform() = 0;
-
-    /**
      * Get the transformation of given link with respect to visualizer world \f$ w_H_{link}\f$
      */
     virtual Transform getWorldLinkTransform(const LinkIndex& linkIndex) = 0;

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -166,7 +166,6 @@ public:
     virtual std::vector<std::string> getFeatures() { return std::vector<std::string>(); }
     virtual bool setFeatureVisibility(const std::string& , bool) { return false; }
     virtual IJetsVisualization& jets() { return m_dummyJets;  }
-    virtual Transform getWorldModelTransform() { return iDynTree::Transform::Identity(); }
     virtual Transform getWorldLinkTransform(const LinkIndex &) { return iDynTree::Transform::Identity(); }
     virtual Transform getWorldFrameTransform(const FrameIndex &) { return iDynTree::Transform::Identity(); }
     virtual Transform getWorldLinkTransform(const std::string &) { return iDynTree::Transform::Identity(); }

--- a/src/visualization/src/ModelVisualization.cpp
+++ b/src/visualization/src/ModelVisualization.cpp
@@ -225,14 +225,6 @@ Model& ModelVisualization::model()
     return this->pimpl->m_model;
 }
 
-Transform ModelVisualization::getWorldModelTransform()
-{
-    Transform w_H_b;
-    irr::core::matrix4 relativeTransform(this->pimpl->modelNode->getRelativeTransformation());
-    w_H_b = irr2idyntree_trans(relativeTransform);
-    return w_H_b;
-}
-
 Transform ModelVisualization::getWorldLinkTransform(const LinkIndex& linkIndex)
 {
     if (linkIndex < 0 || linkIndex >= pimpl->geomNodes.size())

--- a/src/visualization/src/ModelVisualization.h
+++ b/src/visualization/src/ModelVisualization.h
@@ -49,7 +49,6 @@ public:
     void setWireframeVisibility(bool isVisible);
     void setTransparent(bool isTransparent);
     virtual IJetsVisualization& jets();
-    virtual Transform getWorldModelTransform();
     virtual Transform getWorldLinkTransform(const LinkIndex& linkIndex);
     virtual Transform getWorldFrameTransform(const FrameIndex& frameIndex);
     virtual Transform getWorldLinkTransform(const std::string& linkName);


### PR DESCRIPTION
Removed methods:
* `iDynTree::Visualizer::IModelVisualization::getWorldModelTransform`
* `bool getSensorIndex(const SensorType & sensor_type, const std::string & _sensor_name, unsigned int & sensor_index)` (`unsigned int` overload, for this it is not mentioned in the release note to avoid confusion)