### PR TITLE
Add the possibility to display the arrows in MeshcatVizualizer

### DIFF
--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -421,7 +421,7 @@ class MeshcatVisualizer:
         vector = vector / np.linalg.norm(vector)
         dummy_vector = np.array([0, 0, 1])
 
-        # compute the rotation matrix bewteen the two vectors
+        # compute the rotation matrix between the two vectors
         # math taken from
         # https://math.stackexchange.com/questions/180418/calculate-rotation-matrix-to-align-vector-a-to-vector-b-in-3d
         v = np.cross(dummy_vector, vector)

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -414,7 +414,7 @@ class MeshcatVisualizer:
         transform[3, 3] = 1
 
         if np.linalg.norm(vector) < 1e-6:
-            warnings.warn("The vector is too small to be visualized.", category=UserWarning, stacklevel=2)
+            self.viewer[shape_name].set_transform(transform)
             return
 
         # extract rotation matrix from a normalized vector


### PR DESCRIPTION
This PR allows you to easily draw arrows in MeshcatVizualizer

The original idea was taken from @rob-mau and generalized to avoid using non-standard datatype. 

For instance the following code

```python
from idyntree.visualize import MeshcatVisualizer
viz = MeshcatVisualizer()
viz.load_arrow(radius=0.01, shape_name="arrow", color=[255/255, 157/255, 68/255])
viz.set_arrow_transform(origin=[0, 0.5, 0], vector=[0.5, 0.33, 1], shape_name="arrow")
```

draws the following arrow
![image](https://github.com/robotology/idyntree/assets/16744101/c35b5bbc-f9ff-442f-8def-f9b3f665677f)
