### PR TITLE
Permit to build bindings against an external iDynTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add the `is/asPrismaticJoint` methods in the bindings (https://github.com/robotology/idyntree/issues/881, https://github.com/robotology/idyntree/pull/882)
+- Add the possibility of building the binding of iDynTree (`bindings` directory) on their own, against an already compiled system iDynTree (https://github.com/robotology/idyntree/pull/892/, https://github.com/robotology/robotology-superbuild/pull/817).
 
 ### Deprecated
 - The tools that depend on YARP (`urdf2dh`, `yarprobotstatepublisher`, `idyntree-sole-gui`, `iDynTreePlotter`) have been moved in [`idyntree-yarp-tools`](https://github.com/robotology/idyntree-yarp-tools) and their use in iDynTree has been deprecated. The option `IDYNTREE_COMPILES_YARP_TOOLS` has been introduced to disable their compilation. This option is set by default to `ON` on iDynTree 3, will exist but default to `OFF` in iDynTree 4, and will be removed in iDynTree 5.

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,9 +1,27 @@
+cmake_minimum_required(VERSION 3.16)
+project(iDynTreeBindings)
+
+# Detect if we are doing a standalone build of the bindings, using an external iDynTree
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(IDYNTREE_BINDINGS_BUILD_STANDALONE TRUE)
+else()
+  set(IDYNTREE_BINDINGS_BUILD_STANDALONE FALSE)
+endif()
+
+if(IDYNTREE_BINDINGS_BUILD_STANDALONE)
+  # Add CMake helpers
+  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)
+  find_package(iDynTree REQUIRED)
+  set(IDYNTREE_LIBRARIES ${iDynTree_LIBRARIES})
+else()
+  get_property(IDYNTREE_LIBRARIES GLOBAL PROPERTY ${VARS_PREFIX}_TARGETS)
+endif()
+
 
 #############################################################################
 ## Options for compiling supported languages.  There's nothing magical
 ## about this list, any SWIG-supported language should work - take a
 ## look at e.g. ruby code below for how to do it.
-
 option(IDYNTREE_USES_PYTHON "Do you want to create the Python bindings" FALSE)
 option(IDYNTREE_USES_LUA "Do you want to create the Lua bindings" FALSE)
 option(IDYNTREE_USES_MATLAB "Do you want to create the MATLAB bindings" FALSE)
@@ -44,8 +62,6 @@ if(SWIG_FOUND OR IDYNTREE_USES_MATLAB OR IDYNTREE_USES_OCTAVE)
 
     set_source_files_properties(iDynTree.i PROPERTIES CPLUSPLUS ON)
 
-    get_property(IDYNTREE_LIBRARIES GLOBAL PROPERTY ${VARS_PREFIX}_TARGETS)
-
     # From https://github.com/robotology/yarp/blob/v3.3.0/bindings/CMakeLists.txt#L49
     foreach(_lib IN LISTS IDYNTREE_LIBRARIES)
         get_property(_include_dirs TARGET ${_lib} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
@@ -62,8 +78,10 @@ if(SWIG_FOUND OR IDYNTREE_USES_MATLAB OR IDYNTREE_USES_OCTAVE)
 
     link_libraries(${IDYNTREE_LIBRARIES})
 
-    # Remove the deprecation warnings because by definition we always build bindings also of deprecated modules
-    idyntree_disable_deprecation_warnings()
+    if(NOT IDYNTREE_BINDINGS_BUILD_STANDALONE)
+      # Remove the deprecation warnings because by definition we always build bindings also of deprecated modules
+      idyntree_disable_deprecation_warnings()
+    endif()
 
     # list all dependencies of the process of generating
     # SWIG bindings (for now just .i files included in the main

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -111,7 +111,7 @@ if(IDYNTREE_USES_MATLAB)
           ${IDYNTREE_GENERATE_MATLAB}
           ${MEX_BINDINGS_SOURCE_DIR})
 
-  target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} idyntree-core ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY})
+  target_link_libraries(${target_name} ${IDYNTREE_LIBRARIES} ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY})
 
   # Install the generated front-end to ${CMAKE_INSTALL_PREFIX}/mex
   install(


### PR DESCRIPTION
This will permit to compile iDynTree's bindings against an externally provided iDynTree. This will permit to mantain iDynTree conda package in conda-forge (for going in the direction of https://github.com/robotology/robotology-superbuild/issues/752), and still have a `idyntree-matlab-bindings` conda package in the `robotology` channel, as it is not possible to build MATLAB/Simulink mex libraries in conda-forge build infrastructure.