### PR TITLE
Fix python GitHub Action to avoid building muslinux wheels

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,10 @@ on:
   release:
     types:
       - published
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "weekly" build at 2 AM UTC on Thursday
+  - cron:  '0 2 * * *'
 
 jobs:
 
@@ -85,7 +89,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_BUILD: cp37-*_x86_64 cp38-*_x86_64 cp39-*_x86_64
+          CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_24_x86_64
           CIBW_BEFORE_BUILD_LINUX: "apt-get update && apt-get install -y libeigen3-dev libassimp-dev libxml2-dev coinor-libipopt-dev"


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/927 .

Furthermore, add a weekly job to capture future regression created by new versions  of cibuildwheel.