### PR TITLE
Bump iDynTree version to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2022-08-31
+
 ### Fixed
 - Fix compilation against PyPy (https://github.com/robotology/idyntree/pull/1018).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 6.999.999
+project(iDynTree VERSION 7.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
https://github.com/robotology/idyntree/pull/1017 changed the ABI of a public structure, so we need to bump the major number according to iDynTree ABI versioning policy.