### PR TITLE
Fix installation location of deprecated iDynTree/Core headers

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -136,7 +136,7 @@ install(TARGETS ${libraryname}
 set_property(GLOBAL APPEND PROPERTY ${VARS_PREFIX}_TARGETS ${libraryname})
 
 # Install deprecated headers
-install(DIRECTORY include/iDynTree
+install(DIRECTORY include/iDynTree/Core
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/iDynTree)
 
 if(IDYNTREE_COMPILE_TESTS)


### PR DESCRIPTION
There was a wrong find&replace in https://github.com/robotology/idyntree/commit/20672579235827175bc09033292c1731d381040e .

Fix https://github.com/robotology/robotology-superbuild/issues/1470 .