### PR TITLE
🚧 Implement pybind11 bindings for the KinDynComputations object

### DIFF
--- a/bindings/pybind11/CMakeLists.txt
+++ b/bindings/pybind11/CMakeLists.txt
@@ -4,7 +4,8 @@ pybind11_add_module(pybind11_idyntree SYSTEM idyntree.cpp
                                     error_utilities.h error_utilities.cpp
                                     idyntree_model.h idyntree_model.cpp
                                     idyntree_sensors.h idyntree_sensors.cpp
-                                    idyntree_modelio_urdf.h idyntree_modelio_urdf.cpp)
+                                    idyntree_modelio_urdf.h idyntree_modelio_urdf.cpp
+                                    idyntree_type_caster.h)
 
 target_link_libraries(pybind11_idyntree PUBLIC idyntree-core
                                                idyntree-model

--- a/bindings/pybind11/CMakeLists.txt
+++ b/bindings/pybind11/CMakeLists.txt
@@ -5,7 +5,8 @@ pybind11_add_module(pybind11_idyntree SYSTEM idyntree.cpp
                                     idyntree_model.h idyntree_model.cpp
                                     idyntree_sensors.h idyntree_sensors.cpp
                                     idyntree_modelio_urdf.h idyntree_modelio_urdf.cpp
-                                    idyntree_type_caster.h)
+                                    idyntree_type_caster.h
+                                    idyntree_high_level.h idyntree_high_level.cpp)
 
 target_link_libraries(pybind11_idyntree PUBLIC idyntree-core
                                                idyntree-model

--- a/bindings/pybind11/idyntree.cpp
+++ b/bindings/pybind11/idyntree.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 
 #include "idyntree_core.h"
+#include "idyntree_high_level.h"
 #include "idyntree_model.h"
 #include "idyntree_modelio_urdf.h"
 #include "idyntree_sensors.h"
@@ -17,6 +18,7 @@ PYBIND11_MODULE(pybind, m) {
   iDynTree::bindings::iDynTreeModelBindings(m);
   iDynTree::bindings::iDynTreeSensorsBindings(m);
   iDynTree::bindings::iDynTreeModelIoUrdfBindings(m);
+  iDynTree::bindings::iDynTreeHighLevelBindings(m);
 }
 
 }  // namespace

--- a/bindings/pybind11/idyntree_core.cpp
+++ b/bindings/pybind11/idyntree_core.cpp
@@ -11,9 +11,13 @@
 #include <iDynTree/Core/RotationRaw.h>
 #include <iDynTree/Core/RotationalInertiaRaw.h>
 #include <iDynTree/Core/SpatialInertia.h>
+#include <iDynTree/Core/SpatialMotionVector.h>
 #include <iDynTree/Core/Transform.h>
+#include <iDynTree/Core/Twist.h>
 #include <iDynTree/Core/VectorDynSize.h>
 #include <iDynTree/Core/VectorFixSize.h>
+
+#include <pybind11/detail/common.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -47,7 +51,43 @@ void transformClassDefinition(py::class_<Transform>& transform) {
               -> SpatialInertia { return self * inertia; },
           py::is_operator());
 }
-}  // namespace
+
+template <class DerivedSpatialVecT> void spatialVector(pybind11::module& module)
+{
+    py::class_<SpatialVector<DerivedSpatialVecT>>(module,
+                                                  PYBIND11_TOSTRING(
+                                                      PYBIND11_CONCAT(_SpatialVector,
+                                                                      DerivedSpatialVecT)))
+        .def_property("linear_vec3",
+                      py::overload_cast<>(&SpatialVector<DerivedSpatialVecT>::getLinearVec3,
+                                          py::const_),
+                      &SpatialVector<DerivedSpatialVecT>::setLinearVec3)
+        .def_property("angular_vec3",
+                      py::overload_cast<>(&SpatialVector<DerivedSpatialVecT>::getAngularVec3,
+                                          py::const_),
+                      &SpatialVector<DerivedSpatialVecT>::setAngularVec3)
+        .def("__getitem__",
+             py::overload_cast<const unsigned int>(&SpatialVector<DerivedSpatialVecT>::operator(),
+                                                   py::const_))
+        .def("__setitem__",
+             [](SpatialVector<DerivedSpatialVecT>& vector, std::size_t index, double new_value) {
+                 vector(index) = new_value;
+             })
+        .def("__len__", &SpatialVector<DerivedSpatialVecT>::size)
+        .def("as_vector", &SpatialVector<DerivedSpatialVecT>::asVector)
+        .def("__repr__", &SpatialVector<DerivedSpatialVecT>::toString)
+        .def("zero", &SpatialVector<DerivedSpatialVecT>::zero)
+        .def("change_point", &SpatialVector<DerivedSpatialVecT>::changePoint)
+        .def("change_coord_frame", &SpatialVector<DerivedSpatialVecT>::changeCoordFrame)
+        .def(py::self + DerivedSpatialVecT())
+        .def(py::self - DerivedSpatialVecT())
+        .def(-py::self)
+        .def_static("Zero", &SpatialVector<DerivedSpatialVecT>::Zero)
+        .def_static("inverse", &SpatialVector<DerivedSpatialVecT>::inverse)
+        .def_static("compose", &SpatialVector<DerivedSpatialVecT>::compose);
+}
+
+} // namespace
 
 void iDynTreeCoreBindings(pybind11::module& module) {
 
@@ -67,9 +107,9 @@ void iDynTreeCoreBindings(pybind11::module& module) {
       .def_static("Identity", &Rotation::Identity)
       .def("__repr__", &Rotation::toString)
       .def("to_numpy", [](const Rotation& impl){
-			   iDynTree::Matrix3x3 m(impl.data(), 3, 3);
-			   return m;
-		       });
+                           iDynTree::Matrix3x3 m(impl.data(), 3, 3);
+                           return m;
+                       });
 
   py::class_<Transform> transform(module, "Transform");
   transformClassDefinition(transform);
@@ -101,6 +141,39 @@ void iDynTreeCoreBindings(pybind11::module& module) {
       .def("__repr__", [](const SpatialInertia& inertia) {
         return inertia.asMatrix().toString();
       });
+
+  spatialVector<SpatialMotionVector>(module);
+
+  py::class_<SpatialMotionVector, SpatialVector<SpatialMotionVector>>(module,
+                                                                      PYBIND11_TOSTRING(
+                                                                          SpatialMotionVector))
+      .def(py::init<>())
+      .def(py::init<const LinearMotionVector3&, const AngularMotionVector3&>())
+      .def(py::init<const SpatialMotionVector&>())
+      .def(py::init<const SpatialVector<SpatialMotionVector> &>())
+      .def(py::self * float())
+      .def("as_cross_product_matrix", &SpatialMotionVector::asCrossProductMatrix)
+      .def("as_cross_product_matrix_wrench", &SpatialMotionVector::asCrossProductMatrixWrench)
+      .def("exp", &SpatialMotionVector::exp);
+
+  py::class_<Twist, SpatialMotionVector>(module, "Twist")
+      .def(py::init())
+      .def(py::init<const LinVelocity&, const AngVelocity&>())
+      .def(py::init<const SpatialMotionVector&>())
+      .def(py::init<const Twist&>())
+      .def(py::self + py::self)
+      .def(py::self - py::self)
+      .def(-py::self);
+
+  // This is required to implicit convert:
+  // - SpatialMotionVector into Twist
+  // - SpatialVector<SpatialMotionVector> into SpatialMotionVector
+  // without the following lines it is not possible to implicit convert iDynTree.Twist.Zero() into a
+  // twist
+  // https://pybind11.readthedocs.io/en/stable/advanced/classes.html#implicit-conversions
+  py::implicitly_convertible<SpatialVector<SpatialMotionVector>, SpatialMotionVector>();
+  py::implicitly_convertible<SpatialMotionVector, Twist>();
+
 }
 }  // namespace bindings
 }  // namespace iDynTree

--- a/bindings/pybind11/idyntree_core.cpp
+++ b/bindings/pybind11/idyntree_core.cpp
@@ -1,4 +1,5 @@
 #include "idyntree_core.h"
+#include "idyntree_type_caster.h"
 
 #include <iDynTree/Core/Axis.h>
 #include <iDynTree/Core/Direction.h>
@@ -24,136 +25,6 @@ namespace bindings {
 namespace {
 namespace py = ::pybind11;
 
-void vectorDynSizeClassDefinition(py::class_<VectorDynSize>& vector) {
-  vector.def(py::init())
-      .def(py::init<unsigned>())
-      .def("__getitem__", py::overload_cast<const std::size_t>(
-                              &VectorDynSize::operator(), py::const_))
-      .def("__setitem__",
-           [](VectorDynSize& the_vector, std::size_t index, double new_value) {
-             the_vector(index) = new_value;
-           })
-      .def(
-          "__iter__",
-          [](const VectorDynSize& s) {
-            return py::make_iterator(s.begin(), s.end());
-          },
-          py::keep_alive<
-              0, 1>() /* Essential: keep object alive while iterator exists */)
-      .def("__len__", &VectorDynSize::size)
-      .def("set_zero", &VectorDynSize::zero)
-      .def("resize", &VectorDynSize::resize)
-      .def("__repr__", &VectorDynSize::toString)
-      .def_buffer([](VectorDynSize& v) -> py::buffer_info {
-        return py::buffer_info(
-            v.data(),                                /* Pointer to buffer */
-            sizeof(double),                          /* Size of one scalar */
-            py::format_descriptor<double>::format(), /* Python struct-style
-                                                        format descriptor */
-            1,                                       /* Number of dimensions */
-            {v.size()},                              /* Buffer dimensions */
-            {sizeof(double)} /* Strides (in bytes) for each index */
-        );
-      });
-}
-
-template <unsigned size>
-void createFixSizeVector(pybind11::module& module,
-                         const std::string& class_name) {
-  py::class_<VectorFixSize<size>>(module, class_name.c_str(),
-                                  py::buffer_protocol())
-      .def(py::init())
-      .def("__getitem__", py::overload_cast<const std::size_t>(
-                              &VectorFixSize<size>::operator(), py::const_))
-      .def("__setitem__",
-           [](VectorFixSize<size>& the_vector, std::size_t index,
-              double new_value) { the_vector(index) = new_value; })
-      .def("__len__", &VectorFixSize<size>::size)
-      .def(
-          "__iter__",
-          [](const VectorFixSize<size>& s) {
-            return py::make_iterator(s.begin(), s.end());
-          },
-          py::keep_alive<
-              0, 1>() /* Essential: keep object alive while iterator exists */)
-      .def("set_zero", &VectorFixSize<size>::zero)
-      .def("__repr__", &VectorFixSize<size>::toString)
-      .def_buffer([](VectorFixSize<size>& v) -> py::buffer_info {
-        return py::buffer_info(
-            v.data(),                                /* Pointer to buffer */
-            sizeof(double),                          /* Size of one scalar */
-            py::format_descriptor<double>::format(), /* Python struct-style
-                                                        format descriptor */
-            1,                                       /* Number of dimensions */
-            {v.size()},                              /* Buffer dimensions */
-            {sizeof(double)} /* Strides (in bytes) for each index */
-        );
-      });
-}
-
-void matrixDynSizeClassDefinition(py::class_<MatrixDynSize>& matrix) {
-  matrix.def(py::init())
-      .def(py::init<unsigned, unsigned>())
-      .def("__getitem__",
-           [](MatrixDynSize& matrix,
-              std::pair<std::size_t, std::size_t> indices) {
-             return matrix.getVal(indices.first, indices.second);
-           })
-      .def("__setitem__",
-           [](MatrixDynSize& matrix,
-              std::pair<std::size_t, std::size_t> indices, double item) {
-             return matrix.setVal(indices.first, indices.second, item);
-           })
-      .def("rows", &MatrixDynSize::rows)
-      .def("cols", &MatrixDynSize::cols)
-      .def("set_zero", &MatrixDynSize::zero)
-      .def("resize", &MatrixDynSize::resize)
-      .def("__repr__", &MatrixDynSize::toString)
-      .def_buffer([](MatrixDynSize& m) -> py::buffer_info {
-        return py::buffer_info(
-            m.data(),                                /* Pointer to buffer */
-            sizeof(double),                          /* Size of one scalar */
-            py::format_descriptor<double>::format(), /* Python struct-style
-                                                        format descriptor */
-            2,                                       /* Number of dimensions */
-            {m.rows(), m.cols()},                    /* Buffer dimensions */
-            {sizeof(double) * m.cols(), /* Strides (in bytes) for each index */
-             sizeof(double)});
-      });
-}
-
-template <unsigned rows, unsigned cols>
-void createFixSizeMatrix(pybind11::module& module,
-                         const std::string& class_name) {
-  py::class_<MatrixFixSize<rows, cols>>(module, class_name.c_str(),
-                                        py::buffer_protocol())
-      .def(py::init())
-      .def("__getitem__",
-           [](MatrixFixSize<rows, cols>& matrix,
-              std::pair<std::size_t, std::size_t> indices) {
-             return matrix.getVal(indices.first, indices.second);
-           })
-      .def("__setitem__",
-           [](MatrixFixSize<rows, cols>& matrix,
-              std::pair<std::size_t, std::size_t> indices, double item) {
-             return matrix.setVal(indices.first, indices.second, item);
-           })
-      .def("rows", &MatrixFixSize<rows, cols>::rows)
-      .def("cols", &MatrixFixSize<rows, cols>::cols)
-      .def("set_zero", &MatrixFixSize<rows, cols>::zero)
-      .def("__repr__", &MatrixFixSize<rows, cols>::toString)
-      .def_buffer([](MatrixFixSize<rows, cols>& m) -> py::buffer_info {
-        return py::buffer_info(
-            m.data(),                                /* Pointer to buffer */
-            sizeof(double),                          /* Size of one scalar */
-            py::format_descriptor<double>::format(), /* Python struct-style
-                                                        format descriptor */
-            2,                                       /* Number of dimensions */
-            {m.rows(), m.cols()},                    /* Buffer dimensions */
-            {sizeof(double) * m.cols(), /* Strides (in bytes) for each index */
-             sizeof(double)});
-      });
-}
 
 void transformClassDefinition(py::class_<Transform>& transform) {
   transform.def(py::init())
@@ -179,39 +50,8 @@ void transformClassDefinition(py::class_<Transform>& transform) {
 }  // namespace
 
 void iDynTreeCoreBindings(pybind11::module& module) {
-  // Vectors and matrices.
-  py::class_<VectorDynSize> vector_dyn(module, "VectorDynSize",
-                                       py::buffer_protocol());
-  vectorDynSizeClassDefinition(vector_dyn);
-  createFixSizeVector<3>(module, "Vector3");
-  createFixSizeVector<4>(module, "Vector4");
-  createFixSizeVector<6>(module, "Vector6");
 
-  py::class_<MatrixDynSize> matrix_dyn(module, "MatrixDynSize",
-                                       py::buffer_protocol());
-  matrixDynSizeClassDefinition(matrix_dyn);
-  createFixSizeMatrix<3, 3>(module, "Matrix3x3");
-  createFixSizeMatrix<4, 4>(module, "Matrix4x4");
-  createFixSizeMatrix<6, 6>(module, "Matrix6x6");
-
-  // Positions, Rotations and Transforms.
-  py::class_<PositionRaw, VectorFixSize<3>>(module, "_PositionRaw")
-      // Do not expose constructor as we do not want users to use this class.
-      .def("__repr__", &PositionRaw::toString);
-
-  py::class_<Position, PositionRaw>(module, "Position")
-      .def(py::init())
-      .def(py::init<double, double, double>())
-      .def(py::self + py::self)
-      .def(py::self - py::self)
-      .def(-py::self)
-      .def_static("Zero", &Position::Zero);
-
-  py::class_<RotationRaw, MatrixFixSize<3, 3>>(module, "_RotationRaw")
-      // Do not expose constructor as we do not want users to use this class.
-      .def("__repr__", &RotationRaw::toString);
-
-  py::class_<Rotation, RotationRaw>(module, "Rotation")
+  py::class_<Rotation>(module, "Rotation")
       .def(py::init())
       .def(py::init<double, double, double,  //
                     double, double, double,  //
@@ -224,24 +64,23 @@ void iDynTreeCoreBindings(pybind11::module& module) {
             return r * p;
           },
           py::is_operator())
-      .def_static("Identity", &Rotation::Identity);
+      .def_static("Identity", &Rotation::Identity)
+      .def("__repr__", &Rotation::toString)
+      .def("to_numpy", [](const Rotation& impl){
+			   iDynTree::Matrix3x3 m(impl.data(), 3, 3);
+			   return m;
+		       });
 
   py::class_<Transform> transform(module, "Transform");
   transformClassDefinition(transform);
 
   // Other classes.
-  py::class_<Direction, VectorFixSize<3>>(module, "Direction")
-      .def(py::init<double, double, double>());
-
   py::class_<Axis>(module, "Axis")
       .def(py::init<const Direction&, const Position&>())
       .def_property("direction", &Axis::getDirection, &Axis::setDirection)
       .def_property("origin", &Axis::getOrigin, &Axis::setOrigin)
       .def("__repr__", &Axis::toString);
 
-  py::class_<RotationalInertiaRaw, MatrixFixSize<3, 3>>(module,
-                                                        "RotationalInertia")
-      .def(py::init());
 
   py::class_<SpatialInertiaRaw>(module, "_SpatialInertiaRaw")
       .def("from_rotational_inertia_wrt_center_of_mass",

--- a/bindings/pybind11/idyntree_core.cpp
+++ b/bindings/pybind11/idyntree_core.cpp
@@ -31,8 +31,8 @@ void transformClassDefinition(py::class_<Transform>& transform) {
       .def(py::init<const Rotation&, const Position&>())
       .def(py::init<const MatrixFixSize<4, 4>&>())
       .def_static("Identity", &Transform::Identity)
-      .def_property_readonly("rotation", &Transform::getRotation)
-      .def_property_readonly("position", &Transform::getPosition)
+      .def_property("rotation", &Transform::getRotation, &Transform::setRotation)
+      .def_property("position", &Transform::getPosition,  &Transform::setPosition)
       .def("inverse", &Transform::inverse)
       .def(py::self * py::self)
       .def(

--- a/bindings/pybind11/idyntree_high_level.cpp
+++ b/bindings/pybind11/idyntree_high_level.cpp
@@ -1,0 +1,383 @@
+#include "idyntree_high_level.h"
+#include "idyntree_type_caster.h"
+
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/FreeFloatingState.h>
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cstddef>
+
+namespace iDynTree
+{
+namespace bindings
+{
+namespace
+{
+namespace py = ::pybind11;
+
+struct KinDynKinematicsRobotState
+{
+    iDynTree::VectorDynSize jointPositions;
+    iDynTree::VectorDynSize jointVelocities;
+
+    iDynTree::Twist baseVelocity;
+    iDynTree::Transform baseTransform;
+
+    iDynTree::Vector3 worldGravity;
+};
+
+} // namespace
+void iDynTreeHighLevelBindings(pybind11::module& module)
+{
+    py::class_<KinDynKinematicsRobotState>(module, "KinDynKinematicsRobotState")
+        .def(py::init())
+        .def_readwrite("joint_positions", &KinDynKinematicsRobotState::jointPositions)
+        .def_readwrite("joint_velocities", &KinDynKinematicsRobotState::jointVelocities)
+        .def_readwrite("base_velocity", &KinDynKinematicsRobotState::baseVelocity)
+        .def_readwrite("base_transform", &KinDynKinematicsRobotState::baseTransform)
+        .def_readwrite("world_gravity", &KinDynKinematicsRobotState::worldGravity);
+
+    py::class_<KinDynComputations, std::shared_ptr<KinDynComputations>>(module,
+                                                                        "KinDynComputations")
+        .def(py::init())
+        .def("load_robot_model", &KinDynComputations::loadRobotModel, py::arg("model"))
+        .def("is_valid", &KinDynComputations::isValid)
+        .def("get_nr_of_degrees_of_freedom", &KinDynComputations::getNrOfDegreesOfFreedom)
+        .def("get_description_of_degree_of_freedom",
+             &KinDynComputations::getDescriptionOfDegreeOfFreedom)
+        .def("get_description_of_degrees_of_freedom",
+             &KinDynComputations::getDescriptionOfDegreesOfFreedom)
+        .def("get_nr_of_links", &KinDynComputations::getNrOfLinks)
+        .def("get_nr_of_frames", &KinDynComputations::getNrOfFrames)
+        .def("get_floating_base", &KinDynComputations::getFloatingBase)
+        .def("set_floating_base",
+             &KinDynComputations::setFloatingBase,
+             py::arg("floating_base_name"))
+        .def_property("floating_base",
+                      &KinDynComputations::getFloatingBase,
+                      &KinDynComputations::setFloatingBase)
+        .def("get_robot_model", &KinDynComputations::getRobotModel)
+        .def_property("model",
+                      &KinDynComputations::getRobotModel,
+                      &KinDynComputations::loadRobotModel)
+        .def("get_relative_jacobian_sparsity_pattern",
+             [](const KinDynComputations& impl,
+                const iDynTree::FrameIndex refFrameIndex,
+                const iDynTree::FrameIndex frameIndex) -> iDynTree::MatrixDynSize {
+                 iDynTree::MatrixDynSize jacobian;
+                 if (!impl.getRelativeJacobianSparsityPattern(refFrameIndex, frameIndex, jacobian))
+                 {
+                     throw py::value_error("File to get the relative jacobian sparsity pattern.");
+                 }
+                 return jacobian;
+             })
+        .def("get_frame_free_floating_jacobian_sparsity_pattern",
+             [](const KinDynComputations& impl,
+                const iDynTree::FrameIndex frameIndex) -> iDynTree::MatrixDynSize {
+                 iDynTree::MatrixDynSize jacobian;
+                 if (!impl.getFrameFreeFloatingJacobianSparsityPattern(frameIndex, jacobian))
+                 {
+                     throw py::value_error("File to get the free floating jacobian sparsity "
+                                           "pattern.");
+                 }
+                 return jacobian;
+             })
+        .def("set_joint_pos",
+             py::overload_cast<const iDynTree::VectorDynSize&>(&KinDynComputations::setJointPos),
+             py::arg("s"))
+        .def("set_robot_state",
+             py::overload_cast<const iDynTree::Transform&,
+                               const iDynTree::VectorDynSize&,
+                               const iDynTree::Twist&,
+                               const iDynTree::VectorDynSize&,
+                               const iDynTree::Vector3&>(&KinDynComputations::setRobotState),
+             py::arg("world_T_base"),
+             py::arg("s"),
+             py::arg("base_velocity"),
+             py::arg("s_dot"),
+             py::arg("gravity"))
+        .def("set_robot_state",
+             py::overload_cast<const iDynTree::VectorDynSize&,
+                               const iDynTree::VectorDynSize&,
+                               const iDynTree::Vector3&>(&KinDynComputations::setRobotState),
+             py::arg("s"),
+             py::arg("s_dot"),
+             py::arg("gravity"))
+        .def("get_robot_state",
+             [](KinDynComputations& impl) -> KinDynKinematicsRobotState {
+                 KinDynKinematicsRobotState robotState;
+                 impl.getRobotState(robotState.baseTransform,
+                                    robotState.jointPositions,
+                                    robotState.baseVelocity,
+                                    robotState.jointVelocities,
+                                    robotState.worldGravity);
+                 return robotState;
+             })
+        .def("get_world_base_transform",
+             py::overload_cast<>(&KinDynComputations::getWorldBaseTransform, py::const_))
+        .def("get_base_twist", py::overload_cast<>(&KinDynComputations::getBaseTwist, py::const_))
+        .def("get_joint_pos",
+             [](const iDynTree::KinDynComputations& impl) {
+                 VectorDynSize s;
+                 if (!impl.getJointPos(s))
+                 {
+                     throw py::value_error("Failed to get joint position.");
+                 }
+                 return s;
+             })
+        .def("get_joint_vel",
+             [](const iDynTree::KinDynComputations& impl) {
+                 VectorDynSize ds;
+                 if (!impl.getJointVel(ds))
+                 {
+                     throw py::value_error("Failed to get joint velocity.");
+                 }
+                 return ds;
+             })
+        .def("get_model_vel",
+             [](const iDynTree::KinDynComputations& impl) {
+                 VectorDynSize nu;
+                 if (!impl.getModelVel(nu))
+                 {
+                     throw py::value_error("Failed to get model velocity.");
+                 }
+                 return nu;
+             })
+        .def_property_readonly("world_base_transform",
+                               py::overload_cast<>(&KinDynComputations::getWorldBaseTransform,
+                                                   py::const_))
+        .def_property_readonly("base_twist",
+                               py::overload_cast<>(&KinDynComputations::getBaseTwist, py::const_))
+        .def_property_readonly("joint_pos",
+                               [](const iDynTree::KinDynComputations& impl) {
+                                   VectorDynSize s;
+                                   if (!impl.getJointPos(s))
+                                   {
+                                       throw py::value_error("Failed to get joint position.");
+                                   }
+                                   return s;
+                               })
+        .def_property_readonly("joint_vel",
+                               [](const iDynTree::KinDynComputations& impl) {
+                                   VectorDynSize ds;
+                                   if (!impl.getJointVel(ds))
+                                   {
+                                       throw py::value_error("Failed to get joint velocity.");
+                                   }
+                                   return ds;
+                               })
+        .def_property_readonly("get_model_vel",
+                               [](const iDynTree::KinDynComputations& impl) {
+                                   VectorDynSize nu;
+                                   if (!impl.getModelVel(nu))
+                                   {
+                                       throw py::value_error("Failed to get model velocity.");
+                                   }
+                                   return nu;
+                               })
+        .def("get_frame_index", &KinDynComputations::getFrameIndex, py::arg("frame_name"))
+        .def("get_frame_name", &KinDynComputations::getFrameName, py::arg("frame_index"))
+        .def("get_world_transform",
+             py::overload_cast<const iDynTree::FrameIndex>(&KinDynComputations::getWorldTransform),
+             py::arg("frame_index"))
+        .def("get_world_transform",
+             py::overload_cast<const std::string&>(&KinDynComputations::getWorldTransform),
+             py::arg("frame_name"))
+        .def("get_world_transforms_as_homogeneous",
+             &KinDynComputations::getWorldTransformsAsHomogeneous,
+             py::arg("frame_names"))
+        .def("get_relative_transform",
+             py::overload_cast<const iDynTree::FrameIndex, const iDynTree::FrameIndex>(
+                 &KinDynComputations::getRelativeTransform),
+             py::arg("ref_frame_index"),
+             py::arg("frame_index"))
+        .def("get_relative_transform_explcit",
+             py::overload_cast<const iDynTree::FrameIndex,
+                               const iDynTree::FrameIndex,
+                               const iDynTree::FrameIndex,
+                               const iDynTree::FrameIndex>(
+                 &KinDynComputations::getRelativeTransformExplicit),
+             py::arg("ref_frame_origin_index"),
+             py::arg("ref_frame_orientation_index"),
+             py::arg("frame_origin_index"),
+             py::arg("frame_orientation_index"))
+        .def("get_relative_transform",
+             py::overload_cast<const std::string&, const std::string&>(
+                 &KinDynComputations::getRelativeTransform),
+             py::arg("ref_frame_name"),
+             py::arg("frame_name"))
+        .def("get_frame_vel",
+             py::overload_cast<const std::string&>(&KinDynComputations::getFrameVel),
+             py::arg("frame_name"))
+        .def("get_frame_vel",
+             py::overload_cast<const FrameIndex>(&KinDynComputations::getFrameVel),
+             py::arg("frame_index"))
+        .def("get_frame_acc",
+             py::overload_cast<const FrameIndex,
+                               const iDynTree::Vector6&,
+                               const iDynTree::VectorDynSize&>(&KinDynComputations::getFrameAcc),
+             py::arg("frame_index"),
+             py::arg("base_acc"),
+             py::arg("s_ddot"))
+        .def("get_frame_acc",
+             py::overload_cast<const std::string&,
+                               const iDynTree::Vector6&,
+                               const iDynTree::VectorDynSize&>(&KinDynComputations::getFrameAcc),
+             py::arg("frame_name"),
+             py::arg("base_acc"),
+             py::arg("s_ddot"))
+        .def(
+            "get_frame_free_floating_jacobian",
+            [](KinDynComputations& impl, const std::string& frameName) {
+                MatrixDynSize jacobian;
+                if (!impl.getFrameFreeFloatingJacobian(frameName, jacobian))
+                {
+                    throw py::value_error("Unable to get the free floating jacobian.");
+                }
+                return jacobian;
+            },
+            py::arg("frame_name"))
+        .def(
+            "get_frame_free_floating_jacobian",
+            [](KinDynComputations& impl, const FrameIndex frameIndex) {
+                MatrixDynSize jacobian;
+                if (!impl.getFrameFreeFloatingJacobian(frameIndex, jacobian))
+                {
+                    throw py::value_error("Unable to get the free floating jacobian.");
+                }
+                return jacobian;
+            },
+            py::arg("frame_index"))
+        .def(
+            "get_relative_jacobian",
+            [](KinDynComputations& impl,
+               const iDynTree::FrameIndex refFrameIndex,
+               const iDynTree::FrameIndex frameIndex) {
+                MatrixDynSize jacobian;
+                if (!impl.getRelativeJacobian(refFrameIndex, frameIndex, jacobian))
+                {
+                    throw py::value_error("Unable to get the relative jacobian.");
+                }
+                return jacobian;
+            },
+            py::arg("ref_frame_index"),
+            py::arg("frame_index"))
+        .def(
+            "get_relative_jacobian_explicit ",
+            [](KinDynComputations& impl,
+               const iDynTree::FrameIndex refFrameIndex,
+               const iDynTree::FrameIndex frameIndex,
+               const iDynTree::FrameIndex expressedOriginFrameIndex,
+               const iDynTree::FrameIndex expressedOrientationFrameIndex) {
+                MatrixDynSize jacobian;
+                if (!impl.getRelativeJacobianExplicit(refFrameIndex,
+                                                      frameIndex,
+                                                      expressedOriginFrameIndex,
+                                                      expressedOrientationFrameIndex,
+                                                      jacobian))
+                {
+                    throw py::value_error("Unable to get the explicit relative jacobian.");
+                }
+                return jacobian;
+            },
+            py::arg("ref_frame_index"),
+            py::arg("frame_index"),
+            py::arg("expressed_origin_frame_index"),
+            py::arg("expressed_orientation_frame_index"))
+        .def("get_frame_bias_acc",
+             py::overload_cast<const std::string&>(&KinDynComputations::getFrameBiasAcc),
+             py::arg("frame_name"))
+        .def("get_frame_bias_acc",
+             py::overload_cast<const FrameIndex>(&KinDynComputations::getFrameBiasAcc),
+             py::arg("frame_index"))
+        .def("get_center_of_mass_position",
+             py::overload_cast<>(&KinDynComputations::getCenterOfMassPosition))
+        .def("get_center_of_mass_velocity",
+             py::overload_cast<>(&KinDynComputations::getCenterOfMassVelocity))
+        .def("get_center_of_mass_jacobian",
+             [](KinDynComputations& impl) {
+                 MatrixDynSize jacobian;
+                 if (!impl.getCenterOfMassJacobian(jacobian))
+                 {
+                     throw py::value_error("Unable to get the center of mass jacobian.");
+                 }
+                 return jacobian;
+             })
+        .def("get_center_of_mass_bias_acc",
+             py::overload_cast<>(&KinDynComputations::getCenterOfMassBiasAcc))
+        .def("get_average_velocity", py::overload_cast<>(&KinDynComputations::getAverageVelocity))
+        .def("get_average_velocity_jacobian",
+             [](KinDynComputations& impl) {
+                 MatrixDynSize jacobian;
+                 if (!impl.getAverageVelocityJacobian(jacobian))
+                 {
+                     throw py::value_error("Unable to get the center of mass jacobian.");
+                 }
+                 return jacobian;
+             })
+        .def("get_centroidal_average_velocity",
+             py::overload_cast<>(&KinDynComputations::getCentroidalAverageVelocity))
+        .def("get_centroidal_average_velocity_jacobian",
+             [](KinDynComputations& impl) {
+                 MatrixDynSize jacobian;
+                 if (!impl.getCentroidalAverageVelocityJacobian(jacobian))
+                 {
+                     throw py::value_error("Unable to get the center of mass jacobian.");
+                 }
+                 return jacobian;
+             })
+        .def("get_linear_angular_momentum",
+             py::overload_cast<>(&KinDynComputations::getLinearAngularMomentum))
+        .def("get_linear_angular_momentum_jacobian",
+             [](KinDynComputations& impl) {
+                 MatrixDynSize jacobian;
+                 if (!impl.getLinearAngularMomentumJacobian(jacobian))
+                 {
+                     throw py::value_error("Unable to get linear and angular momentum jacobian.");
+                 }
+                 return jacobian;
+             })
+        .def("get_centroidal_total_momentum",
+             py::overload_cast<>(&KinDynComputations::getCentroidalTotalMomentum))
+        .def("get_centroidal_total_momentum_jacobian",
+             [](KinDynComputations& impl) {
+                 MatrixDynSize jacobian;
+                 if (!impl.getCentroidalTotalMomentumJacobian(jacobian))
+                 {
+                     throw py::value_error("Unable to get centroidal momentum jacobian.");
+                 }
+                 return jacobian;
+             })
+        .def("get_free_floating_mass_matrix",
+             [](KinDynComputations& impl) {
+                 MatrixDynSize massMatrix;
+                 if (!impl.getFreeFloatingMassMatrix(massMatrix))
+                 {
+                     throw py::value_error("Unable to get the mass matrix.");
+                 }
+                 return massMatrix;
+             })
+        .def("generalized_bias_forces",
+             [](KinDynComputations& impl) {
+                 FreeFloatingGeneralizedTorques biasForces(impl.model());
+                 if (!impl.generalizedBiasForces(biasForces))
+                 {
+                     throw py::value_error("Unable to get the bias forces.");
+                 }
+                 return biasForces;
+             })
+        .def("generalizedGravityForces", [](KinDynComputations& impl) {
+            FreeFloatingGeneralizedTorques gravitationalForces(impl.model());
+            if (!impl.generalizedGravityForces(gravitationalForces))
+            {
+                throw py::value_error("Unable to get the gravitational forces.");
+            }
+            return gravitationalForces;
+        });
+}
+} // namespace bindings
+} // namespace iDynTree

--- a/bindings/pybind11/idyntree_high_level.h
+++ b/bindings/pybind11/idyntree_high_level.h
@@ -1,0 +1,14 @@
+#ifndef IDYNTREE_PYBIND11_HIGH_LEVEL_H
+#define IDYNTREE_PYBIND11_HIGH_LEVEL_H
+
+#include <pybind11/pybind11.h>
+
+
+namespace iDynTree {
+namespace bindings {
+void iDynTreeHighLevelBindings(pybind11::module& module);
+
+}  // namespace bindings
+}  // namespace iDynTree
+
+#endif /* end of include guard: IDYNTREE_PYBIND11_HIGH_LEVEL_H */

--- a/bindings/pybind11/idyntree_model.cpp
+++ b/bindings/pybind11/idyntree_model.cpp
@@ -1,4 +1,5 @@
 #include "idyntree_model.h"
+#include "idyntree_type_caster.h"
 
 #include "error_utilities.h"
 

--- a/bindings/pybind11/idyntree_modelio_urdf.cpp
+++ b/bindings/pybind11/idyntree_modelio_urdf.cpp
@@ -1,6 +1,6 @@
 #include "idyntree_modelio_urdf.h"
-
 #include "error_utilities.h"
+#include "idyntree_type_caster.h"
 
 #include <string>
 #include <iDynTree/ModelIO/ModelExporter.h>

--- a/bindings/pybind11/idyntree_sensors.cpp
+++ b/bindings/pybind11/idyntree_sensors.cpp
@@ -1,5 +1,6 @@
 #include "idyntree_sensors.h"
 #include "error_utilities.h"
+#include "idyntree_type_caster.h"
 
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>

--- a/bindings/pybind11/idyntree_type_caster.h
+++ b/bindings/pybind11/idyntree_type_caster.h
@@ -1,0 +1,224 @@
+#ifndef IDYNTREE_PYBIND11_IDYNTREE_TYPE_CASTER_H
+#define IDYNTREE_PYBIND11_IDYNTREE_TYPE_CASTER_H
+
+#include <iostream>
+#include <string>
+#include <type_traits>
+
+#include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/Core/MatrixFixSize.h>
+#include <iDynTree/Core/Rotation.h>
+#include <iDynTree/Core/VectorDynSize.h>
+#include <iDynTree/Core/VectorFixSize.h>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace pybind11
+{
+namespace detail
+{
+template <template <unsigned int...> class base, typename derived>
+struct is_base_of_template_int_impl
+{
+    template <unsigned int... Ts> static constexpr std::true_type test(const base<Ts...>*);
+    static constexpr std::false_type test(...);
+    using type = decltype(test(std::declval<derived*>()));
+};
+
+template <template <unsigned int...> class base, typename derived>
+using is_base_of_template_int = typename is_base_of_template_int_impl<base, derived>::type;
+
+template <typename Type>
+using is_idyntree_vector_fix_size = is_base_of_template_int<iDynTree::VectorFixSize, Type>;
+template <typename Type>
+using is_idyntree_matrix_fix_size = is_base_of_template_int<iDynTree::MatrixFixSize, Type>;
+
+
+// Type caster for all the classes that inherits from VectorDynSize
+template <typename Type>
+struct type_caster<Type, enable_if_t<std::is_base_of<iDynTree::VectorDynSize, Type>::value>>
+{
+    PYBIND11_TYPE_CASTER(Type, _(PYBIND11_TOSTRING(Type)));
+
+    /**
+     * Conversion from Python to C++
+     */
+    bool load(handle src, bool convert)
+    {
+        if (!convert && array_t<double>::check_(src))
+        {
+            return false;
+        }
+
+        auto buf = pybind11::array_t<double,
+				     pybind11::array::c_style |
+				     pybind11::array::forcecast>::ensure(src);
+        if (!buf)
+            return false;
+
+	// the number of dimension must be equal to 1 since it is a vector
+        const auto dims = buf.ndim();
+        if (dims != 1)
+            return false;
+
+	// store the data
+        value = Type(buf.data(), buf.size());
+        return true;
+    }
+
+    /**
+     * Conversion from C++ to Python
+     */
+    static handle cast(Type src, return_value_policy policy, handle parent)
+    {
+        pybind11::array a(src.size(), src.data());
+        return a.release();
+    }
+};
+
+// Type caster for all the classes that inherits from MatriDynSize
+template <typename Type>
+struct type_caster<Type, enable_if_t<std::is_base_of<iDynTree::MatrixDynSize, Type>::value>>
+{
+    PYBIND11_TYPE_CASTER(Type, _(PYBIND11_TOSTRING(Type)));
+
+    /**
+     * Conversion from Python to C++
+     */
+    bool load(handle src, bool convert)
+    {
+        if (!convert && array_t<double>::check_(src))
+        {
+            return false;
+        }
+
+        auto buf = pybind11::array_t<double,
+				     pybind11::array::c_style
+				     | pybind11::array::forcecast>::ensure(src);
+        if (!buf)
+            return false;
+
+	// Since it is a matrix the buffer must have 2 dimensions
+        const auto dims = buf.ndim();
+        if (dims != 2)
+            return false;
+
+	// this can be done since numpy and iDynTree store matrices in Row-Major order
+	const auto rows = buf.shape(0);
+	const auto cols = buf.shape(1);
+        value = Type(buf.data(), rows, cols);
+
+        return true;
+    }
+
+    static handle cast(Type src, return_value_policy policy, handle parent)
+    {
+	// this can be done since numpy and iDynTree store matrices in Row-Major order
+        pybind11::array a({src.rows(), src.cols()}, src.data());
+        return a.release();
+    }
+};
+
+// Type caster for all the classes that inherits from VectorFixSize
+template <typename Type>
+struct type_caster<Type, enable_if_t<is_idyntree_vector_fix_size<Type>::value>>
+{
+    PYBIND11_TYPE_CASTER(Type, _(PYBIND11_TOSTRING(Type)));
+
+    /**
+     * Conversion from Python to C++
+     */
+    bool load(handle src, bool convert)
+    {
+        if (!convert && array_t<double>::check_(src))
+        {
+            return false;
+        }
+
+        auto buf = pybind11::array_t<double,
+				     pybind11::array::c_style |
+				     pybind11::array::forcecast>::ensure(src);
+        if (!buf)
+            return false;
+
+	// It must be a vector
+        const auto dims = buf.ndim();
+        if (dims != 1)
+            return false;
+
+        // since the vector is fixed size it is not possible to resize it. This check if the size is
+        // correct
+        if (buf.size() != value.size())
+            return false;
+
+        value = Type(buf.data(), buf.size());
+
+        return true;
+    }
+
+    /**
+     * Conversion from C++ to Python
+     */
+    static handle cast(Type src, return_value_policy policy, handle parent)
+    {
+        pybind11::array a(src.size(), src.data());
+        return a.release();
+    }
+};
+
+// Type caster for all the classes that inherits from MatrixFixSize but that are not rotations
+template <typename Type>
+struct type_caster<Type,
+                   enable_if_t<is_idyntree_matrix_fix_size<Type>::value
+                               && !std::is_same<iDynTree::Rotation, Type>::value>>
+{
+    PYBIND11_TYPE_CASTER(Type, _(PYBIND11_TOSTRING(Type)));
+
+    /**
+     * Conversion from Python to C++
+     */
+    bool load(handle src, bool convert)
+    {
+        if (!convert && array_t<double>::check_(src))
+        {
+            return false;
+        }
+
+        auto buf = pybind11::array_t<double, pybind11::array::c_style
+				     | pybind11::array::forcecast>::ensure(src);
+        if (!buf)
+            return false;
+
+	// since it is a matrix the number of dimension must be equal to 2
+        auto dims = buf.ndim();
+        if (dims != 2)
+            return false;
+
+	// the matrix is fix size so it is not possible to change it's size
+        if (buf.size() != value.rows() * value.cols())
+            return false;
+
+	// this can be done since numpy and iDynTree store matrices in Row-Major order
+	const auto rows = buf.shape(0);
+	const auto cols = buf.shape(1);
+        value = Type(buf.data(), rows, cols);
+
+        return true;
+    }
+
+    /**
+     * Conversion from C++ to Python
+     */
+    static handle cast(Type src, return_value_policy policy, handle parent)
+    {
+	// this can be done since numpy and iDynTree store matrices in Row-Major order
+        pybind11::array a({src.rows(), src.cols()}, src.data());
+        return a.release();
+    }
+};
+
+} // namespace detail
+} // namespace pybind11
+
+#endif /* end of include guard: IDYNTREE_PYBIND11_IDYNTREE_TYPE_CASTER_H */

--- a/src/core/include/iDynTree/Core/Position.h
+++ b/src/core/include/iDynTree/Core/Position.h
@@ -68,6 +68,11 @@ namespace iDynTree
         Position(iDynTree::Span<const double> other);
 
         /**
+         * Constructor from a raw buffer of 3 doubles.
+         */
+        Position(const double* in_data, const unsigned int in_size);
+
+        /**
          * Geometric operations
          */
         const Position & changePoint(const Position & newPoint);

--- a/src/core/src/Position.cpp
+++ b/src/core/src/Position.cpp
@@ -73,6 +73,11 @@ namespace iDynTree
     {
     }
 
+    Position::Position(const double* in_data, const unsigned int in_size)
+        : PositionRaw(in_data, in_size)
+    {
+    }
+
     const Position& Position::changePoint(const Position& newPoint)
     {
         this->PositionRaw::changePoint(newPoint);


### PR DESCRIPTION
The PR is still in draft since I've to implement the bindings for the twist and I've to add the tests

This is an example of usage

```python
import idyntree.pybind as iDynTree

kindyn = iDynTree.KinDynComputations()
kindyn.model = iDynTree.get_random_model(10)
kindyn.set_robot_state([0] * kindyn.get_nr_of_degrees_of_freedom(),
                       [0] * kindyn.get_nr_of_degrees_of_freedom(),
                       [0,0,-9.81])

mass_matrix = kindyn.get_free_floating_mass_matrix()
print(mass_matrix)
```

this is the output
```
array([[  25.57634706,    0.        ,    0.        ,    0.        ,
         -15.9249302 ,  -54.83262385,   -8.8700384 ,    4.9886203 ,
           4.58045113],
       [   0.        ,   25.57634706,    0.        ,   15.9249302 ,
           0.        ,   17.75681755,   12.90257969,   -8.81148874,
           0.98227791],
       [   0.        ,    0.        ,   25.57634706,   54.83262385,
         -17.75681755,    0.        ,  -29.49926001,   -2.30219837,
           3.81275983],
       [   0.        ,   15.9249302 ,   54.83262385,  319.99566805,
         -83.66501237, -109.7314934 ,  -97.47332486,   25.4046302 ,
          -2.72756328],
       [ -15.9249302 ,    0.        ,  -17.75681755,  -83.66501237,
         322.25186762,   50.53625654,   99.22406621,    5.48370803,
          -3.07273261],
       [ -54.83262385,   17.75681755,    0.        , -109.7314934 ,
          50.53625654,  405.52787367,   76.84201426,  -65.68563465,
           2.72448946],
       [  -8.8700384 ,   12.90257969,  -29.49926001,  -97.47332486,
          99.22406621,   76.84201426,  103.53784748,  -33.24504489,
           0.        ],
       [   4.9886203 ,   -8.81148874,   -2.30219837,   25.4046302 ,
           5.48370803,  -65.68563465,  -33.24504489,   27.92202853,
           0.        ],
       [   4.58045113,    0.98227791,    3.81275983,   -2.72756328,
          -3.07273261,    2.72448946,    0.        ,    0.        ,
           6.64783251]])
```