### PR TITLE
Fix obj meshes visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Avoid to use iDynTree material when `.obj` meshes are loaded in the Irrlicht visualizer (https://github.com/robotology/idyntree/pull/974).
+- Avoid to use iDynTree material (for example the one specified in URDF) when `.obj` meshes are loaded in the Irrlicht visualizer (https://github.com/robotology/idyntree/pull/974).
 
 ## [5.0.0] - 2022-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased Major]
 
+### Fixed
+
+- Avoid to use iDynTree material when `.obj` meshes are loaded in the Irrlicht visualizer (https://github.com/robotology/idyntree/pull/974).
+
 ## [5.0.0] - 2022-02-08
 
 ### Added

--- a/src/visualization/src/IrrlichtUtils.h
+++ b/src/visualization/src/IrrlichtUtils.h
@@ -218,7 +218,7 @@ inline irr::scene::ISceneNode * addGeometryToSceneManager(const iDynTree::SolidS
         }
 
         // If multiple mesh are loaded, add them
-        if (getFileExt(externalMesh->getFilename()) == "dae")
+        if (getFileExt(externalMesh->getFilename()) == "dae" || getFileExt(externalMesh->getFilename()) == "obj")
         {
             use_iDynTree_material = false;
         }


### PR DESCRIPTION
This PR fixes the `.obj` meshes visualization that appeared after https://github.com/robotology/idyntree/pull/961.

Before:
![image](https://user-images.githubusercontent.com/29798643/154705307-50decce0-ac8d-40b9-88c5-faaa9ca1c1dc.png)

After:
![image](https://user-images.githubusercontent.com/29798643/154705761-0a8ff2e0-aef6-485f-8157-a9187223839b.png)
