### PR TITLE
Add docker-based CI for apt-based distributions

### DIFF
--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -20,6 +20,7 @@ jobs:
           - "Ninja"
         docker_image:
           - "ubuntu:focal"
+          - "ubuntu:jammy"
           - "debian:testing"
           - "debian:sid"
 

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Dependencies
       run: |
         apt-get update
-        apt-get upgrade
+        apt-get -y upgrade
         apt-get install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
             libxml2-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -36,7 +36,7 @@ jobs:
         apt-get -y upgrade
         apt-get -y install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
-            libxml2-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
+            libxml2-dev python-dev-is-python3 python3-numpy valgrind libassimp-dev libirrlicht-dev
 
     - name: Configure
       run: |

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         apt-get update
         apt-get -y upgrade
-        apt-get install \
+        apt-get -y install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
             libxml2-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
 

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -31,9 +31,9 @@ jobs:
 
     - name: Dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get upgrade
-        sudo apt-get install \
+        apt-get update
+        apt-get upgrade
+       apt-get install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
             libxml2-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
 

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         apt-get update
         apt-get upgrade
-       apt-get install \
+        apt-get install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
             libxml2-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
 

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug,Release]
+        build_type: [Release]
         cmake_generator:
           - "Ninja"
         docker_image:

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -35,7 +35,7 @@ jobs:
         apt-get update
         apt-get -y upgrade
         apt-get -y install \
-            git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
+            git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig liboctave-dev \
             libxml2-dev python-dev-is-python3 python3-numpy valgrind libassimp-dev libirrlicht-dev
 
     - name: Configure

--- a/.github/workflows/apt-docker-ci.yml
+++ b/.github/workflows/apt-docker-ci.yml
@@ -1,0 +1,57 @@
+name: Docker Apt C++ CI Workflow
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+  
+jobs:
+  docker-build:
+    name: '[docker:Tags:${{ matrix.project_tags }}@${{ matrix.docker_image }}@${{ matrix.build_type }}]'
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug,Release]
+        cmake_generator:
+          - "Ninja"
+        docker_image:
+          - "ubuntu:focal"
+          - "debian:testing"
+          - "debian:sid"
+
+    container:
+      image: ${{ matrix.docker_image }}
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade
+        sudo apt-get install \
+            git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
+            libxml2-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build
+        cd build
+        cmake -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
+              -DIDYNTREE_USES_IPOPT:BOOL=ON -DIDYNTREE_USES_OCTAVE:BOOL=ON -DIDYNTREE_USES_IRRLICHT:BOOL=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+
+    - name: Build
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+        
+    - name: Test
+      shell: bash
+      run: |
+        cd build
+        # Visualizer tests excluded as a workaround for https://github.com/robotology/idyntree/issues/808
+        ctest --output-on-failure -C ${{ matrix.build_type }} -E "Visualizer|matlab" . 


### PR DESCRIPTION
Not all options are tested in this CI, but this is meant to early detect problems when apt dependencies change in unstable distribution such as Debian Unstable or Testing.

(The contentigent reason for this PR is to debug https://github.com/robotology/robotology-superbuild/issues/974)