### PR TITLE
Implement KinDynComputations::getCentroidalRobotLockedInertia and KinDynComputations::getRobotLockedInertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.3.0] - 2024-02-07
+
+### Added
+
+- Added getCentroidalRobotLockedInertia and getRobotLockedInertia to KinDynComputations class (https://github.com/robotology/idyntree/pull/1153).
+
 ## [10.2.1] - 2024-02-01
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 10.2.1
+project(iDynTree VERSION 10.3.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/high-level/include/iDynTree/KinDynComputations.h
+++ b/src/high-level/include/iDynTree/KinDynComputations.h
@@ -917,6 +917,15 @@ public:
     bool getAverageVelocityJacobian(iDynTree::MatrixView<double> avgVelocityJacobian);
 
     /**
+     * Get the robot locked inertia matrix.
+     * The quantity is expressed in (B[A]), (A) or (B) depending on the FrameVelocityConvention used.
+     *
+     * @return the locked inertia matrix of the robot.
+     *
+     */
+    SpatialInertia getRobotLockedInertia();
+
+    /**
      * Get the centroidal average velocity of the robot.
      *
      * The quantity is the average velocity returned by getAverageVelocity, but computed in the center of mass
@@ -959,6 +968,15 @@ public:
      * @return true on success, false otherwise.
      */
     bool getCentroidalAverageVelocityJacobian(iDynTree::MatrixView<double> centroidalAvgVelocityJacobian);
+
+    /**
+     * Get the robot locked centroidal inertia matrix.
+     * The quantity is expressed in (G[A]) or (G[B]) depending on the FrameVelocityConvention used.
+     *
+     * @return the locked inertia centroidal matrix of the robot.
+     *
+     */
+    SpatialInertia getCentroidalRobotLockedInertia();
 
     /**
      * Get the linear and angular momentum of the robot.


### PR DESCRIPTION
This PR implements the `getCentroidalRobotLockedInertia` and the `getRobotLockedInertia` for the `KinDynComputations` class.

The two matrices allow to convert the robot average velocity into the associated momentum as explained in the chapter of 3.9.2 and 3.9.3 [@traversaro PhD thesis](https://traversaro.github.io/traversaro-phd-thesis/traversaro-phd-thesis.pdf)

![image](https://github.com/robotology/idyntree/assets/16744101/197f82f8-d3a5-4930-9240-20348d82aeca)


The PR adds also the associated tests