### PR TITLE
Fix crash caused by Visualizer::close on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased Major]
 
+## [5.0.1] - 2022-02-23
+
 ### Fixed
 
 - Avoid to use iDynTree material (for example the one specified in URDF) when `.obj` meshes are loaded in the Irrlicht visualizer (https://github.com/robotology/idyntree/pull/974).
+- Fix crash on `Visualizer::close` on Windows (). The fix works only if the used Irrlicht is compiled with SDL support.
 
 ## [5.0.0] - 2022-02-08
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 5.0.0
+project(iDynTree VERSION 5.0.1
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -267,6 +267,12 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
 
     irr::SIrrlichtCreationParameters irrDevParams;
 
+// If we are on Windows and the SDL backend of Irrlicht is available,
+// let's use it to avoid spurios WM_QUIT signal being raised in the
+// close() method, see https://github.com/robotology/idyntree/issues/975
+#if defined(_WIN32) && defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+    irrDevParams.DeviceType = irr::EIDT_SDL;
+#endif
     irrDevParams.DriverType = irr::video::EDT_OPENGL;
     irrDevParams.WindowSize = irr::core::dimension2d<irr::u32>(visualizerOptions.winWidth, visualizerOptions.winHeight);
     irrDevParams.WithAlphaChannel = true;


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/975, as long as the Irrlicht used is compiled with SDL support. If the used Irrlicht does not have SDL support, the problem described in https://github.com/robotology/idyntree/issues/975 remains but the behaviour of the visualizer is the same as before this fix. 