### PR TITLE
Generate wheels for Python 3.11

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         python-version:
           - "3.10"
+          - "3.11"
 
     steps:
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          - "3.11"
 
     steps:
 
@@ -96,7 +95,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64
+          CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64 cp311-*manylinux*_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_28_x86_64
           CIBW_BEFORE_BUILD_LINUX: |


### PR DESCRIPTION
This PR follows up #1068 and enables the generation of `sdist` and manylinux 2.28 `wheels` for Python 3.11.

cc @traversaro feel free to merge and squash upon acceptance.