### PR TITLE
Use iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw as default parametrization in iDynTree::InverseKinematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.999.0] - 2023-03-05
 
 ### Changed
+
+- Use iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw as default parametrization in iDynTree::InverseKinematics (https://github.com/robotology/idyntree/pull/1058).
+
+#### XML parser API change
+
 The XML parser API has changed. Now an additional `XMLParserState` context object is propagated while parsing.
 To catch logic errors (which are not pure XML errors that are currently caught by the parser itself) the `XMLParserState` contains a `bool` variable. Further logic can be added to the context state.
 

--- a/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
+++ b/src/inverse-kinematics/include/iDynTree/InverseKinematics.h
@@ -35,8 +35,20 @@ namespace iDynTree {
      * @brief type of parametrization for the rotation (SO3) element
      */
     enum InverseKinematicsRotationParametrization {
-        InverseKinematicsRotationParametrizationQuaternion, /*!< Quaternion parametrization */
-        InverseKinematicsRotationParametrizationRollPitchYaw, /*!< Roll Pitch Yaw parametrization */
+	/**
+	 * Quaternion parametrization.
+	 * In theory this parametrization does not suffer from discontinuity like the,
+	 * InverseKinematicsRotationParametrizationRollPitchYaw one, but the existing
+	 * implementation does not work as expected, and so its use is discouraged.
+	 * See https://github.com/robotology/idyntree/issues/1059 for more details.
+	 */
+        InverseKinematicsRotationParametrizationQuaternion, 
+        /**
+	 * Roll Pitch Yaw parametrization. 
+	 * This parametrization is the one used by default, but it may not work 
+	 * properly near the points in which the parametrization has discontinuities.
+	 */
+        InverseKinematicsRotationParametrizationRollPitchYaw,
     };
 
     inline int sizeOfRotationParametrization(enum InverseKinematicsRotationParametrization rotationParametrization)

--- a/src/inverse-kinematics/src/InverseKinematics.cpp
+++ b/src/inverse-kinematics/src/InverseKinematics.cpp
@@ -187,7 +187,7 @@ namespace iDynTree {
         return IK_PIMPL(m_pimpl)->rotationParametrization();
 #else
         missingIpoptErrorReport();
-        return InverseKinematicsRotationParametrizationQuaternion;
+        return InverseKinematicsRotationParametrizationRollPitchYaw;
 #endif
     }
 

--- a/src/inverse-kinematics/src/InverseKinematicsData.cpp
+++ b/src/inverse-kinematics/src/InverseKinematicsData.cpp
@@ -30,7 +30,7 @@ namespace kinematics {
     InverseKinematicsData::InverseKinematicsData()
     : m_defaultTargetResolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraintNone)
     , m_dofs(0)
-    , m_rotationParametrization(iDynTree::InverseKinematicsRotationParametrizationQuaternion)
+    , m_rotationParametrization(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw)
     , m_areBaseInitialConditionsSet(false)
     , m_areJointsInitialConditionsSet(InverseKinematicsInitialConditionNotSet)
     , m_problemInitialized(false)


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/514 . The `iDynTree::InverseKinematicsRotationParametrizationQuaternion` has some well known bug, so it make sense not to use it by default, and clearly document this.