### PR TITLE
iDynTree PyPI binary packaging: Migrate from manylinux_2_24 to manylinux_2_28

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -95,8 +95,8 @@ jobs:
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-          CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_24_x86_64
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_28_x86_64
           CIBW_BEFORE_BUILD_LINUX: |
             apt-get update &&\
             apt-get install -y libeigen3-dev libassimp-dev libxml2-dev coinor-libipopt-dev libirrlicht-dev


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/1067 .

manylinux_2_24 was EOL since the beginnng of 2023: https://github.com/pypa/manylinux/issues/1369 .