### PR TITLE
Remove useless IDYNTREE_COMPILES_YARP_TOOLS

### DIFF
--- a/cmake/iDynTreeOptions.cmake
+++ b/cmake/iDynTreeOptions.cmake
@@ -44,7 +44,6 @@ endif()
 # Turn off compilation of specific parts of iDynTree.
 option(IDYNTREE_COMPILES_OPTIMALCONTROL "Compile iDynTree optimal control part." TRUE)
 option(IDYNTREE_COMPILES_TOOLS "Compile iDynTree tools." TRUE)
-option(IDYNTREE_COMPILES_YARP_TOOLS "Deprecated: Compile iDynTree tools that depend (also) on YARP." OFF)
 
 #########################################################################
 # Deal with RPATH


### PR DESCRIPTION
The option was actually removed in https://github.com/robotology/idyntree/pull/940, but the useless option renamed, this PR actually removes it.