### PR TITLE
Add basic error handling in the XML parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.999.0] - 2023-03-05
+
+### Changed
+The XML parser API has changed. Now an additional `XMLParserState` context object is propagated while parsing.
+To catch logic errors (which are not pure XML errors that are currently caught by the parser itself) the `XMLParserState` contains a `bool` variable. Further logic can be added to the context state.
+
+The following errors are currently check:
+- Duplicate joints in the URDF will cause an error.
+
+
 ## [8.1.0] - 2023-01-16
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 8.1.0
+project(iDynTree VERSION 8.999.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/model_io/codecs/include/private/ForceTorqueSensorElement.h
+++ b/src/model_io/codecs/include/private/ForceTorqueSensorElement.h
@@ -21,13 +21,16 @@ namespace iDynTree {
     class ForceTorqueSensorHelper;
 
     class XMLAttribute;
+    class XMLParserState;
 }
 
 class iDynTree::ForceTorqueSensorElement: public iDynTree::XMLElement {
 private:
     std::shared_ptr<iDynTree::ForceTorqueSensorHelper> m_helper;
 public:
-    ForceTorqueSensorElement(std::shared_ptr<const SensorElement::SensorInfo> sensorInfo);
+    explicit ForceTorqueSensorElement(
+        XMLParserState& parserState, 
+        std::shared_ptr<const SensorElement::SensorInfo> sensorInfo);
 
     std::shared_ptr<XMLElement> childElementForName(const std::string& name) override;
 

--- a/src/model_io/codecs/include/private/GeometryElement.h
+++ b/src/model_io/codecs/include/private/GeometryElement.h
@@ -20,6 +20,7 @@ namespace iDynTree {
     class GeometryElement;
     
     class SolidShape;
+    class XMLParserState;
 }
 
 class iDynTree::GeometryElement: public iDynTree::XMLElement {
@@ -27,7 +28,10 @@ private:
     std::shared_ptr<SolidShape>& m_shape;
     const std::vector<std::string>& packageDirs;
 public:
-    GeometryElement(std::shared_ptr<SolidShape>& shape, const std::vector<std::string>& packageDirs);
+    explicit GeometryElement(
+        XMLParserState& parserState, 
+        std::shared_ptr<SolidShape>& shape, 
+        const std::vector<std::string>& packageDirs);
 
     std::shared_ptr<iDynTree::XMLElement> childElementForName(const std::string& name) override;
 };

--- a/src/model_io/codecs/include/private/InertialElement.h
+++ b/src/model_io/codecs/include/private/InertialElement.h
@@ -20,6 +20,7 @@
 
 namespace iDynTree {
     class InertialElement;
+    class XMLParserState;
 }
 
 class iDynTree::InertialElement: public iDynTree::XMLElement {
@@ -29,7 +30,7 @@ class iDynTree::InertialElement: public iDynTree::XMLElement {
     iDynTree::Link &m_link;
     
 public:
-    InertialElement(iDynTree::Link &link);
+    explicit InertialElement(XMLParserState& parserState, iDynTree::Link &link);
     
     std::shared_ptr<iDynTree::XMLElement> childElementForName(const std::string& name) override;
     

--- a/src/model_io/codecs/include/private/JointElement.h
+++ b/src/model_io/codecs/include/private/JointElement.h
@@ -27,8 +27,8 @@ namespace iDynTree {
     class XMLAttribute;
     
     class IJoint;
+    class XMLParserState;
 }
-
 
 class iDynTree::JointElement : public iDynTree::XMLElement {
     
@@ -62,8 +62,10 @@ private:
     std::shared_ptr<Limits> m_limits;
     
 public:
-    JointElement(std::unordered_map<std::string, JointElement::JointInfo>& joints,
-                 std::unordered_map<std::string, JointElement::JointInfo>& fixedJoints);
+    explicit JointElement(
+        XMLParserState& parserState, 
+        std::unordered_map<std::string, JointElement::JointInfo>& joints,
+        std::unordered_map<std::string, JointElement::JointInfo>& fixedJoints);
     
     bool setAttributes(const std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>& attributes) override;
     

--- a/src/model_io/codecs/include/private/LinkElement.h
+++ b/src/model_io/codecs/include/private/LinkElement.h
@@ -24,6 +24,7 @@ namespace iDynTree {
     class XMLAttribute;
     
     class Model;
+    class XMLParserState;
 }
 
 class iDynTree::LinkElement : public iDynTree::XMLElement {
@@ -35,7 +36,7 @@ class iDynTree::LinkElement : public iDynTree::XMLElement {
     std::vector<VisualElement::VisualInfo> m_collisions;
     
 public:
-    LinkElement(iDynTree::Model &model);
+    explicit LinkElement(XMLParserState& parserState, iDynTree::Model &model);
 
     // Exposing useful properties
     const std::string& linkName() const;

--- a/src/model_io/codecs/include/private/MaterialElement.h
+++ b/src/model_io/codecs/include/private/MaterialElement.h
@@ -25,6 +25,7 @@ namespace iDynTree {
     class MaterialElement;
 
     class XMLAttribute;
+    class XMLParserState;
 }
 
 class iDynTree::MaterialElement: public iDynTree::XMLElement
@@ -40,8 +41,10 @@ private:
     std::shared_ptr<MaterialInfo> m_info;
 
 public:
+    explicit MaterialElement(
+        XMLParserState& parserState, 
+        std::shared_ptr<MaterialInfo> materialInfo);
 
-    MaterialElement(std::shared_ptr<MaterialInfo> materialInfo);
     const std::shared_ptr<MaterialInfo> materialInfo() const;
 
     bool setAttributes(const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes) override;

--- a/src/model_io/codecs/include/private/OriginElement.h
+++ b/src/model_io/codecs/include/private/OriginElement.h
@@ -22,6 +22,7 @@ namespace iDynTree {
 
     class XMLAttribute;
     class Transform;
+    class XMLParserState;
 }
 
 class iDynTree::OriginElement: public iDynTree::XMLElement {
@@ -29,7 +30,7 @@ private:
     iDynTree::Transform& m_jointOrigin;
 
 public:
-    OriginElement(iDynTree::Transform& jointOrigin);
+    explicit OriginElement(XMLParserState& parserState, iDynTree::Transform& jointOrigin);
     
     bool setAttributes(const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes) override;
 

--- a/src/model_io/codecs/include/private/RobotElement.h
+++ b/src/model_io/codecs/include/private/RobotElement.h
@@ -29,6 +29,7 @@ namespace iDynTree {
     class SensorHelper;
     
     class Model;
+    class XMLParserState;
 }
 
 
@@ -44,13 +45,15 @@ private:
     std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &m_collisions;
 
 public:
-    RobotElement(iDynTree::Model& model,
-                 std::vector<std::shared_ptr<SensorHelper>>& sensorHelpers,
-                 std::unordered_map<std::string, JointElement::JointInfo>& joints,
-                 std::unordered_map<std::string, JointElement::JointInfo>& fixedJoints,
-                 std::unordered_map<std::string, MaterialElement::MaterialInfo>& materials,
-                 std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &visuals,
-                 std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &collisions);
+    explicit RobotElement(
+        XMLParserState& parserState, 
+        iDynTree::Model& model,
+        std::vector<std::shared_ptr<SensorHelper>>& sensorHelpers,
+        std::unordered_map<std::string, JointElement::JointInfo>& joints,
+        std::unordered_map<std::string, JointElement::JointInfo>& fixedJoints,
+        std::unordered_map<std::string, MaterialElement::MaterialInfo>& materials,
+        std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &visuals,
+        std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &collisions);
     
     virtual ~RobotElement();
     std::shared_ptr<iDynTree::XMLElement> childElementForName(const std::string& name) override;

--- a/src/model_io/codecs/include/private/SensorElement.h
+++ b/src/model_io/codecs/include/private/SensorElement.h
@@ -32,6 +32,7 @@ namespace iDynTree {
     class XMLAttribute;
     class Sensor;
     class Model;
+    class XMLParserState;
 }
 
 
@@ -57,7 +58,9 @@ public:
 
     // I didn't find another clean way to return the generated Helper, instead of manually adding to
     // the vector
-    SensorElement(std::vector<std::shared_ptr<SensorHelper>>& sensors);
+    explicit SensorElement(
+        XMLParserState& parserState, 
+        std::vector<std::shared_ptr<SensorHelper>>& sensors);
 
     std::shared_ptr<XMLElement> childElementForName(const std::string& name) override;
     bool setAttributes(const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes) override;

--- a/src/model_io/codecs/include/private/URDFDocument.h
+++ b/src/model_io/codecs/include/private/URDFDocument.h
@@ -30,6 +30,7 @@
 
 namespace iDynTree {
     class URDFDocument;
+    class XMLParserState;
 }
 
 
@@ -52,7 +53,7 @@ class iDynTree::URDFDocument: public iDynTree::XMLDocument {
     } m_buffers;
 
 public:
-    URDFDocument();
+    explicit URDFDocument(XMLParserState& parserState);
     virtual ~URDFDocument();
 
     iDynTree::ModelParserOptions& options();

--- a/src/model_io/codecs/include/private/VisualElement.h
+++ b/src/model_io/codecs/include/private/VisualElement.h
@@ -29,6 +29,7 @@ namespace iDynTree {
     class VisualElement;
 
     class XMLAttribute;
+    class XMLParserState;
 }
 
 class iDynTree::VisualElement: public iDynTree::XMLElement
@@ -49,7 +50,10 @@ private:
     VisualInfo m_info;
 
 public:
-    VisualElement(const std::string& name, const std::vector<std::string>& packageDirs);
+    explicit VisualElement(
+        XMLParserState& parserState,
+        const std::string& name,
+        const std::vector<std::string>& packageDirs);
 
     const VisualInfo& visualInfo() const;
 

--- a/src/model_io/codecs/src/ForceTorqueSensorElement.cpp
+++ b/src/model_io/codecs/src/ForceTorqueSensorElement.cpp
@@ -102,8 +102,10 @@ namespace iDynTree {
         return sensor;
     }
 
-    ForceTorqueSensorElement::ForceTorqueSensorElement(std::shared_ptr<const SensorElement::SensorInfo> sensorInfo)
-    : iDynTree::XMLElement("force_torque")
+    ForceTorqueSensorElement::ForceTorqueSensorElement(
+        XMLParserState& parserState,
+        std::shared_ptr<const SensorElement::SensorInfo> sensorInfo)
+    : iDynTree::XMLElement(parserState, "force_torque")
     , m_helper(std::make_shared<ForceTorqueSensorHelper>(sensorInfo)) {}
 
     const std::shared_ptr<iDynTree::SensorHelper> ForceTorqueSensorElement::helper() const
@@ -113,7 +115,8 @@ namespace iDynTree {
 
     std::shared_ptr<XMLElement> ForceTorqueSensorElement::childElementForName(const std::string& name)
     {
-        std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(name);
+        std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(
+            getParserState(), name);
         if (name == "frame") {
             std::weak_ptr<XMLElement> weakElement(element);
             element->setExitScopeCallback([this, weakElement]{

--- a/src/model_io/codecs/src/GeometryElement.cpp
+++ b/src/model_io/codecs/src/GeometryElement.cpp
@@ -20,14 +20,17 @@
 
 namespace iDynTree{
 
-    GeometryElement::GeometryElement(std::shared_ptr<SolidShape>& shape, const std::vector<std::string>& packageDirs)
-    : iDynTree::XMLElement("geometry")
+    GeometryElement::GeometryElement(
+        XMLParserState& parserState, 
+        std::shared_ptr<SolidShape>& shape, const std::vector<std::string>& packageDirs)
+    : iDynTree::XMLElement(parserState, "geometry")
     , m_shape(shape)
     , packageDirs(packageDirs) {}
 
     std::shared_ptr<iDynTree::XMLElement> GeometryElement::childElementForName(const std::string& name)
     {
-        std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(name);
+        std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(
+            getParserState(), name);
         if (name == "box") {
             element->setAttributeCallback([this](const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>> &attributes){
 

--- a/src/model_io/codecs/src/InertialElement.cpp
+++ b/src/model_io/codecs/src/InertialElement.cpp
@@ -20,8 +20,10 @@
 
 namespace iDynTree {
     
-    InertialElement::InertialElement(iDynTree::Link &link)
-    : iDynTree::XMLElement("inertial")
+    InertialElement::InertialElement(
+        XMLParserState& parserState, 
+        iDynTree::Link &link)
+    : iDynTree::XMLElement(parserState, "inertial")
     , m_centerOfMass(iDynTree::Transform::Identity())
     , m_mass(0)
     , m_link(link) {}
@@ -30,10 +32,11 @@ namespace iDynTree {
         // As an alternative for simple elements, instead of creating other classes,
         // I implement the simple functions of the generic element
         if (name == "origin") {
-            return std::make_shared<OriginElement>(m_centerOfMass);
+            return std::make_shared<OriginElement>(getParserState(), m_centerOfMass);
         }
         if (name == "mass") {
-            std::shared_ptr<iDynTree::XMLElement> element = std::make_shared<iDynTree::XMLElement>(name);
+            std::shared_ptr<iDynTree::XMLElement> element = std::make_shared<iDynTree::XMLElement>(
+                getParserState(), name);
             element->setAttributeCallback([this](const std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>& attributes) {
                 m_mass = 0;
                 auto mass = attributes.find("value");
@@ -46,7 +49,8 @@ namespace iDynTree {
             return element;
         }
         if (name == "inertia") {
-            std::shared_ptr<iDynTree::XMLElement> element = std::make_shared<iDynTree::XMLElement>(name);
+            std::shared_ptr<iDynTree::XMLElement> element = std::make_shared<iDynTree::XMLElement>(
+                getParserState(), name);
             element->setAttributeCallback([this](const std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>& attributes) {
                 auto ixx = attributes.find("ixx");
                 auto ixy = attributes.find("ixy");
@@ -90,7 +94,7 @@ namespace iDynTree {
             });
             return element;
         }
-        return std::make_shared<iDynTree::XMLElement>(name);
+        return std::make_shared<iDynTree::XMLElement>(getParserState(), name);
     }
     
     void InertialElement::exitElementScope() {

--- a/src/model_io/codecs/src/LinkElement.cpp
+++ b/src/model_io/codecs/src/LinkElement.cpp
@@ -25,8 +25,10 @@
 
 namespace iDynTree {
     
-    LinkElement::LinkElement(iDynTree::Model &model)
-    : iDynTree::XMLElement("link")
+    LinkElement::LinkElement(
+        XMLParserState& parserState, 
+        iDynTree::Model &model)
+    : iDynTree::XMLElement(parserState, "link")
     , m_model(model)
     {
         iDynTree::SpatialInertia zeroInertia = iDynTree::SpatialInertia::Zero();
@@ -53,13 +55,13 @@ namespace iDynTree {
     
     std::shared_ptr<iDynTree::XMLElement> LinkElement::childElementForName(const std::string& name) {
         if (name == "inertial") {
-            return std::make_shared<InertialElement>(m_link);
+            return std::make_shared<InertialElement>(getParserState(), m_link);
         } else if (name == "visual") {
-            return std::make_shared<VisualElement>("visual", m_model.getPackageDirs());
+            return std::make_shared<VisualElement>(getParserState(), "visual", m_model.getPackageDirs());
         } else if (name == "collision") {
-            return std::make_shared<VisualElement>("collision", m_model.getPackageDirs());
+            return std::make_shared<VisualElement>(getParserState(), "collision", m_model.getPackageDirs());
         }
-        return std::make_shared<iDynTree::XMLElement>(name);
+        return std::make_shared<iDynTree::XMLElement>(getParserState(), name);
     }
 
     void LinkElement::childHasBeenParsed(std::shared_ptr<iDynTree::XMLElement> child)

--- a/src/model_io/codecs/src/MaterialElement.cpp
+++ b/src/model_io/codecs/src/MaterialElement.cpp
@@ -20,8 +20,10 @@
 
 namespace iDynTree {
 
-    MaterialElement::MaterialElement(std::shared_ptr<MaterialInfo> materialInfo)
-    : iDynTree::XMLElement("material")
+    MaterialElement::MaterialElement(
+        XMLParserState& parserState, 
+        std::shared_ptr<MaterialInfo> materialInfo)
+    : iDynTree::XMLElement(parserState, "material")
     , m_info(materialInfo)
     {
         if (!m_info) {
@@ -33,7 +35,8 @@ namespace iDynTree {
 
     std::shared_ptr<XMLElement> MaterialElement::childElementForName(const std::string& name)
     {
-        std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(name);
+        std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(
+            getParserState(), name);
         if (name == "color") {
             element->setAttributeCallback([this](const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes){
                 auto found = attributes.find("rgba");

--- a/src/model_io/codecs/src/ModelLoader.cpp
+++ b/src/model_io/codecs/src/ModelLoader.cpp
@@ -94,7 +94,9 @@ namespace iDynTree
     {
         // Allocate parser
         std::shared_ptr<XMLParser> parser = std::make_shared<XMLParser>();
-        parser->setDocumentFactory([]{ return std::shared_ptr<XMLDocument>(new URDFDocument); });
+        parser->setDocumentFactory([](XMLParserState& state){ 
+            return std::shared_ptr<XMLDocument>(new URDFDocument(state)); 
+            });
         parser->setPackageDirs(packageDirs);
         if (!parser->parseXMLFile(filename)) {
             reportError("ModelLoader", "loadModelFromFile", "Error in parsing model from URDF.");
@@ -117,7 +119,9 @@ namespace iDynTree
     {
         // Allocate parser
         std::shared_ptr<XMLParser> parser = std::make_shared<XMLParser>();
-        parser->setDocumentFactory([]{ return std::shared_ptr<XMLDocument>(new URDFDocument); });
+        parser->setDocumentFactory([](XMLParserState& state){
+            return std::shared_ptr<XMLDocument>(new URDFDocument(state)); 
+            });
         parser->setPackageDirs(packageDirs);
         if (!parser->parseXMLString(modelString)) {
             reportError("ModelLoader", "loadModelFromString", "Error in parsing model from URDF.");

--- a/src/model_io/codecs/src/OriginElement.cpp
+++ b/src/model_io/codecs/src/OriginElement.cpp
@@ -19,8 +19,10 @@
 #include <iDynTree/Core/Transform.h>
 
 namespace iDynTree {
-    OriginElement::OriginElement(iDynTree::Transform& jointOrigin)
-    : iDynTree::XMLElement("origin")
+    OriginElement::OriginElement(
+        XMLParserState& parserState,
+        iDynTree::Transform& jointOrigin)
+    : iDynTree::XMLElement(parserState, "origin")
     , m_jointOrigin(jointOrigin) {}
 
     bool OriginElement::setAttributes(const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes)

--- a/src/model_io/codecs/src/RobotElement.cpp
+++ b/src/model_io/codecs/src/RobotElement.cpp
@@ -24,14 +24,16 @@
 
 namespace iDynTree {
 
-    RobotElement::RobotElement(iDynTree::Model& model,
-                               std::vector<std::shared_ptr<SensorHelper>>& sensorHelpers,
-                               std::unordered_map<std::string, JointElement::JointInfo>& joints,
-                               std::unordered_map<std::string, JointElement::JointInfo>& fixedJoints,
-                               std::unordered_map<std::string, MaterialElement::MaterialInfo>& materials,
-                               std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &visuals,
-                               std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &collisions)
-    : iDynTree::XMLElement("robot")
+    RobotElement::RobotElement(
+        XMLParserState& parserState, 
+        iDynTree::Model& model,
+        std::vector<std::shared_ptr<SensorHelper>>& sensorHelpers,
+        std::unordered_map<std::string, JointElement::JointInfo>& joints,
+        std::unordered_map<std::string, JointElement::JointInfo>& fixedJoints,
+        std::unordered_map<std::string, MaterialElement::MaterialInfo>& materials,
+        std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &visuals,
+        std::unordered_map<std::string, std::vector<VisualElement::VisualInfo>> &collisions)
+    : iDynTree::XMLElement(parserState, "robot")
     , m_model(model)
     , m_sensorHelpers(sensorHelpers)
     , m_joints(joints)
@@ -45,15 +47,15 @@ namespace iDynTree {
     std::shared_ptr<iDynTree::XMLElement> RobotElement::childElementForName(const std::string& name)
     {
         if (name == "link") {
-            return std::make_shared<LinkElement>(m_model);
+            return std::make_shared<LinkElement>(getParserState(), m_model);
         } else if (name == "joint") {
-            return std::make_shared<JointElement>(m_joints, m_fixedJoints);
+            return std::make_shared<JointElement>(getParserState(), m_joints, m_fixedJoints);
         } else if (name == "sensor") {
-            return std::make_shared<SensorElement>(m_sensorHelpers);
+            return std::make_shared<SensorElement>(getParserState(), m_sensorHelpers);
         } else if (name == "material") {
             // These materials constitute a model-level database of materials
             // TODO: the result of the parsing should be added to the database
-            return std::make_shared<MaterialElement>(nullptr);
+            return std::make_shared<MaterialElement>(getParserState(), nullptr);
         }
         //TODO: What to do with an unexpected tag?
         // we would like to support two modes: strict (raise an error for an unexpected tag)
@@ -63,7 +65,8 @@ namespace iDynTree {
         // - How can I specify the strict/non-strict mode? This function is a callback.
         //   (We might propagate an option from the URDFDocument class)
         // - Should I handle the error here or in the XML Parser class (returning a nullptr here)?
-        return std::shared_ptr<iDynTree::XMLElement>(new iDynTree::XMLElement(name));
+        return std::shared_ptr<iDynTree::XMLElement>(
+            new iDynTree::XMLElement(getParserState(), name));
     }
 
     void RobotElement::childHasBeenParsed(std::shared_ptr<iDynTree::XMLElement> child)

--- a/src/model_io/codecs/src/SensorElement.cpp
+++ b/src/model_io/codecs/src/SensorElement.cpp
@@ -29,8 +29,10 @@ namespace iDynTree {
     SensorHelper::~SensorHelper() {}
 
 
-    SensorElement::SensorElement(std::vector<std::shared_ptr<SensorHelper>>& sensors)
-    : iDynTree::XMLElement("sensor")
+    SensorElement::SensorElement(
+        XMLParserState& parserState, 
+        std::vector<std::shared_ptr<SensorHelper>>& sensors)
+    : iDynTree::XMLElement(parserState, "sensor")
     , m_info(std::make_shared<SensorInfo>())
     , m_sensors(sensors)
     {
@@ -41,9 +43,10 @@ namespace iDynTree {
     std::shared_ptr<XMLElement> SensorElement::childElementForName(const std::string& name)
     {
         if (name == "origin") {
-            return std::make_shared<OriginElement>(m_info->m_origin);
+            return std::make_shared<OriginElement>(getParserState(), m_info->m_origin);
         } else if (name == "parent") {
-            std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(name);
+            std::shared_ptr<XMLElement> element = std::make_shared<XMLElement>(
+                getParserState(), name);
             element->setAttributeCallback([this](const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes) {
                 auto found = attributes.find("link");
                 if (found != attributes.end()) {
@@ -61,13 +64,14 @@ namespace iDynTree {
                 // Error
             }
 
-            std::shared_ptr<ForceTorqueSensorElement> element = std::make_shared<ForceTorqueSensorElement>(m_info);
+            std::shared_ptr<ForceTorqueSensorElement> element = std::make_shared<ForceTorqueSensorElement>(
+                getParserState(), m_info);
             // We have to save the helper which is responsible of generating the iDynTree::Sensor class
             // after the XML parsing.
             m_sensors.push_back(element->helper());
             return element;
         }
-        return std::make_shared<XMLElement>(name);
+        return std::make_shared<XMLElement>(getParserState(), name);
     }
 
     bool SensorElement::setAttributes(const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes)

--- a/src/model_io/codecs/src/URDFDocument.cpp
+++ b/src/model_io/codecs/src/URDFDocument.cpp
@@ -38,9 +38,8 @@ namespace iDynTree {
                                            const std::unordered_map<std::string, MaterialElement::MaterialInfo>& materialDatabase,
                                            ModelSolidShapes &modelGeometries);
     
-    URDFDocument::URDFDocument()
-    {
-    }
+    URDFDocument::URDFDocument(XMLParserState& parserState)
+    : XMLDocument(parserState) {}
 
     iDynTree::ModelParserOptions& URDFDocument::options() { return m_options; }
     
@@ -67,7 +66,8 @@ namespace iDynTree {
             m_buffers.fixedJoints.clear();
             m_buffers.materials.clear();
 
-            return std::make_shared<RobotElement>(m_model,
+            return std::make_shared<RobotElement>(getParserState(), 
+                                                  m_model,
                                                   m_buffers.sensorHelpers,
                                                   m_buffers.joints,
                                                   m_buffers.fixedJoints,
@@ -76,7 +76,7 @@ namespace iDynTree {
                                                   m_buffers.collisions);
         }
         // TODO: raise an error here
-        return std::shared_ptr<XMLElement>(new XMLElement());
+        return std::shared_ptr<XMLElement>(new XMLElement(getParserState()));
     }
 
     bool URDFDocument::documentHasBeenParsed()

--- a/src/model_io/codecs/src/VisualElement.cpp
+++ b/src/model_io/codecs/src/VisualElement.cpp
@@ -26,8 +26,11 @@ namespace iDynTree {
     {
     }
 
-    VisualElement::VisualElement(const std::string& name, const std::vector<std::string>& packageDirs)
-    : iDynTree::XMLElement(name)
+    VisualElement::VisualElement(
+        XMLParserState& parserState, 
+        const std::string& name, 
+        const std::vector<std::string>& packageDirs)
+    : iDynTree::XMLElement(parserState, name)
     , m_info(packageDirs)
     {
     }
@@ -52,15 +55,16 @@ namespace iDynTree {
 
     std::shared_ptr<iDynTree::XMLElement> VisualElement::childElementForName(const std::string& name) {
         if (name == "origin") {
-            return std::make_shared<OriginElement>(m_info.m_origin);
+            return std::make_shared<OriginElement>(getParserState(), m_info.m_origin);
         } else if (name == "geometry") {
-            return std::make_shared<GeometryElement>(m_info.m_solidShape, m_info.m_packageDirs);
+            return std::make_shared<GeometryElement>(
+                getParserState(), m_info.m_solidShape, m_info.m_packageDirs);
         } else if (name == "material") {
-            auto ptr = std::make_shared<MaterialElement>(nullptr);
+            auto ptr = std::make_shared<MaterialElement>(getParserState(), nullptr);
             m_info.m_material = ptr->materialInfo();
             return ptr;
         }
-        return std::make_shared<XMLElement>(name);
+        return std::make_shared<XMLElement>(getParserState(), name);
     }
 
 }

--- a/src/model_io/codecs/tests/URDFModelImportUnitTest.cpp
+++ b/src/model_io/codecs/tests/URDFModelImportUnitTest.cpp
@@ -218,7 +218,45 @@ void checkLoadReducedModelOrderIsKept(std::string urdfFileName)
             ASSERT_IS_TRUE(dofsName[joint->getDOFsOffset() + dof] == jointName);
         }
     }
+}
 
+void checkDuplicateJointsReturnsError() {
+    std::string urdf = R"(
+<robot name="robot">
+  <link name="link_1">
+    <inertial>
+      <mass value="1"/>
+    </inertial>
+  </link>
+  <link name="link_2">
+    <inertial>
+      <mass value="2"/>
+    </inertial>
+  </link>
+  <link name="link_3">
+    <inertial>
+      <mass value="3"/>
+    </inertial>
+  </link>
+  <joint name="joint_1" type="revolute">
+    <origin xyz="0.0 0.0 0.0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="link_1"/>
+    <child link="link_2"/>
+    <limit lower="-1.0" upper="1.0"/>
+  </joint>
+  <joint name="joint_1" type="revolute">
+    <origin xyz="0.0 0.0 0.0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="link_1"/>
+    <child link="link_3"/>
+    <limit lower="-2.0" upper="2.0"/>
+  </joint>
+</robot>
+)";
+
+    ModelLoader loader;
+    ASSERT_IS_FALSE(loader.loadModelFromString(urdf));
 
 }
 

--- a/src/model_io/xml/include/iDynTree/XMLDocument.h
+++ b/src/model_io/xml/include/iDynTree/XMLDocument.h
@@ -21,6 +21,7 @@ namespace iDynTree {
     class XMLDocument;
     class XMLElement;
     class XMLParser;
+    class XMLParserState;
 }
 
 class iDynTree::XMLDocument {
@@ -32,7 +33,7 @@ class iDynTree::XMLDocument {
     
 public:
     
-    XMLDocument();
+    explicit XMLDocument(XMLParserState& parserState);
     virtual ~XMLDocument();
 
     /**
@@ -49,6 +50,9 @@ public:
     
     const std::shared_ptr<XMLElement> root() const;
     std::string description() const;
+
+protected:
+    XMLParserState& getParserState();
 };
 
 #endif /* end of include guard: IDYNTREE_MODELIO_XML_XMLDOCUMENT_H */

--- a/src/model_io/xml/include/iDynTree/XMLElement.h
+++ b/src/model_io/xml/include/iDynTree/XMLElement.h
@@ -23,6 +23,7 @@ namespace iDynTree {
     class XMLAttribute;
     class XMLElement;
     class XMLParser;
+    class XMLParserState;
 }
 
 
@@ -51,24 +52,28 @@ public:
      * Default constructor.
      *
      * Constructs an unnamed XML Element with no attributes.
+     * @param parserState a reference to the parser state to propagate to the elements.
      */
-    XMLElement();
+    explicit XMLElement(XMLParserState& parserState);
     
     /**
      * Constructs a named XML Element with no attributes.
+     * @param parserState a reference to the parser state to propagate to the elements.
      * @param name the name of the XML element.
      */
-    XMLElement(const std::string& name);
+    explicit XMLElement(XMLParserState& parserState, const std::string& name);
     
     /**
      * Constructs a named XML Element with the specified attributes.
      *
      * This is the designated initializer.
+     * @param parserState a reference to the parser state to propagate to the elements.
      * @param name the name of the XML element.
      * @param attributes the attributes of the XML element.
      */
-    XMLElement(const std::string& name,
-               const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes);
+    explicit XMLElement(XMLParserState& parserState, 
+                        const std::string& name,
+                        const std::unordered_map<std::string, std::shared_ptr<iDynTree::XMLAttribute>>& attributes);
     
     /**
      * Destructor
@@ -129,6 +134,9 @@ public:
     std::string getParsedTextContent() const;
     
     std::string description() const;
+
+protected:
+    XMLParserState& getParserState();
 
 };
 

--- a/src/model_io/xml/include/iDynTree/XMLParser.h
+++ b/src/model_io/xml/include/iDynTree/XMLParser.h
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -24,6 +25,7 @@ namespace iDynTree {
     class XMLParser;
     class XMLElement;
     class XMLDocument;
+    class XMLParserState;
 }
 
 //TODO: handle errors
@@ -198,12 +200,12 @@ public:
      *
      * By specifying a new factory function, it is possible to change how the XML document will be
      * represented in memory.
-     * The signature of the function is `(void) -> std::shared_ptr<XMLDocument>`, i.e. a function
-     * accepting no arguments and returning a `std::shared_ptr` to an `XMLDocument` object.
+     * The signature of the function is `(XMLParserState&) -> std::shared_ptr<XMLDocument>`, i.e. a function
+     * accepting a reference to the parser state and returning a `std::shared_ptr` to an `XMLDocument` object.
      *
      @param factory the function that will be called for instantiating a new XMLDocument object.
      */
-    void setDocumentFactory(std::function<std::shared_ptr<XMLDocument>()> factory);
+    void setDocumentFactory(std::function<std::shared_ptr<XMLDocument>(XMLParserState&)> factory);
     
     // TODO: check if we want to return a copy, a const or something
 
@@ -215,6 +217,21 @@ public:
     std::shared_ptr<const XMLDocument> document() const;
     
 };
+
+
+class iDynTree::XMLParserState {
+public:
+    void setParsingError();
+  
+private:
+    friend XMLParser;
+    void resetState();  // Acquires m_mutex.
+    bool getParsingErrorState();  // Acquires m_mutex.
+
+    mutable std::mutex m_mutex;
+    bool m_parsing_error;  // Protected by m_mutex.
+};
+
 
 
 #endif /* end of include guard: IDYNTREE_MODELIO_XML_XMLPARSER_H */

--- a/src/model_io/xml/src/XMLDocument.cpp
+++ b/src/model_io/xml/src/XMLDocument.cpp
@@ -22,10 +22,14 @@ namespace iDynTree {
     {
     public:
         std::shared_ptr<XMLElement> m_root;
+        XMLParserState& m_parserState;
+
+        explicit XMLDocumentPimpl(XMLParserState& parserState)
+        : m_parserState(parserState) {}
     };
     
-    XMLDocument::XMLDocument()
-    : m_pimpl(new XMLDocumentPimpl()) {}
+    XMLDocument::XMLDocument(XMLParserState& parserState)
+    : m_pimpl(new XMLDocumentPimpl(parserState)) {}
     
     XMLDocument::~XMLDocument() {}
     
@@ -42,7 +46,7 @@ namespace iDynTree {
     std::shared_ptr<XMLElement> XMLDocument::rootElementForName(const std::string& name,
                                                                 const std::vector<std::string>& packageDirs)
     {
-        return std::make_shared<XMLElement>(name);
+        return std::make_shared<XMLElement>(m_pimpl->m_parserState, name);
     }
 
     bool XMLDocument::documentHasBeenParsed() { return true; }
@@ -55,4 +59,6 @@ namespace iDynTree {
         }
         return str.str();
     }
+
+    XMLParserState& XMLDocument::getParserState() { return m_pimpl->m_parserState; }
 }

--- a/src/model_io/xml/src/XMLElement.cpp
+++ b/src/model_io/xml/src/XMLElement.cpp
@@ -37,23 +37,26 @@ namespace iDynTree {
         std::string m_name;
         std::vector<std::shared_ptr<XMLElement>> m_children;
         std::unordered_map<std::string, std::shared_ptr<XMLAttribute>> m_attributes;
+
+        XMLParserState& m_parserState;
+    
+        explicit XMLElementPimpl(XMLParserState& parserState,
+                                 const std::string& name,
+                                 const std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>& attributes)
+                                 : m_name(name), m_attributes(attributes), m_parserState(parserState) {}
     };
     
     //MARK: - XMLElement definition
     
-    XMLElement::XMLElement()
-    : XMLElement("") {}
+    XMLElement::XMLElement(XMLParserState& parserState)
+    : XMLElement(parserState, "") {}
     
-    XMLElement::XMLElement(const std::string& name)
-    : XMLElement(name, std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>()) {}
+    XMLElement::XMLElement(XMLParserState& parserState, const std::string& name)
+    : XMLElement(parserState, name, std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>()) {}
     
-    XMLElement::XMLElement(const std::string& name,
+    XMLElement::XMLElement(XMLParserState& parserState, const std::string& name,
                            const std::unordered_map<std::string, std::shared_ptr<XMLAttribute>>& attributes)
-    : m_pimpl(new XMLElementPimpl())
-    {
-        m_pimpl->m_name = name;
-        m_pimpl->m_attributes = attributes;
-    }
+    : m_pimpl(new XMLElementPimpl(parserState, name, attributes)) {}
     
     XMLElement::~XMLElement() {}
     
@@ -95,7 +98,7 @@ namespace iDynTree {
     
     std::shared_ptr<XMLElement> XMLElement::childElementForName(const std::string& name)
     {
-        return std::make_shared<XMLElement>(name);
+        return std::make_shared<XMLElement>(m_pimpl->m_parserState, name);
     }
     
     void XMLElement::exitElementScope()
@@ -149,4 +152,6 @@ namespace iDynTree {
         str << "</" << m_pimpl->m_name << ">" << std::endl;
         return str.str();
     }
+
+    XMLParserState& XMLElement::getParserState() { return m_pimpl->m_parserState; }
 }


### PR DESCRIPTION
Currently the only error returned by the parser is for invalid or not well format XML where the parser itself will fail. For any other "semantic" validation there is no way to return an error to the caller, just prints to stderr.

One option could of course being to return all parsed data and do a validation after but this would implies some changes and keeping track of discarded parsed text.

This change introduces a simple state that is propagated to all parser elements. The state is currently a simple bool, enough to report an error but can be easily extended if needed.

The code has a lot of TODOs where to put error notification. Currently this change reports only an error in case two joints are named the same, and a test has been added to verify it.