### PR TITLE
Add the possibility to pass the list containing the mesh path while building the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added the possibility to set the alpha channel while loading a model in the meshcat visualizer (https://github.com/robotology/idyntree/pull/1033).
+- Add the possibility to pass the list containing the mesh path while building the model (https://github.com/robotology/idyntree/pull/1036).
 
 ## [7.0.0] - 2022-08-31
 

--- a/src/model/include/iDynTree/Model/Model.h
+++ b/src/model/include/iDynTree/Model/Model.h
@@ -160,12 +160,6 @@ namespace iDynTree
         Model();
 
         /**
-         * Costructor
-         * @param packageDirs A vector of string containing the path to the directories of the meshes
-         */
-        Model(const std::vector<std::string>& packageDirs);
-
-        /**
          * Copy costructor
          */
         Model(const Model & other);
@@ -197,6 +191,8 @@ namespace iDynTree
          * @return a vector containing all the directories of the meshes
          */
         const std::vector<std::string>& getPackageDirs() const;
+
+        void setPackageDirs(const std::vector<std::string>& packageDirs);
 
         /**
          * Get the name of a link given its index, or

--- a/src/model/include/iDynTree/Model/Model.h
+++ b/src/model/include/iDynTree/Model/Model.h
@@ -19,6 +19,7 @@
 #include <iDynTree/Model/SolidShapes.h>
 
 #include <cstdlib>
+#include <string>
 #include <vector>
 
 namespace iDynTree
@@ -110,6 +111,9 @@ namespace iDynTree
             and the joint connecting to them. */
         std::vector< std::vector<Neighbor> > neighbors;
 
+        /** Vector containing the package directories associated to the model. */
+        std::vector<std::string> packageDirs;
+
         /**
          * Most data structures are not undirected, so we store the original
          * root of the tree, to provide a default root for Traversal generation.
@@ -156,6 +160,12 @@ namespace iDynTree
         Model();
 
         /**
+         * Costructor
+         * @param packageDirs A vector of string containing the path to the directories of the meshes
+         */
+        Model(const std::vector<std::string>& packageDirs);
+
+        /**
          * Copy costructor
          */
         Model(const Model & other);
@@ -182,6 +192,11 @@ namespace iDynTree
          * Get the number of links in the model.
          */
         size_t getNrOfLinks() const;
+
+        /**
+         * @return a vector containing all the directories of the meshes
+         */
+        const std::vector<std::string>& getPackageDirs() const;
 
         /**
          * Get the name of a link given its index, or

--- a/src/model/include/iDynTree/Model/SolidShapes.h
+++ b/src/model/include/iDynTree/Model/SolidShapes.h
@@ -241,9 +241,15 @@ namespace iDynTree
         const std::string& getFilename() const;
 
         /**
+         * Returns the current package directories.
+         */
+        const std::vector<std::string>& getPackageDirs() const;
+
+        /**
          * Returns the filename substituting the prefix "package://" with the corresponding absolute path.
          * The absolute path is determined by searching for the file using the paths specified in the
-         * "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and "AMENT_PREFIX_PATH" environmental variables.
+         * packageDirs vector or if empty in the "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and
+         * "AMENT_PREFIX_PATH" environmental variables.
          */
         std::string getFileLocationOnLocalFileSystem() const;
 
@@ -251,6 +257,14 @@ namespace iDynTree
          * Sets the filename.
          */
         void setFilename(const std::string& filename);
+
+        /**
+         * Sets the the package directories.
+         * @note if not set the absolute path is determined by searching for the file using the
+         * paths specified in the "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and "AMENT_PREFIX_PATH"
+         * environmental variables.
+         */
+        void setPackageDirs(const std::vector<std::string>& packageDirs);
 
         /**
          * Returns the current scale.
@@ -264,6 +278,7 @@ namespace iDynTree
 
     private:
         std::string filename;
+        std::vector<std::string> packageDirs;
         iDynTree::Vector3 scale;
     };
 

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -10,6 +10,7 @@
 
 #include <iDynTree/Model/Model.h>
 #include <iDynTree/Model/Traversal.h>
+#include <iDynTree/Model/SolidShapes.h>
 
 #include <iDynTree/Core/VectorDynSize.h>
 #include <iDynTree/Core/EigenHelpers.h>
@@ -19,6 +20,7 @@
 #include <sstream>
 #include <string>
 
+
 namespace iDynTree
 {
 
@@ -26,15 +28,6 @@ Model::Model()
     : defaultBaseLink(LINK_INVALID_INDEX)
     , nrOfPosCoords(0)
     , nrOfDOFs(0)
-{
-
-}
-
-Model::Model(const std::vector<std::string>& packageDirs)
-    : defaultBaseLink(LINK_INVALID_INDEX)
-    , nrOfPosCoords(0)
-    , nrOfDOFs(0)
-    , packageDirs(packageDirs)
 {
 
 }
@@ -129,6 +122,29 @@ Model Model::copy() const
 const std::vector<std::string>& Model::getPackageDirs() const
 {
     return this->packageDirs;
+}
+
+void Model::setPackageDirs(const std::vector<std::string>& packageDirs)
+{
+    this->packageDirs = packageDirs;
+
+    auto updatePackageDirs = [this](ModelSolidShapes& modelShapes) -> void
+                             {
+                                 for (auto& shapes : modelShapes.getLinkSolidShapes())
+                                 {
+                                     for (auto& shape : shapes)
+                                     {
+                                         if (shape != nullptr && shape->isExternalMesh())
+                                         {
+                                             shape->asExternalMesh()->setPackageDirs(this->packageDirs);
+                                         }
+                                     }
+                                 }
+
+                             };
+
+    updatePackageDirs(this->collisionSolidShapes());
+    updatePackageDirs(this->visualSolidShapes());
 }
 
 size_t Model::getNrOfLinks() const

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -17,11 +17,24 @@
 #include <cassert>
 #include <deque>
 #include <sstream>
+#include <string>
 
 namespace iDynTree
 {
 
-Model::Model(): defaultBaseLink(LINK_INVALID_INDEX), nrOfPosCoords(0), nrOfDOFs(0)
+Model::Model()
+    : defaultBaseLink(LINK_INVALID_INDEX)
+    , nrOfPosCoords(0)
+    , nrOfDOFs(0)
+{
+
+}
+
+Model::Model(const std::vector<std::string>& packageDirs)
+    : defaultBaseLink(LINK_INVALID_INDEX)
+    , nrOfPosCoords(0)
+    , nrOfDOFs(0)
+    , packageDirs(packageDirs)
 {
 
 }
@@ -30,6 +43,8 @@ void Model::copy(const Model& other)
 {
     // reset the base link, the real one will be copied later
     this->defaultBaseLink = LINK_INVALID_INDEX;
+
+    this->packageDirs = other.packageDirs;
 
     // Add all the links, preserving the numbering
     for(unsigned int lnk=0; lnk < other.getNrOfLinks(); lnk++ )
@@ -98,6 +113,7 @@ void Model::destroy()
     additionalFramesLinks.resize(0);
     frameNames.resize(0);
     neighbors.resize(0);
+    packageDirs.clear();
 }
 
 Model::~Model()
@@ -108,6 +124,11 @@ Model::~Model()
 Model Model::copy() const
 {
     return Model(*this);
+}
+
+const std::vector<std::string>& Model::getPackageDirs() const
+{
+    return this->packageDirs;
 }
 
 size_t Model::getNrOfLinks() const

--- a/src/model_io/codecs/include/iDynTree/ModelIO/ModelLoader.h
+++ b/src/model_io/codecs/include/iDynTree/ModelIO/ModelLoader.h
@@ -109,6 +109,11 @@ public:
      * @param modelString string containg the model of the robot.
      * @param filetype type of the file to load, currently supporting only urdf type
      * @param packageDirs a vector containing the different directories where to search for model meshes
+     * @note In case no package is specified ModelLoader will look for the meshes in `GAZEBO_MODEL_PATH`,
+     * `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * @note If a given model searches for the meshes in `package://StrangeModel/Nested/mesh.stl`,
+     * and the actual mesh is in `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs`
+     * should contain `/usr/local/share`.
      */
     bool loadModelFromString(const std::string & modelString,
                              const std::string & filetype="urdf",
@@ -120,6 +125,11 @@ public:
      * @param filename path to the file to load
      * @param filetype type of the file to load, currently supporting only urdf type.
      * @param packageDirs a vector containing the different directories where to search for model meshes
+     * @note In case no package is specified ModelLoader will look for the meshes in `GAZEBO_MODEL_PATH`,
+     * `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * @note If a given model searches for the meshes in `package://StrangeModel/Nested/mesh.stl`,
+     * and the actual mesh is in `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs`
+     * should contain `/usr/local/share`.
      */
     bool loadModelFromFile(const std::string & filename,
                            const std::string & filetype="urdf",
@@ -161,6 +171,11 @@ public:
      *                        search for model meshes
      * @return true if all went well (files were correctly loaded and consistent), false otherwise.
      *
+     * @note In case no package is specified ModelLoader will look for the meshes in `GAZEBO_MODEL_PATH`,
+     * `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * @note If a given model searches for the meshes in `package://StrangeModel/Nested/mesh.stl`,
+     * and the actual mesh is in `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs`
+     * should contain `/usr/local/share`.
      *
      */
     bool loadReducedModelFromString(const std::string modelString,
@@ -182,7 +197,11 @@ public:
      *                        search for model meshes
      * @return true if all went well (files were correctly loaded and consistent), false otherwise.
      *
-     *
+     * @note In case no package is specified ModelLoader will look for the meshes in `GAZEBO_MODEL_PATH`,
+     * `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * @note If a given model searches for the meshes in `package://StrangeModel/Nested/mesh.stl`,
+     * and the actual mesh is in `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs`
+     * should contain `/usr/local/share`.
      */
     bool loadReducedModelFromFile(const std::string filename,
                                   const std::vector<std::string> & consideredJoints,

--- a/src/model_io/codecs/include/iDynTree/ModelIO/ModelLoader.h
+++ b/src/model_io/codecs/include/iDynTree/ModelIO/ModelLoader.h
@@ -107,19 +107,23 @@ public:
      * Load the model of the robot  from a string.
      *
      * @param modelString string containg the model of the robot.
-     * @param filetype type of the file to load, currently supporting only urdf type.
-     *
+     * @param filetype type of the file to load, currently supporting only urdf type
+     * @param packageDirs a vector containing the different directories where to search for model meshes
      */
-    bool loadModelFromString(const std::string & modelString, const std::string & filetype="urdf");
+    bool loadModelFromString(const std::string & modelString,
+                             const std::string & filetype="urdf",
+                             const std::vector<std::string>& packageDirs = {});
 
     /**
      * Load the model of the robot from an external file.
      *
      * @param filename path to the file to load
      * @param filetype type of the file to load, currently supporting only urdf type.
-     *
+     * @param packageDirs a vector containing the different directories where to search for model meshes
      */
-    bool loadModelFromFile(const std::string & filename, const std::string & filetype="urdf");
+    bool loadModelFromFile(const std::string & filename,
+                           const std::string & filetype="urdf",
+                           const std::vector<std::string>& packageDirs = {});
 
     /**
      * Load reduced model from another model, specifyng only the desired joints in the model.
@@ -153,13 +157,16 @@ public:
      * @param[in] consideredJoints list of joints to consider in the model.
      * @param[in] filetype (optional) explicit definiton of the filetype to load.
      *                     Only "urdf" is supported at the moment.
+     * @param[in] packageDirs (optional) a vector containing the different directories where to
+     *                        search for model meshes
      * @return true if all went well (files were correctly loaded and consistent), false otherwise.
      *
      *
      */
     bool loadReducedModelFromString(const std::string modelString,
                                     const std::vector<std::string> & consideredJoints,
-                                    const std::string filetype="");
+                                    const std::string filetype="",
+                                    const std::vector<std::string>& packageDirs = {});
 
     /**
      * Load reduced model from file, specifyng only the desired joints in the model.
@@ -171,13 +178,16 @@ public:
      * @param[in] consideredJoints list of joints to consider in the model.
      * @param[in] filetype (optional) explicit definiton of the filetype to load.
      *                     Only "urdf" is supported at the moment.
+     * @param[in] packageDirs (optional) a vector containing the different directories where to
+     *                        search for model meshes
      * @return true if all went well (files were correctly loaded and consistent), false otherwise.
      *
      *
      */
     bool loadReducedModelFromFile(const std::string filename,
                                   const std::vector<std::string> & consideredJoints,
-                                  const std::string filetype="");
+                                  const std::string filetype="",
+                                  const std::vector<std::string>& packageDirs = {});
 
     /**
      * Get the loaded model.

--- a/src/model_io/codecs/include/private/GeometryElement.h
+++ b/src/model_io/codecs/include/private/GeometryElement.h
@@ -14,6 +14,7 @@
 #define IDYNTREE_MODELIO_URDF_GEOMETRYELEMENT_H
 
 #include <iDynTree/XMLElement.h>
+#include <vector>
 
 namespace iDynTree {
     class GeometryElement;
@@ -24,9 +25,9 @@ namespace iDynTree {
 class iDynTree::GeometryElement: public iDynTree::XMLElement {
 private:
     std::shared_ptr<SolidShape>& m_shape;
-    
+    const std::vector<std::string>& packageDirs;
 public:
-    GeometryElement(std::shared_ptr<SolidShape>& shape);
+    GeometryElement(std::shared_ptr<SolidShape>& shape, const std::vector<std::string>& packageDirs);
 
     std::shared_ptr<iDynTree::XMLElement> childElementForName(const std::string& name) override;
 };

--- a/src/model_io/codecs/include/private/URDFDocument.h
+++ b/src/model_io/codecs/include/private/URDFDocument.h
@@ -60,7 +60,8 @@ public:
     const iDynTree::Model& model() const;
     const iDynTree::SensorsList& sensors() const;
     
-    std::shared_ptr<XMLElement> rootElementForName(const std::string& name) override;
+    std::shared_ptr<XMLElement> rootElementForName(const std::string& name,
+                                                   const std::vector<std::string>& packageDirs) override;
     bool documentHasBeenParsed() override;
 };
 

--- a/src/model_io/codecs/include/private/VisualElement.h
+++ b/src/model_io/codecs/include/private/VisualElement.h
@@ -40,13 +40,16 @@ public:
         iDynTree::Transform m_origin{iDynTree::Transform::Identity()};
         std::shared_ptr<SolidShape> m_solidShape;
         std::shared_ptr<MaterialElement::MaterialInfo> m_material;
+        const std::vector<std::string>& m_packageDirs;
+
+        VisualInfo(const std::vector<std::string>& packageDirs);
     };
 
 private:
     VisualInfo m_info;
 
 public:
-    VisualElement(const std::string& name);
+    VisualElement(const std::string& name, const std::vector<std::string>& packageDirs);
 
     const VisualInfo& visualInfo() const;
 

--- a/src/model_io/codecs/src/GeometryElement.cpp
+++ b/src/model_io/codecs/src/GeometryElement.cpp
@@ -20,9 +20,10 @@
 
 namespace iDynTree{
 
-    GeometryElement::GeometryElement(std::shared_ptr<SolidShape>& shape)
+    GeometryElement::GeometryElement(std::shared_ptr<SolidShape>& shape, const std::vector<std::string>& packageDirs)
     : iDynTree::XMLElement("geometry")
-    , m_shape(shape) {}
+    , m_shape(shape)
+    , packageDirs(packageDirs) {}
 
     std::shared_ptr<iDynTree::XMLElement> GeometryElement::childElementForName(const std::string& name)
     {
@@ -111,6 +112,7 @@ namespace iDynTree{
                     // https://github.com/bulletphysics/bullet3/tree/master/data
                     ExternalMesh * externalMesh = new ExternalMesh();
                     externalMesh->setFilename(found->second->value());
+                    externalMesh->setPackageDirs(this->packageDirs);
                     //                    pExternalMesh->filename = getURDFMeshAbsolutePathFilename(urdf_filename,localName);
                     iDynTree::Vector3 scale;
                     scale(0) = scale(1) = scale(2) = 1.0;

--- a/src/model_io/codecs/src/LinkElement.cpp
+++ b/src/model_io/codecs/src/LinkElement.cpp
@@ -55,9 +55,9 @@ namespace iDynTree {
         if (name == "inertial") {
             return std::make_shared<InertialElement>(m_link);
         } else if (name == "visual") {
-            return std::make_shared<VisualElement>("visual");
+            return std::make_shared<VisualElement>("visual", m_model.getPackageDirs());
         } else if (name == "collision") {
-            return std::make_shared<VisualElement>("collision");
+            return std::make_shared<VisualElement>("collision", m_model.getPackageDirs());
         }
         return std::make_shared<iDynTree::XMLElement>(name);
     }

--- a/src/model_io/codecs/src/ModelLoader.cpp
+++ b/src/model_io/codecs/src/ModelLoader.cpp
@@ -89,11 +89,13 @@ namespace iDynTree
     }
 
     bool ModelLoader::loadModelFromFile(const std::string& filename,
-                                        const std::string& /*filetype*/)
+                                        const std::string& /*filetype*/,
+                                        const std::vector<std::string>& packageDirs /* = {} */)
     {
         // Allocate parser
         std::shared_ptr<XMLParser> parser = std::make_shared<XMLParser>();
         parser->setDocumentFactory([]{ return std::shared_ptr<XMLDocument>(new URDFDocument); });
+        parser->setPackageDirs(packageDirs);
         if (!parser->parseXMLFile(filename)) {
             reportError("ModelLoader", "loadModelFromFile", "Error in parsing model from URDF.");
             return false;
@@ -110,11 +112,13 @@ namespace iDynTree
     }
 
     bool ModelLoader::loadModelFromString(const std::string& modelString,
-                                          const std::string& /*filetype*/)
+                                          const std::string& /*filetype*/,
+                                          const std::vector<std::string>& packageDirs /* = {} */)
     {
         // Allocate parser
         std::shared_ptr<XMLParser> parser = std::make_shared<XMLParser>();
         parser->setDocumentFactory([]{ return std::shared_ptr<XMLDocument>(new URDFDocument); });
+        parser->setPackageDirs(packageDirs);
         if (!parser->parseXMLString(modelString)) {
             reportError("ModelLoader", "loadModelFromString", "Error in parsing model from URDF.");
             return false;
@@ -135,7 +139,7 @@ namespace iDynTree
                                                     const std::string /*filetype*/)
     {
         SensorsList _sensorsFull, _sensorsReduced;
-        Model _modelReduced;
+        Model _modelReduced(fullModel.getPackageDirs());
         bool ok = createReducedModelAndSensors(fullModel,_sensorsFull,consideredJoints,_modelReduced,_sensorsReduced);
 
         if( !ok )
@@ -148,12 +152,13 @@ namespace iDynTree
 
     bool ModelLoader::loadReducedModelFromString(const std::string modelString,
                                                  const std::vector< std::string >& consideredJoints,
-                                                 const std::string /*filetype*/)
+                                                 const std::string filetype,
+                                                 const std::vector<std::string>& packageDirs /*= {}*/)
     {
-        bool parsingCorrect = loadModelFromString(modelString);
+        bool parsingCorrect = loadModelFromString(modelString, filetype, packageDirs);
         if (!parsingCorrect) return false;
         SensorsList _sensorsFull = m_pimpl->m_sensors, _sensorsReduced;
-        Model _modelFull = m_pimpl->m_model, _modelReduced;
+        Model _modelFull = m_pimpl->m_model, _modelReduced(packageDirs);
 
         parsingCorrect = createReducedModelAndSensors(_modelFull, _sensorsFull,
                                                       consideredJoints,
@@ -169,12 +174,13 @@ namespace iDynTree
 
     bool ModelLoader::loadReducedModelFromFile(const std::string filename,
                                                const std::vector< std::string >& consideredJoints,
-                                               const std::string /*filetype*/)
+                                               const std::string filetype,
+                                               const std::vector<std::string>& packageDirs /*= {}*/)
     {
-        bool parsingCorrect = loadModelFromFile(filename);
+        bool parsingCorrect = loadModelFromFile(filename, filetype, packageDirs);
         if (!parsingCorrect) return false;
         SensorsList _sensorsFull = m_pimpl->m_sensors, _sensorsReduced;
-        Model _modelFull = m_pimpl->m_model, _modelReduced;
+        Model _modelFull = m_pimpl->m_model, _modelReduced(packageDirs);
 
         parsingCorrect = createReducedModelAndSensors(_modelFull,_sensorsFull,consideredJoints,_modelReduced,_sensorsReduced);
 

--- a/src/model_io/codecs/src/ModelLoader.cpp
+++ b/src/model_io/codecs/src/ModelLoader.cpp
@@ -139,7 +139,8 @@ namespace iDynTree
                                                     const std::string /*filetype*/)
     {
         SensorsList _sensorsFull, _sensorsReduced;
-        Model _modelReduced(fullModel.getPackageDirs());
+        Model _modelReduced;
+        _modelReduced.setPackageDirs(fullModel.getPackageDirs());
         bool ok = createReducedModelAndSensors(fullModel,_sensorsFull,consideredJoints,_modelReduced,_sensorsReduced);
 
         if( !ok )
@@ -158,7 +159,8 @@ namespace iDynTree
         bool parsingCorrect = loadModelFromString(modelString, filetype, packageDirs);
         if (!parsingCorrect) return false;
         SensorsList _sensorsFull = m_pimpl->m_sensors, _sensorsReduced;
-        Model _modelFull = m_pimpl->m_model, _modelReduced(packageDirs);
+        Model _modelFull = m_pimpl->m_model, _modelReduced;
+        _modelReduced.setPackageDirs(packageDirs);
 
         parsingCorrect = createReducedModelAndSensors(_modelFull, _sensorsFull,
                                                       consideredJoints,
@@ -180,7 +182,8 @@ namespace iDynTree
         bool parsingCorrect = loadModelFromFile(filename, filetype, packageDirs);
         if (!parsingCorrect) return false;
         SensorsList _sensorsFull = m_pimpl->m_sensors, _sensorsReduced;
-        Model _modelFull = m_pimpl->m_model, _modelReduced(packageDirs);
+        Model _modelFull = m_pimpl->m_model, _modelReduced;
+        _modelReduced.setPackageDirs(packageDirs);
 
         parsingCorrect = createReducedModelAndSensors(_modelFull,_sensorsFull,consideredJoints,_modelReduced,_sensorsReduced);
 

--- a/src/model_io/codecs/src/URDFDocument.cpp
+++ b/src/model_io/codecs/src/URDFDocument.cpp
@@ -60,7 +60,8 @@ namespace iDynTree {
     {
         // allowed tag is <robot>
         if (name == "robot") {
-            m_model = iDynTree::Model(packageDirs);
+            m_model = iDynTree::Model();
+            m_model.setPackageDirs(packageDirs);
             m_buffers.sensorHelpers.clear();
             m_buffers.joints.clear();
             m_buffers.fixedJoints.clear();
@@ -120,7 +121,9 @@ namespace iDynTree {
 
         // set the default root in the model
         m_model.setDefaultBaseLink(m_model.getLinkIndex(rootCandidates[0]));
-        iDynTree::Model newModel(m_model.getPackageDirs()), normalizedModel(m_model.getPackageDirs());
+        iDynTree::Model newModel, normalizedModel;
+        newModel.setPackageDirs(m_model.getPackageDirs());
+        normalizedModel.setPackageDirs(m_model.getPackageDirs());
 
         if (!removeFakeLinks(m_model, newModel)) {
             reportError("URDFDocument", "documentHasBeenParsed", "Failed to remove fake links from the model");

--- a/src/model_io/codecs/src/URDFDocument.cpp
+++ b/src/model_io/codecs/src/URDFDocument.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <unordered_set>
+#include <vector>
 
 namespace iDynTree {
 
@@ -54,11 +55,12 @@ namespace iDynTree {
     }
     
     URDFDocument::~URDFDocument() {}
-    std::shared_ptr<XMLElement> URDFDocument::rootElementForName(const std::string& name)
+    std::shared_ptr<XMLElement> URDFDocument::rootElementForName(const std::string& name,
+                                                                 const std::vector<std::string>& packageDirs)
     {
         // allowed tag is <robot>
         if (name == "robot") {
-            m_model = iDynTree::Model();
+            m_model = iDynTree::Model(packageDirs);
             m_buffers.sensorHelpers.clear();
             m_buffers.joints.clear();
             m_buffers.fixedJoints.clear();
@@ -118,7 +120,7 @@ namespace iDynTree {
 
         // set the default root in the model
         m_model.setDefaultBaseLink(m_model.getLinkIndex(rootCandidates[0]));
-        iDynTree::Model newModel, normalizedModel;
+        iDynTree::Model newModel(m_model.getPackageDirs()), normalizedModel(m_model.getPackageDirs());
 
         if (!removeFakeLinks(m_model, newModel)) {
             reportError("URDFDocument", "documentHasBeenParsed", "Failed to remove fake links from the model");
@@ -148,7 +150,6 @@ namespace iDynTree {
         }
 
         // Assign visual properties to objects
-
         if (!addVisualPropertiesToModel(m_model,
                                         m_buffers.visuals,
                                         m_buffers.materials,

--- a/src/model_io/codecs/src/VisualElement.cpp
+++ b/src/model_io/codecs/src/VisualElement.cpp
@@ -21,8 +21,16 @@
 
 namespace iDynTree {
 
-    VisualElement::VisualElement(const std::string& name)
-    : iDynTree::XMLElement(name){}
+    iDynTree::VisualElement::VisualInfo::VisualInfo(const std::vector<std::string>& packageDirs)
+        : m_packageDirs(packageDirs)
+    {
+    }
+
+    VisualElement::VisualElement(const std::string& name, const std::vector<std::string>& packageDirs)
+    : iDynTree::XMLElement(name)
+    , m_info(packageDirs)
+    {
+    }
 
     const VisualElement::VisualInfo& VisualElement::visualInfo() const
     {
@@ -46,7 +54,7 @@ namespace iDynTree {
         if (name == "origin") {
             return std::make_shared<OriginElement>(m_info.m_origin);
         } else if (name == "geometry") {
-            return std::make_shared<GeometryElement>(m_info.m_solidShape);
+            return std::make_shared<GeometryElement>(m_info.m_solidShape, m_info.m_packageDirs);
         } else if (name == "material") {
             auto ptr = std::make_shared<MaterialElement>(nullptr);
             m_info.m_material = ptr->materialInfo();

--- a/src/model_io/xml/include/iDynTree/XMLDocument.h
+++ b/src/model_io/xml/include/iDynTree/XMLDocument.h
@@ -14,6 +14,7 @@
 #define IDYNTREE_MODELIO_XML_XMLDOCUMENT_H
 
 #include <memory>
+#include <vector>
 #include <string>
 
 namespace iDynTree {
@@ -40,7 +41,8 @@ public:
      * @param name name of the element to create
      * @return a new parser element for the corresponding tag
      */
-    virtual std::shared_ptr<XMLElement> rootElementForName(const std::string& name);
+    virtual std::shared_ptr<XMLElement> rootElementForName(const std::string& name,
+                                                           const std::vector<std::string>& packageDirs);
 
     // TODO: find a better name
     virtual bool documentHasBeenParsed();

--- a/src/model_io/xml/include/iDynTree/XMLParser.h
+++ b/src/model_io/xml/include/iDynTree/XMLParser.h
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 #include <string>
 #include <unordered_map>
 
@@ -98,6 +99,10 @@ public:
      * @param keepTreeInMemory true if the tree should be kept in memory.
      */
     void setKeepTreeInMemory(bool keepTreeInMemory);
+
+
+    void setPackageDirs(const std::vector<std::string>& packageDirs);
+    const std::vector<std::string>& packageDirs() const;
 
     /**
      * Returns true if the parser logs the parsing to standard output.

--- a/src/model_io/xml/src/XMLDocument.cpp
+++ b/src/model_io/xml/src/XMLDocument.cpp
@@ -39,7 +39,8 @@ namespace iDynTree {
         return m_pimpl->m_root;
     }
     
-    std::shared_ptr<XMLElement> XMLDocument::rootElementForName(const std::string& name)
+    std::shared_ptr<XMLElement> XMLDocument::rootElementForName(const std::string& name,
+                                                                const std::vector<std::string>& packageDirs)
     {
         return std::make_shared<XMLElement>(name);
     }

--- a/src/model_io/xml/src/XMLParser.cpp
+++ b/src/model_io/xml/src/XMLParser.cpp
@@ -67,7 +67,8 @@ namespace iDynTree {
         bool m_logParsing;
         
         bool m_keepInMemory;
-        
+        std::vector<std::string> m_packageDirs;
+
     public:
         XMLParserPimpl() {
             // ???: SAX2 structure initialization is kept in PIMPL constructor
@@ -220,7 +221,8 @@ namespace iDynTree {
         // Document object
         if (state->m_pimpl->m_parsedTrace.empty()) {
             // it is the root
-            nextElement = state->m_pimpl->m_document->rootElementForName(localNameString);
+            nextElement = state->m_pimpl->m_document->rootElementForName(localNameString,
+                                                                         state->m_pimpl->m_packageDirs);
             if (state->m_pimpl->m_keepInMemory) {
                 state->m_pimpl->m_document->setRootElement(nextElement);
             }
@@ -389,6 +391,9 @@ namespace iDynTree {
     
     bool XMLParser::keepTreeInMemory() const { return m_pimpl->m_keepInMemory; }
     void XMLParser::setKeepTreeInMemory(bool keepTreeInMemory) { m_pimpl->m_keepInMemory = keepTreeInMemory; }
+
+    void XMLParser::setPackageDirs(const std::vector<std::string>& packageDirs) { m_pimpl->m_packageDirs = packageDirs; }
+    const std::vector<std::string>& XMLParser::packageDirs() const { return m_pimpl->m_packageDirs; }
 
 }
 


### PR DESCRIPTION
Currently, iDynTree loads the meshes searching inside the directories listed in some environment variables. i.e., `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`. This PR allows passing a list containing the mesh path while the urdf is loaded by the `ModelLoader` class. In case no package is specified iDynTree will look for the meshes in  `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH` as usual.

Pinocchio already supports this feature and I find it really useful for two possible reasons:
1. I recently added the support of iDynTree in `robot-descriptions` https://github.com/robot-descriptions/robot_descriptions.py/pull/21, this python package automatically clones the package containing the urdf of the robot and the meshes. With the current version of iDynTree, it is impossible to display the meshes if the package path is not added to `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH`, or `AMENT_PREFIX_PATH`. Thanks to this feature I can load the model and its meshes by specifying the package.
2. `robot-log-visualizer` currently supports only the robot stored in icub-models. I found this very limiting https://github.com/ami-iit/robot-log-visualizer/issues/35 a possible solution is to search for the model in `GAZEBO_MODEL_PATH` however as first mitigation I would give the user the possibility to specify the `urdf` path and the `package dirs` manually in one of the menus of the application. Thanks to this the visualizer can be easily used with other robots without changing the environment variables.

cc @traversaro 