### PR TITLE
Switch to run apt CI tests on Debian Testing instead of Debian Sid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         docker_image:
           - "ubuntu:20.04"
           - "ubuntu:22.04"
-          - "debian:sid"
+          - "debian:testing"
 
     container:
       image: ${{ matrix.docker_image }}


### PR DESCRIPTION
Debian Testing should anyhow catch problems in future Ubuntu releases, but with less instabilities than Debian Sid.