### PR TITLE
Fix doxygen documentation in KinDynComputation class

### DIFF
--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -854,15 +854,15 @@ public:
     bool getCenterOfMassVelocity(iDynTree::Span<double> vel);
 
     /**
-     * Return the center of mass jacobian, i.e. the 3 \times (n+6) matrix such that:
-     *  getCenterOfMassVelocity() == getCenterOfMassJacobian() * \nu .
+     * Return the center of mass jacobian, i.e. the \f$3 \times (n+6)\f$ matrix such that:
+     *  getCenterOfMassVelocity() == getCenterOfMassJacobian() * \f$ \nu\f$.
      *
      */
     bool getCenterOfMassJacobian(MatrixDynSize & comJacobian);
 
     /**
-     * Return the center of mass jacobian, i.e. the 3 \times (n+6) matrix such that:
-     *  getCenterOfMassVelocity() == getCenterOfMassJacobian() * \nu .
+     * Return the center of mass jacobian, i.e. the \f$3 \times (n+6)\f$ matrix such that:
+     *  getCenterOfMassVelocity() == getCenterOfMassJacobian() * \f$\nu \f$.
      *
      * @warning the MatrixView object should point an already existing memory. Memory allocation and resizing cannot be achieved with this kind of objects.
      * @return true on success, false otherwise.
@@ -1189,7 +1189,7 @@ public:
      * |`FrameVelocityRepresentation` |  `linkInternalWrenches(i)` |
      * |:----------------------------:|:--------------------------:|
      * | `MIXED_REPRESENTATION` (default) | \f$ {}_{L[A]} \mathrm{f}_{\lambda(L), L} \f$ |
-     * | `BODY_FIXED_REPRESENTATION` | f$ {}_{L} \mathrm{f}_{\lambda(L), L} \f$ |
+     * | `BODY_FIXED_REPRESENTATION` | \f$ {}_{L} \mathrm{f}_{\lambda(L), L} \f$ |
      * | `INERTIAL_FIXED_REPRESENTATION` | \f$ {}_{A} \mathrm{f}_{\lambda(L), L} \f$ |
      *
      * Where if \f$C\f$ is a given frame, \f$ {}_{C} \mathrm{f}_{\lambda(L), L} \f$ is the 6D force/torque that the


### PR DESCRIPTION
The current documentation of the `KinDynComputation` class is broken

![image](https://user-images.githubusercontent.com/16744101/137902621-a2d9705a-8673-45be-894a-078e006bd5f5.png)


This PR fixes it 