### PR TITLE
Disable ConsistencyTestiKin on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,8 @@ jobs:
         # Visualizer tests excluded as a workaround for https://github.com/robotology/idyntree/issues/808
         # Python tests excluded as a workaround for https://github.com/robotology/idyntree/issues/939
         # InverseKinematics tests are excluded as a workaround for https://github.com/robotology/idyntree/issues/1019
-        ctest --output-on-failure -C ${{ matrix.build_type }} -E "Visualizer|matlab|Python|pybind|InverseKinematics" .
+        # ConsistencyTestiKin tests are excluded as a workaround for https://github.com/robotology/idyntree/issues/1029
+        ctest --output-on-failure -C ${{ matrix.build_type }} -E "Visualizer|matlab|Python|pybind|InverseKinematics|ConsistencyTestiKin" .
 
     - name: Install [Conda]
       shell: bash -l {0}


### PR DESCRIPTION
The test is working fine locally, and if there is a regression it will be detected on other OSs . I think we can safely disable this test as a workaround for https://github.com/robotology/idyntree/issues/1029 .