### PR TITLE
[model_io] Fix the color parsing in the model_io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement `idyntree-model-view-meshcat` application. (https://github.com/robotology/idyntree/pull/961)
 ### Fixed
-- Once `VisualElement::childElementForName` is called with input equal to `material` a pointer to the `materialInfo` is stored inside the `VisualElement`. (https://github.com/robotology/idyntree/pull/961)
+- Fix loading material and color information from URDF files. (https://github.com/robotology/idyntree/pull/961)
 
 ## [4.3.1] - 2022-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Implement `idyntree-model-view-meshcat` application. (https://github.com/robotology/idyntree/pull/961)
+### Fixed
+- Once `VisualElement::childElementForName` is called with input equal to `material` a pointer to the `materialInfo` is stored inside the `VisualElement`. (https://github.com/robotology/idyntree/pull/961)
+
 ## [4.3.1] - 2022-01-10
 
 ### Fixed

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -52,6 +52,8 @@ if(WIN32)
     set_target_properties(${target_name} PROPERTIES SUFFIX ".pyd")
 endif(WIN32)
 
+add_subdirectory(scripts)
+
 # if compile tests execute also python tests
 if(IDYNTREE_COMPILE_TESTS)
     add_subdirectory(tests)

--- a/bindings/python/scripts/CMakeLists.txt
+++ b/bindings/python/scripts/CMakeLists.txt
@@ -1,0 +1,4 @@
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/idyntree-model-view-meshcat.py
+  RENAME idyntree-model-view-meshcat
+  PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+  DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/bindings/python/scripts/idyntree-model-view-meshcat.py
+++ b/bindings/python/scripts/idyntree-model-view-meshcat.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+
+"""
+Copyright (C) 2022 Fondazione Istituto Italiano di Tecnologia
+
+Licensed under either the GNU Lesser General Public License v3.0 :
+https://www.gnu.org/licenses/lgpl-3.0.html
+or the GNU Lesser General Public License v2.1 :
+https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+at your option.
+"""
+
+import argparse
+
+from idyntree.visualize import MeshcatVisualizer
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Display the model in the meshcat visualizer.')
+    parser.add_argument('--model', '-m', type = str, required = True, help='Model path.')
+
+    args = parser.parse_args()
+
+    # Load the visualizer
+    viz = MeshcatVisualizer()
+    viz.set_model_from_file(args.model)
+    viz.load_model()
+    viz.open()
+
+    run = True
+    while run:
+        quit = input('Enter q or Q to Quit: ')
+        run = (quit != 'q') and (quit != 'Q')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model_io/urdf/src/VisualElement.cpp
+++ b/src/model_io/urdf/src/VisualElement.cpp
@@ -48,7 +48,9 @@ namespace iDynTree {
         } else if (name == "geometry") {
             return std::make_shared<GeometryElement>(m_info.m_solidShape);
         } else if (name == "material") {
-            return std::make_shared<MaterialElement>(m_info.m_material);
+            auto ptr = std::make_shared<MaterialElement>(nullptr);
+            m_info.m_material = ptr->materialInfo();
+            return ptr;
         }
         return std::make_shared<XMLElement>(name);
     }

--- a/src/tests/data/iCubGenova02.urdf
+++ b/src/tests/data/iCubGenova02.urdf
@@ -17,9 +17,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/root.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="green">
-        <color rgba="0 1 0 1"/>
-      </material>
+      <material name="green"/>
     </visual>
     <collision>
       <origin xyz="-0.0364 0 0.032" rpy="1.57079632679 0 -1.57079632679"/>
@@ -53,9 +51,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_hip_1.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="black">
-        <color rgba="0 0 0 1"/>
-      </material>
+      <material name="black"/>
     </visual>
     <collision>
       <origin xyz="0.0233655 0.151913 0.0428515000001" rpy="0 0 0"/>
@@ -83,9 +79,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_hip_2.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="red">
-        <color rgba="1 0 0 1"/>
-      </material>
+      <material name="red"/>
     </visual>
     <collision>
       <origin xyz="0.0701 0.151913 0.0691961998093" rpy="0 0 0"/>
@@ -113,9 +107,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_hip_3.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="blue">
-        <color rgba="0 0 1 1"/>
-      </material>
+      <material name="blue"/>
     </visual>
     <collision>
       <origin xyz="0.0437089998093 -0.0700999999999 -0.226213" rpy="-1.57079632679 0 -1.57079632679"/>
@@ -141,9 +133,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_upper_leg.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="1 1 0 1"/>
-      </material>
+      <material name="yellow"/>
     </visual>
     <collision>
       <origin xyz="0.0700999999999 0.241013 0.0437089998093" rpy="0 0 0"/>
@@ -248,9 +238,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_lower_leg.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="pink">
-        <color rgba="1 0 1 1"/>
-      </material>
+      <material name="pink"/>
     </visual>
     <collision>
       <origin xyz="0.0462961001907 0.386638 0.0437089998095" rpy="0 0 0"/>
@@ -320,9 +308,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_ankle_1.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="cyan">
-        <color rgba="0 1 1 1"/>
-      </material>
+      <material name="cyan"/>
     </visual>
     <collision>
       <origin xyz="0.105600000191 0.587138 0.0437089998095" rpy="0 0 0"/>
@@ -378,9 +364,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/r_foot.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="white">
-        <color rgba="1 1 1 1"/>
-      </material>
+      <material name="white"/>
     </visual>
     <collision>
       <origin xyz="0.0472089996187 -0.0701000001907 -0.647438" rpy="-1.57079632679 0 -1.57079632679"/>
@@ -427,9 +411,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/l_hip_1.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="dblue">
-        <color rgba="0 0 0.8 1"/>
-      </material>
+      <material name="dblue"/>
     </visual>
     <collision>
       <origin xyz="-0.0223861 0.151913 0.0428515000001" rpy="0 0 0"/>
@@ -457,9 +439,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/l_hip_2.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="dgreen">
-        <color rgba="0.1 0.8 0.1 1"/>
-      </material>
+      <material name="dgreen"/>
     </visual>
     <collision>
       <origin xyz="-0.0701 0.151913 0.0683914998093" rpy="0 0 0"/>
@@ -487,9 +467,7 @@
       <geometry>
         <mesh filename="model://iCubGenova02/meshes/dae/l_hip_3.dae" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="gray">
-        <color rgba="0.5 0.5 0.5 1"/>
-      </material>
+      <material name="gray"/>
     </visual>
     <collision>
       <origin xyz="-0.0701 0.043409 -0.226213" rpy="-1.57079632679 0 0"/>
@@ -1581,4 +1559,39 @@
 		<robotNamefromConfigFile>model://iCubGenova02/conf/gazebo_iCubGenova02_robotname.ini</robotNamefromConfigFile>
 	</plugin>
 	</gazebo>
+
+
+<material name="green">
+  <color rgba="0 1 0 1"/>
+</material>
+<material name="black">
+  <color rgba="0 0 0 1"/>
+</material>
+<material name="red">
+  <color rgba="1 0 0 1"/>
+</material>
+<material name="blue">
+  <color rgba="0 0 1 1"/>
+</material>
+<material name="yellow">
+  <color rgba="1 1 0 1"/>
+</material>
+<material name="pink">
+  <color rgba="1 0 1 1"/>
+</material>
+<material name="cyan">
+  <color rgba="0 1 1 1"/>
+</material>
+<material name="white">
+  <color rgba="1 1 1 1"/>
+</material>
+<material name="dblue">
+  <color rgba="0 0 0.8 1"/>
+</material>
+<material name="dgreen">
+  <color rgba="0.1 0.8 0.1 1"/>
+</material>
+<material name="gray">
+  <color rgba="0.5 0.5 0.5 1"/>
+</material>
 </robot>

--- a/src/visualization/src/IrrlichtUtils.h
+++ b/src/visualization/src/IrrlichtUtils.h
@@ -11,6 +11,7 @@
 #ifndef IDYNTREE_IRRLICHT_UTILS_H
 #define IDYNTREE_IRRLICHT_UTILS_H
 
+#include <EMaterialTypes.h>
 #include <iDynTree/Model/SolidShapes.h>
 #include <iDynTree/Visualizer.h>
 
@@ -78,7 +79,7 @@ inline const irr::core::vector3df idyntree2irr_rot(const iDynTree::Rotation & ro
 
 inline irr::video::SMaterial idyntree2irr(const iDynTree::Vector4 & rgbaMaterialId)
 {
-    double ambientCoeff = 1.0;
+    double ambientCoeff = 0.6;
     double diffuseCoeff = 1.0;
     irr::video::SMaterial ret;
     ret.AmbientColor = irr::video::SColorf(ambientCoeff*rgbaMaterialId(0),


### PR DESCRIPTION
Once `VisualElement::childElementForName` is called with input equal to 'material' a pointer to the
material info is stored inside the VisualElement.

## Rationale
Differently from [`GeometrcElement`](https://github.com/robotology/idyntree/blob/cbb0bf5e593b7add489bccb7dd3ba5054b200573/src/model_io/urdf/src/GeometryElement.cpp#L23), the constructor of `MaterialElement` takes as input a copy of `std::shared_ptr<MaterialInfo>` and not a **reference** to a shared pointer

https://github.com/robotology/idyntree/blob/cbb0bf5e593b7add489bccb7dd3ba5054b200573/src/model_io/urdf/src/MaterialElement.cpp#L23-L30

For this reason in the following line

https://github.com/robotology/idyntree/blob/cbb0bf5e593b7add489bccb7dd3ba5054b200573/src/model_io/urdf/src/VisualElement.cpp#L51

Since `m_info.m_material = nullptr` and `MaterialElement` copies the value, `m_info.m_material` [was not updated by 
](https://github.com/robotology/idyntree/blob/cbb0bf5e593b7add489bccb7dd3ba5054b200573/src/model_io/urdf/src/MaterialElement.cpp#L23-L30)
```cpp
     if (!m_info) { 
         m_info = std::make_shared<MaterialInfo>(); 
     } 
```

Passing a reference to a shared ptr cannot solve the problem in this particular case. Indeed given the following code: 

https://github.com/robotology/idyntree/blob/cbb0bf5e593b7add489bccb7dd3ba5054b200573/src/model_io/urdf/src/RobotElement.cpp#L53-L56

the compiler will complain since `nullptr` is a `r-value` and it cannot be converted into a `l-value`.

## Outcome of the PR

This is how Talos is now displayed with 

### meshcat

![image](https://user-images.githubusercontent.com/16744101/151451889-e147a9e2-dd9b-466e-82ff-8ac8d6af4c2c.png)

### irrlicht 

![image](https://user-images.githubusercontent.com/16744101/151451979-c53d9dbf-0068-4697-9a4a-daf1c0e9ea73.png)


For iCub there is the usual problem with the colors 

### meshcat
![image](https://user-images.githubusercontent.com/16744101/151452199-3c612c88-819b-4cfd-b48c-816368d15abf.png)


### irrlicht

![image](https://user-images.githubusercontent.com/16744101/151452302-d73a70af-be7d-408c-90d8-b3be21225d4d.png)

