### PR TITLE
Add CI step to log conda environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,11 @@ jobs:
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
 
-    - name: Log conda environment
-      shell: base -l {0}
+    - name: Print used environment [Conda]
+      shell: bash -l {0}
       run: |
         mamba list
+        env
 
     - name: Configure [Conda/Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
 
+    - name: Log conda environment
+      shell: base -l {0}
+      run: |
+        mamba list
+
     - name: Configure [Conda/Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -75,6 +75,11 @@ jobs:
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install vs2019_win-64
 
+    - name: Print used environment [Conda]
+      shell: bash -l {0}
+      run: |
+        mamba list
+        env
 
     - name: Configure [Conda - Linux or  macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
I wanted to quickly debug https://github.com/robotology/idyntree/issues/971, but I noticed I did not had the mamba list of the working ci to compare with the not-working one. Adding this step of the CI for the future.