### PR TITLE
Fix support for PrismaticJoint in iDynTree::getRandomModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.999.0] - 2023-03-05
 
+### Fixed
+- Fix export of `iDynTree::PrismaticJoint` in `iDynTree::getRandomModel` (https://github.com/robotology/idyntree/pull/1057).
+
 ### Changed
+
+#### URDF XML parser change 
 The XML parser API has changed. Now an additional `XMLParserState` context object is propagated while parsing.
 To catch logic errors (which are not pure XML errors that are currently caught by the parser itself) the `XMLParserState` contains a `bool` variable. Further logic can be added to the context state.
 

--- a/src/model/include/iDynTree/Model/ModelTestUtils.h
+++ b/src/model/include/iDynTree/Model/ModelTestUtils.h
@@ -52,7 +52,7 @@ inline Link getRandomLink()
 /**
  * Add a random link with random model.
  */
-inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, bool noFixed=false)
+inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, bool onlyRevoluteJoints=false)
 {
     // Add Link
     LinkIndex newLinkIndex = model.addLink(newLinkName,getRandomLink());
@@ -64,9 +64,9 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
 
     int jointType = rand() % nrOfJointTypes;
 
-    if (noFixed && jointType == 0) 
+    if (onlyRevoluteJoints)
     {
-        jointType = (rand() % (nrOfJointTypes - 1)) + 1;
+        jointType = 1;
     }
 
     if( jointType == 0 )
@@ -150,7 +150,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     return model;
 }
 
-inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool noFixed=false)
+inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false)
 {
     Model model;
 
@@ -161,7 +161,7 @@ inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     {
         std::string parentLink = linkName;
         linkName = "link" + int2string(i);
-        addRandomLinkToModel(model,parentLink,linkName,noFixed);
+        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints);
     }
 
     for(unsigned int i=0; i < nrOfAdditionalFrames; i++)

--- a/src/model/include/iDynTree/Model/ModelTestUtils.h
+++ b/src/model/include/iDynTree/Model/ModelTestUtils.h
@@ -64,7 +64,10 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
 
     int jointType = rand() % nrOfJointTypes;
 
-    if( noFixed ) jointType = 1;
+    if (noFixed && jointType == 0) 
+    {
+        jointType = (rand() % (nrOfJointTypes - 1)) + 1;
+    }
 
     if( jointType == 0 )
     {


### PR DESCRIPTION
The actual method was fixed accidentally with a direct push to master (see https://github.com/robotology/idyntree/commit/9c7f2b36a2505f132700744bfffb142728639a57), anyhow more fixes were necessary (for example, when passing `noFixed` argument no prismatic joint were generated), so this PR adds the necessary bits.