### PR TITLE
Fix KinDynComputationsTutorial.py with latest changes in the Python API

### DIFF
--- a/examples/python/KinDynComputationsTutorial.py
+++ b/examples/python/KinDynComputationsTutorial.py
@@ -11,7 +11,7 @@ URDF in your system.
 import idyntree.bindings as iDynTree
 
 
-URDF_FILE = '../../src/tests/data/icub.urdf ';
+URDF_FILE = '../../src/tests/data/icub.urdf';
 
 dynComp = iDynTree.KinDynComputations();
 mdlLoader = iDynTree.ModelLoader();
@@ -23,22 +23,18 @@ print("The loaded model has", dynComp.model().getNrOfDOFs(), \
     "internal degrees of freedom and",dynComp.model().getNrOfLinks(),"links.")
 
 dofs = dynComp.model().getNrOfDOFs();
-s = iDynTree.VectorDynSize(dofs);
-ds = iDynTree.VectorDynSize(dofs);
-dds = iDynTree.VectorDynSize(dofs);
-for dof in range(dofs):
-    # For the sake of the example, we fill the joints vector with gibberish data (remember in any case
-    # that all quantities are expressed in radians-based units
-    s.setVal(dof, 1.0);
-    ds.setVal(dof, 0.4);
-    dds.setVal(dof, 0.3);
+
+# For the sake of the example, we fill the joints vector with gibberish data (remember in any case
+# that all quantities are expressed in radians-based units
+s = [1.0]*dofs
+ds = [0.4]*dofs
+dds = [0.3]*dofs
 
 
 # The gravity acceleration is a 3d acceleration vector.
-gravity = iDynTree.Vector3();
-gravity.zero();
-gravity.setVal(2, -9.81);
-dynComp.setRobotState(s,ds,gravity);
+g = [0.0, 0.0, -9.81]
+
+dynComp.setRobotState(s, ds, g)
 
 jac = iDynTree.MatrixDynSize(6,6+dofs);
 ok = dynComp.getFrameFreeFloatingJacobian("l_sole", jac);
@@ -56,8 +52,7 @@ else:
     print("Orientation between root_link and l_sole is\n" + str(root_R_sole.toNumPy()));
     print("In RPY format:\n" + str(root_R_sole.asRPY().toNumPy()))
 
-baseAcc = iDynTree.Vector6();
-baseAcc.zero();
+baseAcc = [0.0]*6
 links = dynComp.model().getNrOfLinks();
 regr = iDynTree.MatrixDynSize(6+dofs,10*links);
 ok = dynComp.inverseDynamicsInertialParametersRegressor(baseAcc, dds, regr);


### PR DESCRIPTION
Done what described in https://github.com/robotology/idyntree/pull/1037#issuecomment-1348174643 .

I also fixed the example that was not actually working due to a spurious space in `URDF_FILE`.