### PR TITLE
Implement the first version of the meshcat visualizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Release]
         os: [ubuntu-18.04, ubuntu-20.04, windows-latest, macOS-latest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.0] - 2021-07-21
+## [4.1.0] - 2021-07-22
 
 ### Added
 - Add the `MeshcatVisualizer` Python class (https://github.com/robotology/idyntree/pull/901). This class uses [meshcat](https://github.com/rdeits/meshcat-python) to visualize the state of a model either in a browser or in a Jupyter cell. Check the example in `examples/python/MeshcatVisualizerExample.ipynb`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2021-07-21
+
+### Added
+- Add the `MeshcatVisualizer` Python class (https://github.com/robotology/idyntree/pull/901). This class uses [meshcat](https://github.com/rdeits/meshcat-python) to visualize the state of a model either in a browser or in a Jupyter cell. Check the example in `examples/python/MeshcatVisualizerExample.ipynb`.
+
 ## [4.0.0] - 2021-07-16
 
 ### Added
 - Add the visualization of labels in the visualizer (https://github.com/robotology/idyntree/pull/879)
-- Implement the `MeshcatVisualizer` python class (https://github.com/robotology/idyntree/pull/901)
 
 ### Removed
 - Remove headers `iDynTree/Core/AngularForceVector3.h`, `iDynTree/Core/AngularMotionVector3.h`, `include/iDynTree/Core/ForceVector3.h`, `iDynTree/Core/LinearForceVector3.h`, `include/iDynTree/Core/LinearMotionVector3.h`, `include/iDynTree/Core/MotionVector3.h`. They were deprecated in iDynTree 2.0 (https://github.com/robotology/idyntree/pull/708, https://github.com/robotology/idyntree/pull/885).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add the visualization of labels in the visualizer (https://github.com/robotology/idyntree/pull/879)
+- Implement the `MeshcatVisualizer` python class (https://github.com/robotology/idyntree/pull/901)
 
 ### Removed
 - Remove headers `iDynTree/Core/AngularForceVector3.h`, `iDynTree/Core/AngularMotionVector3.h`, `include/iDynTree/Core/ForceVector3.h`, `iDynTree/Core/LinearForceVector3.h`, `include/iDynTree/Core/LinearMotionVector3.h`, `include/iDynTree/Core/MotionVector3.h`. They were deprecated in iDynTree 2.0 (https://github.com/robotology/idyntree/pull/708, https://github.com/robotology/idyntree/pull/885).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 4.0.0
+project(iDynTree VERSION 4.1.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ They are a collection of Matlab/Octave functions that wraps the functionalities 
 | How to read the Six Axis Force Torque sensors information contained in a URDF model. | [examples/matlab/GetJointAxesInWorldFrame.m](examples/matlab/GetJointAxesInWorldFrame.m) | MATLAB |
 | Usage of the MATLAB-native visualizer using the [MATLAB high-level wrappers](bindings/matlab/+iDynTreeWrappers/README.md). | [examples/matlab/iDynTreeWrappers/visualizeRobot.m](examples/matlab/iDynTreeWrappers/visualizeRobot.m) | MATLAB |
 | Basic usage of the [KinDynComputations class](https://robotology.github.io/idyntree/master/classiDynTree_1_1KinDynComputations.html). | [examples/python/KinDynComputationsTutorial.py](examples/python/KinDynComputationsTutorial.py) | Python |
+| Basic usage of the [MeshcatVisualizer class](bindings/python/visualize/meshcat_visualizer.py). | [examples/python/MeshcatVisualizerExample.ipynb](examples/python/MeshcatVisualizerExample.ipynb) | Python |
 
 Are you interested in a tutorial on a specific feature or algorithm? Just [request it on an enhancement issue](https://github.com/robotology/idyntree/issues/new).
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -139,7 +139,7 @@ if (IDYNTREE_USES_PYTHON_PYBIND11 OR IDYNTREE_USES_PYTHON)
     endif()
     # If SWIG is enabled, add the corresponding import.
     if (${IDYNTREE_USES_PYTHON})
-        file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/__init__.py" "from . import swig${NEW_LINE}")
+        file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/__init__.py" "from . import swig${NEW_LINE}from . import visualize${NEW_LINE}")
         # Create also an alias from swig to the old `bindings` import.
         file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/bindings.py" "from .swig import *${NEW_LINE}")
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bindings.py"

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -39,6 +39,8 @@ install(
 
 install(TARGETS ${target_name} DESTINATION ${PYTHON_INSTDIR})
 
+install(DIRECTORY visualize DESTINATION ${PYTHON_INSTDIR})
+
 if(WIN32)
     set_target_properties(${target_name} PROPERTIES SUFFIX ".pyd")
 endif(WIN32)

--- a/bindings/python/visualize/__init__.py
+++ b/bindings/python/visualize/__init__.py
@@ -1,0 +1,1 @@
+from .meshcat_visualizer import MeshcatVisualizer

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -99,7 +99,7 @@ class MeshcatVisualizer:
         import meshcat
 
         if not self.__model_exists(model_name):
-            msg = "The model named: " +  model_name + " already exists."
+            msg = "The model named: " +  model_name + " does not exist."
             warnings.warn(msg, category=UserWarning, stacklevel=2)
             return
 
@@ -165,7 +165,7 @@ class MeshcatVisualizer:
         """Display the robot at given configuration."""
 
         if not self.__model_exists(model_name):
-            msg = "The model named: " +  model_name + " already exists."
+            msg = "The model named: " +  model_name + " does not exist."
             warnings.warn(msg, category=UserWarning, stacklevel=2)
             return
 

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -28,7 +28,7 @@ class MeshcatVisualizer:
         self.model = dict()
         self.link_pos = dict()
 
-    def __is_mesh(self, geometry_object):
+    def __is_mesh(self, geometry_object) -> bool:
 
         mesh_path = geometry_object.asExternalMesh().getFileLocationOnLocalFileSystem()
 

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -1,0 +1,262 @@
+"""
+Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia
+
+Licensed under either the GNU Lesser General Public License v3.0 :
+https://www.gnu.org/licenses/lgpl-3.0.html
+or the GNU Lesser General Public License v2.1 :
+https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+at your option.
+"""
+
+import os
+import idyntree.bindings as idyn
+import numpy as np
+import warnings
+import meshcat
+
+
+class MeshcatVisualizer:
+    """
+    A simple wrapper to the meshcat visualizer. The MeshcatVisualizer class is highly inspired by the Pinocchio version
+    of the MeshCat visualizer
+    https://github.com/stack-of-tasks/pinocchio/blob/b134b25f1409f5bf036105b996da2d29c1a66a12/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+    """
+
+    def __init__(self):
+        self.viewer = meshcat.Visualizer()
+        self.traversal = dict()
+        self.model = dict()
+        self.link_pos = dict()
+
+    def __is_mesh(self, geometry_object):
+
+        mesh_path = geometry_object.asExternalMesh().getFileLocationOnLocalFileSystem()
+
+        # Check whether the geometry object contains a Mesh supported by MeshCat
+        if mesh_path == "":
+            return False
+
+        _, file_extension = os.path.splitext(mesh_path)
+        if file_extension.lower() in [".dae", ".obj", ".stl"]:
+            return True
+
+        return False
+
+    def __load_mesh(self, geometry_object):
+
+        mesh_path = geometry_object.asExternalMesh().getFileLocationOnLocalFileSystem()
+
+        # try to import the mesh
+        if mesh_path == "":
+            return None
+
+        _, file_extension = os.path.splitext(mesh_path)
+
+        basename = os.path.basename(mesh_path)
+        file_name = os.path.splitext(basename)[0]
+
+        geometry_object.asExternalMesh().setName(file_name)
+
+        if file_extension.lower() == ".dae":
+            obj = meshcat.geometry.DaeMeshGeometry.from_file(mesh_path)
+        elif file_extension.lower() == ".obj":
+            obj = meshcat.geometry.ObjMeshGeometry.from_file(mesh_path)
+        elif file_extension.lower() == ".stl":
+            obj = meshcat.geometry.StlMeshGeometry.from_file(mesh_path)
+        else:
+            msg = "The following mesh cannot be loaded: {}.".format(mesh_path)
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            obj = None
+
+        return obj
+
+    def __apply_transform(self, world_H_frame, solid_shape, viewer_name):
+        world_H_geometry = (world_H_frame * solid_shape.getLink_H_geometry()).asHomogeneousTransform().toNumPy()
+        scale = list(solid_shape.asExternalMesh().getScale().toNumPy().flatten())
+        extended_scale = np.diag(np.concatenate((scale, [1.0])))
+        world_H_geometry_scaled = np.array(world_H_geometry).dot(extended_scale)
+
+        # Update viewer configuration.
+        self.viewer[viewer_name].set_transform(world_H_geometry_scaled)
+
+    def __model_exists(self, model_name):
+
+        if model_name in self.model.keys():
+            return True
+
+        if model_name in self.traversal.keys():
+            return True
+
+        if model_name in self.link_pos.keys():
+            return True
+
+        return False
+
+    def __add_model_geometry_to_viewer(self, model, model_geometry: idyn.ModelSolidShapes,
+                                       model_name, color):
+        import meshcat.geometry
+
+        if not self.__model_exists(model_name):
+            msg = "The model named: " +  model_name + " already exists."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        # Solve forward kinematics
+        joint_pos = idyn.VectorDynSize(self.model[model_name].getNrOfJoints())
+        joint_pos.zero()
+        idyn.ForwardPositionKinematics(self.model[model_name], self.traversal[model_name],
+                                       idyn.Transform.Identity(), joint_pos,
+                                       self.link_pos[model_name])
+
+        link_solid_shapes = model_geometry.getLinkSolidShapes()
+
+        for link_index in range(0, self.model[model_name].getNrOfLinks()):
+
+            world_H_frame = self.link_pos[model_name](link_index)
+            link_name = self.model[model_name].getLinkName(link_index)
+
+            is_mesh = False
+            for geom in range(0, len(link_solid_shapes[link_index])):
+                solid_shape = model_geometry.getLinkSolidShapes()[link_index][geom]
+                if self.__is_mesh(solid_shape):
+                    obj = self.__load_mesh(solid_shape)
+                    is_mesh = True
+                else:
+                    msg = "The geometry object named " \
+                          + solid_shape.asExternalMesh().getName() \
+                          + " is not supported by iDynTree/MeshCat for visualization."
+                    warnings.warn(msg, category=UserWarning, stacklevel=2)
+                    continue
+
+                if obj is None:
+                    msg = "The geometry object named " + solid_shape.asExternalMesh().getName() + " is not valid."
+                    warnings.warn(msg, category=UserWarning, stacklevel=2)
+                    continue
+
+                viewer_name = model_name + "/" + link_name + "/" + solid_shape.asExternalMesh().getName()
+
+                if isinstance(obj, meshcat.geometry.Object):
+                    self.viewer[viewer_name].set_object(obj)
+                elif isinstance(obj, meshcat.geometry.Geometry):
+                    material = meshcat.geometry.MeshPhongMaterial()
+                    # Set material color from URDF, converting for triplet of doubles to a single int.
+                    if color is None:
+                        mesh_color = solid_shape.getMaterial().color()
+                    else:
+                        mesh_color = color
+
+                    material.color = int(mesh_color[0] * 255) * 256 ** 2 + \
+                                     int(mesh_color[1] * 255) * 256 + \
+                                     int(mesh_color[2] * 255)
+
+                    # Add transparency, if needed.
+                    if float(mesh_color[3]) != 1.0:
+                        material.transparent = True
+                        material.opacity = float(mesh_color[3])
+
+                    self.viewer[viewer_name].set_object(obj, material)
+
+                    if is_mesh:
+                        self.__apply_transform(world_H_frame, solid_shape, viewer_name)
+
+    def display(self, base_position, base_rotation, joint_value, model_name='iDynTree'):
+        """Display the robot at given configuration."""
+
+        if not self.__model_exists(model_name):
+            msg = "The model named: " +  model_name + " already exists."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        base_rotation_idyn = idyn.Rotation()
+        base_position_idyn = idyn.Position()
+        base_pose_idyn = idyn.Transform()
+
+        for i in range(0, 3):
+            base_position_idyn.setVal(i, base_position[i])
+            for j in range(0, 3):
+                base_rotation_idyn.setVal(i, j, base_rotation[i, j])
+
+        base_pose_idyn.setRotation(base_rotation_idyn)
+        base_pose_idyn.setPosition(base_position_idyn)
+
+        if len(joint_value) != self.model[model_name].getNrOfJoints():
+            msg = "The size of the joint_values is different from the model DoFs"
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        joint_pos_idyn = idyn.VectorDynSize(self.model[model_name].getNrOfJoints())
+        for i in range(0, self.model[model_name].getNrOfJoints()):
+            joint_pos_idyn.setVal(i, joint_value[i])
+
+        # Solve forward kinematics
+        idyn.ForwardPositionKinematics(self.model[model_name], self.traversal[model_name], base_pose_idyn,
+                                       joint_pos_idyn, self.link_pos[model_name])
+
+        # Update the visual shapes
+        model_geometry = self.model[model_name].visualSolidShapes()
+        link_solid_shapes = model_geometry.getLinkSolidShapes()
+
+        for link_index in range(0, self.model[model_name].getNrOfLinks()):
+
+            link_name = self.model[model_name].getLinkName(link_index)
+            for geom in range(0, len(link_solid_shapes[link_index])):
+                solid_shape = model_geometry.getLinkSolidShapes()[link_index][geom]
+                if self.__is_mesh(solid_shape):
+                    viewer_name = model_name + "/" + link_name + "/" + solid_shape.asExternalMesh().getName()
+                    self.__apply_transform(self.link_pos[model_name](link_index), solid_shape, viewer_name)
+
+    def open(self):
+        self.viewer.open()
+
+    def jupyter_cell(self):
+        self.viewer.jupyter_cell()
+
+    def set_model_from_file(self, model_path: str, considered_joints=None, model_name='iDynTree'):
+
+        if self.__model_exists(model_name):
+            msg = "The model named: " +  model_name + " already exists."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+
+        model_loader = idyn.ModelLoader()
+        if considered_joints is None:
+            ok = model_loader.loadModelFromFile(model_path)
+        else:
+            considered_joints_idyn = idyn.StringVector()
+            for joint in considered_joints:
+                considered_joints_idyn.push_back(joint)
+
+            ok = model_loader.loadReducedModelFromFile(model_path, considered_joints_idyn)
+
+        if not ok:
+            msg = "Unable to load the model named: " + model_name + " from the file: " + model_path + "."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        self.model[model_name] = model_loader.model().copy()
+        self.traversal[model_name] = idyn.Traversal()
+        self.link_pos[model_name] = idyn.LinkPositions()
+
+        self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
+        self.link_pos[model_name].resize(self.model[model_name])
+
+    def set_model(self, model: idyn.Model, model_name='iDynTree'):
+
+        if self.__model_exists(model_name):
+            msg = "The model named: " + model_name + " already exists."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        self.model[model_name] = model.copy()
+        self.traversal[model_name] = idyn.Traversal()
+        self.link_pos[model_name] = idyn.LinkPositions()
+
+        self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
+        self.link_pos[model_name].resize(self.model[model_name])
+
+    def load_model(self, model_name='iDynTree', color=None):
+        self.__add_model_geometry_to_viewer(self.model,
+                                            self.model[model_name].visualSolidShapes(),
+                                            model_name,
+                                            color)

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -12,7 +12,6 @@ import os
 import idyntree.bindings as idyn
 import numpy as np
 import warnings
-import meshcat
 
 
 class MeshcatVisualizer:
@@ -23,6 +22,7 @@ class MeshcatVisualizer:
     """
 
     def __init__(self):
+        import meshcat
         self.viewer = meshcat.Visualizer()
         self.traversal = dict()
         self.model = dict()
@@ -43,6 +43,8 @@ class MeshcatVisualizer:
         return False
 
     def __load_mesh(self, geometry_object):
+
+        import meshcat
 
         mesh_path = geometry_object.asExternalMesh().getFileLocationOnLocalFileSystem()
 
@@ -94,7 +96,7 @@ class MeshcatVisualizer:
 
     def __add_model_geometry_to_viewer(self, model, model_geometry: idyn.ModelSolidShapes,
                                        model_name, color):
-        import meshcat.geometry
+        import meshcat
 
         if not self.__model_exists(model_name):
             msg = "The model named: " +  model_name + " already exists."

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -211,7 +211,7 @@ class MeshcatVisualizer:
         self.viewer.open()
 
     def jupyter_cell(self):
-        self.viewer.jupyter_cell()
+        return self.viewer.jupyter_cell()
 
     def set_model_from_file(self, model_path: str, considered_joints=None, model_name='iDynTree'):
 

--- a/examples/python/MeshcatVisualizerExample.ipynb
+++ b/examples/python/MeshcatVisualizerExample.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MeshcatVisualizer a simple example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from idyntree.visualize import MeshcatVisualizer\n",
+    "import numpy as np\n",
+    "import os\n",
+    "from ipywidgets import interact, interactive, fixed, interact_manual\n",
+    "import ipywidgets as widgets\n",
+    "from __future__ import print_function\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clone_model():\n",
+    "    \"\"\"Get the model from icub-models. This is usefull to have a standalone example.\"\"\"\n",
+    "    import zipfile\n",
+    "    import urllib.request\n",
+    "    import tempfile\n",
+    "    model_url = 'https://github.com/robotology/icub-models/archive/refs/tags/v1.20.0.zip'\n",
+    "    model = urllib.request.urlopen(model_url)\n",
+    "    temp = tempfile.NamedTemporaryFile()\n",
+    "    temp_folder = tempfile.TemporaryDirectory()\n",
+    "    temp.write(model.read())\n",
+    "    with zipfile.ZipFile(temp.name, 'r') as zip_obj:\n",
+    "        zip_obj.extractall(temp_folder.name)\n",
+    "\n",
+    "    build_path = os.path.join(temp_folder.name, 'icub-models-1.20.0', 'build')\n",
+    "    os.mkdir(build_path)\n",
+    "    os.chdir(build_path)\n",
+    "\n",
+    "    os.system('cmake ..')\n",
+    "    return temp_folder, build_path\n",
+    "\n",
+    "\n",
+    "def expand_enviroment_variable(build_path):\n",
+    "    \"\"\"Expand the enviroment data. This is usefull to have a standalone example.\"\"\"\n",
+    "    os.environ[\"YARP_DATA_DIRS\"] += os.path.join(build_path, 'iCub')\n",
+    "    os.environ[\"ROS_PACKAGE_PATH\"] += build_path\n",
+    "    os.environ[\"AMENT_PREFIX_PATH\"] += build_path\n",
+    "\n",
+    "def get_model_path(build_path, robot_name='iCubGazeboV2_5'):\n",
+    "    return os.path.join(build_path, 'iCub', 'robots', robot_name, 'model.urdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp_folder, model_parent_dir = clone_model()\n",
+    "expand_enviroment_variable(model_parent_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path = get_model_path(model_parent_dir)\n",
+    "joint_list = [\"torso_pitch\", \"torso_roll\", \"torso_yaw\",\n",
+    "              \"l_shoulder_pitch\", \"l_shoulder_roll\", \"l_shoulder_yaw\", \"l_elbow\",\n",
+    "              \"r_shoulder_pitch\", \"r_shoulder_roll\", \"r_shoulder_yaw\", \"r_elbow\",\n",
+    "              \"l_hip_pitch\", \"l_hip_roll\", \"l_hip_yaw\", \"l_knee\", \"l_ankle_pitch\", \"l_ankle_roll\",\n",
+    "              \"r_hip_pitch\", \"r_hip_roll\", \"r_hip_yaw\", \"r_knee\", \"r_ankle_pitch\", \"r_ankle_roll\"]\n",
+    "joint_dictionary = {joint: (-0.5, 0.5, 0.01) for joint in joint_list}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = MeshcatVisualizer()\n",
+    "viz.set_model_from_file(model_path, joint_list)\n",
+    "viz.load_model(color=[1, 1, 1, 0.8])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def update_the_model(**joint_values):\n",
+    "    R = np.eye(3)\n",
+    "    p = np.array([0.0, 0.0, 0.0])\n",
+    "    s = np.array(list(joint_values.values()))\n",
+    "    viz.display(p, R, s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz.jupyter_cell()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interact(update_the_model, **joint_dictionary);"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR implements the first version of the meshcat visualizer.
You can find further information in #900. 

https://user-images.githubusercontent.com/16744101/126290536-58411e38-bd59-4221-82fc-da8158e7ac85.mp4

Before merging the PR I should:
- [x] Avoid loading `meshcat_visualizer.py` if `meshcat` is not installed in the system
- [ ] Write a test (however I don't know how to test it)
- [x] Update the changelog

@traversaro please modify this comment if you think there is something missing

cc @S-Dafarra 

 