### PR TITLE
Avoid to include GLFW/glfw3native.h header when using glfw

### DIFF
--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -29,7 +29,6 @@
 #endif
 
 #include <GLFW/glfw3.h>
-#include <GLFW/glfw3native.h>
 
 #if defined(_WIN32) && defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
 // Required by SetEnvironmentVariableA, _putenv is not unsetting


### PR DESCRIPTION
Avoid to include GLFW/glfw3native.h header when using glfw. 

I have no idea if this works, but let's try.