### PR TITLE
Fix Conda CI (March 2023) and remove ubuntu-18.04 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,7 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install eigen libxml2 assimp ipopt irrlicht swig pybind11 python numpy
-        # robotology dependencies
-        mamba install yarp icub-main osqp-eigen
+        mamba install cmake compilers make ninja pkg-config eigen libxml2 assimp ipopt irrlicht swig pybind11 python numpy yarp icub-main osqp-eigen
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
The CI was failing as icub-main does not have a Python 3.11 build, while the python was installed by the previous installation step in version 3.11 . By installing everything in one shot, everything should work as expected.