### PR TITLE
Use official version of m.css to generate the documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,11 +37,10 @@ jobs:
       - name: Fetch m.css
         shell: bash -l {0}
         run: |
-          # Use an unofficial version of m.css because of https://github.com/mosra/m.css/pull/189
           cd ${GITHUB_WORKSPACE}
-          git clone https://github.com/crisluengo/m.css.git
+          git clone https://github.com/mosra/m.css.git
           cd m.css
-          git checkout fix-class-parsed-as-function
+          git checkout 4bf4ddade48717ffabbdc6a1fd7ed15a75f9bec3
 
       - name: Build docs
         shell: bash -l {0}


### PR DESCRIPTION
The documentation CI is currently broken. This PR fixes the issue by switching to the official `m.css`. This has been achieved thanks to https://github.com/mosra/m.css/pull/189