### PR TITLE
Feature/viz viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the conversion from irrlicht pixels to iDynTree pixels. Fixed a typo in the environment method of the visualizer. Fixed the running of two visualizer instances in the same process (https://github.com/robotology/idyntree/pull/903).
+
+### Added
+- Added the possibility to draw in different portions of the visualizer window and textures at the same time. Allow disabling the drawing on textures (https://github.com/robotology/idyntree/pull/903)
 
 ## [4.1.0] - 2021-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- Fixed the conversion from irrlicht pixels to iDynTree pixels. Fixed a typo in the environment method of the visualizer. Fixed the running of two visualizer instances in the same process (https://github.com/robotology/idyntree/pull/903).
 
 ### Added
-- Added the possibility to draw in different portions of the visualizer window and textures at the same time. Allow disabling the drawing on textures (https://github.com/robotology/idyntree/pull/903)
+- Added the possibility to draw in different portions of the visualizer window and textures at the same time. Allow disabling the drawing on textures (https://github.com/robotology/idyntree/pull/903).
+
+### Deprecated
+- The `iDynTree::Visualizer::enviroment()` was deprecated. Please use the `iDynTree::Visualizer::environment()` method instead (https://github.com/robotology/idyntree/pull/903).
+
+### Fixed
+- Fixed the conversion from irrlicht pixels to iDynTree pixels. Fixed a typo in the environment method of the visualizer. Fixed the running of two visualizer instances in the same process (https://github.com/robotology/idyntree/pull/903).
 
 ## [4.1.0] - 2021-07-22
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 4.1.0
+project(iDynTree VERSION 5.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -941,12 +941,12 @@ public:
     /**
      * Get the visualizer width. Note: if the window is resized, this returns the correct size only if run is called first.
      */
-    int width();
+    int width() const;
 
     /**
      * Get the visualizer height. Note: if the window is resized, this returns the correct size only if run is called first.
      */
-    int height();
+    int height() const;
 
     /**
      * Wrap the run method of the Irrlicht device.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -774,6 +774,23 @@ public:
      */
     virtual void enableDraw(bool enabled = true) = 0;
 
+    /**
+     * Get the texture width.
+     */
+    virtual int width() const = 0;
+
+    /**
+     * Get the texture height.
+     */
+    virtual int height() const = 0;
+
+    /**
+     * Set the area used for drawing operations. The entirety of the texture is cleared between two draw() calls.
+     * Use this in conjunction with subDraw() to draw on different parts of the same texture.
+     * Use call it with (0, 0, width(), height()) to draw on the full texture (this is done by default).
+     */
+    virtual bool setSubDrawArea(int xOffsetFromTopLeft, int yOffsetFromTopLeft, int subImageWidth, int subImageHeight) = 0;
+
 };
 
 /**

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -757,6 +757,18 @@ public:
     virtual bool getPixels(std::vector<PixelViz>& pixels) const = 0;
 
     /**
+     * Draw the current texture to a image file.
+     *
+     * The format of the image is desumed from the filename.
+     *
+     * For more info on the process of writing the image,
+     * check irr::video::IVideoDriver::writeImageToFile irrlicht method.
+     *
+     * @return true if all went ok, false otherwise.
+     */
+    virtual bool drawToFile(const std::string filename="iDynTreeVisualizerTextureScreenshot.png") const = 0;
+
+    /**
      * @brief Enable/disable the drawing on the texture.
      * @param enabled If true (default), the visualizer will draw on the texture when calling draw();
      */

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -756,6 +756,12 @@ public:
      */
     virtual bool getPixels(std::vector<PixelViz>& pixels) const = 0;
 
+    /**
+     * @brief Enable/disable the drawing on the texture.
+     * @param enabled If true (default), the visualizer will draw on the texture when calling draw();
+     */
+    virtual void enableDraw(bool enabled = true) = 0;
+
 };
 
 /**
@@ -915,6 +921,16 @@ public:
     ILabel& getLabel(const std::string& labelName);
 
     /**
+     * Get the visualizer width. Note: if the window is resized, this returns the correct size only if run is called first.
+     */
+    int width();
+
+    /**
+     * Get the visualizer height. Note: if the window is resized, this returns the correct size only if run is called first.
+     */
+    int height();
+
+    /**
      * Wrap the run method of the Irrlicht device.
      */
     bool run();
@@ -925,7 +941,12 @@ public:
     void draw();
 
     /**
-     * Right the current visualization to a image file.
+     * Draw the visualization in a subportion of the window. Need to call draw once done.
+     */
+    void subDraw(int xOffsetFromTopLeft, int yOffsetFromTopLeft, int subImageWidth, int subImageHeight);
+
+    /**
+     * Draw the current visualization to a image file.
      *
      * The format of the image is desumed from the filename.
      *

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -910,7 +910,13 @@ public:
     /**
      * Return an interface to manipulate the visualization environment.
      */
+    IDYNTREE_DEPRECATED_WITH_MSG("Please use the environment method instead (this method has a typo).")
     IEnvironment& enviroment();
+
+    /**
+     * Return an interface to manipulate the visualization environment.
+     */
+    IEnvironment& environment();
 
     /**
      * Get a reference to the internal IVectorsVisualization interface.

--- a/src/visualization/src/Label.cpp
+++ b/src/visualization/src/Label.cpp
@@ -173,4 +173,12 @@ void Label::setVisible(bool visible)
 {
     assert(m_label);
     m_label->setVisible(visible);
+    if (visible)
+    {
+        setText(m_text);
+    }
+    else
+    {
+        m_label->setText(L""); //This is a workaround since it seems that the visibility of labels is not considered with viewports
+    }
 }

--- a/src/visualization/src/Texture.cpp
+++ b/src/visualization/src/Texture.cpp
@@ -64,10 +64,11 @@ iDynTree::ColorViz iDynTree::Texture::getPixelColor(unsigned int width, unsigned
         irrTexture->unlock();
     }
 
-    pixelOut.r = pixelIrrlicht.getRed();
-    pixelOut.g = pixelIrrlicht.getGreen();
-    pixelOut.b = pixelIrrlicht.getBlue();
-    pixelOut.a = pixelIrrlicht.getAlpha();
+    irr::video::SColorf pixelIrrlichtFloat(pixelIrrlicht);
+    pixelOut.r = pixelIrrlichtFloat.getRed();
+    pixelOut.g = pixelIrrlichtFloat.getGreen();
+    pixelOut.b = pixelIrrlichtFloat.getBlue();
+    pixelOut.a = pixelIrrlichtFloat.getAlpha();
 
     return pixelOut;
 }
@@ -99,12 +100,13 @@ bool iDynTree::Texture::getPixels(std::vector<iDynTree::PixelViz> &pixels) const
             for (size_t height = 0; height < textureDim.Height; ++height)
             {
                 pixelIrrlicht = irr::video::SColor(*(unsigned int*)(buffer + (height * pitch) + (width * bytes)));
+                irr::video::SColorf pixelIrrlichtFloat(pixelIrrlicht);
                 pixels[i].width = width;
                 pixels[i].height = height;
-                pixels[i].r = pixelIrrlicht.getRed();
-                pixels[i].g = pixelIrrlicht.getGreen();
-                pixels[i].b = pixelIrrlicht.getBlue();
-                pixels[i].a = pixelIrrlicht.getAlpha();
+                pixels[i].r = pixelIrrlichtFloat.getRed();
+                pixels[i].g = pixelIrrlichtFloat.getGreen();
+                pixels[i].b = pixelIrrlichtFloat.getBlue();
+                pixels[i].a = pixelIrrlichtFloat.getAlpha();
                 ++i;
             }
         }
@@ -113,4 +115,9 @@ bool iDynTree::Texture::getPixels(std::vector<iDynTree::PixelViz> &pixels) const
     }
 
     return true;
+}
+
+void iDynTree::Texture::enableDraw(bool enabled)
+{
+    shouldDraw = enabled;
 }

--- a/src/visualization/src/Texture.cpp
+++ b/src/visualization/src/Texture.cpp
@@ -17,6 +17,7 @@ void iDynTree::Texture::init(irr::video::IVideoDriver *irrDriverInput,
                              const VisualizerOptions &textureOptions)
 {
     irrTexture = irrDriverInput->addRenderTargetTexture(irr::core::dimension2d<irr::u32>(textureOptions.winWidth, textureOptions.winHeight), name.c_str());
+    viewport = {0, 0, textureOptions.winWidth, textureOptions.winHeight};
     textureEnvironment.init(sceneManager, textureOptions.rootFrameArrowsDimension);
     textureEnvironment.m_envNode->setVisible(false);
     irrDriver = irrDriverInput;
@@ -167,4 +168,55 @@ bool iDynTree::Texture::drawToFile(const std::string filename) const
 void iDynTree::Texture::enableDraw(bool enabled)
 {
     shouldDraw = enabled;
+    forceClear = enabled; //in case the texture has been enabled between one subDraw and the other.
+}
+
+int iDynTree::Texture::width() const
+{
+    if (!irrTexture)
+    {
+        return 0;
+    }
+
+    return irrTexture->getSize().Width;
+}
+
+int iDynTree::Texture::height() const
+{
+    if (!irrTexture)
+    {
+        return 0;
+    }
+
+    return irrTexture->getSize().Height;
+}
+
+bool iDynTree::Texture::setSubDrawArea(int xOffsetFromTopLeft, int yOffsetFromTopLeft, int subImageWidth, int subImageHeight)
+{
+    if (!irrTexture)
+    {
+        reportError("Texture","setSubDrawArea","Cannot get pixel color. The video texture has not been properly initialized.");
+        return false;
+    }
+
+    if (xOffsetFromTopLeft + subImageWidth > width())
+    {
+        reportError("Texture","setSubDrawArea","The specified draw coordinates are out of bounds. The sum of the xOffsetFromTopLeft and width are greater than the texture width.");
+        return false;
+    }
+
+    if (yOffsetFromTopLeft + subImageHeight > height())
+    {
+        reportError("Texture","setSubDrawArea","The specified draw coordinates are out of bounds. The sum of the yOffsetFromTopLeft and height are greater than the texture height.");
+        return false;
+    }
+
+    if (subImageHeight <= 0)
+    {
+        return false;
+    }
+
+    viewport = {xOffsetFromTopLeft, yOffsetFromTopLeft, xOffsetFromTopLeft + subImageWidth, yOffsetFromTopLeft + subImageHeight};
+
+    return true;
 }

--- a/src/visualization/src/Texture.h
+++ b/src/visualization/src/Texture.h
@@ -25,8 +25,10 @@ public:
 
     irr::video::ITexture* irrTexture{nullptr};
     irr::video::IVideoDriver* irrDriver{nullptr};
+    irr::core::rect<irr::s32> viewport;
     Environment textureEnvironment;
     bool shouldDraw{true};
+    bool forceClear{false};
 
     void init(irr::video::IVideoDriver* irrDriverInput, irr::scene::ISceneManager *sceneManager, const std::string& name, const VisualizerOptions& textureOptions);
 
@@ -41,6 +43,12 @@ public:
     virtual bool drawToFile(const std::string filename="iDynTreeVisualizerTextureScreenshot.png") const override;
 
     virtual void enableDraw(bool enabled = true) override;
+
+    virtual int width() const override;
+
+    virtual int height() const override;
+
+    virtual bool setSubDrawArea(int xOffsetFromTopLeft, int yOffsetFromTopLeft, int subImageWidth, int subImageHeight) override;
 
 };
 

--- a/src/visualization/src/Texture.h
+++ b/src/visualization/src/Texture.h
@@ -24,10 +24,11 @@ public:
 
 
     irr::video::ITexture* irrTexture{nullptr};
+    irr::video::IVideoDriver* irrDriver{nullptr};
     Environment textureEnvironment;
     bool shouldDraw{true};
 
-    void init(irr::video::IVideoDriver* irrDriver, irr::scene::ISceneManager *sceneManager, const std::string& name, const VisualizerOptions& textureOptions);
+    void init(irr::video::IVideoDriver* irrDriverInput, irr::scene::ISceneManager *sceneManager, const std::string& name, const VisualizerOptions& textureOptions);
 
     virtual ~Texture();
 
@@ -36,6 +37,8 @@ public:
     virtual ColorViz getPixelColor(unsigned int width, unsigned int height) const override;
 
     virtual bool getPixels(std::vector<PixelViz>& pixels) const override;
+
+    virtual bool drawToFile(const std::string filename="iDynTreeVisualizerTextureScreenshot.png") const override;
 
     virtual void enableDraw(bool enabled = true) override;
 

--- a/src/visualization/src/Texture.h
+++ b/src/visualization/src/Texture.h
@@ -25,16 +25,19 @@ public:
 
     irr::video::ITexture* irrTexture{nullptr};
     Environment textureEnvironment;
+    bool shouldDraw{true};
 
     void init(irr::video::IVideoDriver* irrDriver, irr::scene::ISceneManager *sceneManager, const std::string& name, const VisualizerOptions& textureOptions);
 
     virtual ~Texture();
 
-    virtual IEnvironment& environment();
+    virtual IEnvironment& environment() override;
 
-    virtual ColorViz getPixelColor(unsigned int width, unsigned int height) const;
+    virtual ColorViz getPixelColor(unsigned int width, unsigned int height) const override;
 
-    virtual bool getPixels(std::vector<PixelViz>& pixels) const;
+    virtual bool getPixels(std::vector<PixelViz>& pixels) const override;
+
+    virtual void enableDraw(bool enabled = true) override;
 
 };
 

--- a/src/visualization/src/TexturesHandler.cpp
+++ b/src/visualization/src/TexturesHandler.cpp
@@ -48,20 +48,22 @@ void iDynTree::TexturesHandler::draw(iDynTree::Environment &defaultEnvironment, 
 
     for (auto t = m_textures.begin(); t != m_textures.end(); ++t)
     {
-        t->second->textureEnvironment.m_envNode->setVisible(true); //Enable the texture environment
-        // set render target texture
-       m_irrDriver->setRenderTarget(t->second->irrTexture, true, true,
-                                    t->second->textureEnvironment.m_backgroundColor.toSColor());
+        if (t->second->shouldDraw)
+        {
+            t->second->textureEnvironment.m_envNode->setVisible(true); //Enable the texture environment
+            // set render target texture
+            m_irrDriver->setRenderTarget(t->second->irrTexture, true, true,
+                                         t->second->textureEnvironment.m_backgroundColor.toSColor());
 
-        auto textureDims = t->second->irrTexture->getSize();
+            auto textureDims = t->second->irrTexture->getSize();
 
-        defaultCamera.setAspectRatio(textureDims.Width/ (float)textureDims.Height);
+            defaultCamera.setAspectRatio(textureDims.Width/ (float)textureDims.Height);
 
-        // draw whole scene into render buffer
-        m_sceneManager->drawAll();
+            // draw whole scene into render buffer
+            m_sceneManager->drawAll();
 
-        t->second->textureEnvironment.m_envNode->setVisible(false); //Disable the texture environment
-
+            t->second->textureEnvironment.m_envNode->setVisible(false); //Disable the texture environment
+        }
     }
 
     defaultEnvironment.m_envNode->setVisible(true); //Enable the visualizer environment

--- a/src/visualization/src/TexturesHandler.cpp
+++ b/src/visualization/src/TexturesHandler.cpp
@@ -37,7 +37,7 @@ void iDynTree::TexturesHandler::init(irr::video::IVideoDriver *irrDriver,
     m_areTexturesSupported = m_irrDriver->queryFeature(irr::video::EVDF_RENDER_TO_TARGET);
 }
 
-void iDynTree::TexturesHandler::draw(iDynTree::Environment &defaultEnvironment, iDynTree::Camera &defaultCamera)
+void iDynTree::TexturesHandler::draw(iDynTree::Environment &defaultEnvironment, iDynTree::Camera &defaultCamera, bool clearBuffers)
 {
     if (m_textures.size() == 0)
     {
@@ -51,14 +51,16 @@ void iDynTree::TexturesHandler::draw(iDynTree::Environment &defaultEnvironment, 
         if (t->second->shouldDraw)
         {
             t->second->textureEnvironment.m_envNode->setVisible(true); //Enable the texture environment
+            bool clearThisTexture = clearBuffers || t->second->forceClear;
             // set render target texture
-            m_irrDriver->setRenderTarget(t->second->irrTexture, true, true,
+            m_irrDriver->setRenderTarget(t->second->irrTexture, clearThisTexture, clearThisTexture,
                                          t->second->textureEnvironment.m_backgroundColor.toSColor());
 
-            auto textureDims = t->second->irrTexture->getSize();
-            m_irrDriver->setViewPort(irr::core::rect<irr::s32>(0, 0, textureDims.Width, textureDims.Height)); //Setting the viewport to the full texture
-
-            defaultCamera.setAspectRatio(textureDims.Width/ (float)textureDims.Height);
+            m_irrDriver->setViewPort(irr::core::rect<irr::s32>(0, 0, t->second->irrTexture->getSize().Width, t->second->irrTexture->getSize().Height)); //workaround for http://irrlicht.sourceforge.net/forum/viewtopic.php?f=7&t=47004
+            m_irrDriver->setViewPort(t->second->viewport); //Setting the viewport specified for the texture
+            float width = t->second->viewport.LowerRightCorner.X - t->second->viewport.UpperLeftCorner.X;
+            float height = t->second->viewport.LowerRightCorner.Y - t->second->viewport.UpperLeftCorner.Y;
+            defaultCamera.setAspectRatio(width / height);
 
             // draw whole scene into render buffer
             m_sceneManager->drawAll();
@@ -70,7 +72,7 @@ void iDynTree::TexturesHandler::draw(iDynTree::Environment &defaultEnvironment, 
     defaultEnvironment.m_envNode->setVisible(true); //Enable the visualizer environment
     // set back old render target
     // The buffer might have been distorted, so clear it
-    m_irrDriver->setRenderTarget(0, true, true, defaultEnvironment.m_backgroundColor.toSColor());
+    m_irrDriver->setRenderTarget(0, clearBuffers, clearBuffers, defaultEnvironment.m_backgroundColor.toSColor());
 }
 
 iDynTree::ITexture *iDynTree::TexturesHandler::add(const std::string &name, const iDynTree::VisualizerOptions &textureOptions)

--- a/src/visualization/src/TexturesHandler.cpp
+++ b/src/visualization/src/TexturesHandler.cpp
@@ -56,6 +56,7 @@ void iDynTree::TexturesHandler::draw(iDynTree::Environment &defaultEnvironment, 
                                          t->second->textureEnvironment.m_backgroundColor.toSColor());
 
             auto textureDims = t->second->irrTexture->getSize();
+            m_irrDriver->setViewPort(irr::core::rect<irr::s32>(0, 0, textureDims.Width, textureDims.Height)); //Setting the viewport to the full texture
 
             defaultCamera.setAspectRatio(textureDims.Width/ (float)textureDims.Height);
 

--- a/src/visualization/src/TexturesHandler.h
+++ b/src/visualization/src/TexturesHandler.h
@@ -37,7 +37,7 @@ public:
     void init(irr::video::IVideoDriver* irrDriver,
               irr::scene::ISceneManager *sceneManager);
 
-    void draw(Environment &defaultEnvironment, Camera& defaultCamera);
+    void draw(Environment &defaultEnvironment, Camera& defaultCamera, bool clearBuffers);
 
     /**
      * @brief Add a texture

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -583,6 +583,11 @@ ICamera& Visualizer::camera()
 
 IEnvironment& Visualizer::enviroment()
 {
+    return environment();
+}
+
+IEnvironment &Visualizer::environment()
+{
     return pimpl->m_environment;
 }
 
@@ -761,8 +766,8 @@ bool Visualizer::setColorPalette(const std::string &name)
         return false;
     }
 
-    this->enviroment().setBackgroundColor(irrlicht2idyntree(colors->second.background));
-    this->enviroment().setFloorGridColor(irrlicht2idyntree(colors->second.gridColor));
+    this->environment().setBackgroundColor(irrlicht2idyntree(colors->second.background));
+    this->environment().setFloorGridColor(irrlicht2idyntree(colors->second.gridColor));
 
     this->vectors().setVectorsColor(irrlicht2idyntree(colors->second.vector));
     this->vectors().setVectorsDefaultColor(irrlicht2idyntree(colors->second.vector));

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -722,6 +722,10 @@ void Visualizer::close()
 bool Visualizer::isWindowActive() const
 {
 #ifdef IDYNTREE_USES_IRRLICHT
+    if( !pimpl->m_isInitialized )
+    {
+        return false;
+    }
     return pimpl->m_irrDevice->isWindowActive();
 #else
     return false;

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -644,7 +644,7 @@ ILabel &Visualizer::getLabel(const std::string &labelName)
 #endif
 }
 
-int Visualizer::width()
+int Visualizer::width() const
 {
 #ifdef IDYNTREE_USES_IRRLICHT
     if( !pimpl->m_isInitialized )
@@ -660,7 +660,7 @@ int Visualizer::width()
 #endif
 }
 
-int Visualizer::height()
+int Visualizer::height() const
 {
 #ifdef IDYNTREE_USES_IRRLICHT
     if( !pimpl->m_isInitialized )

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -130,6 +130,11 @@ struct Visualizer::VisualizerPimpl
     irr::video::IVideoDriver* m_irrDriver;
 
     /**
+     * Irrlicht video data.
+     */
+    irr::video::SExposedVideoData m_irrVideoData;
+
+    /**
      * Camera used by the visualization.
      */
     Camera m_camera;
@@ -296,6 +301,10 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
     // Get video driver
     pimpl->m_irrDriver = pimpl->m_irrDevice->getVideoDriver();
 
+    pimpl->m_irrVideoData = pimpl->m_irrDriver->getExposedVideoData(); //save the current window settings.
+                                                                       //This is helpful in case other Viualizer objects are created
+                                                                       // since Irrlicht by default draws on the last window opened.
+
     // Always visualize the mouse cursor
     pimpl->m_irrDevice->getCursorControl()->setVisible(true);
 
@@ -420,7 +429,7 @@ void Visualizer::draw()
             return;
         }
 
-        pimpl->m_irrDriver->beginScene(true,true, pimpl->m_environment.m_backgroundColor.toSColor());
+        pimpl->m_irrDriver->beginScene(true,true, pimpl->m_environment.m_backgroundColor.toSColor(), pimpl->m_irrVideoData);
 
         pimpl->m_irrDriver->setViewPort(irr::core::rect<irr::s32>(0, 0, winWidth, winHeight));
 
@@ -481,7 +490,7 @@ void Visualizer::subDraw(int xOffsetFromTopLeft, int yOffsetFromTopLeft, int sub
 
     if (!pimpl->m_subDrawStarted)
     {
-        pimpl->m_irrDriver->beginScene(true,true, pimpl->m_environment.m_backgroundColor.toSColor());
+        pimpl->m_irrDriver->beginScene(true,true, pimpl->m_environment.m_backgroundColor.toSColor(), pimpl->m_irrVideoData);
         pimpl->m_subDrawStarted = true;
     }
 

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -433,7 +433,7 @@ void Visualizer::draw()
 
         pimpl->m_irrDriver->setViewPort(irr::core::rect<irr::s32>(0, 0, winWidth, winHeight));
 
-        pimpl->m_textures.draw(pimpl->m_environment, pimpl->m_camera);
+        pimpl->m_textures.draw(pimpl->m_environment, pimpl->m_camera, true);
 
         pimpl->m_camera.setAspectRatio(winWidth/ (float)winHeight);
 
@@ -488,16 +488,19 @@ void Visualizer::subDraw(int xOffsetFromTopLeft, int yOffsetFromTopLeft, int sub
         return;
     }
 
+    bool clearTextureBuffers = false;
     if (!pimpl->m_subDrawStarted)
     {
         pimpl->m_irrDriver->beginScene(true,true, pimpl->m_environment.m_backgroundColor.toSColor(), pimpl->m_irrVideoData);
         pimpl->m_subDrawStarted = true;
+        clearTextureBuffers = true;
     }
 
-    pimpl->m_textures.draw(pimpl->m_environment, pimpl->m_camera);
+    pimpl->m_textures.draw(pimpl->m_environment, pimpl->m_camera, clearTextureBuffers);
 
     pimpl->m_camera.setAspectRatio(subImageWidth/ (float)subImageHeight);
 
+    pimpl->m_irrDriver->setViewPort(irr::core::rect<irr::s32>(0, 0, width(), height())); //workaround for http://irrlicht.sourceforge.net/forum/viewtopic.php?f=7&t=47004
     pimpl->m_irrDriver->setViewPort(irr::core::rect<irr::s32>(xOffsetFromTopLeft, yOffsetFromTopLeft,
                                                               xOffsetFromTopLeft + subImageWidth, yOffsetFromTopLeft + subImageHeight));
 

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -121,10 +121,25 @@ void checkAdditionalTexture() {
     ASSERT_IS_TRUE(ok);
 
     ASSERT_IS_TRUE(pixels.size() == static_cast<size_t>(textureOptions.winWidth * textureOptions.winHeight));
-    ASSERT_IS_TRUE(pixels[0].a = backGroundColor.a);
-    ASSERT_IS_TRUE(pixels[0].r = backGroundColor.r);
-    ASSERT_IS_TRUE(pixels[0].g = backGroundColor.g);
-    ASSERT_IS_TRUE(pixels[0].b = backGroundColor.b);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].a, backGroundColor.a, 1e-1);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].r, backGroundColor.r, 1e-1);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].g, backGroundColor.g, 1e-1);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].b, backGroundColor.b, 1e-1);
+
+    iDynTree::ColorViz newBackground(0.0, 0.0, 0.0, 0.0);
+    texture->environment().setBackgroundColor(newBackground);
+    texture->enableDraw(false); //The texture should not be updated, hence the background color should not change
+
+    viz.draw();
+
+    ok = texture->getPixels(pixels);
+    ASSERT_IS_TRUE(ok);
+
+    ASSERT_IS_TRUE(pixels.size() == static_cast<size_t>(textureOptions.winWidth * textureOptions.winHeight));
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].a, backGroundColor.a, 1e-1);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].r, backGroundColor.r, 1e-1);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].g, backGroundColor.g, 1e-1);
+    ASSERT_EQUAL_DOUBLE_TOL(pixels[0].b, backGroundColor.b, 1e-1);
 
 }
 
@@ -207,6 +222,24 @@ void checkLabelVisualization()
     }
 }
 
+void checkViewPorts()
+{
+    iDynTree::Visualizer viz;
+
+    for(int i=0; i < 5; i++)
+    {
+        viz.run(); //to update the output of width() and height() in case of resize
+        viz.getLabel("label").setText("LEFT");
+
+        viz.subDraw(0, 0, viz.width()/2, viz.height());
+
+        viz.getLabel("label").setText("RIGHT");
+
+        viz.subDraw(viz.width()/2, 0, viz.width()/2, viz.height());
+        viz.draw();
+    }
+}
+
 int main()
 {
     threeLinksReducedTest();
@@ -214,6 +247,7 @@ int main()
     checkAdditionalTexture();
     checkFrameVisualization();
     checkLabelVisualization();
+    checkViewPorts();
 
     return EXIT_SUCCESS;
 }

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -225,6 +225,7 @@ void checkLabelVisualization()
 void checkViewPorts()
 {
     iDynTree::Visualizer viz;
+    viz.init();
 
     for(int i=0; i < 5; i++)
     {
@@ -240,6 +241,21 @@ void checkViewPorts()
     }
 }
 
+void checkDoubleViz()
+{
+    iDynTree::Visualizer viz1, viz2;
+
+    viz1.getLabel("dummy").setText("VIZ1");
+    viz2.getLabel("dummy").setText("VIZ2");
+
+
+    for(int i=0; i < 5; i++)
+    {
+        viz1.draw();
+        viz2.draw();
+    }
+}
+
 int main()
 {
     threeLinksReducedTest();
@@ -248,6 +264,7 @@ int main()
     checkFrameVisualization();
     checkLabelVisualization();
     checkViewPorts();
+    checkDoubleViz();
 
     return EXIT_SUCCESS;
 }

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -226,18 +226,25 @@ void checkViewPorts()
 {
     iDynTree::Visualizer viz;
     viz.init();
+    auto texture = viz.textures().add("dummy");
 
     for(int i=0; i < 5; i++)
     {
+        viz.camera().setPosition(iDynTree::Position(1.0, 0.1*i + 1.0, 0.1*i + 1.0));
         viz.run(); //to update the output of width() and height() in case of resize
         viz.getLabel("label").setText("LEFT");
 
+        texture->setSubDrawArea(0, 0, texture->width()/2, texture->height());
+//        texture->enableDraw(false); //Uncomment this line to disable the drawing on the texture
         viz.subDraw(0, 0, viz.width()/2, viz.height());
 
         viz.getLabel("label").setText("RIGHT");
-
+//        texture->enableDraw(true); //Uncomment this line to reenable the drawing on the texture
+        texture->setSubDrawArea(viz.width()/2, 0, texture->width()/2, texture->height());
         viz.subDraw(viz.width()/2, 0, viz.width()/2, viz.height());
         viz.draw();
+//      texture->drawToFile(); //Uncomment this line to check what is contained in the texture
+
     }
 }
 

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -227,18 +227,31 @@ void checkViewPorts()
     iDynTree::Visualizer viz;
     viz.init();
     auto texture = viz.textures().add("dummy");
+    iDynTree::ILabel& leftLabel = viz.getLabel("leftlabel");
+    leftLabel.setText("LEFT");
+    iDynTree::ILabel& rightLabel = viz.getLabel("rightlabel");
+    rightLabel.setText("RIGHT");
+    size_t frameIndex = viz.frames().addFrame(iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position(0.5, 0.5, 0.1)));
+
+
 
     for(int i=0; i < 5; i++)
     {
         viz.camera().setPosition(iDynTree::Position(1.0, 0.1*i + 1.0, 0.1*i + 1.0));
         viz.run(); //to update the output of width() and height() in case of resize
-        viz.getLabel("label").setText("LEFT");
+
+        leftLabel.setVisible(true);
+        rightLabel.setVisible(false);
+        viz.frames().setVisible(frameIndex, false);
 
         texture->setSubDrawArea(0, 0, texture->width()/2, texture->height());
 //        texture->enableDraw(false); //Uncomment this line to disable the drawing on the texture
         viz.subDraw(0, 0, viz.width()/2, viz.height());
 
-        viz.getLabel("label").setText("RIGHT");
+        leftLabel.setVisible(false);
+        rightLabel.setVisible(true);
+        viz.frames().setVisible(frameIndex, true);
+
 //        texture->enableDraw(true); //Uncomment this line to reenable the drawing on the texture
         texture->setSubDrawArea(viz.width()/2, 0, texture->width()/2, texture->height());
         viz.subDraw(viz.width()/2, 0, viz.width()/2, viz.height());


### PR DESCRIPTION
- Fixed the conversion from irrlicht pixels to iDynTree pixels.
- Fixed a typo in the environment method of the visualizer.
- Fixed the running of two visualizer instances in the same process
- Added the possibility to draw in different portions of the visualizer window and textures at the same time.
- Added the possibility to draw textures on file.
- Allow disabling the drawing on textures.
- Fixed the visualization of labels when they should be hidden.