### PR TITLE
fix issue with frames convention in stl meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed compilation of pybind11 bindings (https://github.com/robotology/idyntree/pull/1128).
+- Fixed support for handling correctly STL files that end with `.STL` in iDynTree Irrlicht-based visualizer (https://github.com/robotology/idyntree/pull/1136).
 
 ## [10.0.0] - 2023-10-16
 

--- a/src/visualization/src/IrrlichtUtils.h
+++ b/src/visualization/src/IrrlichtUtils.h
@@ -19,6 +19,8 @@
 
 #include <cmath>
 
+
+
 namespace iDynTree
 {
 
@@ -131,19 +133,22 @@ inline iDynTree::Rotation RotationWithPrescribedZColumn(const iDynTree::Directio
     return R;
 }
 
-inline std::string getFileExt(const std::string filename)
+inline std::string getFileExt(const std::string& filename)
 {
-    std::string::size_type idx;
+    auto idx = filename.rfind('.');
 
-    idx = filename.rfind('.');
-
-    if (idx != std::string::npos)
+    if (idx != std::string::npos && idx + 1 < filename.size())
     {
-       return filename.substr(idx+1);
+        std::string ext = filename.substr(idx + 1);
+        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+            return std::tolower(c);
+        });
+
+        return ext;
     }
     else
     {
-        return "";
+        return ""; // No extension found
     }
 }
 


### PR DESCRIPTION
@S-Dafarra  notes that for the visualizer,  "Irrlicht considers left-handed frames". STL meshes may consider right handed frames, and the mesh files can come with small-case extension string or capital. 