### PR TITLE
Fix CMake warning that occured on Windows

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -54,6 +54,7 @@ if(IDYNTREE_USES_PYTHON OR IDYNTREE_USES_PYTHON_PYBIND11)
         string(STRIP ${_PYTHON_INSTDIR} IDYNTREE_PYTHON_INSTALL_DIR)
         set(PYTHON_INSTDIR ${IDYNTREE_PYTHON_INSTALL_DIR}/idyntree)
     endif()
+    file(TO_CMAKE_PATH "${PYTHON_INSTDIR}" PYTHON_INSTDIR)
 endif()
 
 # It is possible to compile matlab/octave bindings without using SWIG


### PR DESCRIPTION
In some cases, a CMake warning occured on Windows:
~~~
2022-08-28T14:10:16.9042524Z CMake Warning (dev) at bindings/python/cmake_install.cmake:52 (file):
2022-08-28T14:10:16.9043205Z   Syntax error in cmake code at
2022-08-28T14:10:16.9043566Z 
2022-08-28T14:10:16.9045631Z     D:/a/idyntree/idyntree/build/bindings/python/cmake_install.cmake:52
2022-08-28T14:10:16.9046088Z -- Installing: D:/a/idyntree/idyntree/build/${CMAKE_INSTALL_PREFIX}/Lib\site-packages/idyntree/visualize
2022-08-28T14:10:16.9046822Z 
2022-08-28T14:10:16.9048223Z   when parsing string
2022-08-28T14:10:16.9049367Z 
2022-08-28T14:10:16.9049817Z     ${CMAKE_INSTALL_PREFIX}/Lib\site-packages/idyntree
2022-08-28T14:10:16.9050164Z 
2022-08-28T14:10:16.9050411Z   Invalid escape sequence \s
2022-08-28T14:10:16.9050703Z 
2022-08-28T14:10:16.9051025Z   Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
2022-08-28T14:10:16.9051535Z   "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
2022-08-28T14:10:16.9052052Z   command to set the policy and suppress this warning.
2022-08-28T14:10:16.9052657Z -- Installing: D:/a/idyntree/idyntree/build/${CMAKE_INSTALL_PREFIX}/Lib\site-packages/idyntree/visualize/meshcat_visualizer.py
2022-08-28T14:10:16.9053302Z Call Stack (most recent call first):
2022-08-28T14:10:16.9053747Z   bindings/cmake_install.cmake:37 (include)
2022-08-28T14:10:16.9054484Z   cmake_install.cmake:87 (include)
2022-08-28T14:10:16.9054858Z This warning is for project developers.  Use -Wno-dev to suppress it.
~~~

Apparently this is due to the fact that sometimes the `PYTHON_INSTDIR` had the value `Lib\site-packages/idyntree`. Fixing it to have consistent directory separators fixes the warning and the installation location of the meshcat_visualizer .