### PR TITLE
Migrate apt CI to use docker images and remove homebrew jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
 
     - name: Dependencies [apt]
       run: |
+        # See  https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive,
+        # only required by Ubuntu 20.04
+        export DEBIAN_FRONTEND=noninteractive
         apt-get -y update
         apt-get -y install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,8 @@ jobs:
 
     - name: Dependencies [apt]
       run: |
-        apt-get update
-        apt-get install \
+        apt-get -y update
+        apt-get -y install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
             libxml2-dev liboctave-dev python3-dev python3-numpy valgrind libassimp-dev libirrlicht-dev curl unzip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Cache Source-based Dependencies
       id: cache-source-deps
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/install/deps
         key: source-deps-${{ matrix.docker_image }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         apt-get update
         apt-get install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
-            libxml2-dev liboctave-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev curl unzip
+            libxml2-dev liboctave-dev python3-dev python3-numpy valgrind libassimp-dev libirrlicht-dev curl unzip
 
     - name: Install files to enable compilation of mex files [apt]
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
 
     - name: Install files to enable compilation of mex files [apt]
       run: |
+        apt-get install curl unzip
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
         unzip msdk_R2020b_mexa64.zip
         rm msdk_R2020b_mexa64.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
 
 
   build-with-apt-dependencies:
-    name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
+    name: '[apt:${{ matrix.docker_image }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  YCM_TAG: v0.14.2
-  YARP_TAG: v3.7.2
-  ICUB_TAG: v2.0.2
+  YCM_TAG: v0.15.1
+  YARP_TAG: v3.8.0
+  ICUB_TAG: v2.1.1
 
 jobs:
   build-with-conda-dependencies:
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
@@ -160,20 +160,27 @@ jobs:
         cmake --install . --config ${{ matrix.build_type }}
 
 
-  build-with-system-dependencies:
+  build-with-apt-dependencies:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macOS-latest]
+        os:
+          - ubuntu-latest
+        docker_image:
+          - "ubuntu:20.04"
+          - "ubuntu:22.04"
+          - "debian:sid"
+
+    container:
+      image: ${{ matrix.docker_image }}
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
-
-    - name: Install files to enable compilation of mex files [Linux]
+    - name: Install files to enable compilation of mex files [apt]
       if: contains(matrix.os, 'ubuntu')
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
@@ -182,57 +189,25 @@ jobs:
         echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
 
-    - name: Install files to enable compilation of mex files [macOS]
-      if: contains(matrix.os, 'macos')
-      run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
-        unzip msdk_R2020a_mexmaci64.zip
-        rm msdk_R2020a_mexmaci64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
-        echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
-
-    - name: Install files to enable compilation of mex files [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash
-      run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
-        unzip msdk_R2020a_mexw64.zip
-        rm msdk_R2020a_mexw64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
-        echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
-
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash
       run: env
 
-    # Remove apt repos that are known to break from time to time
-    # See https://github.com/actions/virtual-environments/issues/323
-    - name: Remove broken apt repos [Ubuntu]
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-
     # ============
     # DEPENDENCIES
     # ============
 
-    - name: Dependencies [macOS]
-      if: matrix.os == 'macOS-latest'
-      run: |
-        brew install ace assimp boost eigen ipopt irrlicht swig
-
-    - name: Dependencies [Ubuntu]
+    - name: Dependencies [apt]
       if: contains(matrix.os, 'ubuntu')
       run: |
-        sudo apt-get update
-        sudo apt-get install \
+        apt-get update
+        apt-get install \
             git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
             libxml2-dev liboctave-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
 
-
-    - name: Source-based Dependencies [Ubuntu/macOS]
-      if: steps.cache-source-deps.outputs.cache-hit != 'true' && (contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest')
+    - name: Source-based Dependencies [apt]
+      if: steps.cache-source-deps.outputs.cache-hit != 'true' && (contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         # YCM
@@ -257,18 +232,12 @@ jobs:
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
-
-    - name: Dependencies (workaround for portaudio YCM problem) [macOS]
-      if: matrix.os == 'macOS-latest'
-      run: |
-        brew install octave
-
     # ===================
     # CMAKE-BASED PROJECT
     # ===================
 
-    - name: Configure [Ubuntu/macOS]
-      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
+    - name: Configure [apt]
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         mkdir -p build
@@ -276,28 +245,13 @@ jobs:
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps -DIDYNTREE_COMPILE_TESTS:BOOL=ON -DIDYNTREE_USES_YARP:BOOL=ON \
               -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DIDYNTREE_USES_ASSIMP:BOOL=ON \
               -DIDYNTREE_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} -DIDYNTREE_DISABLE_MATLAB_TESTS:BOOL=ON  \
-              -DIDYNTREE_USES_IPOPT:BOOL=ON -DIDYNTREE_USES_OCTAVE:BOOL=ON -DIDYNTREE_USES_IRRLICHT:BOOL=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
-
-    - name: Enable additional Ubuntu options (Valgrind, Python) [Ubuntu]
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        cd build
-        # Assimp is disabled on Ubuntu as a workaround for https://github.com/robotology/idyntree/issues/663
-        cmake -DIDYNTREE_USES_PYTHON:BOOL=ON -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON .
-        # For some reason, Ubuntu 18.04 image in GitHub Actions contain OpenBLAS 0.3.5, that is affected by https://github.com/xianyi/OpenBLAS/issues/2003
-        # As a workaround, we test against the regular blas instead of openblas
-        sudo apt-get install libblas-dev libatlas-base-dev
-        sudo apt-get remove libopenblas-base
+              -DIDYNTREE_USES_IPOPT:BOOL=ON -DIDYNTREE_USES_PYTHON:BOOL=ON -DIDYNTREE_RUN_VALGRIND_TESTS:BOOL=ON -DIDYNTREE_USES_OCTAVE:BOOL=ON -DIDYNTREE_USES_IRRLICHT:BOOL=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
     - name: Build
       shell: bash
       run: |
         cd build
-        # Attempt of fix for using YARP idl generators (that link ACE) in Windows
-        # See https://github.com/robotology/idyntree/issues/569
-        export PATH=$PATH:${GITHUB_WORKSPACE}/install/bin:${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin:${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/debug/bin
         cmake --build . --config ${{ matrix.build_type }}
-
 
     - name: Test
       shell: bash
@@ -307,15 +261,15 @@ jobs:
         ctest --output-on-failure -C ${{ matrix.build_type }} -E "Visualizer|matlab" .
 
 
-    - name: Install [Ubuntu/macOS]
-      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
+    - name: Install [apt]
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }} --target install
 
-    - name: Compile Examples [Ubuntu/macOS]
-      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
+    - name: Compile Examples [apt]
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd examples
@@ -324,8 +278,7 @@ jobs:
         cmake -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install/deps;${GITHUB_WORKSPACE}/install" ..
         cmake --build . --config ${{ matrix.build_type }}
 
-
-    - name: Check build if some dependencies are not enabled [Ubuntu]
+    - name: Check build if some dependencies are not enabled [apt]
       if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,13 @@ jobs:
       shell: bash
       run: env
 
+    - name: Cache Source-based Dependencies
+      id: cache-source-deps
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/install/deps
+        key: source-deps-${{ matrix.docker_image }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-icub-${{ env.ICUB_TAG }}
+
     - name: Source-based Dependencies [apt]
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && contains(matrix.os, 'ubuntu')
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Dependencies [apt]
+      run: |
+        apt-get update
+        apt-get install \
+            git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
+            libxml2-dev liboctave-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev curl unzip
+
     - name: Install files to enable compilation of mex files [apt]
       run: |
-        apt-get install curl unzip
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
         unzip msdk_R2020b_mexa64.zip
         rm msdk_R2020b_mexa64.zip
@@ -193,17 +199,6 @@ jobs:
     - name: Environment Variables
       shell: bash
       run: env
-
-    # ============
-    # DEPENDENCIES
-    # ============
-
-    - name: Dependencies [apt]
-      run: |
-        apt-get update
-        apt-get install \
-            git build-essential cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
-            libxml2-dev liboctave-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
 
     - name: Source-based Dependencies [apt]
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install files to enable compilation of mex files [apt]
-      if: contains(matrix.os, 'ubuntu')
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
         unzip msdk_R2020b_mexa64.zip
@@ -199,7 +198,6 @@ jobs:
     # ============
 
     - name: Dependencies [apt]
-      if: contains(matrix.os, 'ubuntu')
       run: |
         apt-get update
         apt-get install \
@@ -207,7 +205,7 @@ jobs:
             libxml2-dev liboctave-dev python-dev python3-numpy valgrind libassimp-dev libirrlicht-dev
 
     - name: Source-based Dependencies [apt]
-      if: steps.cache-source-deps.outputs.cache-hit != 'true' && (contains(matrix.os, 'ubuntu')
+      if: steps.cache-source-deps.outputs.cache-hit != 'true' && contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         # YCM
@@ -237,7 +235,6 @@ jobs:
     # ===================
 
     - name: Configure [apt]
-      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         mkdir -p build
@@ -262,14 +259,12 @@ jobs:
 
 
     - name: Install [apt]
-      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }} --target install
 
     - name: Compile Examples [apt]
-      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd examples
@@ -279,7 +274,6 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
 
     - name: Check build if some dependencies are not enabled [apt]
-      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd build


### PR DESCRIPTION
General cleanup of the CI, triggered by a failure in using iDynTree with CMake 3.16, highlighting that we did not have a job that tested iDynTree with vanilla Ubuntu images.

So I took the occasion to:
* Migrate apt CI to use Docker images, so we do not have the GitHub Actions images with the latest CMake, and instead use vanilla images for Ubuntu 20.04, Ubuntu 22.04 and Debian Sid
* Drop homebrew CI (see https://github.com/robotology/robotology-superbuild/issues/842)
* Update YARP, icub-main and YCM versions used in the CI
* Remove some outdated workarounds

