### PR TITLE
Add new `python` CMake component

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -142,11 +142,15 @@ if (IDYNTREE_USES_PYTHON_PYBIND11 OR IDYNTREE_USES_PYTHON)
         file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/__init__.py" "from . import swig${NEW_LINE}from . import visualize${NEW_LINE}")
         # Create also an alias from swig to the old `bindings` import.
         file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/bindings.py" "from .swig import *${NEW_LINE}")
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bindings.py"
-                DESTINATION ${PYTHON_INSTDIR})
+        install(
+            FILES "${CMAKE_CURRENT_BINARY_DIR}/bindings.py"
+            DESTINATION ${PYTHON_INSTDIR}
+            COMPONENT python)
         # Add the alias in the __init__.py
         file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/__init__.py" "from . import bindings${NEW_LINE}")
     endif()
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
-             DESTINATION ${PYTHON_INSTDIR})
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
+        DESTINATION ${PYTHON_INSTDIR}
+        COMPONENT python)
 endif()

--- a/bindings/pybind11/CMakeLists.txt
+++ b/bindings/pybind11/CMakeLists.txt
@@ -28,4 +28,7 @@ endif()
 # |- __init__.py (generated from main bindings CMake file).
 # |
 # |_ pybind.<cpython_extension>
-install(TARGETS pybind11_idyntree DESTINATION ${PYTHON_INSTDIR})
+install(
+    TARGETS pybind11_idyntree
+    DESTINATION ${PYTHON_INSTDIR}
+    COMPONENT python)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -35,11 +35,18 @@ endif()
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/idyntree/swig.py
-    DESTINATION ${PYTHON_INSTDIR})
+    DESTINATION ${PYTHON_INSTDIR}
+    COMPONENT python)
 
-install(TARGETS ${target_name} DESTINATION ${PYTHON_INSTDIR})
+install(
+    TARGETS ${target_name}
+    DESTINATION ${PYTHON_INSTDIR}
+    COMPONENT python)
 
-install(DIRECTORY visualize DESTINATION ${PYTHON_INSTDIR})
+install(
+    DIRECTORY visualize
+    DESTINATION ${PYTHON_INSTDIR}
+    COMPONENT python)
 
 if(WIN32)
     set_target_properties(${target_name} PROPERTIES SUFFIX ".pyd")


### PR DESCRIPTION
This is useful to limit the installation of the C++ resources that form the Python module with:

```bash
cmake --install build/ --component python
```

It can be used in `setup.py` to prevent the installation of the entire CMake project. A nice consequence is that the conda-forge recipe can use `pypa/pip` or `pypa/build` to install the Python package, so that it appears properly in `pip list`. 