### PR TITLE
Bump devel version to 5.100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 5.2.1
+project(iDynTree VERSION 5.100.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
https://github.com/robotology/idyntree/pull/991 changed the ABI and API, so we need to bump the minor version in view of a major bump version on release.