### PR TITLE
Migrate conda CI to setup-micromamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,12 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        mamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
+        micromamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
 
     - name: Print used environment [Conda]
       shell: bash -l {0}
       run: |
-        mamba list
+        micromamba list
         env
 
     - name: Configure [Conda]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        miniforge-variant: Mambaforge
-        miniforge-version: latest
-        channels: conda-forge,robotology
-
     - name: Print used environment (no conda) [Conda]
       shell: bash
       run: |
         env
+
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: ci_env.yml
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')
@@ -91,14 +89,6 @@ jobs:
         echo "CONDA_CXX_LIBRARIES_INSTALL_PREFIX=${CONDA_PREFIX}" >> $GITHUB_ENV
         # Visualizer tests excluded as a workaround for https://github.com/robotology/idyntree/issues/808
         echo "IDYNTREE_TEST_TO_SKIP=Visualizer|matlab" >> $GITHUB_ENV
-
-    - name: Dependencies [Conda]
-      shell: bash -l {0}
-      run: |
-        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-        conda config --remove channels defaults
-        # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config eigen libxml2 assimp ipopt irrlicht swig pybind11 python numpy yarp icub-main osqp-eigen
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
       with:
         environment-file: ci_env.yml
         cache-environment-key: environment-${{ steps.week.outputs.week }}
-        cache-downloads-key: downloads-${{ steps.week.outputs.week }}
 
 
     - name: Install files to enable compilation of mex files [Conda/Linux]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,15 @@ jobs:
       shell: bash
       run: |
         env
-
+    - name: Get current week
+      id: week
+      run: echo "week=$(date +%Y-%U)" >> "${GITHUB_OUTPUT}"
     - uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: ci_env.yml
+        cache-environment-key: environment-${{ steps.week.outputs.week }}
+        cache-downloads-key: downloads-${{ steps.week.outputs.week }}
+
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -1,0 +1,22 @@
+name: idyntreedev
+channels:
+  - conda-forge
+  - robotology
+dependencies:
+  - cmake 
+  - compilers
+  - make 
+  - ninja
+  - pkg-config 
+  - eigen
+  - libxml2
+  - assimp
+  - ipopt
+  - irrlicht
+  - swig
+  - pybind11
+  - python
+  - numpy 
+  - yarp
+  - icub-main 
+  - osqp-eigen


### PR DESCRIPTION
The main goal is to speed-up the installation of dev dependencies installed from conda channels.