### PR TITLE
ModelExporter: add the possibility to specify and export additional xmlblobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the possibility of exporting xml blobs w/ ModelExporter (https://github.com/robotology/idyntree/pull/1088)
+
 ## [9.1.0] - 2023-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added the possibility of exporting xml blobs w/ ModelExporter (https://github.com/robotology/idyntree/pull/1088)
+### Added
+
+- Added the possibility of exporting additional XML elements that are added as child of the `<robot>` element in URDF ModelExporter (https://github.com/robotology/idyntree/pull/1088).
+
+### Changed
+
+- The `iDynTree::ModelExporterOptions` class was changed to be defined as a struct (https://github.com/robotology/idyntree/pull/1088).
 
 ## [9.1.0] - 2023-05-25
 

--- a/src/model_io/codecs/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/codecs/include/iDynTree/ModelIO/ModelExporter.h
@@ -64,7 +64,7 @@ struct ModelExporterOptions
     /**
      * Specify the xml blobs to be exported at the end of the urdf as child of the robot tag.
      *
-     * Default: {""}.
+     * Default: {}.
      * Supported formats: urdf.
      */
     std::vector<std::string> xmlBlobs;

--- a/src/model_io/codecs/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/codecs/include/iDynTree/ModelIO/ModelExporter.h
@@ -62,7 +62,7 @@ struct ModelExporterOptions
      */
     std::string robotExportedName;
     /**
-     * Specify the xml blobs to be exported at the end of the urdf.
+     * Specify the xml blobs to be exported at the end of the urdf as child of the robot tag.
      *
      * Default: {""}.
      * Supported formats: urdf.

--- a/src/model_io/codecs/include/iDynTree/ModelIO/ModelExporter.h
+++ b/src/model_io/codecs/include/iDynTree/ModelIO/ModelExporter.h
@@ -26,9 +26,8 @@ namespace iDynTree
  *
  * Options for the iDynTree exporter.
  */
-class ModelExporterOptions
+struct ModelExporterOptions
 {
-public:
     /**
      * Specify the base link of the exported model.
      *
@@ -62,6 +61,13 @@ public:
      * Supported formats: urdf.
      */
     std::string robotExportedName;
+    /**
+     * Specify the xml blobs to be exported at the end of the urdf.
+     *
+     * Default: {""}.
+     * Supported formats: urdf.
+     */
+    std::vector<std::string> xmlBlobs;
 
     /**
      * Constructor.

--- a/src/model_io/codecs/src/ModelExporter.cpp
+++ b/src/model_io/codecs/src/ModelExporter.cpp
@@ -21,7 +21,8 @@ namespace iDynTree
 ModelExporterOptions::ModelExporterOptions()
 : baseLink(""),
     exportFirstBaseLinkAdditionalFrameAsFakeURDFBase(true),
-    robotExportedName("iDynTreeURDFModelExportModelName") {}
+    robotExportedName("iDynTreeURDFModelExportModelName"),
+    xmlBlobs{} {}
 
 
 class ModelExporter::Pimpl {

--- a/src/model_io/codecs/src/URDFModelExport.cpp
+++ b/src/model_io/codecs/src/URDFModelExport.cpp
@@ -433,6 +433,19 @@ enum exportAdditionalFrameDirectionOption {
     FAKE_LINK_IS_CHILD,
     FAKE_LINK_IS_PARENT
 };
+bool exportXMLBlob(std::string xmlBlob, xmlNodePtr parent_element) {
+     xmlNodePtr new_node = nullptr;
+     // Let's remove non printable characters
+     xmlBlob.erase(std::remove_if(xmlBlob.begin(), xmlBlob.end(),
+         [](unsigned char c) {
+             return !std::isprint(c);
+         }),
+         xmlBlob.end());
+    // we assume that 'parent_element' node is already defined
+    xmlParseInNodeContext(parent_element, xmlBlob.c_str(), strlen(xmlBlob.c_str()), 0, &new_node);
+    if (new_node) xmlAddChild(parent_element, new_node);
+    return true;
+}
 bool exportAdditionalFrame(const std::string frame_name, Transform link_H_frame, const std::string link_name, exportAdditionalFrameDirectionOption direction_option, xmlNodePtr parent_element)
 {
     bool ok=true;
@@ -569,7 +582,9 @@ bool URDFStringFromModel(const iDynTree::Model & model,
                                              robot);
         }
     }
-
+    for (auto& xmlBlob : options.xmlBlobs) {
+        ok = ok && exportXMLBlob(xmlBlob, robot);
+    }
     xmlChar *xmlbuff=0;
     int buffersize=0;
     xmlDocDumpFormatMemory(urdf_xml, &xmlbuff, &buffersize, 1);


### PR DESCRIPTION
It fixes #1080
Before exporting all [non-printable characters](https://en.cppreference.com/w/cpp/string/byte/isprint) are removed from the blobs, otherwise they mess up the indentation of the whole urdf.

Please review code.