### PR TITLE
Add idyntree-model-simplify-shapes command line tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for exporting joint position limits to URDF for 1-DoF joints
   (prismatic and revolute).
 - Added pybind11 python bindings for adding and reading joint limits.
+- Added the `ModelTransformsSolidShapes.h` header in the `iDynTree::idyntree-solid-shapes` library.
+  At the moment, this header contains just the `iDynTree::approximateSolidShapesWithPrimitiveShape`
+  function, useful to approximate the solid shapes of a given iDynTree::Model to a series of bounding boxes (https://github.com/robotology/idyntree/pull/941).
+- Added `idyntree-model-simplify-shapes` command line tool. This tool is useful to take in input a model, and 
+  return in output the same model, but with all the geometries of the model approximated with their axis aligned 
+  bounding boxes (https://github.com/robotology/idyntree/issues/933, https://github.com/robotology/idyntree/pull/941).
 
 ### Fixed 
 - In the URDF exporter, export only frames attached to the exported traversal [#914](https://github.com/robotology/idyntree/pull/914).

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Example: Visualize a given model
 idyntree-model-view -m <location-of-the-model>
 ~~~
 
+### `idyntree-model-simplify-shapes`
+
+Tool that reads a model from a file, and returns in output the same model, but with all 
+solid shapes of the model (both collision and visual) substituted with a primitive shape 
+that approximates in some way the original solid shape. At the moment, the only conversion 
+type provided is to approximate each solid shape of the model with its axis aligned bounding box.
+
+Example: Approximate a given model
+~~~
+idyntree-model-simplify-shapes -m <location-of-the-input-model> -o <desired-location-of-the-output-model>
+~~~
+
 
 ## Reference Documentation
 The documentation for the complete API of iDynTree is automatically extracted from the C++ code using [Doxygen](http://www.doxygen.org),

--- a/src/solid-shapes/CMakeLists.txt
+++ b/src/solid-shapes/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(libraryname idyntree-solid-shapes)
 
-set(IDYNTREE_SOLID_SHAPES_SOURCES src/InertialParametersSolidShapesHelpers.cpp)
-set(IDYNTREE_SOLID_SHAPES_HEADERS include/iDynTree/InertialParametersSolidShapesHelpers.h)
+set(IDYNTREE_SOLID_SHAPES_SOURCES src/InertialParametersSolidShapesHelpers.cpp
+                                  src/ModelTransformersSolidShapes.cpp)
+set(IDYNTREE_SOLID_SHAPES_HEADERS include/iDynTree/InertialParametersSolidShapesHelpers.h
+                                  include/iDynTree/ModelTransformersSolidShapes.h)
 
 add_library(${libraryname} ${IDYNTREE_SOLID_SHAPES_HEADERS} ${IDYNTREE_SOLID_SHAPES_SOURCES})
 add_library(iDynTree::${libraryname} ALIAS ${libraryname})

--- a/src/solid-shapes/include/iDynTree/ModelTransformersSolidShapes.h
+++ b/src/solid-shapes/include/iDynTree/ModelTransformersSolidShapes.h
@@ -20,12 +20,12 @@ class Model;
 class SensorsList;
 
 enum ApproximateSolidShapesWithPrimitiveShapeConversionType {
-    ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox
+    ConvertSolidShapesWithEnclosingAxisAlignedBoundingBoxes
 };
 
 struct ApproximateSolidShapesWithPrimitiveShapeOptions 
 {
-    ApproximateSolidShapesWithPrimitiveShapeConversionType conversionType = ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox;
+    ApproximateSolidShapesWithPrimitiveShapeConversionType conversionType = ConvertSolidShapesWithEnclosingAxisAlignedBoundingBoxes;
 };
 
 /**
@@ -35,7 +35,7 @@ struct ApproximateSolidShapesWithPrimitiveShapeOptions
  * solid shapes of the model (both collision and visual) substituted with a primitive shape 
  * that approximates in some way the original solid shape.
  *
- * \note At the moment, the only conversion type provides is to approximate each solid
+ * \note At the moment, the only conversion type provided is to approximate each solid
  * shape of the model with its axis aligned bounding box, using the iDynTree::computeBoundingBoxFromShape
  * function.
  *

--- a/src/solid-shapes/include/iDynTree/ModelTransformersSolidShapes.h
+++ b/src/solid-shapes/include/iDynTree/ModelTransformersSolidShapes.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+
+/**
+ * \file ModelTransformersSolidShapes.h
+ *  \brief Collection of function to modify model, related to solid shapes.
+ *
+*/
+
+
+#ifndef IDYNTREE_MODEL_TRANSFORMERS_SOLID_SHAPES_H
+#define IDYNTREE_MODEL_TRANSFORMERS_SOLID_SHAPES_H
+
+namespace iDynTree
+{
+class Model;
+class SensorsList;
+
+enum ApproximateSolidShapesWithPrimitiveShapeConversionType {
+    ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox
+};
+
+struct ApproximateSolidShapesWithPrimitiveShapeOptions 
+{
+    ApproximateSolidShapesWithPrimitiveShapeConversionType conversionType = ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox;
+};
+
+/**
+ * \function Approximate solid shapes of the input model with some primitive shapes.
+ *
+ * This function takes in input a Model, and returns in output the same model, but with all 
+ * solid shapes of the model (both collision and visual) substituted with a primitive shape 
+ * that approximates in some way the original solid shape.
+ *
+ * \note At the moment, the only conversion type provides is to approximate each solid
+ * shape of the model with its axis aligned bounding box, using the iDynTree::computeBoundingBoxFromShape
+ * function.
+ *
+ */
+bool approximateSolidShapesWithPrimitiveShape(const Model& inputModel,
+                                              Model& outputModel,
+                                              ApproximateSolidShapesWithPrimitiveShapeOptions options=ApproximateSolidShapesWithPrimitiveShapeOptions());
+
+
+}
+
+#endif

--- a/src/solid-shapes/src/ModelTransformersSolidShapes.cpp
+++ b/src/solid-shapes/src/ModelTransformersSolidShapes.cpp
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <iDynTree/ModelTransformersSolidShapes.h>
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/InertialParametersSolidShapesHelpers.h>
+
+#include <cassert>
+#include <set>
+
+namespace iDynTree
+{
+
+bool approximateSolidShapesWithBoundingBoxes(const iDynTree::ModelSolidShapes& inputSolidShapes,
+                                         iDynTree::ModelSolidShapes& outputSolidShapes)
+{
+    bool retValue = true;
+    outputSolidShapes.clear();
+    outputSolidShapes.resize(inputSolidShapes.getLinkSolidShapes().size());
+    auto& inputLinkSolidShapes = inputSolidShapes.getLinkSolidShapes();
+    auto& outputLinkSolidShapes = outputSolidShapes.getLinkSolidShapes();
+    for (size_t link = 0; link < inputLinkSolidShapes.size(); link++)
+    {
+        outputLinkSolidShapes[link].resize(inputLinkSolidShapes[link].size());
+        for (size_t geom = 0; geom < inputLinkSolidShapes[link].size(); geom++)
+        {
+            SolidShape* inputSolidShape = inputLinkSolidShapes[link][geom];
+            Box outputBox;
+            bool approximationOk = computeBoundingBoxFromShape(*inputSolidShape, outputBox);
+            outputLinkSolidShapes[link][geom] = outputBox.clone();
+            retValue = retValue && approximationOk;
+        }
+    }
+
+    return retValue;
+}
+
+bool approximateSolidShapesWithPrimitiveShape(const Model& inputModel,
+                                              Model& outputModel,
+                                              ApproximateSolidShapesWithPrimitiveShapeOptions /*options*/)
+{
+    bool retValue = true;
+
+    // The output model is copied from the input one
+    outputModel = inputModel;
+
+    // For now the only supported option is ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox,
+    // that approximates the solid shapes via the iDynTree::computeBoundingBoxFromShape function
+
+    // Approximate visual shapes
+    retValue = retValue && approximateSolidShapesWithBoundingBoxes(inputModel.visualSolidShapes(), outputModel.visualSolidShapes());
+
+    // Approximate collision shapes
+    retValue = retValue && approximateSolidShapesWithBoundingBoxes(inputModel.collisionSolidShapes(), outputModel.collisionSolidShapes());
+
+    return retValue;
+}
+
+
+}

--- a/src/solid-shapes/tests/CMakeLists.txt
+++ b/src/solid-shapes/tests/CMakeLists.txt
@@ -21,3 +21,4 @@ macro(add_unit_test classname)
 endmacro()
 
 add_unit_test(InertialParametersSolidShapesHelpers)
+add_unit_test(ModelTransformersSolidShapes)

--- a/src/solid-shapes/tests/ModelTransformersSolidShapesIntegrationTest.cpp
+++ b/src/solid-shapes/tests/ModelTransformersSolidShapesIntegrationTest.cpp
@@ -33,7 +33,7 @@ void checkThatOneSphereIsApproximatedToABox()
     // Compute the simplified model
     iDynTree::Model oneBoxModel;
     ApproximateSolidShapesWithPrimitiveShapeOptions options = ApproximateSolidShapesWithPrimitiveShapeOptions();
-    options.conversionType = ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox;
+    options.conversionType = ConvertSolidShapesWithEnclosingAxisAlignedBoundingBoxes;
     bool ok = approximateSolidShapesWithPrimitiveShape(oneSphereModel, oneBoxModel);
     ASSERT_IS_TRUE(ok);
 

--- a/src/solid-shapes/tests/ModelTransformersSolidShapesIntegrationTest.cpp
+++ b/src/solid-shapes/tests/ModelTransformersSolidShapesIntegrationTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <iDynTree/Core/TestUtils.h>
+
+
+#include <iDynTree/ModelTransformersSolidShapes.h>
+
+#include <iDynTree/Core/VectorDynSize.h>
+#include <iDynTree/Model/Model.h>
+
+
+using namespace iDynTree;
+
+void checkThatOneSphereIsApproximatedToABox()
+{
+    // Create a model with one shape with one sphere, and 
+    // convert it with approximateSolidShapesWithPrimitiveShape
+    // with type ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox, 
+    // and verify that the sphere has ben substituted with a box
+
+    iDynTree::Model oneSphereModel;
+    iDynTree::Link oneSphereLink;
+    oneSphereModel.addLink("link0", oneSphereLink);
+    oneSphereModel.collisionSolidShapes().getLinkSolidShapes()[0].resize(1);
+    iDynTree::Sphere oneSphere;
+    oneSphere.setLink_H_geometry(Transform::Identity());
+    oneSphere.setRadius(1.0);
+    oneSphereModel.collisionSolidShapes().getLinkSolidShapes()[0][0] = new iDynTree::Sphere(oneSphere);
+
+    // Compute the simplified model
+    iDynTree::Model oneBoxModel;
+    ApproximateSolidShapesWithPrimitiveShapeOptions options = ApproximateSolidShapesWithPrimitiveShapeOptions();
+    options.conversionType = ConvertSolidShapesWithEnclosingAxiAlignedBoundingBox;
+    bool ok = approximateSolidShapesWithPrimitiveShape(oneSphereModel, oneBoxModel);
+    ASSERT_IS_TRUE(ok);
+
+    // The size of the box should be equal to the diameter of the sphere in all directions
+    ASSERT_IS_TRUE(oneBoxModel.collisionSolidShapes().getLinkSolidShapes().size() == 
+                   oneSphereModel.collisionSolidShapes().getLinkSolidShapes().size());
+    ASSERT_IS_TRUE(oneBoxModel.collisionSolidShapes().getLinkSolidShapes()[0].size() == 
+                   oneSphereModel.collisionSolidShapes().getLinkSolidShapes()[0].size());
+    ASSERT_IS_TRUE(oneBoxModel.collisionSolidShapes().getLinkSolidShapes()[0][0]->isBox());
+    iDynTree::Box* oneBoxPtr = oneBoxModel.collisionSolidShapes().getLinkSolidShapes()[0][0]->asBox();
+    ASSERT_IS_TRUE(oneBoxPtr);
+    ASSERT_EQUAL_DOUBLE(oneBoxPtr->getX(), 2*oneSphere.getRadius());
+    ASSERT_EQUAL_DOUBLE(oneBoxPtr->getY(), 2*oneSphere.getRadius());
+    ASSERT_EQUAL_DOUBLE(oneBoxPtr->getZ(), 2*oneSphere.getRadius());
+}
+
+
+int main()
+{
+    checkThatOneSphereIsApproximatedToABox();
+
+    return EXIT_SUCCESS;
+}
+

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -15,6 +15,9 @@ macro(IDYNTREE_ADD_TOOL tool_name tool_code)
                                                idyntree-visualization
                                                Eigen3::Eigen)
     target_compile_options(${tool_name} PRIVATE ${IDYNTREE_WARNING_FLAGS})
+    if(TARGET idyntree-solid-shapes)
+        target_link_libraries(${tool_name} PRIVATE idyntree-solid-shapes)
+    endif()
     install(TARGETS ${tool_name} DESTINATION bin)
 endmacro(IDYNTREE_ADD_TOOL tool_name tool_code)
 
@@ -22,6 +25,10 @@ idyntree_add_tool(idyntree-model-info idyntree-model-info.cpp)
 
 if(IDYNTREE_USES_IRRLICHT)
     idyntree_add_tool(idyntree-model-view idyntree-model-view.cpp)
+endif()
+
+if(IDYNTREE_USES_ASSIMP)
+    idyntree_add_tool(idyntree-model-simplify-shapes idyntree-model-simplify-shapes.cpp)
 endif()
 
 if(IDYNTREE_COMPILES_YARP_TOOLS)

--- a/src/tools/idyntree-model-simplify-shapes.cpp
+++ b/src/tools/idyntree-model-simplify-shapes.cpp
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <iDynTree/Model/Model.h>
+
+// To load models from file
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+// To approximate shapes of a model
+#include <iDynTree/ModelTransformersSolidShapes.h>
+
+// To write model to file
+#include <iDynTree/ModelIO/ModelExporter.h>
+
+#include "cmdline.h"
+
+#include <iostream>
+#include <cstdlib>
+
+/**
+ * Add the option supported by the idyntree-model-simplify-shapes utility
+ */
+void addOptions(cmdline::parser &cmd)
+{
+    cmd.add<std::string>("model", 'm',
+                         "Input model to load and simplify.",
+                         true);
+
+    cmd.add<std::string>("output-model", 'o',
+                         "Output simplified model.",
+                         true);
+}
+
+int main(int argc, char** argv)
+{
+    cmdline::parser cmd;
+    addOptions(cmd);
+    cmd.parse_check(argc, argv);
+
+    // Read model
+    const std::string& modelPath = cmd.get<std::string>("model");
+    const std::string& outputModelPath = cmd.get<std::string>("output-model");
+
+    iDynTree::ModelLoader mdlLoader;
+    bool ok = mdlLoader.loadModelFromFile(modelPath);
+
+    if (!ok)
+    {
+        std::cerr << "Impossible to read model at file " << modelPath << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Simplify the model
+    iDynTree::ApproximateSolidShapesWithPrimitiveShapeOptions options = 
+        iDynTree::ApproximateSolidShapesWithPrimitiveShapeOptions();
+    options.conversionType = iDynTree::ConvertSolidShapesWithEnclosingAxisAlignedBoundingBoxes;
+    iDynTree::Model simplifiedModel;
+    ok = approximateSolidShapesWithPrimitiveShape(mdlLoader.model(), simplifiedModel);
+
+    if (!ok)
+    {
+        std::cerr << "Impossible to simplify  model loaded from file " << modelPath << std::endl;
+        return EXIT_FAILURE;
+    }
+
+
+    // Export the model to file
+    iDynTree::ModelExporter mdlExporter;
+    iDynTree::ModelExporterOptions exportOptions = iDynTree::ModelExporterOptions();
+    ok = mdlExporter.init(simplifiedModel, iDynTree::SensorsList(), exportOptions);
+    ok = ok && mdlExporter.exportModelToFile(outputModelPath);
+
+    if (!ok)
+    {
+        std::cerr << "Impossible to export simplified model at file " << outputModelPath << std::endl;
+        return EXIT_FAILURE;
+    }
+
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This tool is useful to take in input a model, and return in output the same model, but with all the geometries of the model approximated with their axis aligned bounding boxes. This implements what was described in https://github.com/robotology/idyntree/issues/933 . This tool is only available if iDynTree is compiled with assimp support.

The actual logic of the tool is contained in a function that can operate directly on `iDynTree::Model` instances that is called `iDynTree::approximateSolidShapesWithPrimitiveShape` and is contained in the `iDynTree::idyntree-solid-shapes` target. In this way, the same logic of the command line tool can be used also programatically in C++, MATLAB or Python (SWIG bindings). 