### PR TITLE
Bump minor version to 100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 9.1.0
+project(iDynTree VERSION 9.100.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
So that we remember that next release needs to be 10.0.0 to account for the ABI/API changes.