### PR TITLE
Add function to extract a sub model object from a full model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a new Berdy variant that accounts for estimating the external link wrenches independently of the internal joint torque estimates (https://github.com/robotology/idyntree/pull/991).
+- Added creation of sub model object starting from the full model and a sub traversal (https://github.com/robotology/idyntree/pull/1011#pullrequestreview-1061418689)
 
 ### Changed
 - Changed signature of the method `BerdyHelper::serializeDynamicVariables` in order to serialize also the `RCM_SENSOR` (https://github.com/robotology/idyntree/pull/991).

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -84,6 +84,8 @@
 #include "iDynTree/Model/FreeFloatingState.h"
 #include "iDynTree/Model/ContactWrench.h"
 #include "iDynTree/Model/ModelTestUtils.h"
+#include "iDynTree/Model/ModelTransformers.h"
+#include "iDynTree/Model/SubModel.h"
 
 // Kinematics & Dynamics related functions
 #include "iDynTree/Model/ForwardKinematics.h"
@@ -250,6 +252,8 @@ namespace std {
 %include "iDynTree/Model/FreeFloatingState.h"
 %include "iDynTree/Model/ContactWrench.h"
 %include "iDynTree/Model/ModelTestUtils.h"
+%include "iDynTree/Model/ModelTransformers.h"
+%include "iDynTree/Model/SubModel.h"
 
 %include "joints.i"
 

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -833,13 +833,7 @@ int main()
     testModelConsistencyAllRepresentations("iCubGenova02.urdf");
     testModelConsistencyAllRepresentations("icalibrate.urdf");
 
-    testModelConsistencyAllRepresentations("oneLink.urdf");
-    testModelConsistencyAllRepresentations("twoLinks.urdf");
-    testSubModelConsistencyAllRepresentations("threeLinks.urdf");
-    testModelConsistencyAllRepresentations("bigman.urdf");
-    testModelConsistencyAllRepresentations("icub_skin_frames.urdf");
-    testModelConsistencyAllRepresentations("iCubGenova02.urdf");
-    testModelConsistencyAllRepresentations("icalibrate.urdf");
+    testSubModelConsistencyAllRepresentations("iCubGenova02.urdf");
 
     testSparsityPatternAllRepresentations("oneLink.urdf");
     testSparsityPatternAllRepresentations("twoLinks.urdf");

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -633,31 +633,23 @@ void testSubModelConsistency(std::string modelFilePath, const FrameVelocityRepre
 
             for(JointIndex jntIdx = 0; jntIdx < reducedModel.getNrOfJoints(); jntIdx++)
              {
-                // Check if it is not a fixed joint
-                if (reducedModel.getJoint(jntIdx)->getNrOfDOFs() > 0)
+                size_t posCoordsOffsetReducedModel = reducedModel.getJoint(jntIdx)->getPosCoordsOffset();
+                JointIndex jntIdxFullModel = idxJntReducedModelInFullModel(jntIdx);
+                size_t posCoordsOffsetFullModel = fullModel.getJoint(jntIdxFullModel)->getPosCoordsOffset();
+                for(size_t localPosCoords = 0; localPosCoords < reducedModel.getJoint(jntIdx)->getNrOfPosCoords(); localPosCoords ++)
                 {
-                    size_t posCoordsOffsetReducedModel = reducedModel.getJoint(jntIdx)->getPosCoordsOffset();
-                    JointIndex jntIdxFullModel = idxJntReducedModelInFullModel(jntIdx);
-                    size_t posCoordsOffsetFullModel = fullModel.getJoint(jntIdxFullModel)->getPosCoordsOffset();
-                    for(size_t localPosCoords = 0; localPosCoords < reducedModel.getJoint(jntIdx)->getNrOfPosCoords(); localPosCoords ++)
-                    {
-                        qReducedModel(posCoordsOffsetReducedModel+localPosCoords) = qjFullModel(posCoordsOffsetFullModel+localPosCoords);
-                    }
+                    qReducedModel(posCoordsOffsetReducedModel+localPosCoords) = qjFullModel(posCoordsOffsetFullModel+localPosCoords);
                 }
              }
 
             for(JointIndex jntIdx = 0; jntIdx < reducedModel.getNrOfJoints(); jntIdx++)
             {
-                // Check if it is not a fixed joint
-                if (reducedModel.getJoint(jntIdx)->getNrOfDOFs() > 0)
+                size_t dofsOffsetReducedModel = reducedModel.getJoint(jntIdx)->getDOFsOffset();
+                JointIndex jntIdxFullModel = idxJntReducedModelInFullModel(jntIdx);
+                size_t dofsOffsetFullModel = fullModel.getJoint(jntIdxFullModel)->getDOFsOffset();
+                for(size_t localDofs = 0; localDofs < reducedModel.getJoint(jntIdx)->getNrOfDOFs(); localDofs++)
                 {
-                    size_t dofsOffsetReducedModel = reducedModel.getJoint(jntIdx)->getDOFsOffset();
-                    JointIndex jntIdxFullModel = idxJntReducedModelInFullModel(jntIdx);
-                    size_t dofsOffsetFullModel = fullModel.getJoint(jntIdxFullModel)->getDOFsOffset();
-                    for(size_t localDofs = 0; localDofs < reducedModel.getJoint(jntIdx)->getNrOfDOFs(); localDofs++)
-                    {
-                        dqReducedModel(dofsOffsetReducedModel+localDofs ) = dqjFullModel(dofsOffsetFullModel+localDofs);
-                    }
+                    dqReducedModel(dofsOffsetReducedModel+localDofs ) = dqjFullModel(dofsOffsetFullModel+localDofs);
                 }
             }
 

--- a/src/model/include/iDynTree/Model/ModelTransformers.h
+++ b/src/model/include/iDynTree/Model/ModelTransformers.h
@@ -88,6 +88,20 @@ bool createModelWithNormalizedJointNumbering(const Model& model,
                                              Model& reducedModel);
 
 
+/**
+ * Extract sub model from sub model traversal.
+ *
+ * This function creates a new iDynTree::Model containing links and joints composing the subModelTraversal.
+ * The function takes in input a iDynTree::Model and a iDynTree::Traversal. The new model will contain joints
+ * and links composing the subModelTraversal, with the same order.
+ * The FT sensor frames are added as additional frames.
+ *
+ * @return true if all went well, false if there was an error in creating the sub model.
+ */
+bool extractSubModel(const iDynTree::Model& fullModel, const iDynTree::Traversal& subModelTraversal,
+                     iDynTree::Model& outputSubModel);
+
 }
+
 
 #endif

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -558,12 +558,6 @@ bool createModelWithNormalizedJointNumbering(const Model& model,
 bool extractSubModel(const iDynTree::Model& fullModel, const iDynTree::Traversal& subModelTraversal,
                      iDynTree::Model& outputSubModel)
 {
-    if (&subModelTraversal == NULL)
-    {
-        std::cerr << "[ERROR] subModelTraversal is null" << std::endl;
-        return false;
-    }
-
     size_t nrOfLinksInReducedModel = subModelTraversal.getNrOfVisitedLinks();
 
     LinkPositions subModelBase_X_link(fullModel);

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -555,4 +555,73 @@ bool createModelWithNormalizedJointNumbering(const Model& model,
 }
 
 
+bool extractSubModel(const iDynTree::Model& fullModel, const iDynTree::Traversal& subModelTraversal,
+                     iDynTree::Model& outputSubModel)
+{
+    if (&subModelTraversal == NULL)
+    {
+        std::cerr << "[ERROR] subModelTraversal is null" << std::endl;
+        return false;
+    }
+
+    size_t nrOfLinksInReducedModel = subModelTraversal.getNrOfVisitedLinks();
+
+    LinkPositions subModelBase_X_link(fullModel);
+
+    for (size_t subModelTraversalEl = 0; subModelTraversalEl < nrOfLinksInReducedModel; subModelTraversalEl++)
+    {
+        // Add the new link to the reducedModel
+
+        LinkConstPtr visitedLink = subModelTraversal.getLink(subModelTraversalEl);
+
+        outputSubModel.addLink(fullModel.getLinkName(visitedLink->getIndex()), *visitedLink);
+
+        bool isLinkBaseOfTreeTraversal = (subModelTraversalEl == 0);
+
+        if (!isLinkBaseOfTreeTraversal)
+        {
+            // Add the new joint to the reducedModel
+
+            IJointConstPtr visitedParentJoint = subModelTraversal.getParentJoint(subModelTraversalEl);
+
+            std::string jointName = fullModel.getJointName(visitedParentJoint->getIndex());
+
+            // We get the two links that the joint connects in the old
+            // full model
+            JointIndex fullModelJointIndex = fullModel.getJointIndex(jointName);
+
+            IJointConstPtr oldJoint = fullModel.getJoint(fullModelJointIndex);
+            const std::string link1 = fullModel.getLinkName(subModelTraversal.getParentLinkIndexFromJointIndex(fullModel, fullModelJointIndex));
+            const std::string link2 = fullModel.getLinkName(visitedLink->getIndex());
+
+            outputSubModel.addJoint(link1, link2, jointName, oldJoint);
+        }
+
+        auto visitedLinkIndex = visitedLink->getIndex();
+
+        // Add the additional frames
+        std::vector<FrameIndex> frameIndeces;
+        fullModel.getLinkAdditionalFrames(visitedLinkIndex, frameIndeces);
+
+        // For all the link of the submodel, transfer their additional frame
+        // to the link in the reduced model
+
+        for(size_t i = 0; i < frameIndeces.size(); i++)
+        {
+            FrameIndex additionalFrame = frameIndeces[i];
+            std::string additionalFrameName = fullModel.getFrameName(additionalFrame);
+
+            Transform visitedLink_H_additionalFrame  = fullModel.getFrameTransform(additionalFrame);
+            Transform subModelBase_H_visitedLink     = subModelBase_X_link(visitedLinkIndex);
+            Transform subModelBase_H_additionalFrame =
+                subModelBase_H_visitedLink*visitedLink_H_additionalFrame;
+
+            outputSubModel.addAdditionalFrameToLink(fullModel.getFrameName(visitedLinkIndex),
+                                                    additionalFrameName, subModelBase_H_additionalFrame);
+        }
+    }
+
+    return  true;
+}
+
 }


### PR DESCRIPTION
The PR implements the possibility to create a new `iDynTree::Model` containing links and joints composing the subModelTraversalstarting from a full model and a sub traversal of the full model. Therefore, the new model will contain joints and links composing the subModelTraversal, in the same order, and all the additional frames originally attached to considered links.