### PR TITLE
Do not use R2023b for MATLAB CI

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-20.04, windows-2019, macos-latest]
-        matlab_version: [R2022a, R2022b, latest]
+        matlab_version: [R2022a, R2022b, R2023a]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Workaround for https://github.com/matlab-actions/run-command/issues/43 
Workaround for https://github.com/robotology/robotology-superbuild/issues/1492