### PR TITLE
Enable implicit conversion and change KinDynComputations holder in the iDynTree bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the possibility to set the alpha channel while loading a model in the meshcat visualizer (https://github.com/robotology/idyntree/pull/1033).
 - Add the possibility to pass the list containing the mesh path while building the model (https://github.com/robotology/idyntree/pull/1036).
+- Enable implicit conversion and change KinDynComputations holder in the iDynTree bindings (https://github.com/robotology/idyntree/pull/1037).
 
 ## [7.0.0] - 2022-08-31
 

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -1,8 +1,9 @@
 
 /* File : iDynTree.i */
 %module iDynTree
+#ifdef SWIGPYTHON
 %implicitconv;
-
+#endif
 
 %include "std_string.i"
 %include "std_vector.i"

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -6,7 +6,11 @@
 
 %include "std_string.i"
 %include "std_vector.i"
+
+// std::shared_ptr holder is currently supported only for python bindings
+#ifdef SWIGPYTHON
 %include "std_shared_ptr.i"
+#endif
 
 // Wrap the std::vector<std::string> params
 %template(StringVector) std::vector<std::string>;
@@ -301,7 +305,9 @@ namespace std {
 %include "iDynTree/InertialParametersSolidShapesHelpers.h"
 
 // High level interfaces
+#ifdef SWIGPYTHON
 %shared_ptr(iDynTree::KinDynComputations)
+#endif
 %include "iDynTree/KinDynComputations.h"
 
 #ifdef SWIGMATLAB

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -1,6 +1,8 @@
 
 /* File : iDynTree.i */
 %module iDynTree
+%implicitconv;
+
 
 %include "std_string.i"
 %include "std_vector.i"

--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -6,6 +6,7 @@
 
 %include "std_string.i"
 %include "std_vector.i"
+%include "std_shared_ptr.i"
 
 // Wrap the std::vector<std::string> params
 %template(StringVector) std::vector<std::string>;
@@ -300,6 +301,7 @@ namespace std {
 %include "iDynTree/InertialParametersSolidShapesHelpers.h"
 
 // High level interfaces
+%shared_ptr(iDynTree::KinDynComputations)
 %include "iDynTree/KinDynComputations.h"
 
 #ifdef SWIGMATLAB


### PR DESCRIPTION
As per the title, this PR changes the holder for KinDynComputations and enables the implicit conversion. The former allows the interoperability between iDynTree swig bindings and the blf pybind11 bindings. The latter simplifies calling methods that take as inputs vectors and/or matrices. For instance, now it is possible to call 
```python
import idyntree.swig as idyn

kindyn = idyn.KinDynComputations()
kindyn.setJointPos([1, 0, 1, 1, 1, 1, 1])
```

as you can notice it is not necessary to explicitly create an `iDynTree::VectorDynSize`
This latter modification should work also in Matlab and in theory, can simplify the implementation of the `idyntree high level wrappers`