### PR TITLE
IK: Fix bug of updateRotationTarget/setRotationWeight that updated the PositionWeight instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix bug of `InverseKinematics::updateRotationTarget`  that did not actually changed the RotationWeight, but changed the PositionWeight instead (https://github.com/robotology/idyntree/pull/1012).
+
 ## [6.0.0] - 2022-07-19
 
 ### Added

--- a/src/inverse-kinematics/src/TransformConstraint.cpp
+++ b/src/inverse-kinematics/src/TransformConstraint.cpp
@@ -87,7 +87,7 @@ namespace kinematics {
     const double TransformConstraint::getPositionWeight() const { return m_posWeight; }
     void TransformConstraint::setPositionWeight(const double newPosWeight) { if (newPosWeight >= 0.0) m_posWeight = newPosWeight; }
     const double TransformConstraint::getRotationWeight() const { return m_rotWeight; }
-    void TransformConstraint::setRotationWeight(const double newRotWeight) { if (newRotWeight >= 0.0) m_posWeight = newRotWeight; }
+    void TransformConstraint::setRotationWeight(const double newRotWeight) { if (newRotWeight >= 0.0) m_rotWeight = newRotWeight; }
 
     void TransformConstraint::setTargetResolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraint mode){ m_resolutionMode = mode; }
     iDynTree::InverseKinematicsTreatTargetAsConstraint TransformConstraint::targetResolutionMode() const{ return m_resolutionMode; }


### PR DESCRIPTION
Fix bug spotted by @fedeceola in https://github.com/robotology/idyntree/issues/1003#issuecomment-1204893940 .