### PR TITLE
Implement the possibility to use FromPython to generate rotation and position in the python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Implement the possibility to use `FromPython` to generate rotation and position in the python
-  bindings starting from arrays (https://github.com/robotology/idyntree/pull/959)
+  SWIG bindings starting from arrays (https://github.com/robotology/idyntree/pull/959)
 
 ## [4.3.0] - 2021-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased Major]
 
+### Added
+- Implement the possibility to use `FromPython` to generate rotation and position in the python
+  bindings starting from arrays (https://github.com/robotology/idyntree/pull/959)
+
 ## [4.3.0] - 2021-11-22
 
 ### Added

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -319,6 +319,24 @@ import_array();
     PYTHON_MAGIC_SET_GET_LEN_LINK_ARRAY(iDynTree::Wrench)
 };
 
+%extend iDynTree::Rotation {
+    static iDynTree::Rotation FromPython(double* in, int i, int j) {
+        if (i != 3 || j != 3)
+            throw std::runtime_error("Wrong size of input matrix");
+
+        return iDynTree::RotationRaw(in, static_cast<unsigned>(i), static_cast<unsigned>(j));
+    }
+};
+
+%extend iDynTree::Position {
+    static iDynTree::Position FromPython(double* in, int size) {
+        if (size != 3)
+            throw std::runtime_error("Wrong size of input array");
+
+        return iDynTree::PositionRaw(in, static_cast<unsigned>(size));
+    }
+};
+
 %attributeref(iDynTree::FreeFloatingPos, iDynTree::Transform&, worldBasePos)
 %attributeref(iDynTree::FreeFloatingPos, iDynTree::JointPosDoubleArray&, jointPos)
 %attributeref(iDynTree::FreeFloatingVel, iDynTree::Twist&, baseVel)

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -326,6 +326,13 @@ import_array();
 
         return iDynTree::RotationRaw(in, static_cast<unsigned>(i), static_cast<unsigned>(j));
     }
+
+    Rotation(const double* in_data, const std::ptrdiff_t in_rows, const std::ptrdiff_t in_cols) {
+        iDynTree::Rotation* rot = new iDynTree::Rotation(iDynTree::RotationRaw(in_data,
+                                                                               static_cast<unsigned>(in_rows),
+                                                                               static_cast<unsigned>(in_cols)));
+        return rot;
+    }
 };
 
 %extend iDynTree::Position {
@@ -335,7 +342,28 @@ import_array();
 
         return iDynTree::PositionRaw(in, static_cast<unsigned>(size));
     }
+
+    Position(const double* in_data, const unsigned in_size) {
+        iDynTree::Position* pos = new iDynTree::Position(iDynTree::PositionRaw(in_data, in_size));
+        return pos;
+    }
 };
+
+%extend iDynTree::Transform {
+
+    void setPosition(const double* in_data, const unsigned in_size) {
+        $self->setPosition(iDynTree::PositionRaw(in_data, static_cast<unsigned>(in_size)));
+    }
+
+    void setRotation(const double* in_data,
+                     const std::ptrdiff_t in_rows,
+                     const std::ptrdiff_t in_cols) {
+        $self->setRotation(iDynTree::RotationRaw(in_data,
+                                                 static_cast<unsigned>(in_rows),
+                                                 static_cast<unsigned>(in_cols)));
+    }
+};
+
 
 %attributeref(iDynTree::FreeFloatingPos, iDynTree::Transform&, worldBasePos)
 %attributeref(iDynTree::FreeFloatingPos, iDynTree::JointPosDoubleArray&, jointPos)


### PR DESCRIPTION
With this PR it is possible to use `FromPython` methods to covert a python array into a rotation/position

For instance thanks to this PR it will be possible to write the following code in python

```python
transform = idyn.Transform()

transform.setRotation(idyn.Rotation.FromPython(base_rotation))
transform.setPosition(idyn.Position.FromPython(base_position))
```

Before this PR as far as I know the way to populate a transform object was this one
```python
base_rotation_idyn = idyn.Rotation()
base_position_idyn = idyn.Position()
base_pose_idyn = idyn.Transform()

for i in range(0, 3):
    base_position_idyn.setVal(i, base_position[I])
    for j in range(0, 3):
        base_rotation_idyn.setVal(i, j, base_rotation[i, j])

base_pose_idyn.setRotation(base_rotation_idyn)
base_pose_idyn.setPosition(base_position_idyn)
```