### PR TITLE
Update documentation on IDYNTREE_USES_ASSIMP option

### DIFF
--- a/doc/build-from-source.md
+++ b/doc/build-from-source.md
@@ -12,7 +12,7 @@ In case they are disabled, tipically some functionality of iDynTree is not provi
 |:-----:|:-----------------:|:------------------------:|:-------------------------------:|:------------------------------------------:|
 | [Eigen](http://eigen.tuxfamily.org) | **Yes** |  n.a. | ✔️ | ✔️ |
 | [Libxml2](http://xmlsoft.org/) | **Yes** |  n.a.      | ✔️ | ✔️ |
-| [Assimp](http://www.assimp.org/) | No|  `IDYNTREE_USES_ASSIMP` | ❌ |  ❌ | 
+| [Assimp](http://www.assimp.org/) | No|  `IDYNTREE_USES_ASSIMP` | ✔️ |  ✔️ | 
 | [IPOPT](https://projects.coin-or.org/Ipopt) | No |  `IDYNTREE_USES_IPOPT` | ✔️ | ✔️ |
 | [irrlicht](http://irrlicht.sourceforge.net/) | No | `IDYNTREE_USES_IRRLICHT` | ✔️ | ✔️ |
 | [osqp-eigen](https://github.com/robotology/osqp-eigen) | No | `IDYNTREE_USES_OSQPEIGEN` | ✔️ | ✔️ |


### PR DESCRIPTION
The option is now enabled:
* in conda-forge packages https://github.com/conda-forge/idyntree-feedstock/pull/15
* in superbuild: https://github.com/robotology/robotology-superbuild/pull/918