### PR TITLE
Added workaround for https://github.com/robotology/idyntree/issues/955

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.1] - 2022-01-10
+
+### Fixed
+- Fixed `iDynTree::ModelExporter` class and `idyntree-model-simplify-shapes` utility to generate standard-conforming URDF files, by adding huge velocity and effort limits to joints, as these limits are currently not stored inside the `iDynTree::Model` class (https://github.com/robotology/idyntree/pull/957, https://github.com/robotology/idyntree/issues/955).
+
 ## [4.3.0] - 2021-11-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.3.1] - 2022-01-10
 
 ### Fixed
-- Fixed `iDynTree::ModelExporter` class and `idyntree-model-simplify-shapes` utility to generate standard-conforming URDF files, by adding huge velocity and effort limits to joints, as these limits are currently not stored inside the `iDynTree::Model` class (https://github.com/robotology/idyntree/pull/957, https://github.com/robotology/idyntree/issues/955).
+- Fixed `iDynTree::ModelExporter` class and `idyntree-model-simplify-shapes` utility to generate specification-conforming URDF files, by adding huge velocity and effort limits to joints, as these limits are currently not stored inside the `iDynTree::Model` class (https://github.com/robotology/idyntree/pull/957, https://github.com/robotology/idyntree/issues/955).
 
 ## [4.3.0] - 2021-11-22
 

--- a/src/model_io/urdf/src/URDFModelExport.cpp
+++ b/src/model_io/urdf/src/URDFModelExport.cpp
@@ -396,6 +396,13 @@ bool exportJoint(IJointConstPtr joint, LinkConstPtr parentLink, LinkConstPtr chi
         xmlNewProp(limit_xml, BAD_CAST "lower", BAD_CAST bufStr.c_str());
         ok = ok && doubleToStringWithClassicLocale(max, bufStr);
         xmlNewProp(limit_xml, BAD_CAST "upper", BAD_CAST bufStr.c_str());
+
+        // Workaround for https://github.com/robotology/idyntree/issues/955
+        double reallyHighLimit = 1e9;
+        ok = ok && doubleToStringWithClassicLocale(reallyHighLimit, bufStr);
+        xmlNewProp(limit_xml, BAD_CAST "effort", BAD_CAST bufStr.c_str());
+        ok = ok && doubleToStringWithClassicLocale(reallyHighLimit, bufStr);
+        xmlNewProp(limit_xml, BAD_CAST "velocity", BAD_CAST bufStr.c_str());
     }
 
     // TODO(traversaro) : handle friction


### PR DESCRIPTION
This PR proposes a workaround to allow libraries that use `urdfdom` to load URDF files generated by iDynTree. For more information refer to #955 