### PR TITLE
Fix compilation of SWIG Python extension against PyPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix compilation against PyPy (https://github.com/robotology/idyntree/pull/1018).
+
 ## [6.1.0] - 2022-08-18
 
 ### Added

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -23,6 +23,21 @@ set_property(
     TARGET ${target_name}
     PROPERTY SWIG_DEPENDS python.i numpy.i)
 
+if(WIN32)
+    set_target_properties(${target_name} PROPERTIES SUFFIX ".pyd")
+endif(WIN32)
+
+# Fix for PyPy
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23651
+# See https://github.com/conda-forge/idyntree-feedstock/pull/44
+if(Python3_INTERPRETER_ID STREQUAL "PyPy")
+    execute_process(COMMAND ${Python3_EXECUTABLE}
+                    -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+                    OUTPUT_VARIABLE IDYNTREE_PYTHON_EXT_SUFFIX)
+    string(STRIP ${IDYNTREE_PYTHON_EXT_SUFFIX} IDYNTREE_PYTHON_EXT_SUFFIX)
+    set_property (TARGET ${target_name} PROPERTY SUFFIX "${IDYNTREE_PYTHON_EXT_SUFFIX}")
+endif()
+
 if(NOT MSVC)
     set_property(
         TARGET ${target_name}
@@ -47,10 +62,6 @@ install(
     DIRECTORY visualize
     DESTINATION ${PYTHON_INSTDIR}
     COMPONENT python)
-
-if(WIN32)
-    set_target_properties(${target_name} PROPERTIES SUFFIX ".pyd")
-endif(WIN32)
 
 add_subdirectory(scripts)
 


### PR DESCRIPTION
I am not an expert in [PyPy](https://www.pypy.org/), and I am not aware of anyone using it. Anyhow, conda-forge automatically adds builds for it, and the fix was easy enough. 

In a nutshell, `pypy` does not support Python extensions with just the `.so`/`.pyd` extension, so it is necessary to have the full suggested extension (see https://github.com/conda-forge/idyntree-feedstock/pull/44#issuecomment-1228984029). For this reason, on PyPy we switched to use the full suggested extensions. In theory we should be able to use the same extension also for all other builds, but I am a bit afraid of unintended side effects, so for now we do this change just for PyPy .

I do not change anything on the pybind11 side as I assume (but I did not checked) that the `pybind11_add_module` macro does the right thing.

This was tested in https://github.com/conda-forge/idyntree-feedstock/pull/44 and it is working fine.

