### PR TITLE
Always use \n as new line when generating files with CMake

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -125,11 +125,7 @@ if (IDYNTREE_USES_PYTHON_PYBIND11)
 endif()
 
 if (IDYNTREE_USES_PYTHON_PYBIND11 OR IDYNTREE_USES_PYTHON)
-    if (WIN32)
-        set(NEW_LINE "\n\r")
-    else()
-        set(NEW_LINE "\n")
-    endif()
+    set(NEW_LINE "\n")
 
     # Install main __init__.py
     # Clear the file first if it exists.


### PR DESCRIPTION
As reported in https://github.com/conda-forge/opencv-feedstock/issues/302, `\n\r` do not represent a single newline in Windows (even as in that case it would be `\r\n`). Anyhow, `\n` seems to be working fine, so let's just use that one.