### PR TITLE
Remove qt5 dependency

### DIFF
--- a/cmake/iDynTreeDependencies.cmake
+++ b/cmake/iDynTreeDependencies.cmake
@@ -82,7 +82,6 @@ endif ()
 
 idyntree_handle_dependency(IPOPT)
 idyntree_handle_dependency(Irrlicht DO_NOT_SILENTLY_SEARCH)
-idyntree_handle_dependency(Qt5 COMPONENTS Qml Quick Widgets)
 idyntree_handle_dependency(OsqpEigen MAIN_TARGET OsqpEigen::OsqpEigen)
 idyntree_handle_dependency(ALGLIB DO_NOT_SILENTLY_SEARCH)
 set(ALGLIB_REQUIRED_VERSION 3.14.0)


### PR DESCRIPTION
qt5 is not used anymore in the repo, so we can remove it from the optional dependencies.