### PR TITLE
Move CI jobs from soon to be removed macos-10.15 to macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-latest]
         matlab_version: [R2020a, R2020b, R2021a, latest]
         exclude:
           # R2020* is not supported on Windows on GitHub Actions


### PR DESCRIPTION
`macos-10.15` will be removed soon, see https://github.com/actions/virtual-environments/issues/5583 . 
For this reason we move CI jobs to `macos-latest`. Note that in the past for macos we used fixed release images (i.e. `macos-10.15` instead of `macos-latest`) to reduce the mantainance burden, but as these images are frequently deprecated/removed, perhaps using `-latest` should actually reduce the mantainance burden.