### PR TITLE
Fix various LaTeX syntax problems in Doxygen docs

### DIFF
--- a/src/core/include/iDynTree/Core/Rotation.h
+++ b/src/core/include/iDynTree/Core/Rotation.h
@@ -150,7 +150,7 @@ namespace iDynTree
          /**
          * Get a roll, pitch and yaw corresponding to this rotation.
          *
-         * Get \f$ (r,p,y) \in ( (-π, π] \times (-π/2, π/2) \times (-π, π] ) \cup ( \{0\} \times \{-π/2\} \times (-π,π] ) \cup ( \{0\} \times \{π/2\} \times [-π,π) )\f$
+         * Get \f$ (r,p,y) \in ( (-\pi, \pi] \times (-\frac{\pi}{2}, \frac{\pi}{2}) \times (-\pi, \pi] ) \cup ( \{0\} \times \{-\frac{\pi}{2}\} \times (-\pi,\pi] ) \cup ( \{0\} \times \{\frac{\pi}{2}\} \times [-\pi,\pi) )\f$
          * such that
          * *this == RotZ(y)*RotY(p)*RotX(r)
          *

--- a/src/estimation/include/iDynTree/Estimation/AttitudeEstimatorUtils.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeEstimatorUtils.h
@@ -17,7 +17,6 @@
 #include <cmath>
 #include <vector>
 
-
 /**
  *
  * @brief check a valid measurement
@@ -62,7 +61,7 @@ bool isZeroVector(const iDynTree::Vector3& vec);
 iDynTree::Vector3 crossVector(const iDynTree::Vector3& a, const iDynTree::Vector3& b);
 
 /**
- * @brief computes \f$ 3 \times 3 \f$ skew-symmetric matrix (\f$ \mathbb{so}(3) \$ space) for a given 3d vector (\f$ \mathbb{R}^3 \f$ space)
+ * @brief computes \f$ 3 \times 3 \f$ skew-symmetric matrix (\f$ \mathbb{so}(3) \f$ space) for a given 3d vector (\f$ \mathbb{R}^3 \f$ space)
  *
  * @param[in] omega 3d vector (usually angular velocity)
  * @return iDynTree::Matrix3x3
@@ -192,3 +191,4 @@ inline bool check_are_almost_equal(const T& x, const T& y, int units_in_last_pla
 }
 
 #endif
+

--- a/src/estimation/include/iDynTree/Estimation/AttitudeMahonyFilter.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeMahonyFilter.h
@@ -50,8 +50,8 @@ struct AttitudeMahonyFilterParameters {
  * @note: we will drop the subscripts and superscripts in the rest of the documentation for convenience
  *
  * The discretized dynamics of the filter is implemented in the propagateStates() method and is described by the following equations,
- * \f$ q_{k+1} = q_{k} + \Delta t \frac{1}{2}q_{k} \circ \begin{bmatrix} 0 \\ \Omega_y_{k+1} - b_k + K_p \omega_{mes_{k+1}}\end{bmatrix}\f$
- * \f$ \Omega_{k+1} = \Omega_y_{k+1} - b_k \f$
+ * \f$ q_{k+1} = q_{k} + \Delta t \frac{1}{2}q_{k} \circ \begin{bmatrix} 0 \\ {\Omega_y}_{k+1} - b_k + K_p \omega_{mes_{k+1}}\end{bmatrix}\f$
+ * \f$ \Omega_{k+1} = {\Omega_y}_{k+1} - b_k \f$
  * \f$ b_{k+1} = b_k - K_i \Delta t \frac{1}{2} \omega_{mes_{k+1}} \f$
  *
  * The updateFilterWithMeasurements() uses the recent IMU measurements to compute the term \f$ \omega_{mes} \f$ which gives the vectorial from accelerometer and magnetometer measurements

--- a/src/estimation/include/iDynTree/Estimation/AttitudeQuaternionEKF.h
+++ b/src/estimation/include/iDynTree/Estimation/AttitudeQuaternionEKF.h
@@ -228,8 +228,8 @@ namespace iDynTree
     private:
         /**
          * discrete system propagation \f$ f(X, u) = f(X, y_gyro) \f$
-         * where \f$ X = \begin{bmatrix} q_0 &  q_1 & q_2 & q_3 & \omega_x & \omega_y & \omega_z & \b_x & \b_y & \b_z \end{bmatrix}^T \f$
-         * \f$ u = \begin{bmatrix} y_{gyro}_x & y_{gyro}_y & y_{gyro}_z \end{bmatrix}^T \f$
+         * where \f$ X = \begin{bmatrix} q_0 &  q_1 & q_2 & q_3 & \omega_x & \omega_y & \omega_z & b_x & b_y & b_z \end{bmatrix}^T \f$
+         * \f$ u = \begin{bmatrix} {y_{gyro}}_x & {y_{gyro}}_y & {y_{gyro}}_z \end{bmatrix}^T \f$
          * \f$ f(X, u) = \begin{bmatrix} q_{k} \otimes \text{exp}(\omega \Delta T) \\ y_{gyro} - b \\ (1 - \lambda_{b} \Delta t)b \end{bmatrix}\f$
          */
         bool ekf_f(const iDynTree::VectorDynSize& x_k,

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -1189,7 +1189,7 @@ public:
      * |`FrameVelocityRepresentation` |  `linkInternalWrenches(i)` |
      * |:----------------------------:|:--------------------------:|
      * | `MIXED_REPRESENTATION` (default) | \f$ {}_{L[A]} \mathrm{f}_{\lambda(L), L} \f$ |
-     * | `BODY_FIXED_REPRESENTATION` | f$ {}_{L} \mathrm{f}_{\lambda(L), L} \f$ |
+     * | `BODY_FIXED_REPRESENTATION` | \f$ {}_{L} \mathrm{f}_{\lambda(L), L} \f$ |
      * | `INERTIAL_FIXED_REPRESENTATION` | \f$ {}_{A} \mathrm{f}_{\lambda(L), L} \f$ |
      *
      * Where if \f$C\f$ is a given frame, \f$ {}_{C} \mathrm{f}_{\lambda(L), L} \f$ is the 6D force/torque that the

--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -72,9 +72,9 @@ namespace iDynTree {
  * @brief NLP-based Inverse kinematics
  *
  * Given a mechanical structure configuration
- * \f[ q \in SE(3) \times \mathbb{R}^n \f] and
+ * \f[ q \in \operatorname{SE}(3) \times \mathbb{R}^n \f] and
  * possibly multiple target frames
- * \f[ F_i^d \in \SE(3) \f]
+ * \f[ F_i^d \in \operatorname{SE}(3) \f]
  * the inverse kinematics is responsible to find the
  * configuration \f$ q^* \f$ such that
  * \f[ F_i(q^*) = F_i^d \forall i, \f]
@@ -302,7 +302,7 @@ public:
      * Adds a (constancy) constraint for the specified frame
      *
      * The constraint is
-     * \f$ {}^w_X_{frame}(q) = {}^w_X_{frame}(q^0) \f$
+     * \f$ {}^w X_{frame}(q) = {}^w X_{frame}(q^0) \f$
      * where the robot configuration \f$q\f$ is the one specified with setRobotConfiguration
      * @note you should specify first the robot configuration. Otherwise call the versions
      * with explicit constraint value

--- a/src/inverse-kinematics/include/private/InverseKinematicsData.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsData.h
@@ -83,7 +83,7 @@ public:
      */
     struct {
         iDynTree::VectorDynSize jointsConfiguration; /*!< joint configuration \f$ q_j \in \mathbb{R}^n \f$ */
-        iDynTree::Transform basePose; /*!< base position \f$ w_H_{base} \in SE(3) \f$ */
+        iDynTree::Transform basePose; /*!< base position \f$ {}^w H_{base} \in SE(3) \f$ */
         iDynTree::VectorDynSize jointsVelocity; /*!< joint velotiy \f$ \dot{q}_j \in \mathbb{R}^n \f$ */
         iDynTree::Twist baseTwist; /*!< base velocity \f$ [\dot{p}, {}^I \omega] \in se(3) \f$ */
         iDynTree::Vector3 worldGravity; /*!< gravity acceleration in inertial frame, i.e. -9.81 along z */

--- a/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
+++ b/src/inverse-kinematics/include/private/InverseKinematicsNLP.h
@@ -189,14 +189,14 @@ public:
  *
  * Implements the following optimization problem
  * \f{align}{
- * \min_{x} & \Sum_i || w_H_{f_i} (w_H_{f_i}^d)^{-1} ||^2 + w_q || q_j - q_j^d ||^2 \\
- * \text{s.t.} & w_H_{f_i} = w_H_{f_i}^d \\
+ * \min_{x} & \sum_i || {}^w H_{f_i} ( {}^w H_{f_i}^d)^{-1} ||^2 + w_q || q_j - q_j^d ||^2 \\
+ * \text{s.t.} & {}^w H_{f_i} = {}^w H_{f_i}^d \\
  *             & q_{min} \leq q \leq q_{max}
  * \f}
  * where
  * \f{align}{
- * & q = \{w_H_{base}, q_j\} \in SE(3) \times \mathbb{R}^n \\
- * & w_H_{f_i} \in SE(3)
+ * & q = \{ {}^w H_{base}, q_j\} \in SE(3) \times \mathbb{R}^n \\
+ * & {}^w H_{f_i} \in SE(3)
  * \f}
  *
  * A target (entirely or partially, with partial meaning the two components composing

--- a/src/model/include/iDynTree/Model/DynamicsLinearization.h
+++ b/src/model/include/iDynTree/Model/DynamicsLinearization.h
@@ -62,7 +62,7 @@ namespace iDynTree
          * Buffer to store the derivative of
          * the product
          * \f[
-         *   V_l \bar\cross^* M_l V_l
+         *   V_l \bar\times^* M_l V_l
          * \f]
          *
          * with respect to V_l

--- a/src/model/include/iDynTree/Model/DynamicsUtils.h
+++ b/src/model/include/iDynTree/Model/DynamicsUtils.h
@@ -21,7 +21,7 @@ namespace iDynTree
      * Given a rigid body inertia \f$M\f$ and spatial motion vector \f$V\f$,
      * the bias wrench \f$B\f$ of rigid body is defined as:
      * \f[
-     *   B =  \cross
+     *   B =  \times
      * \f]
      *
      */

--- a/src/model/include/iDynTree/Model/IJoint.h
+++ b/src/model/include/iDynTree/Model/IJoint.h
@@ -149,7 +149,7 @@ namespace iDynTree
          *
          * In particular, if the selected position coordinate is \f$q\f$, return the derivative:
          * \f[
-         * \frac{partial \texttt{child}_H_\texttt{parent} }{\partial q}
+         * \frac{\partial {}^\texttt{child} H_\texttt{parent} }{\partial q}
          * \f]
          *
          * If posCoord_i is not >= 0 and < getNrOfPosCoords(), the returned value is undefined.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -688,22 +688,22 @@ public:
     virtual IJetsVisualization& jets() = 0;
 
     /**
-     * Get the transformation of given link with respect to visualizer world \f$ w_H_{link}\f$
+     * Get the transformation of given link with respect to visualizer world \f$ {}^w wH_{link}\f$
      */
     virtual Transform getWorldLinkTransform(const LinkIndex& linkIndex) = 0;
 
     /**
-     * Get the transformation of given link with respect to visualizer world \f$ w_H_{link}\f$
+     * Get the transformation of given link with respect to visualizer world \f$ {}^w H_{link}\f$
      */
     virtual Transform getWorldLinkTransform(const std::string& linkName) = 0;
 
     /**
-     * Get the transformation of given frame with respect to visualizer world \f$ w_H_{frame}\f$
+     * Get the transformation of given frame with respect to visualizer world \f$ {}^w H_{frame}\f$
      */
     virtual Transform getWorldFrameTransform(const FrameIndex& frameIndex) = 0;
 
     /**
-     * Get the transformation of given frame with respect to visualizer world \f$ w_H_{frame}\f$
+     * Get the transformation of given frame with respect to visualizer world \f$ {}^w H_{frame}\f$
      */
     virtual Transform getWorldFrameTransform(const std::string& frameName) = 0;
 


### PR DESCRIPTION
I did a first attempt to port iDynTree to [m.css's Doxygen theme](https://mcss.mosra.cz/documentation/doxygen/) using the same structure used in [blf](https://github.com/ami-iit/bipedal-locomotion-framework). While I still need to cleanup a bit the part generating the documentation (that was however changed in https://github.com/ami-iit/bipedal-locomotion-framework/pull/457), most of the fixes are fixes to the LaTeX formulas that can be submitted indipendently from the migration to m.css .