### PR TITLE
Fix working directory for pybind11 tests

### DIFF
--- a/bindings/pybind11/tests/CMakeLists.txt
+++ b/bindings/pybind11/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_test (NAME pybind11_idyntree_test
   COMMAND ${Python3_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR}
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/bindings/pybind11
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/pybind11
 )


### PR DESCRIPTION
Without this fix the tests were failing with the following error
```
ctest -R pybind11_idyntree_test
Test project /home/gromualdi/robot-code/robotology-superbuild/build/src/iDynTree
    Start 63: pybind11_idyntree_test
Failed to change working directory to /home/gromualdi/robot-code/robotology-superbuild/build/src/iDynTree/bindings/bindings/pybind11 : No such file or directory
1/1 Test #63: pybind11_idyntree_test ...........***Not Run   0.00 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.00 sec

The following tests FAILED:
	 63 - pybind11_idyntree_test (Not Run)
Errors while running CTest
```

I think we should implement a job for pybind11 #782 