### PR TITLE
Add non collocated external wrenches estimation Berdy variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a new Berdy variant that accounts for estimating the external link wrenches independently of the internal joint torque estimates (https://github.com/robotology/idyntree/pull/991).
+
 ### Changed
 - No warning is printed if a sensor not supported by iDynTree is found in an URDF file (https://github.com/robotology/idyntree/pull/997).
+- Changed signature of the method `BerdyHelper::serializeDynamicVariables` in order to serialize also the `RCM_SENSOR` (https://github.com/robotology/idyntree/pull/991).
 
 ## [5.2.1] - 2022-05-19
 

--- a/bindings/matlab/autogenerated/+iDynTree/ACCELEROMETER_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ACCELEROMETER_SENSOR.m
@@ -1,7 +1,7 @@
 function v = ACCELEROMETER_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 24);
+    vInitialized = iDynTreeMEX(0, 25);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
@@ -7,13 +7,23 @@ classdef AttitudeEstimatorState < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1635, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1636, self, varargin{1});
+      end
+    end
+    function varargout = m_angular_velocity(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1637, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1638, self, varargin{1});
       end
     end
-    function varargout = m_angular_velocity(self, varargin)
+    function varargout = m_gyroscope_bias(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,30 +33,20 @@ classdef AttitudeEstimatorState < iDynTreeSwigRef
         iDynTreeMEX(1640, self, varargin{1});
       end
     end
-    function varargout = m_gyroscope_bias(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1641, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1642, self, varargin{1});
-      end
-    end
     function self = AttitudeEstimatorState(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1643, varargin{:});
+        tmp = iDynTreeMEX(1641, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1644, self);
+        iDynTreeMEX(1642, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeEstimatorState.m
@@ -7,30 +7,30 @@ classdef AttitudeEstimatorState < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1634, self);
+        varargout{1} = iDynTreeMEX(1637, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1635, self, varargin{1});
+        iDynTreeMEX(1638, self, varargin{1});
       end
     end
     function varargout = m_angular_velocity(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1636, self);
+        varargout{1} = iDynTreeMEX(1639, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1637, self, varargin{1});
+        iDynTreeMEX(1640, self, varargin{1});
       end
     end
     function varargout = m_gyroscope_bias(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1638, self);
+        varargout{1} = iDynTreeMEX(1641, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1639, self, varargin{1});
+        iDynTreeMEX(1642, self, varargin{1});
       end
     end
     function self = AttitudeEstimatorState(varargin)
@@ -39,14 +39,14 @@ classdef AttitudeEstimatorState < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1640, varargin{:});
+        tmp = iDynTreeMEX(1643, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1641, self);
+        iDynTreeMEX(1644, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
@@ -7,68 +7,68 @@ classdef AttitudeMahonyFilter < iDynTree.IAttitudeEstimator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1668, varargin{:});
+        tmp = iDynTreeMEX(1666, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = useMagnetoMeterMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1669, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1667, self, varargin{:});
     end
     function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1670, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1668, self, varargin{:});
     end
     function varargout = setGainkp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1671, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1669, self, varargin{:});
     end
     function varargout = setGainki(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1672, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1670, self, varargin{:});
     end
     function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1673, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1671, self, varargin{:});
     end
     function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1674, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1672, self, varargin{:});
     end
     function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1675, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1673, self, varargin{:});
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1676, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1674, self, varargin{:});
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1677, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1675, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1678, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1676, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1679, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1677, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1678, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1679, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1687, self);
+        iDynTreeMEX(1685, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilter.m
@@ -7,68 +7,68 @@ classdef AttitudeMahonyFilter < iDynTree.IAttitudeEstimator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1665, varargin{:});
+        tmp = iDynTreeMEX(1668, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = useMagnetoMeterMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1666, self, varargin{:});
-    end
-    function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1667, self, varargin{:});
-    end
-    function varargout = setGainkp(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1668, self, varargin{:});
-    end
-    function varargout = setGainki(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1669, self, varargin{:});
     end
-    function varargout = setTimeStepInSeconds(self,varargin)
+    function varargout = setConfidenceForMagnetometerMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1670, self, varargin{:});
     end
-    function varargout = setGravityDirection(self,varargin)
+    function varargout = setGainkp(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1671, self, varargin{:});
     end
-    function varargout = setParameters(self,varargin)
+    function varargout = setGainki(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1672, self, varargin{:});
     end
-    function varargout = getParameters(self,varargin)
+    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1673, self, varargin{:});
     end
-    function varargout = updateFilterWithMeasurements(self,varargin)
+    function varargout = setGravityDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1674, self, varargin{:});
     end
-    function varargout = propagateStates(self,varargin)
+    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1675, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
+    function varargout = getParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1676, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
+    function varargout = updateFilterWithMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1677, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1678, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1679, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1680, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1681, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getInternalStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1682, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getInternalState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1683, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1684, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1684, self);
+        iDynTreeMEX(1687, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
@@ -7,50 +7,50 @@ classdef AttitudeMahonyFilterParameters < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1653, self);
+        varargout{1} = iDynTreeMEX(1656, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1654, self, varargin{1});
+        iDynTreeMEX(1657, self, varargin{1});
       end
     end
     function varargout = kp(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1655, self);
+        varargout{1} = iDynTreeMEX(1658, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1656, self, varargin{1});
+        iDynTreeMEX(1659, self, varargin{1});
       end
     end
     function varargout = ki(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1657, self);
+        varargout{1} = iDynTreeMEX(1660, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1658, self, varargin{1});
+        iDynTreeMEX(1661, self, varargin{1});
       end
     end
     function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1659, self);
+        varargout{1} = iDynTreeMEX(1662, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1660, self, varargin{1});
+        iDynTreeMEX(1663, self, varargin{1});
       end
     end
     function varargout = confidence_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1661, self);
+        varargout{1} = iDynTreeMEX(1664, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1662, self, varargin{1});
+        iDynTreeMEX(1665, self, varargin{1});
       end
     end
     function self = AttitudeMahonyFilterParameters(varargin)
@@ -59,14 +59,14 @@ classdef AttitudeMahonyFilterParameters < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1663, varargin{:});
+        tmp = iDynTreeMEX(1666, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1664, self);
+        iDynTreeMEX(1667, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeMahonyFilterParameters.m
@@ -7,13 +7,23 @@ classdef AttitudeMahonyFilterParameters < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1654, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1655, self, varargin{1});
+      end
+    end
+    function varargout = kp(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1656, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1657, self, varargin{1});
       end
     end
-    function varargout = kp(self, varargin)
+    function varargout = ki(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,7 +33,7 @@ classdef AttitudeMahonyFilterParameters < iDynTreeSwigRef
         iDynTreeMEX(1659, self, varargin{1});
       end
     end
-    function varargout = ki(self, varargin)
+    function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -33,7 +43,7 @@ classdef AttitudeMahonyFilterParameters < iDynTreeSwigRef
         iDynTreeMEX(1661, self, varargin{1});
       end
     end
-    function varargout = use_magnetometer_measurements(self, varargin)
+    function varargout = confidence_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,30 +53,20 @@ classdef AttitudeMahonyFilterParameters < iDynTreeSwigRef
         iDynTreeMEX(1663, self, varargin{1});
       end
     end
-    function varargout = confidence_magnetometer_measurements(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1664, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1665, self, varargin{1});
-      end
-    end
     function self = AttitudeMahonyFilterParameters(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1666, varargin{:});
+        tmp = iDynTreeMEX(1664, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1667, self);
+        iDynTreeMEX(1665, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
@@ -11,74 +11,74 @@ classdef AttitudeQuaternionEKF < iDynTree.IAttitudeEstimator & iDynTree.Discrete
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1730, varargin{:});
+        tmp = iDynTreeMEX(1733, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1731, self, varargin{:});
-    end
-    function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
-    end
-    function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
-    end
-    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
     end
-    function varargout = setBiasCorrelationTimeFactor(self,varargin)
+    function varargout = setParameters(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
     end
-    function varargout = useMagnetometerMeasurements(self,varargin)
+    function varargout = setGravityDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
     end
-    function varargout = setMeasurementNoiseVariance(self,varargin)
+    function varargout = setTimeStepInSeconds(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
     end
-    function varargout = setSystemNoiseVariance(self,varargin)
+    function varargout = setBiasCorrelationTimeFactor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1738, self, varargin{:});
     end
-    function varargout = setInitialStateCovariance(self,varargin)
+    function varargout = useMagnetometerMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1739, self, varargin{:});
     end
-    function varargout = initializeFilter(self,varargin)
+    function varargout = setMeasurementNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1740, self, varargin{:});
     end
-    function varargout = updateFilterWithMeasurements(self,varargin)
+    function varargout = setSystemNoiseVariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1741, self, varargin{:});
     end
-    function varargout = propagateStates(self,varargin)
+    function varargout = setInitialStateCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1742, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
+    function varargout = initializeFilter(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1743, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
+    function varargout = updateFilterWithMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1744, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1745, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1746, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1747, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1748, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getInternalStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1749, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getInternalState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1750, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1751, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1752, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1753, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1751, self);
+        iDynTreeMEX(1754, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKF.m
@@ -11,74 +11,74 @@ classdef AttitudeQuaternionEKF < iDynTree.IAttitudeEstimator & iDynTree.Discrete
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1733, varargin{:});
+        tmp = iDynTreeMEX(1731, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = getParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1732, self, varargin{:});
     end
     function varargout = setParameters(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1733, self, varargin{:});
     end
     function varargout = setGravityDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1734, self, varargin{:});
     end
     function varargout = setTimeStepInSeconds(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1735, self, varargin{:});
     end
     function varargout = setBiasCorrelationTimeFactor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1738, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1736, self, varargin{:});
     end
     function varargout = useMagnetometerMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1739, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1737, self, varargin{:});
     end
     function varargout = setMeasurementNoiseVariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1740, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1738, self, varargin{:});
     end
     function varargout = setSystemNoiseVariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1741, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1739, self, varargin{:});
     end
     function varargout = setInitialStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1742, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1740, self, varargin{:});
     end
     function varargout = initializeFilter(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1743, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1741, self, varargin{:});
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1744, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1742, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1745, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1743, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1746, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1744, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1747, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1745, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1748, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1746, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1749, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1747, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1750, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1748, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1751, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1749, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1752, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1750, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1753, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1751, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1754, self);
+        iDynTreeMEX(1752, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
@@ -7,100 +7,100 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1708, self);
+        varargout{1} = iDynTreeMEX(1711, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1709, self, varargin{1});
+        iDynTreeMEX(1712, self, varargin{1});
       end
     end
     function varargout = bias_correlation_time_factor(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1710, self);
+        varargout{1} = iDynTreeMEX(1713, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1711, self, varargin{1});
+        iDynTreeMEX(1714, self, varargin{1});
       end
     end
     function varargout = accelerometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1712, self);
+        varargout{1} = iDynTreeMEX(1715, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1713, self, varargin{1});
+        iDynTreeMEX(1716, self, varargin{1});
       end
     end
     function varargout = magnetometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1714, self);
+        varargout{1} = iDynTreeMEX(1717, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1715, self, varargin{1});
+        iDynTreeMEX(1718, self, varargin{1});
       end
     end
     function varargout = gyroscope_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1716, self);
+        varargout{1} = iDynTreeMEX(1719, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1717, self, varargin{1});
+        iDynTreeMEX(1720, self, varargin{1});
       end
     end
     function varargout = gyro_bias_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1718, self);
+        varargout{1} = iDynTreeMEX(1721, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1719, self, varargin{1});
+        iDynTreeMEX(1722, self, varargin{1});
       end
     end
     function varargout = initial_orientation_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1720, self);
+        varargout{1} = iDynTreeMEX(1723, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1721, self, varargin{1});
+        iDynTreeMEX(1724, self, varargin{1});
       end
     end
     function varargout = initial_ang_vel_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1722, self);
+        varargout{1} = iDynTreeMEX(1725, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1723, self, varargin{1});
+        iDynTreeMEX(1726, self, varargin{1});
       end
     end
     function varargout = initial_gyro_bias_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1724, self);
+        varargout{1} = iDynTreeMEX(1727, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1725, self, varargin{1});
+        iDynTreeMEX(1728, self, varargin{1});
       end
     end
     function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1726, self);
+        varargout{1} = iDynTreeMEX(1729, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1727, self, varargin{1});
+        iDynTreeMEX(1730, self, varargin{1});
       end
     end
     function self = AttitudeQuaternionEKFParameters(varargin)
@@ -109,14 +109,14 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1728, varargin{:});
+        tmp = iDynTreeMEX(1731, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1729, self);
+        iDynTreeMEX(1732, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
+++ b/bindings/matlab/autogenerated/+iDynTree/AttitudeQuaternionEKFParameters.m
@@ -7,13 +7,23 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1709, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1710, self, varargin{1});
+      end
+    end
+    function varargout = bias_correlation_time_factor(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1711, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1712, self, varargin{1});
       end
     end
-    function varargout = bias_correlation_time_factor(self, varargin)
+    function varargout = accelerometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,7 +33,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1714, self, varargin{1});
       end
     end
-    function varargout = accelerometer_noise_variance(self, varargin)
+    function varargout = magnetometer_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -33,7 +43,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1716, self, varargin{1});
       end
     end
-    function varargout = magnetometer_noise_variance(self, varargin)
+    function varargout = gyroscope_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -43,7 +53,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1718, self, varargin{1});
       end
     end
-    function varargout = gyroscope_noise_variance(self, varargin)
+    function varargout = gyro_bias_noise_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -53,7 +63,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1720, self, varargin{1});
       end
     end
-    function varargout = gyro_bias_noise_variance(self, varargin)
+    function varargout = initial_orientation_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -63,7 +73,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1722, self, varargin{1});
       end
     end
-    function varargout = initial_orientation_error_variance(self, varargin)
+    function varargout = initial_ang_vel_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -73,7 +83,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1724, self, varargin{1});
       end
     end
-    function varargout = initial_ang_vel_error_variance(self, varargin)
+    function varargout = initial_gyro_bias_error_variance(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -83,7 +93,7 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1726, self, varargin{1});
       end
     end
-    function varargout = initial_gyro_bias_error_variance(self, varargin)
+    function varargout = use_magnetometer_measurements(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -93,30 +103,20 @@ classdef AttitudeQuaternionEKFParameters < iDynTreeSwigRef
         iDynTreeMEX(1728, self, varargin{1});
       end
     end
-    function varargout = use_magnetometer_measurements(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1729, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1730, self, varargin{1});
-      end
-    end
     function self = AttitudeQuaternionEKFParameters(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1731, varargin{:});
+        tmp = iDynTreeMEX(1729, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1732, self);
+        iDynTreeMEX(1730, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES.m
@@ -1,0 +1,7 @@
+function v = BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 16);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
@@ -7,23 +7,13 @@ classdef BerdyDynamicVariable < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1576, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1577, self, varargin{1});
-      end
-    end
-    function varargout = id(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1578, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1579, self, varargin{1});
       end
     end
-    function varargout = range(self, varargin)
+    function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -33,11 +23,21 @@ classdef BerdyDynamicVariable < iDynTreeSwigRef
         iDynTreeMEX(1581, self, varargin{1});
       end
     end
+    function varargout = range(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1582, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1583, self, varargin{1});
+      end
+    end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1582, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1584, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1583, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1585, self, varargin{:});
     end
     function self = BerdyDynamicVariable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -45,14 +45,14 @@ classdef BerdyDynamicVariable < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1584, varargin{:});
+        tmp = iDynTreeMEX(1586, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1585, self);
+        iDynTreeMEX(1587, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyDynamicVariable.m
@@ -7,13 +7,23 @@ classdef BerdyDynamicVariable < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1576, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1577, self, varargin{1});
+      end
+    end
+    function varargout = id(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1578, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1579, self, varargin{1});
       end
     end
-    function varargout = id(self, varargin)
+    function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,21 +33,11 @@ classdef BerdyDynamicVariable < iDynTreeSwigRef
         iDynTreeMEX(1581, self, varargin{1});
       end
     end
-    function varargout = range(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1582, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1583, self, varargin{1});
-      end
-    end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1584, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1582, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1585, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1583, self, varargin{:});
     end
     function self = BerdyDynamicVariable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -45,14 +45,14 @@ classdef BerdyDynamicVariable < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1586, varargin{:});
+        tmp = iDynTreeMEX(1584, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1587, self);
+        iDynTreeMEX(1585, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
@@ -9,104 +9,107 @@ classdef BerdyHelper < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1586, varargin{:});
+        tmp = iDynTreeMEX(1588, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1587, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1588, self, varargin{:});
-    end
-    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1589, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1590, self, varargin{:});
     end
-    function varargout = init(self,varargin)
+    function varargout = sensors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1591, self, varargin{:});
     end
-    function varargout = getOptions(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
     end
-    function varargout = getNrOfDynamicVariables(self,varargin)
+    function varargout = init(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1593, self, varargin{:});
     end
-    function varargout = getNrOfDynamicEquations(self,varargin)
+    function varargout = getOptions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1594, self, varargin{:});
     end
-    function varargout = getNrOfSensorsMeasurements(self,varargin)
+    function varargout = getNrOfDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1595, self, varargin{:});
     end
-    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
+    function varargout = getNrOfDynamicEquations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1596, self, varargin{:});
     end
-    function varargout = getBerdyMatrices(self,varargin)
+    function varargout = getNrOfSensorsMeasurements(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1597, self, varargin{:});
     end
-    function varargout = getSensorsOrdering(self,varargin)
+    function varargout = resizeAndZeroBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
     end
-    function varargout = getRangeSensorVariable(self,varargin)
+    function varargout = getBerdyMatrices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1599, self, varargin{:});
     end
-    function varargout = getRangeDOFSensorVariable(self,varargin)
+    function varargout = getSensorsOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
     end
-    function varargout = getRangeJointSensorVariable(self,varargin)
+    function varargout = getRangeSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
     end
-    function varargout = getRangeLinkSensorVariable(self,varargin)
+    function varargout = getRangeDOFSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1602, self, varargin{:});
     end
-    function varargout = getRangeLinkVariable(self,varargin)
+    function varargout = getRangeJointSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1603, self, varargin{:});
     end
-    function varargout = getRangeJointVariable(self,varargin)
+    function varargout = getRangeLinkSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1604, self, varargin{:});
     end
-    function varargout = getRangeDOFVariable(self,varargin)
+    function varargout = getRangeRCMSensorVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1605, self, varargin{:});
     end
-    function varargout = getDynamicVariablesOrdering(self,varargin)
+    function varargout = getRangeLinkVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
     end
-    function varargout = serializeDynamicVariables(self,varargin)
+    function varargout = getRangeJointVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
     end
-    function varargout = serializeSensorVariables(self,varargin)
+    function varargout = getRangeDOFVariable(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1608, self, varargin{:});
     end
-    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
+    function varargout = getDynamicVariablesOrdering(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1609, self, varargin{:});
     end
-    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
+    function varargout = serializeDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1610, self, varargin{:});
     end
-    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
+    function varargout = serializeSensorVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1611, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFloatingBase(self,varargin)
+    function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1612, self, varargin{:});
     end
-    function varargout = updateKinematicsFromFixedBase(self,varargin)
+    function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1613, self, varargin{:});
     end
-    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+    function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1614, self, varargin{:});
     end
-    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = updateKinematicsFromFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1615, self, varargin{:});
     end
-    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+    function varargout = updateKinematicsFromFixedBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
+    end
+    function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
+    end
+    function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1618, self, varargin{:});
+    end
+    function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1619, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1617, self);
+        iDynTreeMEX(1620, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyHelper.m
@@ -9,107 +9,107 @@ classdef BerdyHelper < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1588, varargin{:});
+        tmp = iDynTreeMEX(1586, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = dynamicTraversal(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1589, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1587, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1590, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1588, self, varargin{:});
     end
     function varargout = sensors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1591, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1589, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1590, self, varargin{:});
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1593, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1591, self, varargin{:});
     end
     function varargout = getOptions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1594, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1592, self, varargin{:});
     end
     function varargout = getNrOfDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1595, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1593, self, varargin{:});
     end
     function varargout = getNrOfDynamicEquations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1596, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1594, self, varargin{:});
     end
     function varargout = getNrOfSensorsMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1597, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1595, self, varargin{:});
     end
     function varargout = resizeAndZeroBerdyMatrices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1596, self, varargin{:});
     end
     function varargout = getBerdyMatrices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1599, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1597, self, varargin{:});
     end
     function varargout = getSensorsOrdering(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1598, self, varargin{:});
     end
     function varargout = getRangeSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1599, self, varargin{:});
     end
     function varargout = getRangeDOFSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1602, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1600, self, varargin{:});
     end
     function varargout = getRangeJointSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1603, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1601, self, varargin{:});
     end
     function varargout = getRangeLinkSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1604, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1602, self, varargin{:});
     end
     function varargout = getRangeRCMSensorVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1605, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1603, self, varargin{:});
     end
     function varargout = getRangeLinkVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1604, self, varargin{:});
     end
     function varargout = getRangeJointVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1605, self, varargin{:});
     end
     function varargout = getRangeDOFVariable(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1608, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1606, self, varargin{:});
     end
     function varargout = getDynamicVariablesOrdering(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1609, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1607, self, varargin{:});
     end
     function varargout = serializeDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1610, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1608, self, varargin{:});
     end
     function varargout = serializeSensorVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1611, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1609, self, varargin{:});
     end
     function varargout = serializeDynamicVariablesComputedFromFixedBaseRNEA(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1612, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1610, self, varargin{:});
     end
     function varargout = extractJointTorquesFromDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1613, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1611, self, varargin{:});
     end
     function varargout = extractLinkNetExternalWrenchesFromDynamicVariables(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1614, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1612, self, varargin{:});
     end
     function varargout = updateKinematicsFromFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1615, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1613, self, varargin{:});
     end
     function varargout = updateKinematicsFromFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1614, self, varargin{:});
     end
     function varargout = updateKinematicsFromTraversalFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1615, self, varargin{:});
     end
     function varargout = setNetExternalWrenchMeasurementFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1618, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1616, self, varargin{:});
     end
     function varargout = getNetExternalWrenchMeasurementFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1619, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1617, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1620, self);
+        iDynTreeMEX(1618, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
@@ -64,7 +64,7 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1557, self, varargin{1});
       end
     end
-    function varargout = includeFixedBaseExternalWrench(self, varargin)
+    function varargout = rcmConstraintLinkNamesVector(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -74,7 +74,7 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1559, self, varargin{1});
       end
     end
-    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
+    function varargout = includeFixedBaseExternalWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -84,7 +84,7 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1561, self, varargin{1});
       end
     end
-    function varargout = baseLink(self, varargin)
+    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -94,12 +94,22 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1563, self, varargin{1});
       end
     end
+    function varargout = baseLink(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1564, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1565, self, varargin{1});
+      end
+    end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1566, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1565, self);
+        iDynTreeMEX(1567, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdyOptions.m
@@ -64,7 +64,7 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1557, self, varargin{1});
       end
     end
-    function varargout = rcmConstraintLinkNamesVector(self, varargin)
+    function varargout = includeFixedBaseExternalWrench(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -74,7 +74,7 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1559, self, varargin{1});
       end
     end
-    function varargout = includeFixedBaseExternalWrench(self, varargin)
+    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -84,7 +84,7 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1561, self, varargin{1});
       end
     end
-    function varargout = jointOnWhichTheInternalWrenchIsMeasured(self, varargin)
+    function varargout = baseLink(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -94,22 +94,12 @@ classdef BerdyOptions < iDynTreeSwigRef
         iDynTreeMEX(1563, self, varargin{1});
       end
     end
-    function varargout = baseLink(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1564, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1565, self, varargin{1});
-      end
-    end
     function varargout = checkConsistency(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1566, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1564, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1567, self);
+        iDynTreeMEX(1565, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
@@ -7,13 +7,23 @@ classdef BerdySensor < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1566, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1567, self, varargin{1});
+      end
+    end
+    function varargout = id(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1568, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1569, self, varargin{1});
       end
     end
-    function varargout = id(self, varargin)
+    function varargout = range(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,21 +33,11 @@ classdef BerdySensor < iDynTreeSwigRef
         iDynTreeMEX(1571, self, varargin{1});
       end
     end
-    function varargout = range(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1572, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1573, self, varargin{1});
-      end
-    end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1574, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1572, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1575, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1573, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -45,14 +45,14 @@ classdef BerdySensor < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1576, varargin{:});
+        tmp = iDynTreeMEX(1574, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1577, self);
+        iDynTreeMEX(1575, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySensor.m
@@ -7,23 +7,13 @@ classdef BerdySensor < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1566, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1567, self, varargin{1});
-      end
-    end
-    function varargout = id(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1568, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1569, self, varargin{1});
       end
     end
-    function varargout = range(self, varargin)
+    function varargout = id(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -33,11 +23,21 @@ classdef BerdySensor < iDynTreeSwigRef
         iDynTreeMEX(1571, self, varargin{1});
       end
     end
+    function varargout = range(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1572, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1573, self, varargin{1});
+      end
+    end
     function varargout = eq(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1572, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1574, self, varargin{:});
     end
     function varargout = lt(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1573, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1575, self, varargin{:});
     end
     function self = BerdySensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -45,14 +45,14 @@ classdef BerdySensor < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1574, varargin{:});
+        tmp = iDynTreeMEX(1576, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1575, self);
+        iDynTreeMEX(1577, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
@@ -9,58 +9,58 @@ classdef BerdySparseMAPSolver < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1618, varargin{:});
+        tmp = iDynTreeMEX(1621, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1619, self);
+        iDynTreeMEX(1622, self);
         self.SwigClear();
       end
     end
     function varargout = setDynamicsConstraintsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1620, self, varargin{:});
-    end
-    function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
-    end
-    function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
-    end
-    function varargout = setMeasurementsPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
     end
-    function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
+    function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
     end
-    function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
+    function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
     end
-    function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
+    function varargout = setMeasurementsPriorCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
     end
-    function varargout = measurementsPriorCovarianceInverse(self,varargin)
+    function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
     end
-    function varargout = isValid(self,varargin)
+    function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
     end
-    function varargout = initialize(self,varargin)
+    function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
     end
-    function varargout = updateEstimateInformationFixedBase(self,varargin)
+    function varargout = measurementsPriorCovarianceInverse(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
     end
-    function varargout = updateEstimateInformationFloatingBase(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
     end
-    function varargout = doEstimate(self,varargin)
+    function varargout = initialize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
     end
-    function varargout = getLastEstimate(self,varargin)
+    function varargout = updateEstimateInformationFixedBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
+    end
+    function varargout = updateEstimateInformationFloatingBase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
+    end
+    function varargout = doEstimate(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
+    end
+    function varargout = getLastEstimate(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
+++ b/bindings/matlab/autogenerated/+iDynTree/BerdySparseMAPSolver.m
@@ -9,58 +9,58 @@ classdef BerdySparseMAPSolver < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1621, varargin{:});
+        tmp = iDynTreeMEX(1619, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1622, self);
+        iDynTreeMEX(1620, self);
         self.SwigClear();
       end
     end
     function varargout = setDynamicsConstraintsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1621, self, varargin{:});
     end
     function varargout = setDynamicsRegularizationPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1622, self, varargin{:});
     end
     function varargout = setDynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1623, self, varargin{:});
     end
     function varargout = setMeasurementsPriorCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1624, self, varargin{:});
     end
     function varargout = dynamicsConstraintsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1625, self, varargin{:});
     end
     function varargout = dynamicsRegularizationPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1626, self, varargin{:});
     end
     function varargout = dynamicsRegularizationPriorExpectedValue(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1627, self, varargin{:});
     end
     function varargout = measurementsPriorCovarianceInverse(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1628, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1629, self, varargin{:});
     end
     function varargout = initialize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1630, self, varargin{:});
     end
     function varargout = updateEstimateInformationFixedBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1631, self, varargin{:});
     end
     function varargout = updateEstimateInformationFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1632, self, varargin{:});
     end
     function varargout = doEstimate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1635, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1633, self, varargin{:});
     end
     function varargout = getLastEstimate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1636, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1634, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,13 +7,23 @@ classdef ColorViz < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1853, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1854, self, varargin{1});
+      end
+    end
+    function varargout = g(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1855, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1856, self, varargin{1});
       end
     end
-    function varargout = g(self, varargin)
+    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,7 +33,7 @@ classdef ColorViz < iDynTreeSwigRef
         iDynTreeMEX(1858, self, varargin{1});
       end
     end
-    function varargout = b(self, varargin)
+    function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -33,30 +43,20 @@ classdef ColorViz < iDynTreeSwigRef
         iDynTreeMEX(1860, self, varargin{1});
       end
     end
-    function varargout = a(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1861, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1862, self, varargin{1});
-      end
-    end
     function self = ColorViz(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1863, varargin{:});
+        tmp = iDynTreeMEX(1861, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1864, self);
+        iDynTreeMEX(1862, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ColorViz.m
@@ -7,40 +7,40 @@ classdef ColorViz < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1852, self);
+        varargout{1} = iDynTreeMEX(1855, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1853, self, varargin{1});
+        iDynTreeMEX(1856, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1854, self);
+        varargout{1} = iDynTreeMEX(1857, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1855, self, varargin{1});
+        iDynTreeMEX(1858, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1856, self);
+        varargout{1} = iDynTreeMEX(1859, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1857, self, varargin{1});
+        iDynTreeMEX(1860, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1858, self);
+        varargout{1} = iDynTreeMEX(1861, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1859, self, varargin{1});
+        iDynTreeMEX(1862, self, varargin{1});
       end
     end
     function self = ColorViz(varargin)
@@ -49,14 +49,14 @@ classdef ColorViz < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1860, varargin{:});
+        tmp = iDynTreeMEX(1863, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1861, self);
+        iDynTreeMEX(1864, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
@@ -4,15 +4,25 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = setActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2013, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2011, self, varargin{:});
     end
     function varargout = isActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2014, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2012, self, varargin{:});
     end
     function varargout = getNrOfConstraints(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2015, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2013, self, varargin{:});
     end
     function varargout = projectedConvexHull(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2014, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2015, self, varargin{1});
+      end
+    end
+    function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -22,7 +32,7 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2017, self, varargin{1});
       end
     end
-    function varargout = A(self, varargin)
+    function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -32,7 +42,7 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2019, self, varargin{1});
       end
     end
-    function varargout = b(self, varargin)
+    function varargout = P(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -42,7 +52,7 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2021, self, varargin{1});
       end
     end
-    function varargout = P(self, varargin)
+    function varargout = Pdirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -52,7 +62,7 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2023, self, varargin{1});
       end
     end
-    function varargout = Pdirection(self, varargin)
+    function varargout = AtimesP(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -62,7 +72,7 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2025, self, varargin{1});
       end
     end
-    function varargout = AtimesP(self, varargin)
+    function varargout = o(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -72,20 +82,20 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2027, self, varargin{1});
       end
     end
-    function varargout = o(self, varargin)
+    function varargout = buildConvexHull(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2028, self, varargin{:});
+    end
+    function varargout = supportFrameIndices(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2028, self);
+        varargout{1} = iDynTreeMEX(2029, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2029, self, varargin{1});
+        iDynTreeMEX(2030, self, varargin{1});
       end
     end
-    function varargout = buildConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2030, self, varargin{:});
-    end
-    function varargout = supportFrameIndices(self, varargin)
+    function varargout = absoluteFrame_X_supportFrame(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -95,27 +105,17 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2032, self, varargin{1});
       end
     end
-    function varargout = absoluteFrame_X_supportFrame(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2033, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(2034, self, varargin{1});
-      end
-    end
     function varargout = project(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2035, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2033, self, varargin{:});
     end
     function varargout = computeMargin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2036, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2034, self, varargin{:});
     end
     function varargout = setProjectionAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2037, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2035, self, varargin{:});
     end
     function varargout = projectAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2038, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2036, self, varargin{:});
     end
     function self = ConvexHullProjectionConstraint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -123,14 +123,14 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2039, varargin{:});
+        tmp = iDynTreeMEX(2037, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2040, self);
+        iDynTreeMEX(2038, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ConvexHullProjectionConstraint.m
@@ -4,88 +4,75 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = setActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2010, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2013, self, varargin{:});
     end
     function varargout = isActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2011, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2014, self, varargin{:});
     end
     function varargout = getNrOfConstraints(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2012, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2015, self, varargin{:});
     end
     function varargout = projectedConvexHull(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2013, self);
+        varargout{1} = iDynTreeMEX(2016, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2014, self, varargin{1});
+        iDynTreeMEX(2017, self, varargin{1});
       end
     end
     function varargout = A(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2015, self);
+        varargout{1} = iDynTreeMEX(2018, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2016, self, varargin{1});
+        iDynTreeMEX(2019, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2017, self);
+        varargout{1} = iDynTreeMEX(2020, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2018, self, varargin{1});
+        iDynTreeMEX(2021, self, varargin{1});
       end
     end
     function varargout = P(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2019, self);
+        varargout{1} = iDynTreeMEX(2022, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2020, self, varargin{1});
+        iDynTreeMEX(2023, self, varargin{1});
       end
     end
     function varargout = Pdirection(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2021, self);
+        varargout{1} = iDynTreeMEX(2024, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2022, self, varargin{1});
+        iDynTreeMEX(2025, self, varargin{1});
       end
     end
     function varargout = AtimesP(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2023, self);
+        varargout{1} = iDynTreeMEX(2026, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2024, self, varargin{1});
+        iDynTreeMEX(2027, self, varargin{1});
       end
     end
     function varargout = o(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2025, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(2026, self, varargin{1});
-      end
-    end
-    function varargout = buildConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2027, self, varargin{:});
-    end
-    function varargout = supportFrameIndices(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -95,27 +82,40 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
         iDynTreeMEX(2029, self, varargin{1});
       end
     end
+    function varargout = buildConvexHull(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2030, self, varargin{:});
+    end
+    function varargout = supportFrameIndices(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(2031, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(2032, self, varargin{1});
+      end
+    end
     function varargout = absoluteFrame_X_supportFrame(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2030, self);
+        varargout{1} = iDynTreeMEX(2033, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2031, self, varargin{1});
+        iDynTreeMEX(2034, self, varargin{1});
       end
     end
     function varargout = project(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2032, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2035, self, varargin{:});
     end
     function varargout = computeMargin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2033, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2036, self, varargin{:});
     end
     function varargout = setProjectionAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2034, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2037, self, varargin{:});
     end
     function varargout = projectAlongDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2035, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2038, self, varargin{:});
     end
     function self = ConvexHullProjectionConstraint(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -123,14 +123,14 @@ classdef ConvexHullProjectionConstraint < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2036, varargin{:});
+        tmp = iDynTreeMEX(2039, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2037, self);
+        iDynTreeMEX(2040, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DIRECTIONAL_LIGHT.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DIRECTIONAL_LIGHT.m
@@ -1,7 +1,7 @@
 function v = DIRECTIONAL_LIGHT()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 33);
+    vInitialized = iDynTreeMEX(0, 35);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_ACCELERATION.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_ACCELERATION.m
@@ -1,7 +1,7 @@
 function v = DOF_ACCELERATION()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 21);
+    vInitialized = iDynTreeMEX(0, 22);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_ACCELERATION_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_ACCELERATION_SENSOR.m
@@ -1,7 +1,7 @@
 function v = DOF_ACCELERATION_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 28);
+    vInitialized = iDynTreeMEX(0, 29);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_TORQUE.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_TORQUE.m
@@ -1,7 +1,7 @@
 function v = DOF_TORQUE()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 19);
+    vInitialized = iDynTreeMEX(0, 20);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DOF_TORQUE_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DOF_TORQUE_SENSOR.m
@@ -1,7 +1,7 @@
 function v = DOF_TORQUE_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 29);
+    vInitialized = iDynTreeMEX(0, 30);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
@@ -4,65 +4,65 @@ classdef DiscreteExtendedKalmanFilterHelper < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = ekf_f(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1685, self, varargin{:});
-    end
-    function varargout = ekf_h(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
-    end
-    function varargout = ekfComputeJacobianF(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1687, self, varargin{:});
-    end
-    function varargout = ekfComputeJacobianH(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1688, self, varargin{:});
     end
-    function varargout = ekfPredict(self,varargin)
+    function varargout = ekf_h(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1689, self, varargin{:});
     end
-    function varargout = ekfUpdate(self,varargin)
+    function varargout = ekfComputeJacobianF(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1690, self, varargin{:});
     end
-    function varargout = ekfInit(self,varargin)
+    function varargout = ekfComputeJacobianH(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1691, self, varargin{:});
     end
-    function varargout = ekfReset(self,varargin)
+    function varargout = ekfPredict(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1692, self, varargin{:});
     end
-    function varargout = ekfSetMeasurementVector(self,varargin)
+    function varargout = ekfUpdate(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1693, self, varargin{:});
     end
-    function varargout = ekfSetInputVector(self,varargin)
+    function varargout = ekfInit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1694, self, varargin{:});
     end
-    function varargout = ekfSetInitialState(self,varargin)
+    function varargout = ekfReset(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
     end
-    function varargout = ekfSetStateCovariance(self,varargin)
+    function varargout = ekfSetMeasurementVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
     end
-    function varargout = ekfSetSystemNoiseCovariance(self,varargin)
+    function varargout = ekfSetInputVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
     end
-    function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
+    function varargout = ekfSetInitialState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
     end
-    function varargout = ekfSetStateSize(self,varargin)
+    function varargout = ekfSetStateCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
     end
-    function varargout = ekfSetInputSize(self,varargin)
+    function varargout = ekfSetSystemNoiseCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
     end
-    function varargout = ekfSetOutputSize(self,varargin)
+    function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
     end
-    function varargout = ekfGetStates(self,varargin)
+    function varargout = ekfSetStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
     end
-    function varargout = ekfGetStateCovariance(self,varargin)
+    function varargout = ekfSetInputSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
+    end
+    function varargout = ekfSetOutputSize(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
+    end
+    function varargout = ekfGetStates(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
+    end
+    function varargout = ekfGetStateCovariance(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1704, self);
+        iDynTreeMEX(1707, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
+++ b/bindings/matlab/autogenerated/+iDynTree/DiscreteExtendedKalmanFilterHelper.m
@@ -4,65 +4,65 @@ classdef DiscreteExtendedKalmanFilterHelper < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = ekf_f(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1688, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1686, self, varargin{:});
     end
     function varargout = ekf_h(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1689, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1687, self, varargin{:});
     end
     function varargout = ekfComputeJacobianF(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1690, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1688, self, varargin{:});
     end
     function varargout = ekfComputeJacobianH(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1691, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1689, self, varargin{:});
     end
     function varargout = ekfPredict(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1692, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1690, self, varargin{:});
     end
     function varargout = ekfUpdate(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1693, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1691, self, varargin{:});
     end
     function varargout = ekfInit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1694, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1692, self, varargin{:});
     end
     function varargout = ekfReset(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1693, self, varargin{:});
     end
     function varargout = ekfSetMeasurementVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1694, self, varargin{:});
     end
     function varargout = ekfSetInputVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1695, self, varargin{:});
     end
     function varargout = ekfSetInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1696, self, varargin{:});
     end
     function varargout = ekfSetStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1697, self, varargin{:});
     end
     function varargout = ekfSetSystemNoiseCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1698, self, varargin{:});
     end
     function varargout = ekfSetMeasurementNoiseCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1699, self, varargin{:});
     end
     function varargout = ekfSetStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1700, self, varargin{:});
     end
     function varargout = ekfSetInputSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1701, self, varargin{:});
     end
     function varargout = ekfSetOutputSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1702, self, varargin{:});
     end
     function varargout = ekfGetStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1705, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1703, self, varargin{:});
     end
     function varargout = ekfGetStateCovariance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1706, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1704, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1707, self);
+        iDynTreeMEX(1705, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/GYROSCOPE_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/GYROSCOPE_SENSOR.m
@@ -1,7 +1,7 @@
 function v = GYROSCOPE_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 25);
+    vInitialized = iDynTreeMEX(0, 26);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
@@ -5,39 +5,39 @@ classdef IAttitudeEstimator < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1645, self);
+        iDynTreeMEX(1643, self);
         self.SwigClear();
       end
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
     end
     function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsQuaternion(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
     end
     function varargout = getOrientationEstimateAsRPY(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
     end
     function varargout = getInternalStateSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
     end
     function varargout = getInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
     end
     function varargout = getDefaultInternalInitialState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1653, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
     end
     function varargout = setInternalState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1654, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
     end
     function varargout = setInternalStateInitialOrientation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1655, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1653, self, varargin{:});
     end
     function self = IAttitudeEstimator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IAttitudeEstimator.m
@@ -5,39 +5,39 @@ classdef IAttitudeEstimator < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1642, self);
+        iDynTreeMEX(1645, self);
         self.SwigClear();
       end
     end
     function varargout = updateFilterWithMeasurements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1643, self, varargin{:});
-    end
-    function varargout = propagateStates(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1644, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1645, self, varargin{:});
-    end
-    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1646, self, varargin{:});
     end
-    function varargout = getOrientationEstimateAsRPY(self,varargin)
+    function varargout = propagateStates(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1647, self, varargin{:});
     end
-    function varargout = getInternalStateSize(self,varargin)
+    function varargout = getOrientationEstimateAsRotationMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1648, self, varargin{:});
     end
-    function varargout = getInternalState(self,varargin)
+    function varargout = getOrientationEstimateAsQuaternion(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1649, self, varargin{:});
     end
-    function varargout = getDefaultInternalInitialState(self,varargin)
+    function varargout = getOrientationEstimateAsRPY(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1650, self, varargin{:});
     end
-    function varargout = setInternalState(self,varargin)
+    function varargout = getInternalStateSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1651, self, varargin{:});
     end
-    function varargout = setInternalStateInitialOrientation(self,varargin)
+    function varargout = getInternalState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1652, self, varargin{:});
+    end
+    function varargout = getDefaultInternalInitialState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1653, self, varargin{:});
+    end
+    function varargout = setInternalState(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1654, self, varargin{:});
+    end
+    function varargout = setInternalStateInitialOrientation(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1655, self, varargin{:});
     end
     function self = IAttitudeEstimator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,27 +5,27 @@ classdef ICamera < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1845, self);
+        iDynTreeMEX(1848, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
-    end
-    function varargout = setTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
-    end
-    function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
-    end
-    function varargout = getTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
     end
-    function varargout = setUpVector(self,varargin)
+    function varargout = setTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
     end
-    function varargout = animator(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
+    end
+    function varargout = getTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
+    end
+    function varargout = setUpVector(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
+    end
+    function varargout = animator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICamera.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICamera.m
@@ -5,27 +5,27 @@ classdef ICamera < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1848, self);
+        iDynTreeMEX(1846, self);
         self.SwigClear();
       end
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1847, self, varargin{:});
     end
     function varargout = setTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1848, self, varargin{:});
     end
     function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1849, self, varargin{:});
     end
     function varargout = getTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1850, self, varargin{:});
     end
     function varargout = setUpVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1853, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1851, self, varargin{:});
     end
     function varargout = animator(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1854, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1852, self, varargin{:});
     end
     function self = ICamera(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ICameraAnimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICameraAnimator.m
@@ -4,29 +4,29 @@ classdef ICameraAnimator < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = enableMouseControl(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
-    end
-    function varargout = getMoveSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
-    end
-    function varargout = setMoveSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
-    end
-    function varargout = getRotateSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
-    function varargout = setRotateSpeed(self,varargin)
+    function varargout = getMoveSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
     end
-    function varargout = getZoomSpeed(self,varargin)
+    function varargout = setMoveSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
-    function varargout = setZoomSpeed(self,varargin)
+    function varargout = getRotateSpeed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
+    end
+    function varargout = setRotateSpeed(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
+    end
+    function varargout = getZoomSpeed(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
+    end
+    function varargout = setZoomSpeed(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1844, self);
+        iDynTreeMEX(1847, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/ICameraAnimator.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ICameraAnimator.m
@@ -4,29 +4,29 @@ classdef ICameraAnimator < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = enableMouseControl(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
     end
     function varargout = getMoveSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1839, self, varargin{:});
     end
     function varargout = setMoveSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1840, self, varargin{:});
     end
     function varargout = getRotateSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1841, self, varargin{:});
     end
     function varargout = setRotateSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1842, self, varargin{:});
     end
     function varargout = getZoomSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1845, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1843, self, varargin{:});
     end
     function varargout = setZoomSpeed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1846, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1844, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1847, self);
+        iDynTreeMEX(1845, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,36 +5,36 @@ classdef IEnvironment < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1885, self);
+        iDynTreeMEX(1883, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
     end
     function varargout = setElementVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
     end
     function varargout = setBackgroundColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
     end
     function varargout = setFloorGridColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
     end
     function varargout = setAmbientLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
     end
     function varargout = getLights(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
     end
     function varargout = addLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
     end
     function varargout = lightViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
     end
     function varargout = removeLight(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IEnvironment.m
@@ -5,36 +5,36 @@ classdef IEnvironment < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1882, self);
+        iDynTreeMEX(1885, self);
         self.SwigClear();
       end
     end
     function varargout = getElements(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
-    end
-    function varargout = setElementVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
-    end
-    function varargout = setBackgroundColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1885, self, varargin{:});
-    end
-    function varargout = setFloorGridColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1886, self, varargin{:});
     end
-    function varargout = setAmbientLight(self,varargin)
+    function varargout = setElementVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1887, self, varargin{:});
     end
-    function varargout = getLights(self,varargin)
+    function varargout = setBackgroundColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1888, self, varargin{:});
     end
-    function varargout = addLight(self,varargin)
+    function varargout = setFloorGridColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1889, self, varargin{:});
     end
-    function varargout = lightViz(self,varargin)
+    function varargout = setAmbientLight(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1890, self, varargin{:});
     end
-    function varargout = removeLight(self,varargin)
+    function varargout = getLights(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1891, self, varargin{:});
+    end
+    function varargout = addLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1892, self, varargin{:});
+    end
+    function varargout = lightViz(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
+    end
+    function varargout = removeLight(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
     end
     function self = IEnvironment(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IFrameVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IFrameVisualization.m
@@ -5,27 +5,27 @@ classdef IFrameVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1921, self);
+        iDynTreeMEX(1924, self);
         self.SwigClear();
       end
     end
     function varargout = addFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
-    end
-    function varargout = setVisible(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
-    end
-    function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
-    end
-    function varargout = getFrameTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
     end
-    function varargout = updateFrame(self,varargin)
+    function varargout = setVisible(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
     end
-    function varargout = getFrameLabel(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
+    end
+    function varargout = getFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
+    end
+    function varargout = updateFrame(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
+    end
+    function varargout = getFrameLabel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
     end
     function self = IFrameVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IFrameVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IFrameVisualization.m
@@ -5,27 +5,27 @@ classdef IFrameVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1924, self);
+        iDynTreeMEX(1922, self);
         self.SwigClear();
       end
     end
     function varargout = addFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
     end
     function varargout = setVisible(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1924, self, varargin{:});
     end
     function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1925, self, varargin{:});
     end
     function varargout = getFrameTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1926, self, varargin{:});
     end
     function varargout = updateFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1927, self, varargin{:});
     end
     function varargout = getFrameLabel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1928, self, varargin{:});
     end
     function self = IFrameVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1895, self);
+        iDynTreeMEX(1893, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1896, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
     end
     function varargout = getNrOfJets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
     end
     function varargout = getJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1896, self, varargin{:});
     end
     function varargout = setJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
     end
     function varargout = setJetColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1900, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
     end
     function varargout = setJetsDimensions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
     end
     function varargout = setJetsIntensity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1900, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IJetsVisualization.m
@@ -5,30 +5,30 @@ classdef IJetsVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1892, self);
+        iDynTreeMEX(1895, self);
         self.SwigClear();
       end
     end
     function varargout = setJetsFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1893, self, varargin{:});
-    end
-    function varargout = getNrOfJets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1894, self, varargin{:});
-    end
-    function varargout = getJetDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1895, self, varargin{:});
-    end
-    function varargout = setJetDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1896, self, varargin{:});
     end
-    function varargout = setJetColor(self,varargin)
+    function varargout = getNrOfJets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1897, self, varargin{:});
     end
-    function varargout = setJetsDimensions(self,varargin)
+    function varargout = getJetDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1898, self, varargin{:});
     end
-    function varargout = setJetsIntensity(self,varargin)
+    function varargout = setJetDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1899, self, varargin{:});
+    end
+    function varargout = setJetColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1900, self, varargin{:});
+    end
+    function varargout = setJetsDimensions(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
+    end
+    function varargout = setJetsIntensity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
     end
     function self = IJetsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILabel.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILabel.m
@@ -5,36 +5,36 @@ classdef ILabel < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1900, self);
+        iDynTreeMEX(1903, self);
         self.SwigClear();
       end
     end
     function varargout = setText(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1901, self, varargin{:});
-    end
-    function varargout = getText(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
-    end
-    function varargout = setSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1903, self, varargin{:});
-    end
-    function varargout = width(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
     end
-    function varargout = height(self,varargin)
+    function varargout = getText(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
     end
-    function varargout = setPosition(self,varargin)
+    function varargout = setSize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
     end
-    function varargout = getPosition(self,varargin)
+    function varargout = width(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
     end
-    function varargout = setColor(self,varargin)
+    function varargout = height(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
     end
-    function varargout = setVisible(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
+    end
+    function varargout = getPosition(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
+    end
+    function varargout = setColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
+    end
+    function varargout = setVisible(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
     end
     function self = ILabel(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILabel.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILabel.m
@@ -5,36 +5,36 @@ classdef ILabel < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1903, self);
+        iDynTreeMEX(1901, self);
         self.SwigClear();
       end
     end
     function varargout = setText(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1902, self, varargin{:});
     end
     function varargout = getText(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1903, self, varargin{:});
     end
     function varargout = setSize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1904, self, varargin{:});
     end
     function varargout = width(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1905, self, varargin{:});
     end
     function varargout = height(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1906, self, varargin{:});
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1907, self, varargin{:});
     end
     function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1908, self, varargin{:});
     end
     function varargout = setColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1909, self, varargin{:});
     end
     function varargout = setVisible(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1910, self, varargin{:});
     end
     function self = ILabel(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1871, self);
+        iDynTreeMEX(1869, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
     end
     function varargout = setType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
     end
     function varargout = getType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
     end
     function varargout = setPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
     end
     function varargout = getPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
     end
     function varargout = setDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
     end
     function varargout = getDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
     function varargout = setAmbientColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
     end
     function varargout = getAmbientColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
     end
     function varargout = setSpecularColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
     end
     function varargout = getSpecularColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
     end
     function varargout = setDiffuseColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
     end
     function varargout = getDiffuseColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ILight.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ILight.m
@@ -5,48 +5,48 @@ classdef ILight < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1868, self);
+        iDynTreeMEX(1871, self);
         self.SwigClear();
       end
     end
     function varargout = getName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1869, self, varargin{:});
-    end
-    function varargout = setType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1870, self, varargin{:});
-    end
-    function varargout = getType(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1871, self, varargin{:});
-    end
-    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1872, self, varargin{:});
     end
-    function varargout = getPosition(self,varargin)
+    function varargout = setType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1873, self, varargin{:});
     end
-    function varargout = setDirection(self,varargin)
+    function varargout = getType(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1874, self, varargin{:});
     end
-    function varargout = getDirection(self,varargin)
+    function varargout = setPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1875, self, varargin{:});
     end
-    function varargout = setAmbientColor(self,varargin)
+    function varargout = getPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1876, self, varargin{:});
     end
-    function varargout = getAmbientColor(self,varargin)
+    function varargout = setDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1877, self, varargin{:});
     end
-    function varargout = setSpecularColor(self,varargin)
+    function varargout = getDirection(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1878, self, varargin{:});
     end
-    function varargout = getSpecularColor(self,varargin)
+    function varargout = setAmbientColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1879, self, varargin{:});
     end
-    function varargout = setDiffuseColor(self,varargin)
+    function varargout = getAmbientColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1880, self, varargin{:});
     end
-    function varargout = getDiffuseColor(self,varargin)
+    function varargout = setSpecularColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1881, self, varargin{:});
+    end
+    function varargout = getSpecularColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1882, self, varargin{:});
+    end
+    function varargout = setDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1883, self, varargin{:});
+    end
+    function varargout = getDiffuseColor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1884, self, varargin{:});
     end
     function self = ILight(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,60 +5,60 @@ classdef IModelVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1931, self);
+        iDynTreeMEX(1929, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
     end
     function varargout = setLinkPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
     end
     function varargout = getInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
     function varargout = setModelVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
     end
     function varargout = setModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
     end
     function varargout = resetModelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
     end
     function varargout = setLinkColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
     end
     function varargout = resetLinkColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
     end
     function varargout = getLinkNames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
     function varargout = setLinkVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
     function varargout = getFeatures(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
     end
     function varargout = setFeatureVisibility(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
     function varargout = jets(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
     end
     function varargout = getWorldLinkTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
     end
     function varargout = getWorldFrameTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
     end
     function varargout = label(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IModelVisualization.m
@@ -5,60 +5,60 @@ classdef IModelVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1928, self);
+        iDynTreeMEX(1931, self);
         self.SwigClear();
       end
     end
     function varargout = setPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1929, self, varargin{:});
-    end
-    function varargout = setLinkPositions(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1930, self, varargin{:});
-    end
-    function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1931, self, varargin{:});
-    end
-    function varargout = getInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1932, self, varargin{:});
     end
-    function varargout = setModelVisibility(self,varargin)
+    function varargout = setLinkPositions(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1933, self, varargin{:});
     end
-    function varargout = setModelColor(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1934, self, varargin{:});
     end
-    function varargout = resetModelColor(self,varargin)
+    function varargout = getInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1935, self, varargin{:});
     end
-    function varargout = setLinkColor(self,varargin)
+    function varargout = setModelVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1936, self, varargin{:});
     end
-    function varargout = resetLinkColor(self,varargin)
+    function varargout = setModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1937, self, varargin{:});
     end
-    function varargout = getLinkNames(self,varargin)
+    function varargout = resetModelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1938, self, varargin{:});
     end
-    function varargout = setLinkVisibility(self,varargin)
+    function varargout = setLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1939, self, varargin{:});
     end
-    function varargout = getFeatures(self,varargin)
+    function varargout = resetLinkColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1940, self, varargin{:});
     end
-    function varargout = setFeatureVisibility(self,varargin)
+    function varargout = getLinkNames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1941, self, varargin{:});
     end
-    function varargout = jets(self,varargin)
+    function varargout = setLinkVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1942, self, varargin{:});
     end
-    function varargout = getWorldLinkTransform(self,varargin)
+    function varargout = getFeatures(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1943, self, varargin{:});
     end
-    function varargout = getWorldFrameTransform(self,varargin)
+    function varargout = setFeatureVisibility(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1944, self, varargin{:});
     end
-    function varargout = label(self,varargin)
+    function varargout = jets(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1945, self, varargin{:});
+    end
+    function varargout = getWorldLinkTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1946, self, varargin{:});
+    end
+    function varargout = getWorldFrameTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
+    end
+    function varargout = label(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
     end
     function self = IModelVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ITexture.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ITexture.m
@@ -5,33 +5,33 @@ classdef ITexture < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1949, self);
+        iDynTreeMEX(1947, self);
         self.SwigClear();
       end
     end
     function varargout = environment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
     end
     function varargout = getPixelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
     end
     function varargout = getPixels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
     end
     function varargout = drawToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
     end
     function varargout = enableDraw(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
     end
     function varargout = width(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
     end
     function varargout = height(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
     end
     function varargout = setSubDrawArea(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
     end
     function self = ITexture(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ITexture.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ITexture.m
@@ -5,33 +5,33 @@ classdef ITexture < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1946, self);
+        iDynTreeMEX(1949, self);
         self.SwigClear();
       end
     end
     function varargout = environment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1947, self, varargin{:});
-    end
-    function varargout = getPixelColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1948, self, varargin{:});
-    end
-    function varargout = getPixels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1949, self, varargin{:});
-    end
-    function varargout = drawToFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1950, self, varargin{:});
     end
-    function varargout = enableDraw(self,varargin)
+    function varargout = getPixelColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1951, self, varargin{:});
     end
-    function varargout = width(self,varargin)
+    function varargout = getPixels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1952, self, varargin{:});
     end
-    function varargout = height(self,varargin)
+    function varargout = drawToFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1953, self, varargin{:});
     end
-    function varargout = setSubDrawArea(self,varargin)
+    function varargout = enableDraw(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1954, self, varargin{:});
+    end
+    function varargout = width(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1955, self, varargin{:});
+    end
+    function varargout = height(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1956, self, varargin{:});
+    end
+    function varargout = setSubDrawArea(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1957, self, varargin{:});
     end
     function self = ITexture(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ITexturesHandler.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ITexturesHandler.m
@@ -5,15 +5,15 @@ classdef ITexturesHandler < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1965, self);
+        iDynTreeMEX(1968, self);
         self.SwigClear();
       end
     end
     function varargout = add(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1966, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
     end
     function varargout = get(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
     end
     function self = ITexturesHandler(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/ITexturesHandler.m
+++ b/bindings/matlab/autogenerated/+iDynTree/ITexturesHandler.m
@@ -5,15 +5,15 @@ classdef ITexturesHandler < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1968, self);
+        iDynTreeMEX(1966, self);
         self.SwigClear();
       end
     end
     function varargout = add(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1969, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1967, self, varargin{:});
     end
     function varargout = get(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1968, self, varargin{:});
     end
     function self = ITexturesHandler(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,39 +5,39 @@ classdef IVectorsVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1913, self);
+        iDynTreeMEX(1911, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
     end
     function varargout = getNrOfVectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
     end
     function varargout = getVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
     end
     function varargout = updateVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
     end
     function varargout = setVectorColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
     end
     function varargout = setVectorsDefaultColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
     end
     function varargout = setVectorsColor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
     end
     function varargout = setVectorsAspect(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
     end
     function varargout = setVisible(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
     end
     function varargout = getVectorLabel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/IVectorsVisualization.m
@@ -5,39 +5,39 @@ classdef IVectorsVisualization < iDynTreeSwigRef
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1910, self);
+        iDynTreeMEX(1913, self);
         self.SwigClear();
       end
     end
     function varargout = addVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1911, self, varargin{:});
-    end
-    function varargout = getNrOfVectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1912, self, varargin{:});
-    end
-    function varargout = getVector(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1913, self, varargin{:});
-    end
-    function varargout = updateVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1914, self, varargin{:});
     end
-    function varargout = setVectorColor(self,varargin)
+    function varargout = getNrOfVectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1915, self, varargin{:});
     end
-    function varargout = setVectorsDefaultColor(self,varargin)
+    function varargout = getVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1916, self, varargin{:});
     end
-    function varargout = setVectorsColor(self,varargin)
+    function varargout = updateVector(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1917, self, varargin{:});
     end
-    function varargout = setVectorsAspect(self,varargin)
+    function varargout = setVectorColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1918, self, varargin{:});
     end
-    function varargout = setVisible(self,varargin)
+    function varargout = setVectorsDefaultColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1919, self, varargin{:});
     end
-    function varargout = getVectorLabel(self,varargin)
+    function varargout = setVectorsColor(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1920, self, varargin{:});
+    end
+    function varargout = setVectorsAspect(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1921, self, varargin{:});
+    end
+    function varargout = setVisible(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1922, self, varargin{:});
+    end
+    function varargout = getVectorLabel(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1923, self, varargin{:});
     end
     function self = IVectorsVisualization(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
@@ -9,187 +9,187 @@ classdef InverseKinematics < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2039, varargin{:});
+        tmp = iDynTreeMEX(2042, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2040, self);
+        iDynTreeMEX(2043, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2041, self, varargin{:});
-    end
-    function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2042, self, varargin{:});
-    end
-    function varargout = setJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2043, self, varargin{:});
-    end
-    function varargout = getJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2044, self, varargin{:});
     end
-    function varargout = clearProblem(self,varargin)
+    function varargout = setModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2045, self, varargin{:});
     end
-    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
+    function varargout = setJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2046, self, varargin{:});
     end
-    function varargout = setCurrentRobotConfiguration(self,varargin)
+    function varargout = getJointLimits(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2047, self, varargin{:});
     end
-    function varargout = setJointConfiguration(self,varargin)
+    function varargout = clearProblem(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2048, self, varargin{:});
     end
-    function varargout = setRotationParametrization(self,varargin)
+    function varargout = setFloatingBaseOnFrameNamed(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2049, self, varargin{:});
     end
-    function varargout = rotationParametrization(self,varargin)
+    function varargout = setCurrentRobotConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2050, self, varargin{:});
     end
-    function varargout = setMaxIterations(self,varargin)
+    function varargout = setJointConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2051, self, varargin{:});
     end
-    function varargout = maxIterations(self,varargin)
+    function varargout = setRotationParametrization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2052, self, varargin{:});
     end
-    function varargout = setMaxCPUTime(self,varargin)
+    function varargout = rotationParametrization(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2053, self, varargin{:});
     end
-    function varargout = maxCPUTime(self,varargin)
+    function varargout = setMaxIterations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2054, self, varargin{:});
     end
-    function varargout = setCostTolerance(self,varargin)
+    function varargout = maxIterations(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2055, self, varargin{:});
     end
-    function varargout = costTolerance(self,varargin)
+    function varargout = setMaxCPUTime(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2056, self, varargin{:});
     end
-    function varargout = setConstraintsTolerance(self,varargin)
+    function varargout = maxCPUTime(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2057, self, varargin{:});
     end
-    function varargout = constraintsTolerance(self,varargin)
+    function varargout = setCostTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2058, self, varargin{:});
     end
-    function varargout = setVerbosity(self,varargin)
+    function varargout = costTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2059, self, varargin{:});
     end
-    function varargout = linearSolverName(self,varargin)
+    function varargout = setConstraintsTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2060, self, varargin{:});
     end
-    function varargout = setLinearSolverName(self,varargin)
+    function varargout = constraintsTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2061, self, varargin{:});
     end
-    function varargout = addFrameConstraint(self,varargin)
+    function varargout = setVerbosity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2062, self, varargin{:});
     end
-    function varargout = addFramePositionConstraint(self,varargin)
+    function varargout = linearSolverName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2063, self, varargin{:});
     end
-    function varargout = addFrameRotationConstraint(self,varargin)
+    function varargout = setLinearSolverName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2064, self, varargin{:});
     end
-    function varargout = activateFrameConstraint(self,varargin)
+    function varargout = addFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2065, self, varargin{:});
     end
-    function varargout = deactivateFrameConstraint(self,varargin)
+    function varargout = addFramePositionConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2066, self, varargin{:});
     end
-    function varargout = isFrameConstraintActive(self,varargin)
+    function varargout = addFrameRotationConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2067, self, varargin{:});
     end
-    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
+    function varargout = activateFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2068, self, varargin{:});
     end
-    function varargout = getCenterOfMassProjectionMargin(self,varargin)
+    function varargout = deactivateFrameConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2069, self, varargin{:});
     end
-    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
+    function varargout = isFrameConstraintActive(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2070, self, varargin{:});
     end
-    function varargout = addTarget(self,varargin)
+    function varargout = addCenterOfMassProjectionConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2071, self, varargin{:});
     end
-    function varargout = addPositionTarget(self,varargin)
+    function varargout = getCenterOfMassProjectionMargin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2072, self, varargin{:});
     end
-    function varargout = addRotationTarget(self,varargin)
+    function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2073, self, varargin{:});
     end
-    function varargout = updateTarget(self,varargin)
+    function varargout = addTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2074, self, varargin{:});
     end
-    function varargout = updatePositionTarget(self,varargin)
+    function varargout = addPositionTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2075, self, varargin{:});
     end
-    function varargout = updateRotationTarget(self,varargin)
+    function varargout = addRotationTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2076, self, varargin{:});
     end
-    function varargout = setDefaultTargetResolutionMode(self,varargin)
+    function varargout = updateTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2077, self, varargin{:});
     end
-    function varargout = defaultTargetResolutionMode(self,varargin)
+    function varargout = updatePositionTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2078, self, varargin{:});
     end
-    function varargout = setTargetResolutionMode(self,varargin)
+    function varargout = updateRotationTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2079, self, varargin{:});
     end
-    function varargout = targetResolutionMode(self,varargin)
+    function varargout = setDefaultTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2080, self, varargin{:});
     end
-    function varargout = setDesiredFullJointsConfiguration(self,varargin)
+    function varargout = defaultTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2081, self, varargin{:});
     end
-    function varargout = setDesiredReducedJointConfiguration(self,varargin)
+    function varargout = setTargetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2082, self, varargin{:});
     end
-    function varargout = setFullJointsInitialCondition(self,varargin)
+    function varargout = targetResolutionMode(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2083, self, varargin{:});
     end
-    function varargout = setReducedInitialCondition(self,varargin)
+    function varargout = setDesiredFullJointsConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2084, self, varargin{:});
     end
-    function varargout = solve(self,varargin)
+    function varargout = setDesiredReducedJointConfiguration(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2085, self, varargin{:});
     end
-    function varargout = getFullJointsSolution(self,varargin)
+    function varargout = setFullJointsInitialCondition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2086, self, varargin{:});
     end
-    function varargout = getReducedSolution(self,varargin)
+    function varargout = setReducedInitialCondition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2087, self, varargin{:});
     end
-    function varargout = getPoseForFrame(self,varargin)
+    function varargout = solve(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2088, self, varargin{:});
     end
-    function varargout = fullModel(self,varargin)
+    function varargout = getFullJointsSolution(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2089, self, varargin{:});
     end
-    function varargout = reducedModel(self,varargin)
+    function varargout = getReducedSolution(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2090, self, varargin{:});
     end
-    function varargout = setCOMTarget(self,varargin)
+    function varargout = getPoseForFrame(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2091, self, varargin{:});
     end
-    function varargout = setCOMAsConstraint(self,varargin)
+    function varargout = fullModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2092, self, varargin{:});
     end
-    function varargout = setCOMAsConstraintTolerance(self,varargin)
+    function varargout = reducedModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2093, self, varargin{:});
     end
-    function varargout = isCOMAConstraint(self,varargin)
+    function varargout = setCOMTarget(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2094, self, varargin{:});
     end
-    function varargout = isCOMTargetActive(self,varargin)
+    function varargout = setCOMAsConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2095, self, varargin{:});
     end
-    function varargout = deactivateCOMTarget(self,varargin)
+    function varargout = setCOMAsConstraintTolerance(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2096, self, varargin{:});
     end
-    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+    function varargout = isCOMAConstraint(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(2097, self, varargin{:});
+    end
+    function varargout = isCOMTargetActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2098, self, varargin{:});
+    end
+    function varargout = deactivateCOMTarget(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2099, self, varargin{:});
+    end
+    function varargout = setCOMConstraintProjectionDirection(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2100, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematics.m
@@ -9,187 +9,187 @@ classdef InverseKinematics < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2042, varargin{:});
+        tmp = iDynTreeMEX(2040, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2043, self);
+        iDynTreeMEX(2041, self);
         self.SwigClear();
       end
     end
     function varargout = loadModelFromFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2044, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2042, self, varargin{:});
     end
     function varargout = setModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2045, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2043, self, varargin{:});
     end
     function varargout = setJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2046, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2044, self, varargin{:});
     end
     function varargout = getJointLimits(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2047, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2045, self, varargin{:});
     end
     function varargout = clearProblem(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2048, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2046, self, varargin{:});
     end
     function varargout = setFloatingBaseOnFrameNamed(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2049, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2047, self, varargin{:});
     end
     function varargout = setCurrentRobotConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2050, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2048, self, varargin{:});
     end
     function varargout = setJointConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2051, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2049, self, varargin{:});
     end
     function varargout = setRotationParametrization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2052, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2050, self, varargin{:});
     end
     function varargout = rotationParametrization(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2053, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2051, self, varargin{:});
     end
     function varargout = setMaxIterations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2054, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2052, self, varargin{:});
     end
     function varargout = maxIterations(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2055, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2053, self, varargin{:});
     end
     function varargout = setMaxCPUTime(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2056, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2054, self, varargin{:});
     end
     function varargout = maxCPUTime(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2057, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2055, self, varargin{:});
     end
     function varargout = setCostTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2058, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2056, self, varargin{:});
     end
     function varargout = costTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2059, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2057, self, varargin{:});
     end
     function varargout = setConstraintsTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2060, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2058, self, varargin{:});
     end
     function varargout = constraintsTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2061, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2059, self, varargin{:});
     end
     function varargout = setVerbosity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2062, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2060, self, varargin{:});
     end
     function varargout = linearSolverName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2063, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2061, self, varargin{:});
     end
     function varargout = setLinearSolverName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2064, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2062, self, varargin{:});
     end
     function varargout = addFrameConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2065, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2063, self, varargin{:});
     end
     function varargout = addFramePositionConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2066, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2064, self, varargin{:});
     end
     function varargout = addFrameRotationConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2067, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2065, self, varargin{:});
     end
     function varargout = activateFrameConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2068, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2066, self, varargin{:});
     end
     function varargout = deactivateFrameConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2069, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2067, self, varargin{:});
     end
     function varargout = isFrameConstraintActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2070, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2068, self, varargin{:});
     end
     function varargout = addCenterOfMassProjectionConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2071, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2069, self, varargin{:});
     end
     function varargout = getCenterOfMassProjectionMargin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2072, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2070, self, varargin{:});
     end
     function varargout = getCenterOfMassProjectConstraintConvexHull(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2073, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2071, self, varargin{:});
     end
     function varargout = addTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2074, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2072, self, varargin{:});
     end
     function varargout = addPositionTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2075, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2073, self, varargin{:});
     end
     function varargout = addRotationTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2076, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2074, self, varargin{:});
     end
     function varargout = updateTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2077, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2075, self, varargin{:});
     end
     function varargout = updatePositionTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2078, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2076, self, varargin{:});
     end
     function varargout = updateRotationTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2079, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2077, self, varargin{:});
     end
     function varargout = setDefaultTargetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2080, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2078, self, varargin{:});
     end
     function varargout = defaultTargetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2081, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2079, self, varargin{:});
     end
     function varargout = setTargetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2082, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2080, self, varargin{:});
     end
     function varargout = targetResolutionMode(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2083, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2081, self, varargin{:});
     end
     function varargout = setDesiredFullJointsConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2084, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2082, self, varargin{:});
     end
     function varargout = setDesiredReducedJointConfiguration(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2085, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2083, self, varargin{:});
     end
     function varargout = setFullJointsInitialCondition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2086, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2084, self, varargin{:});
     end
     function varargout = setReducedInitialCondition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2087, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2085, self, varargin{:});
     end
     function varargout = solve(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2088, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2086, self, varargin{:});
     end
     function varargout = getFullJointsSolution(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2089, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2087, self, varargin{:});
     end
     function varargout = getReducedSolution(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2090, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2088, self, varargin{:});
     end
     function varargout = getPoseForFrame(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2091, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2089, self, varargin{:});
     end
     function varargout = fullModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2092, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2090, self, varargin{:});
     end
     function varargout = reducedModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2093, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2091, self, varargin{:});
     end
     function varargout = setCOMTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2094, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2092, self, varargin{:});
     end
     function varargout = setCOMAsConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2095, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2093, self, varargin{:});
     end
     function varargout = setCOMAsConstraintTolerance(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2096, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2094, self, varargin{:});
     end
     function varargout = isCOMAConstraint(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2097, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2095, self, varargin{:});
     end
     function varargout = isCOMTargetActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2098, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2096, self, varargin{:});
     end
     function varargout = deactivateCOMTarget(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2099, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2097, self, varargin{:});
     end
     function varargout = setCOMConstraintProjectionDirection(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2100, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2098, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationQuaternion.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationQuaternion.m
@@ -1,7 +1,7 @@
 function v = InverseKinematicsRotationParametrizationQuaternion()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 34);
+    vInitialized = iDynTreeMEX(0, 36);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationRollPitchYaw.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsRotationParametrizationRollPitchYaw.m
@@ -1,7 +1,7 @@
 function v = InverseKinematicsRotationParametrizationRollPitchYaw()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 35);
+    vInitialized = iDynTreeMEX(0, 37);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintFull.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintFull.m
@@ -1,7 +1,7 @@
 function v = InverseKinematicsTreatTargetAsConstraintFull()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 39);
+    vInitialized = iDynTreeMEX(0, 41);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintNone.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintNone.m
@@ -1,7 +1,7 @@
 function v = InverseKinematicsTreatTargetAsConstraintNone()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 36);
+    vInitialized = iDynTreeMEX(0, 38);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintPositionOnly.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintPositionOnly.m
@@ -1,7 +1,7 @@
 function v = InverseKinematicsTreatTargetAsConstraintPositionOnly()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 37);
+    vInitialized = iDynTreeMEX(0, 39);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintRotationOnly.m
+++ b/bindings/matlab/autogenerated/+iDynTree/InverseKinematicsTreatTargetAsConstraintRotationOnly.m
@@ -1,7 +1,7 @@
 function v = InverseKinematicsTreatTargetAsConstraintRotationOnly()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 38);
+    vInitialized = iDynTreeMEX(0, 40);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_WRENCH.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_WRENCH.m
@@ -1,7 +1,7 @@
 function v = JOINT_WRENCH()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 18);
+    vInitialized = iDynTreeMEX(0, 19);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/JOINT_WRENCH_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/JOINT_WRENCH_SENSOR.m
@@ -1,7 +1,7 @@
 function v = JOINT_WRENCH_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 31);
+    vInitialized = iDynTreeMEX(0, 32);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -9,178 +9,178 @@ classdef KinDynComputations < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1758, varargin{:});
+        tmp = iDynTreeMEX(1756, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1759, self);
+        iDynTreeMEX(1757, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1758, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
     end
     function varargout = setFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
     end
     function varargout = getFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
     end
     function varargout = getNrOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
     end
     function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
     end
     function varargout = getNrOfLinks(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
     end
     function varargout = getNrOfFrames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
     end
     function varargout = getFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
     end
     function varargout = setFloatingBase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
     end
     function varargout = model(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
     end
     function varargout = getRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
     end
     function varargout = getRelativeJacobianSparsityPattern(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
     end
     function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
     end
     function varargout = setJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
     end
     function varargout = setRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
     end
     function varargout = getRobotState(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
     end
     function varargout = getWorldBaseTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
     end
     function varargout = getBaseTwist(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
     end
     function varargout = getJointPos(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
     end
     function varargout = getJointVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
     end
     function varargout = getModelVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
     end
     function varargout = getFrameIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
     end
     function varargout = getFrameName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
     end
     function varargout = getWorldTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
     end
     function varargout = getWorldTransformsAsHomogeneous(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
     end
     function varargout = getRelativeTransformExplicit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
     end
     function varargout = getRelativeTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
     end
     function varargout = getFrameVel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
     end
     function varargout = getFrameAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
     end
     function varargout = getFrameFreeFloatingJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
     end
     function varargout = getRelativeJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1792, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
     end
     function varargout = getRelativeJacobianExplicit(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
     end
     function varargout = getFrameBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1792, self, varargin{:});
     end
     function varargout = getCenterOfMassPosition(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
     end
     function varargout = getCenterOfMassVelocity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
     end
     function varargout = getCenterOfMassJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
     end
     function varargout = getCenterOfMassBiasAcc(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
     end
     function varargout = getAverageVelocity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
     end
     function varargout = getAverageVelocityJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
     end
     function varargout = getCentroidalAverageVelocity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
     end
     function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
     end
     function varargout = getLinearAngularMomentum(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
     end
     function varargout = getLinearAngularMomentumJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
     end
     function varargout = getCentroidalTotalMomentum(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
     end
     function varargout = getCentroidalTotalMomentumJacobian(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
     end
     function varargout = getFreeFloatingMassMatrix(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
     end
     function varargout = inverseDynamics(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
     end
     function varargout = inverseDynamicsWithInternalJointForceTorques(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
     end
     function varargout = generalizedBiasForces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
     end
     function varargout = generalizedGravityForces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
     end
     function varargout = generalizedExternalForces(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
     end
     function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
+++ b/bindings/matlab/autogenerated/+iDynTree/KinDynComputations.m
@@ -9,178 +9,178 @@ classdef KinDynComputations < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1755, varargin{:});
+        tmp = iDynTreeMEX(1758, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1756, self);
+        iDynTreeMEX(1759, self);
         self.SwigClear();
       end
     end
     function varargout = loadRobotModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1757, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1758, self, varargin{:});
-    end
-    function varargout = setFrameVelocityRepresentation(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1759, self, varargin{:});
-    end
-    function varargout = getFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1760, self, varargin{:});
     end
-    function varargout = getNrOfDegreesOfFreedom(self,varargin)
+    function varargout = isValid(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1761, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
+    function varargout = setFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1762, self, varargin{:});
     end
-    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
+    function varargout = getFrameVelocityRepresentation(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1763, self, varargin{:});
     end
-    function varargout = getNrOfLinks(self,varargin)
+    function varargout = getNrOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1764, self, varargin{:});
     end
-    function varargout = getNrOfFrames(self,varargin)
+    function varargout = getDescriptionOfDegreeOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1765, self, varargin{:});
     end
-    function varargout = getFloatingBase(self,varargin)
+    function varargout = getDescriptionOfDegreesOfFreedom(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1766, self, varargin{:});
     end
-    function varargout = setFloatingBase(self,varargin)
+    function varargout = getNrOfLinks(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1767, self, varargin{:});
     end
-    function varargout = model(self,varargin)
+    function varargout = getNrOfFrames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1768, self, varargin{:});
     end
-    function varargout = getRobotModel(self,varargin)
+    function varargout = getFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1769, self, varargin{:});
     end
-    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
+    function varargout = setFloatingBase(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1770, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
+    function varargout = model(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1771, self, varargin{:});
     end
-    function varargout = setJointPos(self,varargin)
+    function varargout = getRobotModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1772, self, varargin{:});
     end
-    function varargout = setRobotState(self,varargin)
+    function varargout = getRelativeJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1773, self, varargin{:});
     end
-    function varargout = getRobotState(self,varargin)
+    function varargout = getFrameFreeFloatingJacobianSparsityPattern(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1774, self, varargin{:});
     end
-    function varargout = getWorldBaseTransform(self,varargin)
+    function varargout = setJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1775, self, varargin{:});
     end
-    function varargout = getBaseTwist(self,varargin)
+    function varargout = setRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1776, self, varargin{:});
     end
-    function varargout = getJointPos(self,varargin)
+    function varargout = getRobotState(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1777, self, varargin{:});
     end
-    function varargout = getJointVel(self,varargin)
+    function varargout = getWorldBaseTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1778, self, varargin{:});
     end
-    function varargout = getModelVel(self,varargin)
+    function varargout = getBaseTwist(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1779, self, varargin{:});
     end
-    function varargout = getFrameIndex(self,varargin)
+    function varargout = getJointPos(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1780, self, varargin{:});
     end
-    function varargout = getFrameName(self,varargin)
+    function varargout = getJointVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1781, self, varargin{:});
     end
-    function varargout = getWorldTransform(self,varargin)
+    function varargout = getModelVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1782, self, varargin{:});
     end
-    function varargout = getWorldTransformsAsHomogeneous(self,varargin)
+    function varargout = getFrameIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1783, self, varargin{:});
     end
-    function varargout = getRelativeTransformExplicit(self,varargin)
+    function varargout = getFrameName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1784, self, varargin{:});
     end
-    function varargout = getRelativeTransform(self,varargin)
+    function varargout = getWorldTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1785, self, varargin{:});
     end
-    function varargout = getFrameVel(self,varargin)
+    function varargout = getWorldTransformsAsHomogeneous(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1786, self, varargin{:});
     end
-    function varargout = getFrameAcc(self,varargin)
+    function varargout = getRelativeTransformExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1787, self, varargin{:});
     end
-    function varargout = getFrameFreeFloatingJacobian(self,varargin)
+    function varargout = getRelativeTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1788, self, varargin{:});
     end
-    function varargout = getRelativeJacobian(self,varargin)
+    function varargout = getFrameVel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1789, self, varargin{:});
     end
-    function varargout = getRelativeJacobianExplicit(self,varargin)
+    function varargout = getFrameAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1790, self, varargin{:});
     end
-    function varargout = getFrameBiasAcc(self,varargin)
+    function varargout = getFrameFreeFloatingJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1791, self, varargin{:});
     end
-    function varargout = getCenterOfMassPosition(self,varargin)
+    function varargout = getRelativeJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1792, self, varargin{:});
     end
-    function varargout = getCenterOfMassVelocity(self,varargin)
+    function varargout = getRelativeJacobianExplicit(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1793, self, varargin{:});
     end
-    function varargout = getCenterOfMassJacobian(self,varargin)
+    function varargout = getFrameBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1794, self, varargin{:});
     end
-    function varargout = getCenterOfMassBiasAcc(self,varargin)
+    function varargout = getCenterOfMassPosition(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1795, self, varargin{:});
     end
-    function varargout = getAverageVelocity(self,varargin)
+    function varargout = getCenterOfMassVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1796, self, varargin{:});
     end
-    function varargout = getAverageVelocityJacobian(self,varargin)
+    function varargout = getCenterOfMassJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1797, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocity(self,varargin)
+    function varargout = getCenterOfMassBiasAcc(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1798, self, varargin{:});
     end
-    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
+    function varargout = getAverageVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1799, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentum(self,varargin)
+    function varargout = getAverageVelocityJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1800, self, varargin{:});
     end
-    function varargout = getLinearAngularMomentumJacobian(self,varargin)
+    function varargout = getCentroidalAverageVelocity(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1801, self, varargin{:});
     end
-    function varargout = getCentroidalTotalMomentum(self,varargin)
+    function varargout = getCentroidalAverageVelocityJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1802, self, varargin{:});
     end
-    function varargout = getCentroidalTotalMomentumJacobian(self,varargin)
+    function varargout = getLinearAngularMomentum(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1803, self, varargin{:});
     end
-    function varargout = getFreeFloatingMassMatrix(self,varargin)
+    function varargout = getLinearAngularMomentumJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1804, self, varargin{:});
     end
-    function varargout = inverseDynamics(self,varargin)
+    function varargout = getCentroidalTotalMomentum(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1805, self, varargin{:});
     end
-    function varargout = inverseDynamicsWithInternalJointForceTorques(self,varargin)
+    function varargout = getCentroidalTotalMomentumJacobian(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1806, self, varargin{:});
     end
-    function varargout = generalizedBiasForces(self,varargin)
+    function varargout = getFreeFloatingMassMatrix(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1807, self, varargin{:});
     end
-    function varargout = generalizedGravityForces(self,varargin)
+    function varargout = inverseDynamics(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1808, self, varargin{:});
     end
-    function varargout = generalizedExternalForces(self,varargin)
+    function varargout = inverseDynamicsWithInternalJointForceTorques(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1809, self, varargin{:});
     end
-    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+    function varargout = generalizedBiasForces(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1810, self, varargin{:});
+    end
+    function varargout = generalizedGravityForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
+    end
+    function varargout = generalizedExternalForces(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
+    end
+    function varargout = inverseDynamicsInertialParametersRegressor(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_BODY_PROPER_ACCELERATION.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_BODY_PROPER_ACCELERATION.m
@@ -1,7 +1,7 @@
 function v = LINK_BODY_PROPER_ACCELERATION()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 16);
+    vInitialized = iDynTreeMEX(0, 17);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/LINK_BODY_PROPER_CLASSICAL_ACCELERATION.m
+++ b/bindings/matlab/autogenerated/+iDynTree/LINK_BODY_PROPER_CLASSICAL_ACCELERATION.m
@@ -1,7 +1,7 @@
 function v = LINK_BODY_PROPER_CLASSICAL_ACCELERATION()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 22);
+    vInitialized = iDynTreeMEX(0, 23);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
@@ -4,49 +4,49 @@ classdef Matrix4x4Vector < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = pop(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1811, self, varargin{:});
-    end
-    function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
-    end
-    function varargout = setbrace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
-    end
-    function varargout = append(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
     end
-    function varargout = empty(self,varargin)
+    function varargout = brace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
     end
-    function varargout = size(self,varargin)
+    function varargout = setbrace(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
     end
-    function varargout = swap(self,varargin)
+    function varargout = append(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
     end
-    function varargout = begin(self,varargin)
+    function varargout = empty(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
     end
-    function varargout = end(self,varargin)
+    function varargout = size(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
     end
-    function varargout = rbegin(self,varargin)
+    function varargout = swap(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
     end
-    function varargout = rend(self,varargin)
+    function varargout = begin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
     end
-    function varargout = clear(self,varargin)
+    function varargout = end(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
     end
-    function varargout = get_allocator(self,varargin)
+    function varargout = rbegin(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
     end
-    function varargout = pop_back(self,varargin)
+    function varargout = rend(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
     end
-    function varargout = erase(self,varargin)
+    function varargout = clear(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
+    end
+    function varargout = get_allocator(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
+    end
+    function varargout = pop_back(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
+    end
+    function varargout = erase(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
     end
     function self = Matrix4x4Vector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -54,41 +54,41 @@ classdef Matrix4x4Vector < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1826, varargin{:});
+        tmp = iDynTreeMEX(1829, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = push_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
-    end
-    function varargout = front(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
-    end
-    function varargout = back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
-    end
-    function varargout = assign(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
     end
-    function varargout = resize(self,varargin)
+    function varargout = front(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
     end
-    function varargout = insert(self,varargin)
+    function varargout = back(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
     end
-    function varargout = reserve(self,varargin)
+    function varargout = assign(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
     end
-    function varargout = capacity(self,varargin)
+    function varargout = resize(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
     end
-    function varargout = toMatlab(self,varargin)
+    function varargout = insert(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
+    end
+    function varargout = reserve(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
+    end
+    function varargout = capacity(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
+    end
+    function varargout = toMatlab(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1836, self);
+        iDynTreeMEX(1839, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Matrix4x4Vector.m
@@ -4,49 +4,49 @@ classdef Matrix4x4Vector < iDynTreeSwigRef
       this = iDynTreeMEX(3, self);
     end
     function varargout = pop(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1812, self, varargin{:});
     end
     function varargout = brace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1813, self, varargin{:});
     end
     function varargout = setbrace(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1814, self, varargin{:});
     end
     function varargout = append(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1815, self, varargin{:});
     end
     function varargout = empty(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1816, self, varargin{:});
     end
     function varargout = size(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1817, self, varargin{:});
     end
     function varargout = swap(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1818, self, varargin{:});
     end
     function varargout = begin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1819, self, varargin{:});
     end
     function varargout = end(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1820, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1821, self, varargin{:});
     end
     function varargout = rend(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1822, self, varargin{:});
     end
     function varargout = clear(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1823, self, varargin{:});
     end
     function varargout = get_allocator(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1824, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1827, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1825, self, varargin{:});
     end
     function varargout = erase(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1826, self, varargin{:});
     end
     function self = Matrix4x4Vector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
@@ -54,41 +54,41 @@ classdef Matrix4x4Vector < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1829, varargin{:});
+        tmp = iDynTreeMEX(1827, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = push_back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1828, self, varargin{:});
     end
     function varargout = front(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1829, self, varargin{:});
     end
     function varargout = back(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1830, self, varargin{:});
     end
     function varargout = assign(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1831, self, varargin{:});
     end
     function varargout = resize(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1832, self, varargin{:});
     end
     function varargout = insert(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1833, self, varargin{:});
     end
     function varargout = reserve(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1834, self, varargin{:});
     end
     function varargout = capacity(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1837, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1835, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1838, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1836, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1839, self);
+        iDynTreeMEX(1837, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/NET_EXT_WRENCH.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NET_EXT_WRENCH.m
@@ -1,7 +1,7 @@
 function v = NET_EXT_WRENCH()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 20);
+    vInitialized = iDynTreeMEX(0, 21);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/NET_EXT_WRENCH_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NET_EXT_WRENCH_SENSOR.m
@@ -1,7 +1,7 @@
 function v = NET_EXT_WRENCH_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 30);
+    vInitialized = iDynTreeMEX(0, 31);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV.m
+++ b/bindings/matlab/autogenerated/+iDynTree/NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV.m
@@ -1,7 +1,7 @@
 function v = NET_INT_AND_EXT_WRENCHES_ON_LINK_WITHOUT_GRAV()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 17);
+    vInitialized = iDynTreeMEX(0, 18);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/POINT_LIGHT.m
+++ b/bindings/matlab/autogenerated/+iDynTree/POINT_LIGHT.m
@@ -1,7 +1,7 @@
 function v = POINT_LIGHT()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 32);
+    vInitialized = iDynTreeMEX(0, 34);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/PixelViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PixelViz.m
@@ -4,20 +4,20 @@ classdef PixelViz < iDynTree.ColorViz
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1865, self);
+        varargout{1} = iDynTreeMEX(1863, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1866, self, varargin{1});
+        iDynTreeMEX(1864, self, varargin{1});
       end
     end
     function varargout = height(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1867, self);
+        varargout{1} = iDynTreeMEX(1865, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1868, self, varargin{1});
+        iDynTreeMEX(1866, self, varargin{1});
       end
     end
     function self = PixelViz(varargin)
@@ -27,14 +27,14 @@ classdef PixelViz < iDynTree.ColorViz
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1869, varargin{:});
+        tmp = iDynTreeMEX(1867, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1870, self);
+        iDynTreeMEX(1868, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/PixelViz.m
+++ b/bindings/matlab/autogenerated/+iDynTree/PixelViz.m
@@ -4,20 +4,20 @@ classdef PixelViz < iDynTree.ColorViz
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1862, self);
+        varargout{1} = iDynTreeMEX(1865, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1863, self, varargin{1});
+        iDynTreeMEX(1866, self, varargin{1});
       end
     end
     function varargout = height(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1864, self);
+        varargout{1} = iDynTreeMEX(1867, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1865, self, varargin{1});
+        iDynTreeMEX(1868, self, varargin{1});
       end
     end
     function self = PixelViz(varargin)
@@ -27,14 +27,14 @@ classdef PixelViz < iDynTree.ColorViz
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1866, varargin{:});
+        tmp = iDynTreeMEX(1869, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1867, self);
+        iDynTreeMEX(1870, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon.m
@@ -7,10 +7,10 @@ classdef Polygon < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1992, self);
+        varargout{1} = iDynTreeMEX(1995, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1993, self, varargin{1});
+        iDynTreeMEX(1996, self, varargin{1});
       end
     end
     function self = Polygon(varargin)
@@ -19,36 +19,36 @@ classdef Polygon < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1994, varargin{:});
+        tmp = iDynTreeMEX(1997, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1995, self, varargin{:});
-    end
-    function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1996, self, varargin{:});
-    end
-    function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1997, self, varargin{:});
-    end
-    function varargout = applyTransform(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
     end
-    function varargout = paren(self,varargin)
+    function varargout = getNrOfVertices(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
+    end
+    function varargout = isValid(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
+    end
+    function varargout = applyTransform(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
+    end
+    function varargout = paren(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2001, self);
+        iDynTreeMEX(2004, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = XYRectangleFromOffsets(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(2000, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(2003, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon.m
@@ -7,10 +7,10 @@ classdef Polygon < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1995, self);
+        varargout{1} = iDynTreeMEX(1993, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1996, self, varargin{1});
+        iDynTreeMEX(1994, self, varargin{1});
       end
     end
     function self = Polygon(varargin)
@@ -19,36 +19,36 @@ classdef Polygon < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1997, varargin{:});
+        tmp = iDynTreeMEX(1995, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1996, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1997, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1998, self, varargin{:});
     end
     function varargout = applyTransform(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2001, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1999, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2002, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2000, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2004, self);
+        iDynTreeMEX(2002, self);
         self.SwigClear();
       end
     end
   end
   methods(Static)
     function varargout = XYRectangleFromOffsets(varargin)
-     [varargout{1:nargout}] = iDynTreeMEX(2003, varargin{:});
+     [varargout{1:nargout}] = iDynTreeMEX(2001, varargin{:});
     end
   end
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
@@ -7,10 +7,10 @@ classdef Polygon2D < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2005, self);
+        varargout{1} = iDynTreeMEX(2003, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2006, self, varargin{1});
+        iDynTreeMEX(2004, self, varargin{1});
       end
     end
     function self = Polygon2D(varargin)
@@ -19,26 +19,26 @@ classdef Polygon2D < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2007, varargin{:});
+        tmp = iDynTreeMEX(2005, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2009, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2007, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2010, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2011, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2009, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2012, self);
+        iDynTreeMEX(2010, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Polygon2D.m
@@ -7,10 +7,10 @@ classdef Polygon2D < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(2002, self);
+        varargout{1} = iDynTreeMEX(2005, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(2003, self, varargin{1});
+        iDynTreeMEX(2006, self, varargin{1});
       end
     end
     function self = Polygon2D(varargin)
@@ -19,26 +19,26 @@ classdef Polygon2D < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(2004, varargin{:});
+        tmp = iDynTreeMEX(2007, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function varargout = setNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2005, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
     end
     function varargout = getNrOfVertices(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2006, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2009, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2007, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2010, self, varargin{:});
     end
     function varargout = paren(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(2008, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(2011, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(2009, self);
+        iDynTreeMEX(2012, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/RCM_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/RCM_SENSOR.m
@@ -1,0 +1,7 @@
+function v = RCM_SENSOR()
+  persistent vInitialized;
+  if isempty(vInitialized)
+    vInitialized = iDynTreeMEX(0, 33);
+  end
+  v = vInitialized;
+end

--- a/bindings/matlab/autogenerated/+iDynTree/SIX_AXIS_FORCE_TORQUE_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/SIX_AXIS_FORCE_TORQUE_SENSOR.m
@@ -1,7 +1,7 @@
 function v = SIX_AXIS_FORCE_TORQUE_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 23);
+    vInitialized = iDynTreeMEX(0, 24);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/THREE_AXIS_ANGULAR_ACCELEROMETER_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/THREE_AXIS_ANGULAR_ACCELEROMETER_SENSOR.m
@@ -1,7 +1,7 @@
 function v = THREE_AXIS_ANGULAR_ACCELEROMETER_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 26);
+    vInitialized = iDynTreeMEX(0, 27);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/THREE_AXIS_FORCE_TORQUE_CONTACT_SENSOR.m
+++ b/bindings/matlab/autogenerated/+iDynTree/THREE_AXIS_FORCE_TORQUE_CONTACT_SENSOR.m
@@ -1,7 +1,7 @@
 function v = THREE_AXIS_FORCE_TORQUE_CONTACT_SENSOR()
   persistent vInitialized;
   if isempty(vInitialized)
-    vInitialized = iDynTreeMEX(0, 27);
+    vInitialized = iDynTreeMEX(0, 28);
   end
   v = vInitialized;
 end

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,82 +9,82 @@ classdef Visualizer < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1968, varargin{:});
+        tmp = iDynTreeMEX(1971, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1969, self);
+        iDynTreeMEX(1972, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1970, self, varargin{:});
-    end
-    function varargout = getNrOfVisualizedModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1971, self, varargin{:});
-    end
-    function varargout = getModelInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1972, self, varargin{:});
-    end
-    function varargout = getModelInstanceIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
     end
-    function varargout = addModel(self,varargin)
+    function varargout = getNrOfVisualizedModels(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
     end
-    function varargout = modelViz(self,varargin)
+    function varargout = getModelInstanceName(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
     end
-    function varargout = camera(self,varargin)
+    function varargout = getModelInstanceIndex(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
     end
-    function varargout = enviroment(self,varargin)
+    function varargout = addModel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
     end
-    function varargout = environment(self,varargin)
+    function varargout = modelViz(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
     end
-    function varargout = vectors(self,varargin)
+    function varargout = camera(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
     end
-    function varargout = frames(self,varargin)
+    function varargout = enviroment(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
     end
-    function varargout = textures(self,varargin)
+    function varargout = environment(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
     end
-    function varargout = getLabel(self,varargin)
+    function varargout = vectors(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
     end
-    function varargout = width(self,varargin)
+    function varargout = frames(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
     end
-    function varargout = height(self,varargin)
+    function varargout = textures(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
     end
-    function varargout = run(self,varargin)
+    function varargout = getLabel(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
     end
-    function varargout = draw(self,varargin)
+    function varargout = width(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
     end
-    function varargout = subDraw(self,varargin)
+    function varargout = height(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
     end
-    function varargout = drawToFile(self,varargin)
+    function varargout = run(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
     end
-    function varargout = close(self,varargin)
+    function varargout = draw(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
     end
-    function varargout = isWindowActive(self,varargin)
+    function varargout = subDraw(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
     end
-    function varargout = setColorPalette(self,varargin)
+    function varargout = drawToFile(self,varargin)
       [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
+    end
+    function varargout = close(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
+    end
+    function varargout = isWindowActive(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
+    end
+    function varargout = setColorPalette(self,varargin)
+      [varargout{1:nargout}] = iDynTreeMEX(1994, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/Visualizer.m
@@ -9,82 +9,82 @@ classdef Visualizer < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1971, varargin{:});
+        tmp = iDynTreeMEX(1969, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1972, self);
+        iDynTreeMEX(1970, self);
         self.SwigClear();
       end
     end
     function varargout = init(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1971, self, varargin{:});
     end
     function varargout = getNrOfVisualizedModels(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1972, self, varargin{:});
     end
     function varargout = getModelInstanceName(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1973, self, varargin{:});
     end
     function varargout = getModelInstanceIndex(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1974, self, varargin{:});
     end
     function varargout = addModel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1975, self, varargin{:});
     end
     function varargout = modelViz(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1976, self, varargin{:});
     end
     function varargout = camera(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1977, self, varargin{:});
     end
     function varargout = enviroment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1978, self, varargin{:});
     end
     function varargout = environment(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1979, self, varargin{:});
     end
     function varargout = vectors(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1980, self, varargin{:});
     end
     function varargout = frames(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1981, self, varargin{:});
     end
     function varargout = textures(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1982, self, varargin{:});
     end
     function varargout = getLabel(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1983, self, varargin{:});
     end
     function varargout = width(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1984, self, varargin{:});
     end
     function varargout = height(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1985, self, varargin{:});
     end
     function varargout = run(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1986, self, varargin{:});
     end
     function varargout = draw(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1987, self, varargin{:});
     end
     function varargout = subDraw(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1988, self, varargin{:});
     end
     function varargout = drawToFile(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1989, self, varargin{:});
     end
     function varargout = close(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1990, self, varargin{:});
     end
     function varargout = isWindowActive(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1993, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1991, self, varargin{:});
     end
     function varargout = setColorPalette(self,varargin)
-      [varargout{1:nargout}] = iDynTreeMEX(1994, self, varargin{:});
+      [varargout{1:nargout}] = iDynTreeMEX(1992, self, varargin{:});
     end
   end
   methods(Static)

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,13 +7,23 @@ classdef VisualizerOptions < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = iDynTreeMEX(1956, self);
+      else
+        nargoutchk(0, 0)
+        iDynTreeMEX(1957, self, varargin{1});
+      end
+    end
+    function varargout = winWidth(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = iDynTreeMEX(1958, self);
       else
         nargoutchk(0, 0)
         iDynTreeMEX(1959, self, varargin{1});
       end
     end
-    function varargout = winWidth(self, varargin)
+    function varargout = winHeight(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -23,7 +33,7 @@ classdef VisualizerOptions < iDynTreeSwigRef
         iDynTreeMEX(1961, self, varargin{1});
       end
     end
-    function varargout = winHeight(self, varargin)
+    function varargout = rootFrameArrowsDimension(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -33,30 +43,20 @@ classdef VisualizerOptions < iDynTreeSwigRef
         iDynTreeMEX(1963, self, varargin{1});
       end
     end
-    function varargout = rootFrameArrowsDimension(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1964, self);
-      else
-        nargoutchk(0, 0)
-        iDynTreeMEX(1965, self, varargin{1});
-      end
-    end
     function self = VisualizerOptions(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'iDynTreeSwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1966, varargin{:});
+        tmp = iDynTreeMEX(1964, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1967, self);
+        iDynTreeMEX(1965, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/VisualizerOptions.m
@@ -7,40 +7,40 @@ classdef VisualizerOptions < iDynTreeSwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1955, self);
+        varargout{1} = iDynTreeMEX(1958, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1956, self, varargin{1});
+        iDynTreeMEX(1959, self, varargin{1});
       end
     end
     function varargout = winWidth(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1957, self);
+        varargout{1} = iDynTreeMEX(1960, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1958, self, varargin{1});
+        iDynTreeMEX(1961, self, varargin{1});
       end
     end
     function varargout = winHeight(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1959, self);
+        varargout{1} = iDynTreeMEX(1962, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1960, self, varargin{1});
+        iDynTreeMEX(1963, self, varargin{1});
       end
     end
     function varargout = rootFrameArrowsDimension(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = iDynTreeMEX(1961, self);
+        varargout{1} = iDynTreeMEX(1964, self);
       else
         nargoutchk(0, 0)
-        iDynTreeMEX(1962, self, varargin{1});
+        iDynTreeMEX(1965, self, varargin{1});
       end
     end
     function self = VisualizerOptions(varargin)
@@ -49,14 +49,14 @@ classdef VisualizerOptions < iDynTreeSwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = iDynTreeMEX(1963, varargin{:});
+        tmp = iDynTreeMEX(1966, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        iDynTreeMEX(1964, self);
+        iDynTreeMEX(1967, self);
         self.SwigClear();
       end
     end

--- a/bindings/matlab/autogenerated/+iDynTree/computeBoundingBoxFromShape.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeBoundingBoxFromShape.m
@@ -1,3 +1,3 @@
 function varargout = computeBoundingBoxFromShape(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1756, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1754, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/computeBoundingBoxFromShape.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeBoundingBoxFromShape.m
@@ -1,3 +1,3 @@
 function varargout = computeBoundingBoxFromShape(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1753, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1756, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/computeBoxVertices.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeBoxVertices.m
@@ -1,3 +1,3 @@
 function varargout = computeBoxVertices(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1757, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1755, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/computeBoxVertices.m
+++ b/bindings/matlab/autogenerated/+iDynTree/computeBoxVertices.m
@@ -1,3 +1,3 @@
 function varargout = computeBoxVertices(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1754, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1757, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
@@ -1,3 +1,3 @@
 function varargout = estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1755, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1753, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
+++ b/bindings/matlab/autogenerated/+iDynTree/estimateInertialParametersFromLinkBoundingBoxesAndTotalMass.m
@@ -1,3 +1,3 @@
 function varargout = estimateInertialParametersFromLinkBoundingBoxesAndTotalMass(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(1752, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(1755, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
@@ -1,3 +1,3 @@
 function v = input_dimensions()
-  v = iDynTreeMEX(1710);
+  v = iDynTreeMEX(1708);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
+++ b/bindings/matlab/autogenerated/+iDynTree/input_dimensions.m
@@ -1,3 +1,3 @@
 function v = input_dimensions()
-  v = iDynTreeMEX(1707);
+  v = iDynTreeMEX(1710);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_with_magnetometer()
-  v = iDynTreeMEX(1708);
+  v = iDynTreeMEX(1706);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_with_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_with_magnetometer()
-  v = iDynTreeMEX(1705);
+  v = iDynTreeMEX(1708);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_without_magnetometer()
-  v = iDynTreeMEX(1706);
+  v = iDynTreeMEX(1709);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
+++ b/bindings/matlab/autogenerated/+iDynTree/output_dimensions_without_magnetometer.m
@@ -1,3 +1,3 @@
 function v = output_dimensions_without_magnetometer()
-  v = iDynTreeMEX(1709);
+  v = iDynTreeMEX(1707);
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
@@ -1,3 +1,3 @@
 function varargout = sizeOfRotationParametrization(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(2038, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(2041, varargin{:});
 end

--- a/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
+++ b/bindings/matlab/autogenerated/+iDynTree/sizeOfRotationParametrization.m
@@ -1,3 +1,3 @@
 function varargout = sizeOfRotationParametrization(varargin)
-  [varargout{1:nargout}] = iDynTreeMEX(2041, varargin{:});
+  [varargout{1:nargout}] = iDynTreeMEX(2039, varargin{:});
 end

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -388,6 +388,15 @@ inline void setSubVector(VectorDynSize& vec,
 
 inline void setSubVector(VectorDynSize& vec,
                          const IndexRange range,
+                         const LinearMotionVector3& linMotionVector)
+{
+    assert(range.size==3);
+    toEigen(vec).segment(range.offset, range.size) = toEigen(linMotionVector);
+    return;
+}
+
+inline void setSubVector(VectorDynSize& vec,
+                         const IndexRange range,
                          const SpatialForceVector& wrench)
 {
     assert(range.size==6);

--- a/src/core/include/iDynTree/Core/EigenHelpers.h
+++ b/src/core/include/iDynTree/Core/EigenHelpers.h
@@ -388,15 +388,6 @@ inline void setSubVector(VectorDynSize& vec,
 
 inline void setSubVector(VectorDynSize& vec,
                          const IndexRange range,
-                         const LinearMotionVector3& linMotionVector)
-{
-    assert(range.size==3);
-    toEigen(vec).segment(range.offset, range.size) = toEigen(linMotionVector);
-    return;
-}
-
-inline void setSubVector(VectorDynSize& vec,
-                         const IndexRange range,
                          const SpatialForceVector& wrench)
 {
     assert(range.size==6);

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(${libraryname} PUBLIC idyntree-core idyntree-model idyntree-sensors idyntree-modelio
+target_link_libraries(${libraryname} PUBLIC idyntree-core idyntree-model idyntree-sensors idyntree-modelio iDynTree::idyntree-high-level
                                      PRIVATE Eigen3::Eigen)
 
 target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS})

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(iDynTree::${libraryname} ALIAS ${libraryname})
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(${libraryname} PUBLIC idyntree-core idyntree-model idyntree-sensors idyntree-modelio iDynTree::idyntree-high-level
+target_link_libraries(${libraryname} PUBLIC idyntree-core idyntree-model idyntree-sensors idyntree-modelio
                                      PRIVATE Eigen3::Eigen)
 
 target_compile_options(${libraryname} PRIVATE ${IDYNTREE_WARNING_FLAGS})

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -404,10 +404,6 @@ class BerdyHelper
     size_t m_nrOfDynamicEquations;
     size_t m_nrOfSensorsMeasurements;
 
-    /**
-     * Base transform
-     */
-    Transform m_baseTransform;
 
     /**
      * Joint positions
@@ -535,7 +531,7 @@ class BerdyHelper
      * LinkPositions variable containing the transforms between the base and the model links
      *
      */
-    LinkPositions world_H_links;
+    LinkPositions base_H_links;
 
 
 public:
@@ -729,14 +725,12 @@ public:
      * @param[in] floatingFrame the index of the frame for which kinematic information is provided.
      * @param[in] angularVel angular velocity (wrt to any inertial frame) of the specified floating frame,
      *                       expressed in the specified floating frame orientation.
-     * @param[in] w_H_b wptional transformation between floating base and world with default value set to Identity
      * @return true if all went ok, false otherwise.
      */
     bool updateKinematicsFromFloatingBase(const JointPosDoubleArray  & jointPos,
                                           const JointDOFsDoubleArray & jointVel,
                                           const FrameIndex & floatingFrame,
-                                          const Vector3 & angularVel,
-                                          const Transform & w_H_b = iDynTree::Transform::Identity());
+                                          const Vector3 & angularVel);
 
     /**
      * Set the kinematic information necessary for the dynamics estimation assuming that a

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -405,14 +405,9 @@ class BerdyHelper
     size_t m_nrOfSensorsMeasurements;
 
     /**
-     * Buffer of link-specific body velocities.
-     */
-
-    /**
      * Base transform
      */
     Transform m_baseTransform;
-
 
     /**
      * Joint positions
@@ -621,14 +616,15 @@ public:
      */
     bool resizeAndZeroBerdyMatrices(MatrixDynSize & D, VectorDynSize & bD,
                                     MatrixDynSize & Y, VectorDynSize & bY);
+
     /**
-     * Get Berdy matrices.
+     * Get Berdy matrices
      */
     bool getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize &bD,
                           SparseMatrix<iDynTree::ColumnMajor>& Y, VectorDynSize &bY);
 
     /**
-     * Get Berdy matrices - new method
+     * Get Berdy matrices
      *
      * \note internally this function uses sparse matrices
      * Prefer the use of resizeAndZeroBerdyMatrices(SparseMatrix &, VectorDynSize &, SparseMatrix &, VectorDynSize &)
@@ -722,7 +718,6 @@ public:
      *       are invariant with respect to an offset in linear velocity. This convenient to avoid
      *       any dependency on any prior floating base estimation.
      *
-     * @param[in] baseTransform the transformation from floating base to world
      * @param[in] jointPos the position of the joints of the model.
      * @param[in] jointVel the velocities of the joints of the model.
      * @param[in] floatingFrame the index of the frame for which kinematic information is provided.

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -459,7 +459,11 @@ class BerdyHelper
     IndexRange getRangeAccelerationPropagationFloatingBase(const LinkIndex idx) const;
     IndexRange getRangeNewtonEulerEquationsFloatingBase(const LinkIndex idx) const;
 
+    // Y matrices computation 
     bool computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>& Y, VectorDynSize& bY);
+    bool computeBerdySensorsMatricesFromModel(SparseMatrix<iDynTree::ColumnMajor>& Y, VectorDynSize& bY);
+
+    // D matrices computation
     bool computeBerdyDynamicsMatricesFixedBase(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD);
     bool computeBerdyDynamicsMatricesFloatingBase(SparseMatrix<iDynTree::ColumnMajor>& D, VectorDynSize& bD);
 
@@ -486,6 +490,8 @@ class BerdyHelper
                                                JointDOFsDoubleArray    & jointAccs,
                                                VectorDynSize& d);
 
+    bool serializeDynamicVariablesNonCollocatedWrenches(LinkNetExternalWrenches& netExtWrenches,
+                                                        VectorDynSize& d);
     /**
      * Helper for mapping sensors measurements to the Y vector.
      */
@@ -678,8 +684,8 @@ public:
                                   JointDOFsDoubleArray    & jointTorques,
                                   JointDOFsDoubleArray    & jointAccs,
                                   LinkInternalWrenches    & linkJointWrenches,
-                                  VectorDynSize           & y,
-                                  SpatialMomentum           rocm = SpatialMomentum::Zero()); // Rate of Change of Momentum (rocm ) denoted through 6x1 spatial momentum vector. //TODO Double check this
+                                  SpatialMomentum         & rocm,
+                                  VectorDynSize           & y); // Rate of Change of Momentum (rocm ) denoted through 6x1 spatial momentum vector. //TODO Double check this
 
 
     /**

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -674,7 +674,7 @@ public:
                                   JointDOFsDoubleArray    & jointTorques,
                                   JointDOFsDoubleArray    & jointAccs,
                                   LinkInternalWrenches    & linkJointWrenches,
-                                  SpatialMomentum         & rocm,
+                                  Vector6                 & rocm,
                                   VectorDynSize           & y); // Rate of Change of Momentum (rocm ) denoted through 6x1 spatial momentum vector. //TODO Double check this
 
 

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -674,8 +674,8 @@ public:
                                   JointDOFsDoubleArray    & jointTorques,
                                   JointDOFsDoubleArray    & jointAccs,
                                   LinkInternalWrenches    & linkJointWrenches,
-                                  Vector6                 & rocm,
-                                  VectorDynSize           & y); // Rate of Change of Momentum (rocm ) denoted through 6x1 spatial momentum vector. //TODO Double check this
+                                  SpatialForceVector      & rocm, // Rate of Change of Momentum (rocm )
+                                  VectorDynSize           & y);
 
 
     /**

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -138,10 +138,10 @@ enum BerdySensorTypes
     JOINT_WRENCH_SENSOR     = 1003,
 
     /**
-     * Non-physical sensor that holds the value of Rate of Change of Momentum (ROCM) of the system
+     * Non-physical sensor that holds the value of Rate of Change of Momentum (RCM) of the system
      * for centroidal dynamics constraint
      */
-    ROCM_SENSOR = 1004
+    RCM_SENSOR = 1004
 };
 
 bool isLinkBerdyDynamicVariable(const BerdyDynamicVariablesTypes dynamicVariableType);
@@ -165,7 +165,7 @@ public:
                      includeAllJointAccelerationsAsSensors(true),
                      includeAllJointTorquesAsSensors(false),
                      includeAllNetExternalWrenchesAsSensors(true),
-                     includeROCMAsSensor(false),
+                     includeRcmAsSensor(false),
                      includeFixedBaseExternalWrench(false),
                      baseLink("")
     {
@@ -217,19 +217,19 @@ public:
     bool includeAllNetExternalWrenchesAsSensors;
 
     /*
-     * If true, includes the Rate of Change of Momentum (ROCM) in the task sensors vector.
+     * If true, includes the Rate of Change of Momentum (RCM) in the task sensors vector.
      * It is compatible only with BERDY_FLOATING_BASE and BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
      *
      * Default value: false .
      */
-    bool includeROCMAsSensor;
+    bool includeRcmAsSensor;
 
     /**
      * Vector of link names that are considered for rate of change of momentum constraint using
-     * Rate of Change of Momentum (ROCM) sensor
+     * Rate of Change of Momentum (RCM) sensor
      * The default value is set to contain all the links present in the model
      */
-    std::vector<std::string> rocmConstraintLinkNamesVector;
+    std::vector<std::string> rcmConstraintLinkNamesVector;
 
     /**
      * If includeNetExternalWrenchesAsSensors is true and the
@@ -490,7 +490,7 @@ class BerdyHelper
         size_t dofTorquesOffset;
         size_t netExtWrenchOffset;
         size_t jointWrenchOffset;
-        size_t rocmOffset;
+        size_t rcmOffset;
     } berdySensorTypeOffsets;
 
     /**
@@ -645,7 +645,7 @@ public:
     IndexRange getRangeDOFSensorVariable(const BerdySensorTypes sensorType, const DOFIndex idx) const;
     IndexRange getRangeJointSensorVariable(const BerdySensorTypes sensorType, const JointIndex idx) const;
     IndexRange getRangeLinkSensorVariable(const BerdySensorTypes sensorType, const LinkIndex idx) const;
-    IndexRange getRangeROCMSensorVariable(const BerdySensorTypes sensorType) const;
+    IndexRange getRangeRCMSensorVariable(const BerdySensorTypes sensorType) const;
 
     /**
      * Ranges of dynamic variables
@@ -674,7 +674,7 @@ public:
                                   JointDOFsDoubleArray    & jointTorques,
                                   JointDOFsDoubleArray    & jointAccs,
                                   LinkInternalWrenches    & linkJointWrenches,
-                                  SpatialForceVector      & rocm, // Rate of Change of Momentum (rocm )
+                                  SpatialForceVector      & rcm, // Rate of Change of Momentum (RCM)
                                   VectorDynSize           & y);
 
 

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -165,7 +165,6 @@ public:
                      includeAllJointAccelerationsAsSensors(true),
                      includeAllJointTorquesAsSensors(false),
                      includeAllNetExternalWrenchesAsSensors(true),
-                     includeRcmAsSensor(false),
                      includeFixedBaseExternalWrench(false),
                      baseLink("")
     {
@@ -215,14 +214,6 @@ public:
      * Default value: true .
      */
     bool includeAllNetExternalWrenchesAsSensors;
-
-    /*
-     * If true, includes the Rate of Change of Momentum (RCM) in the task sensors vector.
-     * It is compatible only with BERDY_FLOATING_BASE and BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
-     *
-     * Default value: false .
-     */
-    bool includeRcmAsSensor;
 
     /**
      * Vector of link names that are considered for rate of change of momentum constraint using

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -68,14 +68,8 @@ enum BerdyVariants
      * Modified version of floating base Berdy
      * for accounting centroidal dynamics constraints towards estimating the external link wrench independently of the internal joint torque estimates.
      */
-    HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK = 2,
+    BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES = 2
 
-    /**
-     * Modified version of floating base Berdy
-     * for accounting full dynamics using estimated external forces
-     * (aka Stack of Tasks Berdy Berdy i.e., SOT Berdy)
-     */
-    HIERARCHICAL_BERDY_FLOATING_BASE_FULL_DYNAMICS_TASK = 3
 };
 
 /**
@@ -145,7 +139,7 @@ enum BerdySensorTypes
 
     /**
      * Non-physical sensor that holds the value of Rate of Change of Momentum (ROCM) of the system
-     * for centroidal dynamics constraint used in HIERARCHICAL_BERDY_FLOATING_BASE Berdy variation
+     * for centroidal dynamics constraint
      */
     ROCM_SENSOR = 1004
 };
@@ -224,7 +218,7 @@ public:
 
     /*
      * If true, includes the Rate of Change of Momentum (ROCM) in the task sensors vector.
-     * It is compatible only with HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK and HIERARCHICAL_BERDY_FLOATING_BASE_FULL_DYNAMICS_TASK
+     * It is compatible only with BERDY_FLOATING_BASE and BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
      *
      * Default value: false .
      */
@@ -232,8 +226,8 @@ public:
 
     /**
      * Vector of link names that are considered for rate of change of momentum constraint using
-     * Rate of Change of Momentum (ROCM) sensor for HIERARCHICAL_BERDY_FLOATING_BASE variation
-     * The default value is set to contains all the links present in the model
+     * Rate of Change of Momentum (ROCM) sensor
+     * The default value is set to contain all the links present in the model
      */
     std::vector<std::string> rocmConstraintLinkNamesVector;
 

--- a/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdyHelper.h
@@ -216,13 +216,6 @@ public:
     bool includeAllNetExternalWrenchesAsSensors;
 
     /**
-     * Vector of link names that are considered for rate of change of momentum constraint using
-     * Rate of Change of Momentum (RCM) sensor
-     * The default value is set to contain all the links present in the model
-     */
-    std::vector<std::string> rcmConstraintLinkNamesVector;
-
-    /**
      * If includeNetExternalWrenchesAsSensors is true and the
      * variant is ORIGINAL_BERDY_FIXED_BASE, if this is
      * true the external wrench acting on the base fixed link

--- a/src/estimation/include/iDynTree/Estimation/BerdySparseMAPSolver.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdySparseMAPSolver.h
@@ -12,6 +12,7 @@
 #define IDYNTREE_BERDY_SPARSEMAPSOLVER_H
 
 #include <iDynTree/Core/Utils.h>
+#include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/VectorFixSize.h>
 #include <iDynTree/Model/Indices.h>
 
@@ -68,13 +69,12 @@ namespace iDynTree {
                                                    const JointDOFsDoubleArray& jointsVelocity,
                                                    const FrameIndex floatingFrame,
                                                    const Vector3& bodyAngularVelocityOfSpecifiedFrame,
-                                                   const VectorDynSize& measurements);
+                                                   const VectorDynSize& measurements,
+                                                   const Transform& w_H_b = iDynTree::Transform::Identity());
 
         bool doEstimate();
-
         void getLastEstimate(iDynTree::VectorDynSize& lastEstimate) const;
         const iDynTree::VectorDynSize& getLastEstimate() const;
-
 
     };
 }

--- a/src/estimation/include/iDynTree/Estimation/BerdySparseMAPSolver.h
+++ b/src/estimation/include/iDynTree/Estimation/BerdySparseMAPSolver.h
@@ -12,7 +12,6 @@
 #define IDYNTREE_BERDY_SPARSEMAPSOLVER_H
 
 #include <iDynTree/Core/Utils.h>
-#include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/VectorFixSize.h>
 #include <iDynTree/Model/Indices.h>
 
@@ -69,12 +68,13 @@ namespace iDynTree {
                                                    const JointDOFsDoubleArray& jointsVelocity,
                                                    const FrameIndex floatingFrame,
                                                    const Vector3& bodyAngularVelocityOfSpecifiedFrame,
-                                                   const VectorDynSize& measurements,
-                                                   const Transform& w_H_b = iDynTree::Transform::Identity());
+                                                   const VectorDynSize& measurements);
 
         bool doEstimate();
+
         void getLastEstimate(iDynTree::VectorDynSize& lastEstimate) const;
         const iDynTree::VectorDynSize& getLastEstimate() const;
+
 
     };
 }

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -241,7 +241,7 @@ bool BerdyHelper::init(const Model& model,
             break;
 
         case BERDY_FLOATING_BASE:
-        case BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES: //TODO for this case too?
+        case BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES:
             res = initBerdyFloatingBase();
             cacheDynamicVariablesOrderingFloatingBase();
             break;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -130,19 +130,6 @@ bool BerdyOptions::checkConsistency()
         }
     }
 
-    if(this->includeRcmAsSensor &&
-       !(this->berdyVariant==BERDY_FLOATING_BASE || this->berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES))
-    {
-        reportError("BerdyOptions","checkConsistency","Impossible to load berdy, as includeRcmAsSensor is supported only by BERDY_FLOATING_BASE or BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES variants");
-        return false;
-    }
-
-    if(this->includeRcmAsSensor && !this->includeAllNetExternalWrenchesAsDynamicVariables)
-    {
-        reportError("BerdyOptions","checkConsistency","Impossible to load berdy, as includeRcmAsSensor can be used only if includeAllNetExternalWrenchesAsDynamicVariables is enabled");
-        return false;
-    }
-
     return true;
 }
 
@@ -342,7 +329,7 @@ bool BerdyHelper::initSensorsMeasurements()
     }
 
     // Add Rate of Change of Momentum (RCM) sensor
-    if (m_options.includeRcmAsSensor)
+    if (m_options.berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES)
     {
         berdySensorTypeOffsets.rcmOffset = m_nrOfSensorsMeasurements;
         m_nrOfSensorsMeasurements += 6;
@@ -1483,7 +1470,7 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
     ////////////////////////////////////////////////////////////////////////
     ///// Rate of Change of Momentum (RCM) SENSOR
     ////////////////////////////////////////////////////////////////////////
-    if (m_options.includeRcmAsSensor)
+    if (m_options.berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES)
     {
         // Get the row index corresponding to the RCM sensor
         IndexRange rcmRange = this->getRangeRCMSensorVariable(RCM_SENSOR);
@@ -1540,7 +1527,7 @@ bool BerdyHelper::initBerdyFloatingBase()
         m_nrOfDynamicEquations   = 6*m_model.getNrOfLinks() + 6*m_model.getNrOfJoints();
     }
 
-    if (m_options.includeRcmAsSensor) {
+    if (m_options.berdyVariant!=BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES) {
         if (m_options.rcmConstraintLinkNamesVector.size() == 0)
         {
             reportInfo("BerdyHelpers","initBerdyFloatingBase","rcmConstraintLinkNamesVector is not initialized using berdy helper options. Considering all the model links");
@@ -1859,7 +1846,7 @@ void BerdyHelper::cacheSensorsOrdering()
         m_sensorsOrdering.push_back(jointSens);
     }
 
-    if(m_options.includeRcmAsSensor) {
+    if(m_options.berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES) {
 
         IndexRange sensorRange = this->getRangeRCMSensorVariable(RCM_SENSOR);
 
@@ -2311,7 +2298,7 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
     ///// Rate of Change of Momentum (RCM)
     ////////////////////////////////////////////////////////////////////////
     /// This method serializeSensorVariables is used in Testing for the Berdy estimator helper class
-    if (m_options.includeRcmAsSensor)
+    if (m_options.berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES)
     {
         IndexRange sensorRange = this->getRangeRCMSensorVariable(RCM_SENSOR);
 

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1724,6 +1724,10 @@ bool BerdyHelper::getBerdyMatrices(SparseMatrix<iDynTree::ColumnMajor>& D, Vecto
         break;
     case BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES:
         // D and bD are not used with this variant
+        D.resize(m_nrOfDynamicEquations,m_nrOfDynamicalVariables);
+        bD.resize(m_nrOfDynamicEquations);
+        matrixDElements.clear();
+        bD.zero();
         break;
     default:
         reportError("BerdyHelpers", "getBerdyMatrices", "unknown berdy variant");

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -2209,7 +2209,7 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
                                            JointDOFsDoubleArray& jointTorques,
                                            JointDOFsDoubleArray& jointAccs,
                                            LinkInternalWrenches& linkJointWrenches,
-                                           SpatialMomentum& rocm,
+                                           Vector6& rocm,
                                            VectorDynSize& y)
 {
     bool ret=true;
@@ -2289,7 +2289,7 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
     {
         IndexRange sensorRange = this->getRangeROCMSensorVariable(ROCM_SENSOR);
 
-        setSubVector(y, sensorRange, static_cast<SpatialForceVector>(rocm));
+        setSubVector(y, sensorRange, rocm);
     }
 
     return ret;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -2213,7 +2213,7 @@ bool BerdyHelper::serializeSensorVariables(SensorsMeasurements& sensMeas,
                                            JointDOFsDoubleArray& jointTorques,
                                            JointDOFsDoubleArray& jointAccs,
                                            LinkInternalWrenches& linkJointWrenches,
-                                           Vector6& rocm,
+                                           SpatialForceVector& rocm,
                                            VectorDynSize& y)
 {
     bool ret=true;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -702,7 +702,7 @@ IndexRange BerdyHelper::getRangeROCMSensorVariable(const BerdySensorTypes sensor
         iDynTree::reportWarning("BerdyHelpers","getRangeROCMSensorVariable","Wrong sensor types passed for retrieving sensor range");
     }
 
-    if (isBerdyVariantHierarchical(m_options.berdyVariant))
+    if (!isBerdyVariantHierarchical(m_options.berdyVariant))
     {
         iDynTree::reportWarning("BerdyHelpers","getRangeROCMSensorVariable","Rate of Change of Momentum (ROCM) sensor is only available in HIERARCHICAL_BERDY_FLOATING_BASE_X_TASK");
     }
@@ -1988,7 +1988,7 @@ void BerdyHelper::cacheDynamicVariablesOrderingFixedBase()
         BerdyDynamicVariable jointTorque;
         jointTorque.type = DOF_TORQUE;
         jointTorque.id = parentJointName;
-        //TODO: for now assume 1 dof joint
+        //TODO[yeshi]: for now assume 1 dof joint
         jointTorque.range = getRangeDOFVariable(jointTorque.type, jointIndex);
 
         BerdyDynamicVariable netExternalWrench;
@@ -1999,7 +1999,7 @@ void BerdyHelper::cacheDynamicVariablesOrderingFixedBase()
         BerdyDynamicVariable jointAcceleration;
         jointAcceleration.type = DOF_ACCELERATION;
         jointAcceleration.id = parentJointName;
-        //TODO: for now assume 1 dof joint
+        //TODO[yeshi]: for now assume 1 dof joint
         jointAcceleration.range = getRangeDOFVariable(jointAcceleration.type, jointIndex);
 
         m_dynamicVariablesOrdering.push_back(acceleration);

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1497,14 +1497,14 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
             LinkIndex idx = m_model.getLinkIndex(linkName);
 
             // Get the column index corresponding to the net link external wrench sensor
-            IndexRange netExternalWrenchSensor = this->getRangeLinkSensorVariable(NET_EXT_WRENCH_SENSOR, idx);
+            IndexRange netExternalWrenchVariableIndexRange = this->getRangeLinkVariable(NET_EXT_WRENCH, idx);
 
             // Get base to link transform
             Transform base_X_link = base_H_links(idx);
 
             // Get link to base rotation
             matrixYElements.addSubMatrix(rocmRange.offset,
-                                         netExternalWrenchSensor.offset,
+                                         netExternalWrenchVariableIndexRange.offset,
                                          base_X_link.asAdjointTransformWrench());
 
         }

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -137,6 +137,12 @@ bool BerdyOptions::checkConsistency()
         return false;
     }
 
+    if(this->includeROCMAsSensor && !this->includeAllNetExternalWrenchesAsDynamicVariables)
+    {
+        reportError("BerdyOptions","checkConsistency","Impossible to load berdy, as includeROCMAsSensor can be used only if includeAllNetExternalWrenchesAsDynamicVariables is enabled");
+        return false;
+    }
+
     return true;
 }
 

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -128,6 +128,12 @@ bool BerdyOptions::checkConsistency()
             reportError("BerdyOptions","checkConsistency","Impossible to load berdy, as HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK does not support includeAllJointTorquesAsSensors");
             return false;
         }
+
+        if(!this->includeAllNetExternalWrenchesAsSensors)
+        {
+            reportError("BerdyOptions","checkConsistency","Impossible to load berdy, as HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK requires includeAllNetExternalWrenchesAsSensors");
+            return false;
+        }
     }
 
     if(this->includeROCMAsSensor && !isBerdyVariantHierarchical(this->berdyVariant))

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -260,7 +260,15 @@ bool BerdyHelper::initSensorsMeasurements()
     // contained in the robot model) plus the additional/fictious sensors
     // specified in the BerdyOptions
     // List is empty if Berdy variant is HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK
-    m_nrOfSensorsMeasurements = m_sensors.getSizeOfAllSensorsMeasurements();
+    if(m_options.berdyVariant != HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK)
+    {
+        m_nrOfSensorsMeasurements = m_sensors.getSizeOfAllSensorsMeasurements();
+    }
+    else
+    {
+        m_nrOfSensorsMeasurements = 0;
+    }
+    
 
     // The offset of joint accelerations
     berdySensorTypeOffsets.dofAccelerationOffset = m_nrOfSensorsMeasurements;
@@ -513,7 +521,7 @@ IndexRange BerdyHelper::getRangeJointVariable(BerdyDynamicVariablesTypes dynamic
     else
     {
         IndexRange ret;
-        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE || isBerdyVariantHierarchical(m_options.berdyVariant));
         assert(m_options.includeAllNetExternalWrenchesAsDynamicVariables);
 
         int totalSizeOfLinkVariables  = 12*m_model.getNrOfLinks();
@@ -550,7 +558,7 @@ IndexRange BerdyHelper::getRangeDOFVariable(BerdyDynamicVariablesTypes dynamicVa
     else
     {
         IndexRange ret;
-        assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+        assert(m_options.berdyVariant == BERDY_FLOATING_BASE || isBerdyVariantHierarchical(m_options.berdyVariant));
         assert(m_options.includeAllNetExternalWrenchesAsDynamicVariables);
 
         int totalSizeOfLinkVariables  = 12*m_model.getNrOfLinks();
@@ -786,7 +794,7 @@ IndexRange BerdyHelper::getRangeAccelerationPropagationFloatingBase(const JointI
 
 IndexRange BerdyHelper::getRangeNewtonEulerEquationsFloatingBase(const LinkIndex idx) const
 {
-    assert(m_options.berdyVariant == BERDY_FLOATING_BASE);
+    assert(m_options.berdyVariant == BERDY_FLOATING_BASE || isBerdyVariantHierarchical(m_options.berdyVariant));
     IndexRange ret;
     ret.offset = 6*idx;
     ret.size = 6;

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -204,15 +204,6 @@ bool BerdyHelper::init(const Model& model,
     base_H_links.resize(m_model.getNrOfLinks());
 
     bool res = m_options.checkConsistency();
-    for(std::string& rcmConstraintLinkName : m_options.rcmConstraintLinkNamesVector)
-    {
-        if(!m_model.isLinkNameUsed(rcmConstraintLinkName))
-        {
-            
-            reportError("BerdyHelpers","init",("Link name "+rcmConstraintLinkName+" specified in rcmConstraintLinkNamesVector does not exist.").c_str());
-            res = false;
-        }
-    }
 
     if( !res )
     {
@@ -1475,14 +1466,8 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
         // Get the row index corresponding to the RCM sensor
         IndexRange rcmRange = this->getRangeRCMSensorVariable(RCM_SENSOR);
 
-        for(size_t i = 0; i < m_options.rcmConstraintLinkNamesVector.size(); i++)
+        for(LinkIndex idx = 0 ; idx < m_model.getNrOfLinks(); idx++)
         {
-            // Get link name from the vector
-            std::string linkName = m_options.rcmConstraintLinkNamesVector.at(i);
-
-            // Get link index from the vector
-            LinkIndex idx = m_model.getLinkIndex(linkName);
-
             // Get the column index corresponding to the net link external wrench sensor
             IndexRange netExternalWrenchVariableIndexRange = this->getRangeLinkVariable(NET_EXT_WRENCH, idx);
 
@@ -1493,9 +1478,7 @@ bool BerdyHelper::computeBerdySensorMatrices(SparseMatrix<iDynTree::ColumnMajor>
             matrixYElements.addSubMatrix(rcmRange.offset,
                                          netExternalWrenchVariableIndexRange.offset,
                                          base_X_link.asAdjointTransformWrench());
-
         }
-
 
         // bY for the RCM sensor is zero
     }
@@ -1525,18 +1508,6 @@ bool BerdyHelper::initBerdyFloatingBase()
         // The dynamics equations considered by floating berdy are the acceleration propagation for each joint and the
         // Newton-Euler equations for each link
         m_nrOfDynamicEquations   = 6*m_model.getNrOfLinks() + 6*m_model.getNrOfJoints();
-    }
-
-    if (m_options.berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES) {
-        if (m_options.rcmConstraintLinkNamesVector.size() == 0)
-        {
-            reportInfo("BerdyHelpers","initBerdyFloatingBase","rcmConstraintLinkNamesVector is not initialized using berdy helper options. Considering all the model links");
-            m_options.rcmConstraintLinkNamesVector.resize(m_model.getNrOfLinks());
-            for (size_t l = 0; l < m_model.getNrOfLinks(); l++)
-            {
-                m_options.rcmConstraintLinkNamesVector.at(l) = m_model.getLinkName(l);
-            }
-        }
     }
 
     initSensorsMeasurements();

--- a/src/estimation/src/BerdyHelper.cpp
+++ b/src/estimation/src/BerdyHelper.cpp
@@ -1527,7 +1527,7 @@ bool BerdyHelper::initBerdyFloatingBase()
         m_nrOfDynamicEquations   = 6*m_model.getNrOfLinks() + 6*m_model.getNrOfJoints();
     }
 
-    if (m_options.berdyVariant!=BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES) {
+    if (m_options.berdyVariant==BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES) {
         if (m_options.rcmConstraintLinkNamesVector.size() == 0)
         {
             reportInfo("BerdyHelpers","initBerdyFloatingBase","rcmConstraintLinkNamesVector is not initialized using berdy helper options. Considering all the model links");

--- a/src/estimation/src/BerdySparseMAPSolver.cpp
+++ b/src/estimation/src/BerdySparseMAPSolver.cpp
@@ -285,7 +285,10 @@ namespace iDynTree {
         else
         {
 			// \bar{mu_D} = mu_d
-            expectedDynamicsPrior = priorDynamicsRegularizationExpectedValue;
+            expectedDynamicsPrior.zero();
+
+            // \bar{Sigma_D^{-1}} = 0
+            covarianceDynamicsPriorInverse = covarianceDynamicsPriorInverse * 0;
         }
         
         // Final result: covariance matrix of the whole-body dynamics, Eq. 11a

--- a/src/estimation/src/BerdySparseMAPSolver.cpp
+++ b/src/estimation/src/BerdySparseMAPSolver.cpp
@@ -200,8 +200,7 @@ namespace iDynTree {
                                                                      const iDynTree::JointDOFsDoubleArray& jointsVelocity,
                                                                      const FrameIndex floatingFrame,
                                                                      const Vector3& bodyAngularVelocityOfSpecifiedFrame,
-                                                                     const iDynTree::VectorDynSize& measurements,
-                                                                     const Transform& w_H_b)
+                                                                     const iDynTree::VectorDynSize& measurements)
     {
         assert(m_pimpl);
 
@@ -210,7 +209,7 @@ namespace iDynTree {
         m_pimpl->measurements = measurements;
 
         m_pimpl->berdy.updateKinematicsFromFloatingBase(m_pimpl->jointsConfiguration, m_pimpl->jointsVelocity,
-                                                        floatingFrame, bodyAngularVelocityOfSpecifiedFrame, w_H_b);
+                                                        floatingFrame, bodyAngularVelocityOfSpecifiedFrame);
     }
 
     bool BerdySparseMAPSolver::doEstimate()

--- a/src/estimation/src/BerdySparseMAPSolver.cpp
+++ b/src/estimation/src/BerdySparseMAPSolver.cpp
@@ -257,9 +257,9 @@ namespace iDynTree {
 
         // Intermediate quantities
 		
-		//TODO check HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK solution!
+		//TODO check BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES solution!
 
-        if(berdy.getOptions().berdyVariant!=HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK)
+        if(berdy.getOptions().berdyVariant!=BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES)
         {
             // Covariance matrix of the prior of the dynamics: var[p(d)], Eq. 10a
             //TODO: find a way to map to iDynTree::SparseMatrix
@@ -299,7 +299,7 @@ namespace iDynTree {
 
         // Final result: expected value of the whole-body dynamics, Eq. 11b
         toEigen(expectedDynamicsAPosterioriRHS) = toEigen(measurementsMatrix).transpose() * toEigen(priorMeasurementsCovarianceInverse) * (toEigen(measurements) - toEigen(measurementsBias));
-        if(berdy.getOptions().berdyVariant!=HIERARCHICAL_BERDY_FLOATING_BASE_CENTROIDAL_TASK) //TODO check
+        if(berdy.getOptions().berdyVariant!=BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES) //TODO check
         {
             toEigen(expectedDynamicsAPosterioriRHS) += covarianceDynamicsPriorInverse * toEigen(expectedDynamicsPrior);
         }

--- a/src/estimation/src/BerdySparseMAPSolver.cpp
+++ b/src/estimation/src/BerdySparseMAPSolver.cpp
@@ -92,6 +92,7 @@ namespace iDynTree {
     void BerdySparseMAPSolver::setDynamicsConstraintsPriorCovariance(const iDynTree::SparseMatrix<iDynTree::ColumnMajor>& covariance)
     {
         assert(m_pimpl);
+        assert(m_pimpl->berdy.getOptions().berdyVariant!=BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES);
         assert(covariance.rows() == m_pimpl->priorDynamicsConstraintsCovarianceInverse.rows()
                && covariance.columns() == m_pimpl->priorDynamicsConstraintsCovarianceInverse.columns());
         BerdySparseMAPSolver::BerdySparseMAPSolverPimpl::invertSparseMatrix(covariance, m_pimpl->priorDynamicsConstraintsCovarianceInverse);
@@ -283,7 +284,7 @@ namespace iDynTree {
         }
         else
         {
-			//TODO this workaround to leave the following lines as the original problem
+			// \bar{mu_D} = mu_d
             expectedDynamicsPrior = priorDynamicsRegularizationExpectedValue;
         }
         

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -16,6 +16,7 @@
 #include "testModels.h"
 #include <iDynTree/Core/EigenHelpers.h>
 #include <iDynTree/Core/EigenSparseHelpers.h>
+#include <iDynTree/Core/TransformDerivative.h>
 #include <iDynTree/Core/TestUtils.h>
 #include <iDynTree/Core/SparseMatrix.h>
 #include <iDynTree/Model/ModelTestUtils.h>
@@ -23,10 +24,265 @@
 #include <iDynTree/Model/ForwardKinematics.h>
 #include <iDynTree/Model/Dynamics.h>
 
+#include <iDynTree/KinDynComputations.h>
+
 #include <cstdio>
 #include <cstdlib>
 
 using namespace iDynTree;
+
+//TODO remove
+/**
+ * Get random robot positions, velocities and accelerations
+ * and external wrenches to be given as an input to InverseDynamics.
+ */
+inline bool getRandomInverseDynamicsInputsCustom(FreeFloatingPos& pos,
+                                                FreeFloatingVel& vel,
+                                                FreeFloatingAcc& acc,
+                                                LinkNetExternalWrenches& extWrenches)
+{
+    //srand(time(NULL));
+    pos.worldBasePos() = Transform::Identity();
+    //pos.worldBasePos().setPosition(getRandomPosition());
+    //pos.worldBasePos().setPosition(Position(3,5,0));
+    //pos.worldBasePos().setRotation(Rotation::RPY(0., M_PI/2., 0.));
+    //pos.worldBasePos() = getRandomTransform();
+    
+    vel.baseVel().zero();
+    acc.baseAcc().zero();
+
+
+    //acc.baseAcc()(0) = 17;
+    //for(int i=0;i<6; i++) acc.baseAcc()(i) = 17;
+
+    acc.baseAcc() = getRandomTwist();
+    //acc.baseAcc()(0) = 11.;
+    //acc.baseAcc()(1) = 13.;
+    //acc.baseAcc()(2) = 17.;
+    //acc.baseAcc()(3) = 7.;
+    //acc.baseAcc()(4) = 7.;
+    //acc.baseAcc()(5) = 9.;
+    
+    vel.baseVel() =  getRandomTwist();
+    //vel.baseVel()(0) = 2.;
+    //vel.baseVel()(1) = 3.;
+    //vel.baseVel()(2) = 5.;
+    //vel.baseVel()(3) = 7.;
+
+    for(unsigned int jnt=0; jnt < pos.getNrOfPosCoords(); jnt++)
+    {
+        pos.jointPos()(jnt) = 0;
+    }
+
+    for(unsigned int jnt=0; jnt < vel.getNrOfDOFs(); jnt++)
+    {
+        vel.jointVel()(jnt) = 0;
+        acc.jointAcc()(jnt) = 0;
+    }
+
+    return true;
+}
+
+Vector6 computeROCMInBaseUsingMeasurements(BerdyHelper& berdy,
+                                          KinDynComputations& kinDynComputations,
+                                          LinkPositions& linkPos,
+                                          LinkVelArray&  linkVels,
+                                          LinkAccArray&  linkProperAccs, //TODO check if prop acc
+                                          LinkNetExternalWrenches& extWrenches,
+                                          LinkIndex baseIdx)
+{
+    // Get link spatial inertias
+    LinkInertias linkInertias(berdy.model());
+    for(size_t linkIdx = 0; linkIdx < berdy.model().getNrOfLinks(); linkIdx++)
+    {
+        linkInertias(linkIdx) = berdy.model().getLink(linkIdx)->getInertia();
+    }
+
+    // Set gravitational wrench vector
+    iDynTree::SpatialForceVector gravitationalWrenchInCentroidal;
+    gravitationalWrenchInCentroidal.zero();
+    gravitationalWrenchInCentroidal(2) = berdy.model().getTotalMass() * -9.81;
+
+    iDynTree::Vector6 centroidalMomentum;
+    centroidalMomentum.zero();
+
+    iDynTree::Vector6 rocmInBaseRaw;
+    rocmInBaseRaw.zero();
+
+    // {}^B_X*dot_Gbar {}^Gbar_h
+    iDynTree::Vector6 rocmInBaseBias;
+    rocmInBaseBias.zero();
+
+    // Set centroidal to world transform
+    iDynTree::Transform world_H_centroidal = iDynTree::Transform::Identity();
+    world_H_centroidal.setPosition(kinDynComputations.getCenterOfMassPosition());
+    std::cerr<<"Center of mass position: "<<kinDynComputations.getCenterOfMassPosition().toString()<<std::endl;
+    std::cerr<<"Base link idx: " <<baseIdx<<std::endl;
+
+    // base_H_centroidal transform
+    const iDynTree::Transform base_H_centroidal = kinDynComputations.getWorldBaseTransform().inverse() * world_H_centroidal;
+
+    // Compute gravitational wrench expressed in base
+    iDynTree::Vector6 gravitationalWrenchInBase;
+    gravitationalWrenchInBase.zero();
+    iDynTree::toEigen(gravitationalWrenchInBase) = iDynTree::toEigen(base_H_centroidal.asAdjointTransformWrench()) * iDynTree::toEigen(gravitationalWrenchInCentroidal);
+
+    // Get base transform A_H_B
+    const iDynTree::Transform world_H_base = linkPos(baseIdx);
+
+    // Get base velocity A_v_A,B
+    const iDynTree::Twist baseVelocityExpressedInWorld = linkVels(baseIdx);
+
+    // Get base acceleration A_a_A,B
+    const iDynTree::Twist baseAccelerationExpressedInWorld = linkProperAccs(baseIdx);
+
+    // Get base velocity in base B_v_B
+    iDynTree::Vector6 baseVelocityExpressedInBaseVector;
+    iDynTree::toEigen(baseVelocityExpressedInBaseVector) = iDynTree::toEigen(world_H_base.inverse().asAdjointTransform()) * iDynTree::toEigen(baseVelocityExpressedInWorld);
+    iDynTree::Twist baseVelocityExpressedInBase = Twist(SpatialVector<SpatialMotionVector>(baseVelocityExpressedInBaseVector));
+
+    // Iterate over measurements
+    for(LinkIndex visitedLinkIndex = 0; visitedLinkIndex < berdy.model().getNrOfLinks(); visitedLinkIndex++)
+    {
+        // Get world_H_link transform
+        const iDynTree::Transform world_H_link = linkPos(visitedLinkIndex);
+
+        // Get link to base transform
+        const iDynTree::Transform base_H_link = world_H_base.inverse() * world_H_link;
+
+        // Compute link to centroidal transform
+        const iDynTree::Transform centroidal_H_link = world_H_centroidal.inverse() * world_H_link;
+
+        // Get link velocity A_v_A,L
+        const iDynTree::Twist linkVelocityExpressedInWorld = linkVels(visitedLinkIndex);
+
+        // Get link acceleration A_a_A,L
+        const iDynTree::Twist linkAccelerationExpressedInWorld = linkProperAccs(visitedLinkIndex);
+
+        // Get L_v_A,L = L_X_A * L_v_A,L
+        iDynTree::Vector6 linkVelocityExpressedInLink;
+        {
+            linkVelocityExpressedInLink.zero();
+            iDynTree::toEigen(linkVelocityExpressedInLink) = iDynTree::toEigen(world_H_link.inverse().asAdjointTransform()) * iDynTree::toEigen(linkVelocityExpressedInWorld);
+        }
+
+        // Get L_v_B,L = (L_X_A * A_v_A,L) - (L_X_B * B_X_A * A_v_A,B) = L_X_A * (A_v_A,L - A_v_A,B)
+        // from Eq (3.5a) from silvio's thesis https://traversaro.github.io/phd-thesis/traversaro-phd-thesis.pdf (Broken reference)
+        iDynTree::Vector6 linkVelocityWrtBaseExpressedInLink;
+        {
+            linkVelocityWrtBaseExpressedInLink.zero();
+            iDynTree::toEigen(linkVelocityWrtBaseExpressedInLink) = iDynTree::toEigen(world_H_link.inverse().asAdjointTransform()) * iDynTree::toEigen(linkVelocityExpressedInWorld - baseVelocityExpressedInWorld);
+        }
+        const iDynTree::Twist linkVelocityWrtBaseExpressedInLinkTwist = Twist(SpatialVector<SpatialMotionVector>(linkVelocityWrtBaseExpressedInLink));
+
+        // Get L_a_A,L = L_X*_A * A_a_A,L 
+        iDynTree::Vector6 linkAccelerationExpressedInLink;
+        {
+            linkAccelerationExpressedInLink.zero();
+            iDynTree::toEigen(linkAccelerationExpressedInLink) = iDynTree::toEigen(world_H_link.inverse().asAdjointTransformWrench()) * iDynTree::toEigen(linkAccelerationExpressedInWorld);
+            std::cerr<<std::endl<<"L_a_A,L:"
+                     <<std::endl<<"L_X*_A: "<<std::endl<<world_H_link.inverse().asAdjointTransformWrench().toString()
+                     <<std::endl<<"A_a_A,L: "<<linkAccelerationExpressedInWorld.toString()<<std::endl;
+        }
+
+        // Compute link momentum - G_X*_L * I_L * L_v_A,L
+        iDynTree::Vector6 linkMomentum;
+        {
+            linkMomentum.zero();
+            iDynTree::toEigen(linkMomentum) = iDynTree::toEigen(centroidal_H_link.asAdjointTransformWrench()) *
+                                              iDynTree::toEigen(linkInertias(visitedLinkIndex).asMatrix()) *
+                                              iDynTree::toEigen(linkVelocityExpressedInLink);
+
+            //std::cerr<<std::endl<<"Link momentum for link "<<visitedLinkIndex<<": "<<std::endl<<
+            //            "G_H*_L:"<< std::endl<<centroidal_H_link.asAdjointTransformWrench().toString()<<
+            //            "L_I_L: "<< std::endl<<linkInertias(visitedLinkIndex).asMatrix().toString()<<
+            //            "L_v_A,L: "<< std::endl<<linkVelocityExpressedInLink.toString()<<std::endl<<std::endl;
+                    
+        }
+
+        // Update centroidal momentum
+        iDynTree::toEigen(centroidalMomentum) += iDynTree::toEigen(linkMomentum);
+        std::cerr<<"Link "<<visitedLinkIndex<<" momentum: "<<centroidalMomentum.toString()<<std::endl;
+
+        // Compute link rate of change of momentum (expressed in base) term with accelerations -  B_X*_L * I_L * L_a_A,L
+        //TODO is it okay with B_X*_L * I_L * L_a_A,L?? check inertia
+        iDynTree::Vector6 linkROCMInBase_acc_term;
+        iDynTree::toEigen(linkROCMInBase_acc_term) = iDynTree::toEigen(base_H_link.asAdjointTransformWrench()) *
+                                                     iDynTree::toEigen(linkInertias(visitedLinkIndex).asMatrix()) *
+                                                     iDynTree::toEigen(linkAccelerationExpressedInLink);
+
+        std::cerr<<std::endl<<
+        "Link rocm in base acceleration term:"<<std::endl<<
+        "B_X*_L: "<<std::endl<<base_H_link.asAdjointTransformWrench().toString()<<std::endl<<
+        "L_I_L: "<<std::endl<<linkInertias(visitedLinkIndex).asMatrix().toString()<<std::endl<<
+        "L_a_A,L: "<<linkAccelerationExpressedInLink.toString()<<std::endl;
+                    
+
+        // Compute link rate of change of momentum (expressed in base) term with velocity - B_Xdot*_L * I_L * L_v_A,L
+        iDynTree::Vector6 linkROCMInBase_vel_term;
+        iDynTree::toEigen(linkROCMInBase_vel_term) = iDynTree::toEigen(base_H_link.asAdjointTransformWrench()) *
+                                                      iDynTree::toEigen(linkVelocityWrtBaseExpressedInLinkTwist.asCrossProductMatrixWrench()) *
+                                                      iDynTree::toEigen(linkInertias(visitedLinkIndex).asMatrix()) *
+                                                      iDynTree::toEigen(linkVelocityExpressedInLink);
+
+        // Update ROCM in base
+        // Update rate of change of momentum
+        iDynTree::toEigen(rocmInBaseRaw) += iDynTree::toEigen(linkROCMInBase_acc_term) +
+                                        iDynTree::toEigen(linkROCMInBase_vel_term);
+
+        std::cerr<<"ROCM: "<<
+                    std::endl<<"ROCM in base: "<<rocmInBaseRaw.toString()<<
+                    std::endl<<"Acc term: "<<linkROCMInBase_acc_term.toString()<<
+                    std::endl<<"Vel term: "<<linkROCMInBase_vel_term.toString()<<std::endl;
+
+    }
+
+
+
+    // Compute position derivative (comVel - baseLinVel)
+    iDynTree::Vector3 posDerivative;
+    {
+        posDerivative.setVal(0, kinDynComputations.getCenterOfMassVelocity().getVal(0) - baseVelocityExpressedInWorld.getLinearVec3().getVal(0));
+        posDerivative.setVal(1, kinDynComputations.getCenterOfMassVelocity().getVal(1) - baseVelocityExpressedInWorld.getLinearVec3().getVal(1));
+        posDerivative.setVal(2, kinDynComputations.getCenterOfMassVelocity().getVal(2) - baseVelocityExpressedInWorld.getLinearVec3().getVal(2));
+    }
+    
+    // Compute rotation derivative ( base_dotR_world = ( Skew(baseAngVel) * world_R_base)' )
+    iDynTree::Matrix3x3 rotDerivative;
+    //iDynTree::toEigen(rotDerivative) = iDynTree::toEigen(world_H_base.getRotation()).transpose() *
+    //                                   iDynTree::skew( iDynTree::toEigen(baseVelocityExpressedInWorld.getAngularVec3() ) ).transpose();
+
+    iDynTree::toEigen(rotDerivative) = iDynTree::skew(-iDynTree::toEigen(baseVelocityExpressedInBase.getAngularVec3() ) ) * iDynTree::toEigen(base_H_centroidal.getRotation());
+    
+    std::cerr<<"ROT derivative: "<<rotDerivative.toString()<<std::endl;
+    std::cerr<<"Skew :"<<iDynTree::skew(-iDynTree::toEigen(baseVelocityExpressedInWorld.getAngularVec3() ) )<<std::endl;
+    std::cerr<<"Rot :"<<world_H_base.getRotation().toString()<<std::endl;
+
+    iDynTree::TransformDerivative base_dotH_centroidal(rotDerivative, posDerivative);
+
+    // Compute the bias term with centroidal momentum
+    iDynTree::SpatialMomentum centroidalMom = iDynTree::SpatialMomentum(SpatialVector<SpatialForceVector>(centroidalMomentum));
+
+    // Compute base_dotX*_centroidal * centroidal momentum
+    iDynTree::SpatialForceVector biasTermFromCentroidalMomentum; 
+    biasTermFromCentroidalMomentum = base_dotH_centroidal.transform(base_H_centroidal, centroidalMom);
+
+    std::cerr<<"Computed ROCM:"<<
+                std::endl<<"ROCM in base: "<<rocmInBaseRaw.toString()<<
+                std::endl<<"Bias term: "<<biasTermFromCentroidalMomentum.toString()<<
+                "Gravitational wrench in base:"<<gravitationalWrenchInBase.toString()<<std::endl;
+    
+    //TODO check this
+    gravitationalWrenchInBase.zero();
+
+    // Computed rate of change of momentum
+    Vector6 rocmInBase;
+    iDynTree::toEigen(rocmInBase) = iDynTree::toEigen(rocmInBaseRaw)
+                                    - iDynTree::toEigen(biasTermFromCentroidalMomentum.asVector())
+                                    - iDynTree::toEigen(gravitationalWrenchInBase);
+
+    return rocmInBase;
+}
 
 void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
 {
@@ -37,7 +293,7 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     FreeFloatingAcc generalizedProperAccs(berdy.model());
     LinkNetExternalWrenches extWrenches(berdy.model());
 
-    getRandomInverseDynamicsInputs(pos,vel,generalizedProperAccs,extWrenches);
+    getRandomInverseDynamicsInputsCustom(pos,vel,generalizedProperAccs,extWrenches);
 
     // Force the base linear velocity to be zero for ensure consistency with the compute buffers
     vel.baseVel().setLinearVec3(LinVelocity(0.0, 0.0, 0.0));
@@ -53,15 +309,30 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     ForwardPosVelAccKinematics(berdy.model(),berdy.dynamicTraversal(),
                                pos, vel, generalizedProperAccs,
                                linkPos,linkVels,linkProperAccs);
+    
+    LinkAccArray linkAccs(berdy.model());
+    for(LinkIndex visitedLinkIndex = 0; visitedLinkIndex < berdy.model().getNrOfLinks(); visitedLinkIndex++)
+    {
+        linkAccs(visitedLinkIndex).setLinearVec3(linkProperAccs(visitedLinkIndex).getLinearVec3());
+        linkAccs(visitedLinkIndex).setAngularVec3(linkProperAccs(visitedLinkIndex).getAngularVec3());
+        //TODO gravity?
+        //linkAccs(visitedLinkIndex).getLinearVec3()(2) += -9.81;
+    }
+
     RNEADynamicPhase(berdy.model(),berdy.dynamicTraversal(),
-                     pos.jointPos(),linkVels,linkProperAccs,
+                     pos.jointPos(),linkVels,linkAccs,//linkAccs,linkProperAccs
                      extWrenches,intWrenches,genTrqs);
 
     // Propagate kinematics also inside berdy
 
+    std::cerr<<"LINK PROP ACC: "<< linkProperAccs.toString(berdy.model());
+    std::cerr<<"LINK accelerations used: "<< linkProperAccs.toString(berdy.model());
+    std::cerr<<"Link vels: "<<linkVels.toString(berdy.model());
+    std::cerr<<"Link positions: "<<std::endl<<linkPos.toString(berdy.model());
+
     // Correct for the unconsistency between the input net wrenches and the residual of the RNEA
     extWrenches(berdy.dynamicTraversal().getBaseLink()->getIndex()) = extWrenches(berdy.dynamicTraversal().getBaseLink()->getIndex())+genTrqs.baseWrench();
-
+    // extWrenches(berdy.dynamicTraversal().getBaseLink()->getIndex())(2) = 9.81;
     // Generate the d vector of dynamical variables
     VectorDynSize d(berdy.getNrOfDynamicVariables());
 
@@ -82,6 +353,8 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     LinkIndex baseIdx = berdy.dynamicTraversal().getBaseLink()->getIndex();
     berdy.updateKinematicsFromFloatingBase(pos.jointPos(),vel.jointVel(),baseIdx,linkVels(baseIdx).getAngularVec3());
 
+    std::cerr<<"Ext wrenches are: "<<std::endl<<extWrenches.toString(berdy.model());
+
     berdy.serializeDynamicVariables(linkProperAccs,
                                     linkNetWrenchesWithoutGravity,
                                     extWrenches,
@@ -99,20 +372,24 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     bool ok = berdy.getBerdyMatrices(D,bD,Y,bY);
     ASSERT_IS_TRUE(ok);
 
-    VectorDynSize dynamicsResidual(berdy.getNrOfDynamicEquations()), zeroRes(berdy.getNrOfDynamicEquations());
+    // Variant BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES does not have D and bD
+    if(berdy.getOptions().berdyVariant != BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES)
+    {
+        VectorDynSize dynamicsResidual(berdy.getNrOfDynamicEquations()), zeroRes(berdy.getNrOfDynamicEquations());
 
-    toEigen(dynamicsResidual) = toEigen(D)*toEigen(d) + toEigen(bD);
+        toEigen(dynamicsResidual) = toEigen(D)*toEigen(d) + toEigen(bD);
 
-    /*
-    std::cerr << "D : " << std::endl;
-    std::cerr << D.description(true) << std::endl;
-    std::cerr << "d :\n" << d.toString() << std::endl;
-    std::cerr << "D*d :\n" << toEigen(D)*toEigen(d) << std::endl;
-    std::cerr << "bD :\n" << bD.toString() << std::endl;
-    */
+        /*
+        std::cerr << "D : " << std::endl;
+        std::cerr << D.description(true) << std::endl;
+        std::cerr << "d :\n" << d.toString() << std::endl;
+        std::cerr << "D*d :\n" << toEigen(D)*toEigen(d) << std::endl;
+        std::cerr << "bD :\n" << bD.toString() << std::endl;
+        */
 
-    ASSERT_EQUAL_VECTOR(dynamicsResidual, zeroRes);
-    
+        ASSERT_EQUAL_VECTOR(dynamicsResidual, zeroRes);
+    }
+
     if( berdy.getNrOfSensorsMeasurements() > 0 )
     {
         std::cout << "BerdyHelperUnitTest, testing sensors matrix for model " << filename <<  std::endl;
@@ -122,10 +399,42 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
         y.zero();
         SensorsMeasurements sensMeas(berdy.sensors());
         bool ok = predictSensorsMeasurementsFromRawBuffers(berdy.model(),berdy.sensors(),berdy.dynamicTraversal(),
-                                                           linkVels,linkProperAccs,intWrenches,sensMeas);
+                                                           linkVels,linkAccs,intWrenches,sensMeas);
+ 
+        Vector6 rocm;
+        rocm.zero();
+        if(berdy.getOptions().includeROCMAsSensor)
+        {
+            // set kyndyncomputations object for ROCM computation
+            KinDynComputations kinDynComputations;
+            kinDynComputations.loadRobotModel(berdy.model());
+
+            Vector3 worldGravityAcc;
+            worldGravityAcc.zero();
+            //worldGravityAcc[2] = -9.81;
+
+            if(true)
+            {
+                kinDynComputations.setRobotState(linkPos(baseIdx), //w_T_base
+                                                pos.jointPos(), //joint positions
+                                                linkVels(baseIdx), //base velocity
+                                                vel.jointVel(), // joint velocities
+                                                worldGravityAcc); // world gravity
+            }
+
+            rocm = computeROCMInBaseUsingMeasurements(berdy,
+                                                      kinDynComputations,
+                                                      linkPos,
+                                                      linkVels,
+                                                      linkAccs,
+                                                      extWrenches,
+                                                      baseIdx);
+            
+            std::cerr<<std::endl<<"Rocm is "<<rocm.toString()<<std::endl<<std::endl;
+        }
 
         ASSERT_IS_TRUE(ok);
-        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,y);
+        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,rocm,y);
         ASSERT_IS_TRUE(ok);
 
         // Check that y = Y*d + bY
@@ -139,13 +448,14 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
         //std::cerr << "Y : " << std::endl;
         //std::cerr << Y.description(true) << std::endl;
         //std::cerr << "d :\n" << d.toString() << std::endl;
-        /*
+        
         std::cerr << "Y*d :\n" << toEigen(Y)*toEigen(d) << std::endl;
         std::cerr << "bY :\n" << bY.toString() << std::endl;
         std::cerr << "y from model:\n" << y.toString() << std::endl;
-        */
+        
 
         // Check if the two vectors are equal
+        std::cerr << "Testing y and yFromBerdy" << std::endl;
         ASSERT_EQUAL_VECTOR(y,yFromBerdy);
     }
 }
@@ -275,8 +585,9 @@ void testBerdyOriginalFixedBase(BerdyHelper & berdy, std::string filename)
         ok = predictSensorsMeasurementsFromRawBuffers(berdy.model(),berdy.sensors(),berdy.dynamicTraversal(),
                                                       linkVels,linkProperAccs,intWrenches,sensMeas);
         ASSERT_IS_TRUE(ok);
-
-        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,y);
+        Vector6 dummyRocm;
+        dummyRocm.zero();
+        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,dummyRocm,y);
         ASSERT_IS_TRUE(ok);
 
         // Check that y = Y*d + bY
@@ -345,7 +656,7 @@ void testBerdyHelpers(std::string fileName)
         std::cerr << "Skipping ORIGINAL_BERDY_FIXED_BASE tests for model " << fileName << " because some assumptions of ORIGINAL_BERDY_FIXED_BASE are not respected" << std::endl;
     }
 
-    // We test the floating base BERDY
+    /*// We test the floating base BERDY
     options.berdyVariant = iDynTree::BERDY_FLOATING_BASE;
     // For now floating berdy needs all the ext wrenches as dynamic variables
     options.includeAllNetExternalWrenchesAsDynamicVariables = true;
@@ -361,7 +672,19 @@ void testBerdyHelpers(std::string fileName)
     ok = berdyHelper.init(estimator.model(), estimator.sensors(), options);
     ASSERT_IS_TRUE(ok);
     testBerdySensorMatrices(berdyHelper, fileName);
-
+*/
+    // We test the floating base BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
+    options.berdyVariant = iDynTree::BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES;
+    // Include Rate Of Change of Momentum
+    options.includeROCMAsSensor = true;
+    options.includeAllJointTorquesAsSensors = false;
+    options.includeAllJointAccelerationsAsSensors = false;
+    options.includeAllNetExternalWrenchesAsSensors = true;
+    //options.jointOnWhichTheInternalWrenchIsMeasured.clear();
+    ok = berdyHelper.init(estimator.model(), estimator.sensors(), options);
+    ASSERT_IS_TRUE(ok);
+    testBerdySensorMatrices(berdyHelper, fileName);
+    std::cerr<<"OK DONE"<<std::endl;ASSERT_IS_TRUE(false);
 }
 
 int main()

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -377,8 +377,6 @@ void testBerdyHelpers(std::string fileName)
 
     // We test the floating base BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
     options.berdyVariant = iDynTree::BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES;
-    // Include Rate Of Change of Momentum (RCM)
-    options.includeRcmAsSensor = true;
     options.includeAllJointTorquesAsSensors = false;
     options.includeAllJointAccelerationsAsSensors = false;
     options.includeAllNetExternalWrenchesAsSensors = true;

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -264,8 +264,8 @@ Vector6 computeROCMInBaseUsingMeasurements(BerdyHelper& berdy,
     iDynTree::SpatialMomentum centroidalMom = iDynTree::SpatialMomentum(SpatialVector<SpatialForceVector>(centroidalMomentum));
 
     // Compute base_dotX*_centroidal * centroidal momentum
-    iDynTree::SpatialForceVector biasTermFromCentroidalMomentum; 
-    biasTermFromCentroidalMomentum = base_dotH_centroidal.transform(base_H_centroidal, centroidalMom);
+    iDynTree::Vector6 biasTermFromCentroidalMomentum; 
+    iDynTree::toEigen(biasTermFromCentroidalMomentum) = iDynTree::toEigen(base_dotH_centroidal.asAdjointTransformWrenchDerivative(base_H_centroidal)) * iDynTree::toEigen(centroidalMom);
 
     std::cerr<<"Computed ROCM:"<<
                 std::endl<<"ROCM in base: "<<rocmInBaseRaw.toString()<<
@@ -278,7 +278,7 @@ Vector6 computeROCMInBaseUsingMeasurements(BerdyHelper& berdy,
     // Computed rate of change of momentum
     Vector6 rocmInBase;
     iDynTree::toEigen(rocmInBase) = iDynTree::toEigen(rocmInBaseRaw)
-                                    - iDynTree::toEigen(biasTermFromCentroidalMomentum.asVector())
+                                    - iDynTree::toEigen(biasTermFromCentroidalMomentum)
                                     - iDynTree::toEigen(gravitationalWrenchInBase);
 
     return rocmInBase;

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -33,7 +33,7 @@ using namespace iDynTree;
 
 
 //computes \sum{{}^{B}X^{*}_{L} {}^{L}f^{x}_{L}}{L} = {}^{B}X^{*}_{G} {}^{G}hdot  
-Vector6 computeROCMInBaseUsingMeasurements(BerdyHelper& berdy,
+SpatialForceVector computeROCMInBaseUsingMeasurements(BerdyHelper& berdy,
                                           KinDynComputations& kinDynComputations,
                                           LinkPositions& linkPos,
                                           LinkVelArray&  linkVels,
@@ -83,9 +83,7 @@ Vector6 computeROCMInBaseUsingMeasurements(BerdyHelper& berdy,
     // base_H_centroidal transform
     const iDynTree::Transform base_H_centroidal = kinDynComputations.getWorldBaseTransform().inverse() * world_H_centroidal;
 
-    const iDynTree::Vector6 rocmInBase = (base_H_centroidal * rocm).asVector(); 
-
-    return rocmInBase;
+    return base_H_centroidal * rocm;
 }
 
 void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
@@ -185,7 +183,7 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
                                                            linkVels,linkProperAccs,intWrenches,sensMeas);
  
 	    // Handle rate of change of momentum in base
-        Vector6 rocm;
+        SpatialForceVector rocm;
         rocm.zero();
         if(berdy.getOptions().includeROCMAsSensor)
         {
@@ -364,7 +362,7 @@ void testBerdyOriginalFixedBase(BerdyHelper & berdy, std::string filename)
                                                       linkVels,linkProperAccs,intWrenches,sensMeas);
         ASSERT_IS_TRUE(ok);
 	    // rocm is not used with this variant
-        Vector6 dummyRocm;
+        SpatialForceVector dummyRocm;
         dummyRocm.zero();
         ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,dummyRocm,y);
         ASSERT_IS_TRUE(ok);

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -125,18 +125,18 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
         bool ok = predictSensorsMeasurementsFromRawBuffers(berdy.model(),berdy.sensors(),berdy.dynamicTraversal(),
                                                            linkVels,linkProperAccs,intWrenches,sensMeas);
  
-	    // Handle rate of change of momentum (transformed in base)
-        SpatialForceVector rocm;
-        rocm.zero();
+	    // Handle rate of change of momentum in base
+        SpatialForceVector rcm;
+        rcm.zero();
         for(int linkIdx = 0; linkIdx<extWrenches.getNrOfLinks(); linkIdx++)
         {
             // compute {}^{B}H_{L}
             Transform base_H_link = linkPos(baseIdx).inverse() * linkPos(linkIdx); 
-            rocm = rocm + (base_H_link * extWrenches(linkIdx));
+            rcm = rcm + (base_H_link * extWrenches(linkIdx));
         }
 
         ASSERT_IS_TRUE(ok);
-        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,rocm,y);
+        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,rcm,y);
         ASSERT_IS_TRUE(ok);
 
         // Check that y = Y*d + bY
@@ -286,10 +286,10 @@ void testBerdyOriginalFixedBase(BerdyHelper & berdy, std::string filename)
         ok = predictSensorsMeasurementsFromRawBuffers(berdy.model(),berdy.sensors(),berdy.dynamicTraversal(),
                                                       linkVels,linkProperAccs,intWrenches,sensMeas);
         ASSERT_IS_TRUE(ok);
-	    // rocm is not used with this variant
-        SpatialForceVector dummyRocm;
-        dummyRocm.zero();
-        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,dummyRocm,y);
+	    // Rate of Change of Momentum (RCM) is not used with this variant
+        SpatialForceVector dummyRcm;
+        dummyRcm.zero();
+        ok = berdy.serializeSensorVariables(sensMeas,extWrenches,genTrqs.jointTorques(),generalizedProperAccs.jointAcc(),intWrenches,dummyRcm,y);
         ASSERT_IS_TRUE(ok);
 
         // Check that y = Y*d + bY
@@ -377,8 +377,8 @@ void testBerdyHelpers(std::string fileName)
 
     // We test the floating base BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
     options.berdyVariant = iDynTree::BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES;
-    // Include Rate Of Change of Momentum
-    options.includeROCMAsSensor = true;
+    // Include Rate Of Change of Momentum (RCM)
+    options.includeRcmAsSensor = true;
     options.includeAllJointTorquesAsSensors = false;
     options.includeAllJointAccelerationsAsSensors = false;
     options.includeAllNetExternalWrenchesAsSensors = true;

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -159,24 +159,20 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     bool ok = berdy.getBerdyMatrices(D,bD,Y,bY);
     ASSERT_IS_TRUE(ok);
 
-    // Variant BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES does not have D and bD
-    if(berdy.getOptions().berdyVariant != BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES)
-    {
-        VectorDynSize dynamicsResidual(berdy.getNrOfDynamicEquations()), zeroRes(berdy.getNrOfDynamicEquations());
+    VectorDynSize dynamicsResidual(berdy.getNrOfDynamicEquations()), zeroRes(berdy.getNrOfDynamicEquations());
 
-        toEigen(dynamicsResidual) = toEigen(D)*toEigen(d) + toEigen(bD);
+    toEigen(dynamicsResidual) = toEigen(D)*toEigen(d) + toEigen(bD);
 
-        /*
-        std::cerr << "D : " << std::endl;
-        std::cerr << D.description(true) << std::endl;
-        std::cerr << "d :\n" << d.toString() << std::endl;
-        std::cerr << "D*d :\n" << toEigen(D)*toEigen(d) << std::endl;
-        std::cerr << "bD :\n" << bD.toString() << std::endl;
-        */
+    /*
+    std::cerr << "D : " << std::endl;
+    std::cerr << D.description(true) << std::endl;
+    std::cerr << "d :\n" << d.toString() << std::endl;
+    std::cerr << "D*d :\n" << toEigen(D)*toEigen(d) << std::endl;
+    std::cerr << "bD :\n" << bD.toString() << std::endl;
+    */
 
-        ASSERT_EQUAL_VECTOR(dynamicsResidual, zeroRes);
-    }
-
+    ASSERT_EQUAL_VECTOR(dynamicsResidual, zeroRes);
+    
     if( berdy.getNrOfSensorsMeasurements() > 0 )
     {
         std::cout << "BerdyHelperUnitTest, testing sensors matrix for model " << filename <<  std::endl;
@@ -439,7 +435,7 @@ void testBerdyHelpers(std::string fileName)
         std::cerr << "Skipping ORIGINAL_BERDY_FIXED_BASE tests for model " << fileName << " because some assumptions of ORIGINAL_BERDY_FIXED_BASE are not respected" << std::endl;
     }
 
-    /*// We test the floating base BERDY
+    // We test the floating base BERDY
     options.berdyVariant = iDynTree::BERDY_FLOATING_BASE;
     // For now floating berdy needs all the ext wrenches as dynamic variables
     options.includeAllNetExternalWrenchesAsDynamicVariables = true;
@@ -455,7 +451,7 @@ void testBerdyHelpers(std::string fileName)
     ok = berdyHelper.init(estimator.model(), estimator.sensors(), options);
     ASSERT_IS_TRUE(ok);
     testBerdySensorMatrices(berdyHelper, fileName);
-*/
+
     // We test the floating base BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES
     options.berdyVariant = iDynTree::BERDY_FLOATING_BASE_NON_COLLOCATED_EXT_WRENCHES;
     // Include Rate Of Change of Momentum
@@ -463,11 +459,11 @@ void testBerdyHelpers(std::string fileName)
     options.includeAllJointTorquesAsSensors = false;
     options.includeAllJointAccelerationsAsSensors = false;
     options.includeAllNetExternalWrenchesAsSensors = true;
-    //options.jointOnWhichTheInternalWrenchIsMeasured.clear();
+    options.includeAllNetExternalWrenchesAsDynamicVariables = true;
     ok = berdyHelper.init(estimator.model(), estimator.sensors(), options);
     ASSERT_IS_TRUE(ok);
     testBerdySensorMatrices(berdyHelper, fileName);
-    //std::cerr<<"OK DONE"<<std::endl;ASSERT_IS_TRUE(false);
+
 }
 
 int main()


### PR DESCRIPTION
This PR adds a new variant to the Berdy MAP Estimator for estimating the external wrenches acting on a multi-rigid body, which is the relation (25b) of https://ieeexplore.ieee.org/abstract/document/9526592.

The PR adds a new fictitious sensor for the Rate of Change of Momentum (RCM), which provides a new measurement for the berdy problem.

### ⚠️ WARNING
The Rate of Change of Momentum (RCM) should be computed in the CoM as per https://ieeexplore.ieee.org/abstract/document/9526592, but here the adjoint wrench transforms related to the RCM are not from the i-th link to the centroidal frame, but to the base one. For this reason `Y*d` will compute the sum of the estimated external wrenches transformed in the base frame, not the centroidal one. 

For this reason, the measurement of the fictitious sensor should account for the bias terms generated by this transformation. 