### PR TITLE
Add workaround for using iDynTree.Visualizer on Windows with SDL 1.2.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased Major]
 
-## [5.2.0] - 2022-05-06
+## [5.2.0] - 2022-05-09
 
 ### Added
 - Added `DHChain` class to the bindings (https://github.com/robotology/idyntree/pull/984).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased Major]
 
+## [5.2.0] - 2022-05-06
+
 ### Added
-- Added `DHChain` class to the bindings.
+- Added `DHChain` class to the bindings (https://github.com/robotology/idyntree/pull/984).
+
+### Fixed
+- Fixed problems of running two (or more) times the `iDynTree.Visualizer` class on Windows when using SDL >= 1.2.52 (https://github.com/robotology/idyntree/pull/988, https://github.com/robotology/idyntree/pull/986).
 
 ## [5.1.0] - 2022-02-25
 

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -23,6 +23,15 @@
 #include "TexturesHandler.h"
 #include "CameraAnimator.h"
 #include "Label.h"
+
+#if defined(_WIN32) && defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+// Required by SetEnvironmentVariableA, _putenv is not unsetting
+// correctly the variables
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 #endif
 
 #include "DummyImplementations.h"
@@ -285,8 +294,26 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
     }
 
     pimpl->m_irrDevice = 0;
+
+// The Irrlicht SDL device overwrites the value of the SDL_VIDEODRIVER
+// environment variable, and this prevents the driver to work correctly.
+// For this reason, we save the value before the irr::createDeviceEx call,
+// and we restore it (or we unset it) after call
+// Workaround for https://github.com/robotology/idyntree/issues/986
+#if defined(_WIN32) && defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+    const char * SDL_VIDEODRIVER_value = NULL;
+    if (irrDevParams.DeviceType == irr::EIDT_SDL) {
+        SDL_VIDEODRIVER_value = std::getenv("SDL_VIDEODRIVER");
+    }
+#endif
+
     pimpl->m_irrDevice = irr::createDeviceEx(irrDevParams);
 
+#if defined(_WIN32) && defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+    if (irrDevParams.DeviceType == irr::EIDT_SDL) {
+        SetEnvironmentVariableA("SDL_VIDEODRIVER", SDL_VIDEODRIVER_value);
+    }
+#endif
 
     if (pimpl->m_irrDevice == 0)
     {

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -28,6 +28,12 @@ void checkVizLoading(const iDynTree::Model & model)
     label.setSize(1.0);
     label.setPosition(iDynTree::Position(-1.0, -1.0, 0.3));
 
+    // Check if run is returning true
+    // Regression test for https://github.com/robotology/idyntree/issues/986
+    ok = viz.run();
+    ASSERT_IS_TRUE(ok);
+
+
     for(int i=0; i < 5; i++)
     {
         viz.draw();


### PR DESCRIPTION
Workaround for https://github.com/robotology/idyntree/issues/986 .