### PR TITLE
Improve MeshcatVisualizerExample.ipynb

### DIFF
--- a/examples/python/MeshcatVisualizerExample.ipynb
+++ b/examples/python/MeshcatVisualizerExample.ipynb
@@ -4,7 +4,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# MeshcatVisualizer a simple example"
+    "# iDynTree MeshcatVisualizer a simple example\n",
+    "\n",
+    "The `idyntree.visualize.MeshcatVisualizer` is a simple class that permits to display `iDynTree::Model` instances  in Python, for example loaded from URDF models, directly  as part of a Jupyter Notebook, thanks to the use of the [MeshCat](https://github.com/rdeits/meshcat-python), a WebGL-based 3D visualizer for Python. The API of this class is inspired by [the similar class of Pinocchio](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/md_doc_b-examples_display_b-meshcat-viewer.html), but the iDynTree version permit to specify arbitrary joint orders for the model.\n",
+    "\n",
+    "To run this example, you first need to install some dependencies. It is recommend to install them via `conda`. \n",
+    "If you do not have any conda distribution, it is recommended to install `miniforge` by following the guide in [`robotology-superbuild` docs](https://github.com/robotology/robotology-superbuild/blob/v2021.05/doc/install-miniforge.md). \n",
+    "\n",
+    "Once you have conda installed on your system, you can open a terminal and create on the fly an environment called `idyntree-jupyter` and activate it and then clone the idyntree repo:\n",
+    "~~~\n",
+    "conda create -n idyntree-jupyter -c conda-forge -c robotology numpy matplotlib idyntree icub-models ipywidgets \n",
+    "conda activate idyntree-jupyter \n",
+    "~~~\n",
+    "\n",
+    "Then, we can clone the idyntree repo to easily open this notebook, and then we can start the `jupyter notebook` application and open the `MeshcatVisualizerExample.ipynb` file from the Jupyter Notebook user interface:\n",
+    "~~~\n",
+    "git clone https://github.com/robotology/idyntree \n",
+    "cd idyntree/examples/python\n",
+    "jupyter notebook\n",
+    "~~~\n",
+    "\n",
+    "Once you opened the notebook in the Jupyter Notebook, you can start executing the following cells."
    ]
   },
   {
@@ -18,7 +38,6 @@
     "import os\n",
     "from ipywidgets import interact, interactive, fixed, interact_manual\n",
     "import ipywidgets as widgets\n",
-    "from __future__ import print_function\n",
     "import numpy as np"
    ]
   },
@@ -28,35 +47,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def clone_model():\n",
-    "    \"\"\"Get the model from icub-models. This is usefull to have a standalone example.\"\"\"\n",
-    "    import zipfile\n",
-    "    import urllib.request\n",
-    "    import tempfile\n",
-    "    model_url = 'https://github.com/robotology/icub-models/archive/refs/tags/v1.20.0.zip'\n",
-    "    model = urllib.request.urlopen(model_url)\n",
-    "    temp = tempfile.NamedTemporaryFile()\n",
-    "    temp_folder = tempfile.TemporaryDirectory()\n",
-    "    temp.write(model.read())\n",
-    "    with zipfile.ZipFile(temp.name, 'r') as zip_obj:\n",
-    "        zip_obj.extractall(temp_folder.name)\n",
+    "# Workaround for https://github.com/robotology/icub-models/issues/91\n",
+    "# it assumes that icub-models is installed via conda/mamba \n",
+    "# If icub-models is installed somewhere else, just specify its installation prefix\n",
+    "# by setting the icub_models_install_prefix variable\n",
+    "if os.name == 'nt':\n",
+    "    icub_models_install_prefix = os.path.join(os.environ[\"CONDA_PREFIX\"],\"Library\")\n",
+    "else:\n",
+    "    icub_models_install_prefix = os.environ[\"CONDA_PREFIX\"]\n",
     "\n",
-    "    build_path = os.path.join(temp_folder.name, 'icub-models-1.20.0', 'build')\n",
-    "    os.mkdir(build_path)\n",
-    "    os.chdir(build_path)\n",
+    "icub_dir = os.path.join(icub_models_install_prefix, \"share\", \"iCub\")\n",
+    "share_dir = os.path.join(icub_models_install_prefix, \"share\")\n",
     "\n",
-    "    os.system('cmake ..')\n",
-    "    return temp_folder, build_path\n",
-    "\n",
-    "\n",
-    "def expand_enviroment_variable(build_path):\n",
-    "    \"\"\"Expand the enviroment data. This is usefull to have a standalone example.\"\"\"\n",
-    "    os.environ[\"YARP_DATA_DIRS\"] += os.path.join(build_path, 'iCub')\n",
-    "    os.environ[\"ROS_PACKAGE_PATH\"] += build_path\n",
-    "    os.environ[\"AMENT_PREFIX_PATH\"] += build_path\n",
-    "\n",
-    "def get_model_path(build_path, robot_name='iCubGazeboV2_5'):\n",
-    "    return os.path.join(build_path, 'iCub', 'robots', robot_name, 'model.urdf')"
+    "def get_model_path(robot_name='iCubGazeboV2_5'):\n",
+    "    return os.path.join(icub_dir, 'robots', robot_name, 'model.urdf')"
    ]
   },
   {
@@ -65,17 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "temp_folder, model_parent_dir = clone_model()\n",
-    "expand_enviroment_variable(model_parent_dir)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_path = get_model_path(model_parent_dir)\n",
+    "model_path = get_model_path()\n",
     "joint_list = [\"torso_pitch\", \"torso_roll\", \"torso_yaw\",\n",
     "              \"l_shoulder_pitch\", \"l_shoulder_roll\", \"l_shoulder_yaw\", \"l_elbow\",\n",
     "              \"r_shoulder_pitch\", \"r_shoulder_roll\", \"r_shoulder_yaw\", \"r_elbow\",\n",
@@ -129,7 +123,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -143,7 +137,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Clarify how to setup an environment to use it via conda.
* Get models from the icub-models package instead of manual download, that was failing on Windows
* Remove unused print_function import

I tested the notebook on Windows, but I imagine it should work fine also on Linux and macOS.