### PR TITLE
Add the possibility to set the alpha channel in the meshcat viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added the possibility to set the alpha channel while loading a model in the meshcat visualizer (https://github.com/robotology/idyntree/pull/1033).
+
 ## [7.0.0] - 2022-08-31
 
 ### Fixed

--- a/bindings/python/scripts/idyntree-model-view-meshcat.py
+++ b/bindings/python/scripts/idyntree-model-view-meshcat.py
@@ -21,12 +21,13 @@ def main():
         description="Display the model in the meshcat visualizer."
     )
     parser.add_argument("--model", "-m", type=str, required=True, help="Model path.")
+    parser.add_argument("--alpha", "-a", type=float, required=False, help="Alpha channel of the model.")
 
     args = parser.parse_args()
 
     # Load the visualizer
     viz = MeshcatVisualizer()
-    viz.load_model_from_file(args.model)
+    viz.load_model_from_file(args.model, color=args.alpha)
     viz.open()
 
     run = True

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -158,8 +158,31 @@ class MeshcatVisualizer:
     def __primitive_geometry_exists(self, geometry_name: str):
         return geometry_name in self.primitive_geometries_names
 
+    def __get_color_from_shape(self, solid_shape, color):
+        if color is None:
+            mesh_color = solid_shape.getMaterial().color()
+        elif isinstance(color, float):
+            mesh_color = solid_shape.getMaterial().color()
+            mesh_color[3] = color
+        elif isinstance(color, list):
+            if len(color) == 4:
+                mesh_color = color
+            elif len(color) == 3:
+                mesh_color = color
+                mesh_color.append(1.0)
+            else:
+                mesh_color = [1.0, 1.0, 1.0, 1.0]
+                msg = "Not compatible color type. Please pass a list if you want to specify the rgb and the alpha or just a float to specify the alpha channel."
+                warnings.warn(msg, category=UserWarning, stacklevel=2)
+        else:
+            mesh_color = [1.0, 1.0, 1.0, 1.0]
+            msg = "Not compatible color type. Please pass a list if you want to specify the rgb and the alpha or just a float to specify the alpha channel."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+
+        return mesh_color
+
     def __add_model_geometry_to_viewer(
-        self, model_geometry: idyn.ModelSolidShapes, model_name: str, color: list
+        self, model_geometry: idyn.ModelSolidShapes, model_name: str, color
     ):
         import meshcat
 
@@ -223,12 +246,8 @@ class MeshcatVisualizer:
                     self.viewer[viewer_name].set_object(obj)
                 elif isinstance(obj, meshcat.geometry.Geometry):
                     material = meshcat.geometry.MeshPhongMaterial()
-                    # Set material color from URDF, converting for triplet of doubles to a single int.
-                    if color is None:
-                        mesh_color = solid_shape.getMaterial().color()
-                    else:
-                        mesh_color = color
 
+                    mesh_color = self.__get_color_from_shape(solid_shape, color)
                     material.color = (
                         int(mesh_color[0] * 255) * 256 ** 2
                         + int(mesh_color[1] * 255) * 256
@@ -347,12 +366,8 @@ class MeshcatVisualizer:
             self.viewer[viewer_name].set_object(obj)
         elif isinstance(obj, meshcat.geometry.Geometry):
             material = meshcat.geometry.MeshPhongMaterial()
-            # Set material color from URDF, converting for triplet of doubles to a single int.
-            if color is None:
-                mesh_color = solid_shape.getMaterial().color()
-            else:
-                mesh_color = color
 
+            mesh_color = self.__get_color_from_shape(solid_shape, color)
             material.color = (
                 int(mesh_color[0] * 255) * 256 ** 2
                 + int(mesh_color[1] * 255) * 256


### PR DESCRIPTION
If you want to use the idyntree-model-view-meshcat script with the alpha channel you can open a terminal and write
```console
idyntree-model-view-meshcat -m <model_path/model.urdf> -a 0.5
```

This will show the model with an alpha equal to `0.5` as follows 

![image](https://user-images.githubusercontent.com/16744101/197762430-05fb1fe8-baeb-456a-a11e-489b259f7882.png)

In general, you can now load the urdf as
```python
model_path = "model.urdf"
viz.load_model_from_file(model_path)  # in this case the color is retrieved from the urdf.
viz.load_model_from_file(model_path, color=0.5) # in this case the color is retrieved from the urdf but the alpha is set to 0.5 .
viz.load_model_from_file(model_path, color=[1,0,0,0.5]) # in this case the color is set to be [1,0,0] (RGB format) and the  alpha is set to 0.5.
viz.load_model_from_file(model_path, color=[1,0,0]) # in this case the color is set to be [1,0,0] (RGB format) and the  alpha is set to 1 (no transparency).
```


cc @rob-mau @Giulero  
