### PR TITLE
Do not emit a warning if a URDF file contain a sensor that is not parsed by iDynTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased Major]
 
+## [Unreleased]
+
+### Changed
+- No warning is printed if a sensor not supported by iDynTree is found in an URDF file (https://github.com/robotology/idyntree/pull/997).
+
 ## [5.2.1] - 2022-05-19
+
+### Fixed 
 - Fixed compatibility with YARP 3.7  (https://github.com/robotology/idyntree/pull/992).
 
 ## [5.2.0] - 2022-05-09

--- a/src/model_io/codecs/src/SensorElement.cpp
+++ b/src/model_io/codecs/src/SensorElement.cpp
@@ -96,7 +96,7 @@ namespace iDynTree {
         } else if (type == "force_torque") {
             m_info->m_sensorType = SIX_AXIS_FORCE_TORQUE;
         } else {
-            // See 
+            // See https://github.com/robotology/idyntree/pull/997
             // std::string message = "iDynTree does not support sensor of type " + type;
             // reportWarning("SensorElement", "setAttributes", message.c_str());
         }

--- a/src/model_io/codecs/src/SensorElement.cpp
+++ b/src/model_io/codecs/src/SensorElement.cpp
@@ -96,8 +96,9 @@ namespace iDynTree {
         } else if (type == "force_torque") {
             m_info->m_sensorType = SIX_AXIS_FORCE_TORQUE;
         } else {
-            std::string message = "iDynTree does not support sensor of type " + type;
-            reportWarning("SensorElement", "setAttributes", message.c_str());
+            // See 
+            // std::string message = "iDynTree does not support sensor of type " + type;
+            // reportWarning("SensorElement", "setAttributes", message.c_str());
         }
 
         return true;


### PR DESCRIPTION
URDF files can contain sensors of different types that are not supported by iDynTree, such as `depth` or `camera`. This is totally fine, and it does not make a lot of sense for users to get spam, as the URDF models are not used only with iDynTree and so they cannot remove those sensors from the model. 

Even if tipically I am against leaving unused uncommented code, in this case I left it as I think it help explains why nothing happens if a sensor is unsupported.
