### PR TITLE
Several improvements in the swig python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added the possibility to draw in different portions of the visualizer window and textures at the same time. Allow disabling the drawing on textures (https://github.com/robotology/idyntree/pull/903).
+- Implement the `operator[]` for `LinkPositions`, `LinkVelArray` and `LinkAccArray` in the swig python bindings (https://github.com/robotology/idyntree/pull/949)
+- Expose `ModelTestUtils` in swig bindings (https://github.com/robotology/idyntree/pull/949)
+- Define base and joints attributes for `FreeFloatingPos`, `FreeFloatingVel` and `FreeFloatingAcc` in swig bindings (https://github.com/robotology/idyntree/pull/949)
 
 ### Deprecated
 - The `iDynTree::Visualizer::enviroment()` was deprecated. Please use the `iDynTree::Visualizer::environment()` method instead (https://github.com/robotology/idyntree/pull/903).

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -83,6 +83,7 @@
 #include "iDynTree/Model/FreeFloatingMatrices.h"
 #include "iDynTree/Model/FreeFloatingState.h"
 #include "iDynTree/Model/ContactWrench.h"
+#include "iDynTree/Model/ModelTestUtils.h"
 
 // Kinematics & Dynamics related functions
 #include "iDynTree/Model/ForwardKinematics.h"
@@ -247,6 +248,7 @@ namespace std {
 %include "iDynTree/Model/FreeFloatingMatrices.h"
 %include "iDynTree/Model/FreeFloatingState.h"
 %include "iDynTree/Model/ContactWrench.h"
+%include "iDynTree/Model/ModelTestUtils.h"
 
 %include "joints.i"
 

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -76,6 +76,38 @@ import_array();
     %}
 %enddef
 
+
+// Magic Python method for using [] on vectors associated to the links
+%define PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(ElementType)
+     const ElementType& __getitem__(unsigned int index) {
+        if (index >= self->getNrOfLinks()) {
+            const std::string error = "Index " + std::to_string(index)
+                                    + " not valid. The vector has a size of "
+                                    + std::to_string(self->getNrOfLinks());
+            throw std::out_of_range(error);
+        }
+
+        return (*self)(index);
+     }
+
+     void __setitem__(unsigned int index, const ElementType& element) {
+        if (index >= self->getNrOfLinks()) {
+            const std::string error = "Index " + std::to_string(index)
+                                    + " not valid. The vector has a size of "
+                                    + std::to_string(self->getNrOfLinks());
+            throw std::out_of_range(error);
+        }
+
+        (*self)(index) = element;
+     }
+
+     %pythoncode %{
+        def __len__(self):
+            return self.getNrOfLinks()
+     %}
+%enddef
+
+
 // Magic Python method for using [] on matrices
 %define PYTHON_MAGIC_SET_GET_LEN_MATRIX()
     %pythoncode %{
@@ -263,4 +295,19 @@ import_array();
     CPP_SPATIAL_CLASS_LINANG_CONSTRUCTOR(SpatialAcc);
     CPP_TO_NUMPY_SPATIAL_VECTOR(iDynTree::SpatialAcc)
 
+};
+
+//
+// Vector associated to the links
+//
+%extend iDynTree::LinkPositions {
+    PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::Transform)
+};
+
+%extend iDynTree::LinkVelArray {
+    PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::Twist)
+};
+
+%extend iDynTree::LinkAccArray {
+    PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::SpatialAcc)
 };

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -311,3 +311,7 @@ import_array();
 %extend iDynTree::LinkAccArray {
     PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::SpatialAcc)
 };
+
+%extend iDynTree::LinkWrenches {
+    PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::Wrench)
+};

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -15,6 +15,9 @@
 // Include NumPy typemaps
 %include "numpy.i"
 
+// Include attributes
+%include <attribute.i>
+
 // Initialize NumPy
 %init %{
 import_array();
@@ -315,3 +318,10 @@ import_array();
 %extend iDynTree::LinkWrenches {
     PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::Wrench)
 };
+
+%attributeref(iDynTree::FreeFloatingPos, iDynTree::Transform&, worldBasePos)
+%attributeref(iDynTree::FreeFloatingPos, iDynTree::JointPosDoubleArray&, jointPos)
+%attributeref(iDynTree::FreeFloatingVel, iDynTree::Twist&, baseVel)
+%attributeref(iDynTree::FreeFloatingVel, iDynTree::JointDOFsDoubleArray&, jointVel)
+%attributeref(iDynTree::FreeFloatingAcc, iDynTree::SpatialAcc&, baseAcc)
+%attributeref(iDynTree::FreeFloatingAcc, iDynTree::JointDOFsDoubleArray&, jointAcc)


### PR DESCRIPTION
Thanks to this PR it is possible to access the elements of `LinkPositions`, `LinkVelArray`, and `LinkAccArray`. Without the PR the elements are inaccessible 