### PR TITLE
Fix frame export for multi-root models.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Added
 - Added support for exporting joint position limits to URDF for 1-DoF joints
   (prismatic and revolute).
 - Added pybind11 python bindings for adding and reading joint limits.
+
+### Fixed 
+- In the URDF exporter, export only frames attached to the exported traversal [#914](https://github.com/robotology/idyntree/pull/914).
 
 ## [4.2.0] - 2021-07-23
 

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -10,11 +10,12 @@
 #include <iDynTree/Core/SpatialInertia.h>
 #include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/VectorFixSize.h>
-#include <iDynTree/Model/Model.h>
-#include <iDynTree/Model/Traversal.h>
 #include <iDynTree/Model/FixedJoint.h>
+#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Model/Model.h>
 #include <iDynTree/Model/PrismaticJoint.h>
 #include <iDynTree/Model/RevoluteJoint.h>
+#include <iDynTree/Model/Traversal.h>
 
 #include "URDFParsingUtils.h"
 
@@ -503,7 +504,7 @@ bool URDFStringFromModel(const iDynTree::Model & model,
     // options.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase is set to false
     // If options.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase is set to false,
     // baseFakeLinkFrameIndex remains set to FRAME_INVALID_INDEX, a
-    // and all the additional frames of the base link get exported as child fake links 
+    // and all the additional frames of the base link get exported as child fake links
     // in the loop and the end of this function
     FrameIndex baseFakeLinkFrameIndex = FRAME_INVALID_INDEX;
     std::vector<FrameIndex> frameIndices;
@@ -546,10 +547,14 @@ bool URDFStringFromModel(const iDynTree::Model & model,
         ok = ok && exportLink(*visitedLink, visitedLinkName, model, robot);
     }
 
-    // Export all the additional frames that are not parent of the base link
+    // Export all the additional frames.
     for (FrameIndex frameIndex=model.getNrOfLinks(); frameIndex < static_cast<FrameIndex>(model.getNrOfFrames()); frameIndex++)
     {
-        if (frameIndex != baseFakeLinkFrameIndex) {
+        // Check that the frame is not parent of the base link and that the
+        // frame link is present in the traversal.
+        if (frameIndex != baseFakeLinkFrameIndex
+            && exportTraversal.getTraversalIndexFromLinkIndex(model.getFrameLink(frameIndex)) != TRAVERSAL_INVALID_INDEX) {
+
             ok = ok && exportAdditionalFrame(model.getFrameName(frameIndex),
                                              model.getFrameTransform(frameIndex),
                                              model.getLinkName(model.getFrameLink(frameIndex)),


### PR DESCRIPTION
Do not export frames if corresponding link is not in the traversal.
This can happen if the model has links (and frames attached to those links) that
are not present in the exported traversal.