### PR TITLE
Fix for documentation of Position default constructor.

### DIFF
--- a/src/core/include/iDynTree/Core/Position.h
+++ b/src/core/include/iDynTree/Core/Position.h
@@ -43,7 +43,8 @@ namespace iDynTree
     {
     public:
         /**
-         * Default constructor: initialize all the coordinates to 0
+         * Default constructor.
+         * The data is not initialized, please initialize the data in the created object before use.
          */
         Position();
 


### PR DESCRIPTION
Currently the default constructor for `Position` just delegates to the default constructor for `RawPosition`, which doesn't initialize the underlying data.

Another option would be to make sure `Position::Position()` does initialize the data to zero, with a small performance cost.