### PR TITLE
Release iDynTree 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0] - 2022-12-14
+
 ### Added
 - Added the possibility to set the alpha channel while loading a model in the meshcat visualizer (https://github.com/robotology/idyntree/pull/1033).
 - Add the possibility to pass the list containing the mesh path while building the model (https://github.com/robotology/idyntree/pull/1036).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 7.100.0
+project(iDynTree VERSION 8.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://pure.tue.nl/ws/portalfiles/portal/139293126/A_Multibody_Dynamics_Notatio
 
 To avoid confusion, it is also useful to clarify what **iDynTree is not**:
 * It is not the **fastest C++ library** for kinematics and dynamics multibody computations for robotics. It is not slow, but if have an application in which you need the absolute fastest library, check out [Pinocchio](https://github.com/stack-of-tasks/pinocchio).
-* It is not a **multibody simulator** library. It provides the building blocks that you could use to build a multibody simulator, but it is not a multibody simulator per se. If you need a simulator library in C++, check out [DART](https://dartsim.github.io/), [Simbody](https://github.com/simbody/simbody), [Drake](https://drake.mit.edu/), [MuJoCo](https://mujoco.org/) or the abstraction layer [`ignition-physics`](https://github.com/ignitionrobotics/ign-physics). If you need a simulator implemented in MATLAB/Simulink (built on iDynTree), check [`matlab-whole-body-simulator`](https://github.com/ami-iit/matlab-whole-body-simulator).
+* It is not a **multibody simulator** library. It provides the building blocks that you could use to build a multibody simulator, but it is not a multibody simulator per se. If you need a simulator library in C++, check out [DART](https://dartsim.github.io/), [Simbody](https://github.com/simbody/simbody), [Drake](https://drake.mit.edu/), [MuJoCo](https://mujoco.org/) or the abstraction layer [`Gazebo Physics`](https://github.com/gazebosim/gz-physics). If you need a simulator implemented in MATLAB/Simulink (built on iDynTree), check [`matlab-whole-body-simulator`](https://github.com/ami-iit/matlab-whole-body-simulator).
 
 
 ##  Contents


### PR DESCRIPTION
The major change bump was required by the ABI change in https://github.com/robotology/idyntree/pull/1036 .