### PR TITLE
Facilitate creation of Model from Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/*
 .DS_Store
 *.txt.user*
 .idea/*
+
+.vs/*
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 10.4.0
+project(iDynTree VERSION 11.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 10.3.0
+project(iDynTree VERSION 10.4.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -73,7 +73,7 @@ import_array();
                 IndexError(f"Index {index} not valid. The vector has a size of {self.size()}.")
 
             return self.getVal(index)
-            
+
         def __len__(self):
             return self.size()
     %}
@@ -114,7 +114,7 @@ import_array();
 // Magic Python method for using [] on matrices
 %define PYTHON_MAGIC_SET_GET_LEN_MATRIX()
     %pythoncode %{
-        def __setitem__(self, indices, value):            
+        def __setitem__(self, indices, value):
             if not (len(indices) == 2 and indices[0] < self.rows() and indices[1] < self.cols()):
                 raise IndexError(f"Indices {indices} not valid. The matrix has dimesions of ({self.rows()}, {self.cols()}).")
 
@@ -126,7 +126,7 @@ import_array();
                 raise IndexError(f"Indices {indices} not valid. The matrix has dimesions of ({self.rows()}, {self.cols()}).")
 
             return self.getVal(indices[0], indices[1])
-        
+
         def __len__(self):
             return self.rows() * self.cols()
     %}
@@ -145,7 +145,7 @@ import_array();
 // New constructors to build objects inheriting from SpatialVector with two 1x3 arrays
 // and one 1x6 array
 %define CPP_SPATIAL_CLASS_LINANG_CONSTRUCTOR(SpatialClass)
-    SpatialClass(const double* linear_data, const unsigned linear_size, 
+    SpatialClass(const double* linear_data, const unsigned linear_size,
                  const double* angular_data, const unsigned angular_size)
     {
         if (linear_size != 3)
@@ -153,17 +153,17 @@ import_array();
 
         if (angular_size != 3)
             throw std::runtime_error("Wrong size of angular component");
-        
-        return new iDynTree::SpatialClass({linear_data, linear_size}, 
+
+        return new iDynTree::SpatialClass({linear_data, linear_size},
                                           {angular_data, angular_size});
     }
-    
+
     SpatialClass(const double* in_data, const unsigned in_size)
     {
         if (in_size != 6)
             throw std::runtime_error("Wrong size of input spatial vector");
-        
-        return new iDynTree::SpatialClass({in_data, 3}, 
+
+        return new iDynTree::SpatialClass({in_data, 3},
                                           {in_data + 3, 3});
     }
 %enddef
@@ -213,7 +213,7 @@ import_array();
 
     PYTHON_MAGIC_SET_GET_LEN_VECTOR()
 
-    void toNumPy(double** out, int* size) {        
+    void toNumPy(double** out, int* size) {
         *out = static_cast<double*>(malloc(self->size() * sizeof(double)));
         std::copy(self->begin(), self->end(), *out);
         *size = self->size();
@@ -270,7 +270,7 @@ import_array();
 %extend iDynTree::Wrench {
 
     PYTHON_MAGIC_SET_GET_LEN_VECTOR()
-    
+
     CPP_SPATIAL_CLASS_LINANG_CONSTRUCTOR(Wrench);
     CPP_TO_NUMPY_SPATIAL_VECTOR(iDynTree::Wrench)
 
@@ -282,7 +282,7 @@ import_array();
 %extend iDynTree::Twist {
 
     PYTHON_MAGIC_SET_GET_LEN_VECTOR()
-    
+
     CPP_SPATIAL_CLASS_LINANG_CONSTRUCTOR(Twist);
     CPP_TO_NUMPY_SPATIAL_VECTOR(iDynTree::Twist)
 
@@ -294,7 +294,7 @@ import_array();
 %extend iDynTree::SpatialAcc {
 
     PYTHON_MAGIC_SET_GET_LEN_VECTOR()
-    
+
     CPP_SPATIAL_CLASS_LINANG_CONSTRUCTOR(SpatialAcc);
     CPP_TO_NUMPY_SPATIAL_VECTOR(iDynTree::SpatialAcc)
 

--- a/src/model/include/iDynTree/FixedJoint.h
+++ b/src/model/include/iDynTree/FixedJoint.h
@@ -174,15 +174,15 @@ namespace iDynTree
         virtual bool getPosLimits(const size_t _index, double & min, double & max) const;
         virtual double getMinPosLimit(const size_t _index) const;
         virtual double getMaxPosLimit(const size_t _index) const;
-        virtual bool setPosLimits(const size_t _index, double & min, double & max);
+        virtual bool setPosLimits(const size_t _index, double min, double max);
 
         // DYNAMICS METHODS
         virtual JointDynamicsType getJointDynamicsType() const;
         virtual bool setJointDynamicsType(const JointDynamicsType enable);
         virtual double getDamping(const size_t _index) const;
         virtual double getStaticFriction(const size_t _index) const;
-        virtual bool setDamping(const size_t _index, double& damping);
-        virtual bool setStaticFriction(const size_t _index, double& staticFriction);
+        virtual bool setDamping(const size_t _index, double damping);
+        virtual bool setStaticFriction(const size_t _index, double staticFriction);
     };
 }
 

--- a/src/model/include/iDynTree/IJoint.h
+++ b/src/model/include/iDynTree/IJoint.h
@@ -28,12 +28,12 @@ namespace iDynTree
 
         /**
          * URDFJointDynamics: Dynamics described by the URDF 1.0 specification.
-         * 
+         *
          * This joint dynamics type consider the following parameters:
          *  * `Damping`
          *  * `StaticFriction`
          */
-        URDFJointDynamics = 1    
+        URDFJointDynamics = 1
     };
 
     /**
@@ -372,21 +372,21 @@ namespace iDynTree
          * @note This just sets the internal position limits of the joint.
          *       To set them as enabled, you need to call the enablePosLimits(true) method.
          */
-        virtual bool setPosLimits(const size_t _index, double & min, double & max) = 0;
+        virtual bool setPosLimits(const size_t _index, double min, double max) = 0;
 
         /**
          * @name Joint dynamics methods.
-         * 
-         *  Methods for handling representation of joint dynamics. 
+         *
+         *  Methods for handling representation of joint dynamics.
          *  The precise definition of "joint dynamics" is not precisely, as depending on the
          *  specific application the kind of joint dynamics model can be different, and in some
          *  case it may be even just instantaneous models (for example, when only the damping is considered).
          *
          *  For the type of joint dynamics supported, see the iDynTree::JointDynamicsType enum documentation.
-         *  
+         *
          *  The joint dynamics model are used in the following contexts:
          *   * In methods to serialize and deserialize URDF files
-         * 
+         *
          *  The joint dynamics are **not used at all** in classes to compute kinematics and dynamics quantities,
          *  such as iDynTree::KinDynComputations .
          */
@@ -399,7 +399,7 @@ namespace iDynTree
          * @return the specific joint dynamics type used for the joint.
          */
         virtual JointDynamicsType getJointDynamicsType() const = 0;
-         
+
          /**
          * Method to get the specific joint dynamics type used for the joint.
          * \note: It is assume that all the degrees of freedom of a joint share the same joint dynamics type.
@@ -411,26 +411,26 @@ namespace iDynTree
          /**
          * Set damping parameter of the joint, for the _index dof.
          * The damping coefficient is expressed in N∙s/m for a prismatic joint, N∙m∙s/rad for a revolute joint.
-         * 
+         *
          * This parameter is considered in the following joint dynamics types:
          * * `URDFJointDynamics`
          *
          * @param[in] _index index of the dof for which the dynamic parameters are obtained.
          * @return true if everything is correct, false otherwise.
          */
-        virtual bool setDamping(const size_t _index, double& damping) = 0;
+        virtual bool setDamping(const size_t _index, double damping) = 0;
 
          /**
          * Set static friction parameter of the joint, for the _index dof.
          * The static friction coefficient is expressed in N for a prismatic joint, N∙m for a revolute joint.
-         * 
+         *
          * This parameter is considered in the following joint dynamics types:
          * * `URDFJointDynamics`
          *
          * @param[in] _index index of the dof for which the dynamic parameters are obtained.
          * @return true if everything is correct, false otherwise.
          */
-        virtual bool setStaticFriction(const size_t _index, double& staticFriction) = 0;
+        virtual bool setStaticFriction(const size_t _index, double staticFriction) = 0;
 
         /**
          * Get the damping coefficient of the joint.
@@ -444,7 +444,7 @@ namespace iDynTree
         /**
          * Get the static friction coefficient of the joint.
          * The unit is N for a prismatic joint, N∙m for a revolute joint.
-         * 
+         *
          * This parameter is considered in the following joint dynamics types:
          * * `URDFJointDynamics`
          */

--- a/src/model/include/iDynTree/PrismaticJoint.h
+++ b/src/model/include/iDynTree/PrismaticJoint.h
@@ -39,7 +39,7 @@ namespace iDynTree
         JointDynamicsType m_joint_dynamics_type;
         double m_damping;
         double m_static_friction;
-        
+
         // Cache attributes
         mutable double q_previous;
         mutable Transform link1_X_link2;
@@ -202,15 +202,15 @@ namespace iDynTree
         virtual bool getPosLimits(const size_t _index, double & min, double & max) const;
         virtual double getMinPosLimit(const size_t _index) const;
         virtual double getMaxPosLimit(const size_t _index) const;
-        virtual bool setPosLimits(const size_t _index, double & min, double & max);
+        virtual bool setPosLimits(const size_t _index, double min, double max);
 
         // DYNAMICS METHODS
         virtual JointDynamicsType getJointDynamicsType() const;
         virtual bool setJointDynamicsType(const JointDynamicsType enable);
         virtual double getDamping(const size_t _index) const;
         virtual double getStaticFriction(const size_t _index) const;
-        virtual bool setDamping(const size_t _index, double& damping);
-        virtual bool setStaticFriction(const size_t _index, double& staticFriction);
+        virtual bool setDamping(const size_t _index, double damping);
+        virtual bool setStaticFriction(const size_t _index, double staticFriction);
     };
 }
 

--- a/src/model/include/iDynTree/RevoluteJoint.h
+++ b/src/model/include/iDynTree/RevoluteJoint.h
@@ -210,15 +210,15 @@ namespace iDynTree
         virtual bool getPosLimits(const size_t _index, double & min, double & max) const;
         virtual double getMinPosLimit(const size_t _index) const;
         virtual double getMaxPosLimit(const size_t _index) const;
-        virtual bool setPosLimits(const size_t _index, double & min, double & max);
+        virtual bool setPosLimits(const size_t _index, double min, double max);
 
         // DYNAMICS METHODS
         virtual JointDynamicsType getJointDynamicsType() const;
         virtual bool setJointDynamicsType(const JointDynamicsType enable);
         virtual double getDamping(const size_t _index) const;
         virtual double getStaticFriction(const size_t _index) const;
-        virtual bool setDamping(const size_t _index, double& damping);
-        virtual bool setStaticFriction(const size_t _index, double& staticFriction);
+        virtual bool setDamping(const size_t _index, double damping);
+        virtual bool setStaticFriction(const size_t _index, double staticFriction);
     };
 }
 

--- a/src/model/include/iDynTree/SolidShapes.h
+++ b/src/model/include/iDynTree/SolidShapes.h
@@ -46,7 +46,7 @@ namespace iDynTree
         explicit SolidShape();
 
         virtual ~SolidShape()=0;
-        virtual SolidShape* clone()=0;
+        virtual SolidShape* clone() const = 0;
 
         /**
          * Returns the name of the shape.
@@ -125,7 +125,7 @@ namespace iDynTree
     public:
         virtual ~Sphere();
 
-        virtual SolidShape* clone();
+        virtual SolidShape* clone() const;
 
         /**
          * Returns the current radius.
@@ -153,7 +153,7 @@ namespace iDynTree
     {
     public:
         virtual ~Box();
-        virtual SolidShape* clone();
+        virtual SolidShape* clone() const;
 
         /**
          * Returns the current x side length.
@@ -195,7 +195,7 @@ namespace iDynTree
     {
     public:
         virtual ~Cylinder();
-        virtual SolidShape* clone();
+        virtual SolidShape* clone() const;
 
         /**
          * Returns the current cylinder length.
@@ -226,7 +226,7 @@ namespace iDynTree
     {
     public:
         virtual ~ExternalMesh();
-        virtual SolidShape* clone();
+        virtual SolidShape* clone() const;
 
         /**
          * Returns the current filename.
@@ -295,6 +295,9 @@ namespace iDynTree
         void resize(size_t nrOfLinks);
         void resize(const Model& model);
         bool isConsistent(const Model & model) const;
+
+        void clearSingleLinkSolidShapes(LinkIndex linkIndex);
+        void addSingleLinkSolidShape(LinkIndex linkIndex, const SolidShape& shape);
 
         std::vector<std::vector<SolidShape *> >& getLinkSolidShapes();
 

--- a/src/model/src/FixedJoint.cpp
+++ b/src/model/src/FixedJoint.cpp
@@ -255,7 +255,7 @@ double FixedJoint::getMaxPosLimit(const size_t _index) const
     return 0.0;
 }
 
-bool FixedJoint::setPosLimits(const size_t /*_index*/, double & /*min*/, double & /*max*/)
+bool FixedJoint::setPosLimits(const size_t /*_index*/, double /*min*/, double /*max*/)
 {
     return false;
 }
@@ -279,12 +279,12 @@ double FixedJoint::getStaticFriction(const size_t _index) const
     return 0.0;
 }
 
-bool FixedJoint::setDamping(const size_t /*_index*/, double& /*damping*/)
+bool FixedJoint::setDamping(const size_t /*_index*/, double /*damping*/)
 {
     return false;
 }
 
-bool FixedJoint::setStaticFriction(const size_t /*_index*/, double& /*staticFriction*/)
+bool FixedJoint::setStaticFriction(const size_t /*_index*/, double /*staticFriction*/)
 {
     return false;
 }

--- a/src/model/src/PrismaticJoint.cpp
+++ b/src/model/src/PrismaticJoint.cpp
@@ -372,7 +372,7 @@ double PrismaticJoint::getMaxPosLimit(const size_t /*_index*/) const
     return m_maxPos;
 }
 
-bool PrismaticJoint::setPosLimits(const size_t /*_index*/, double & min, double & max)
+bool PrismaticJoint::setPosLimits(const size_t /*_index*/, double min, double max)
 {
     m_minPos = min;
     m_maxPos = max;
@@ -407,14 +407,14 @@ double PrismaticJoint::getStaticFriction(const size_t _index) const
     return m_static_friction;
 }
 
-bool PrismaticJoint::setDamping(const size_t _index, double& damping)
+bool PrismaticJoint::setDamping(const size_t _index, double damping)
 {
     m_damping = damping;
 
     return true;
 }
 
-bool PrismaticJoint::setStaticFriction(const size_t _index, double& staticFriction)
+bool PrismaticJoint::setStaticFriction(const size_t _index, double staticFriction)
 {
     m_static_friction = staticFriction;
 

--- a/src/model/src/RevoluteJoint.cpp
+++ b/src/model/src/RevoluteJoint.cpp
@@ -387,7 +387,7 @@ double RevoluteJoint::getMaxPosLimit(const size_t /*_index*/) const
     return m_maxPos;
 }
 
-bool RevoluteJoint::setPosLimits(const size_t /*_index*/, double & min, double & max)
+bool RevoluteJoint::setPosLimits(const size_t /*_index*/, double min, double max)
 {
     m_minPos = min;
     m_maxPos = max;
@@ -423,14 +423,14 @@ double RevoluteJoint::getStaticFriction(const size_t _index) const
     return m_static_friction;
 }
 
-bool RevoluteJoint::setDamping(const size_t _index, double& damping)
+bool RevoluteJoint::setDamping(const size_t _index, double damping)
 {
     m_damping = damping;
 
     return true;
 }
 
-bool RevoluteJoint::setStaticFriction(const size_t _index, double& staticFriction)
+bool RevoluteJoint::setStaticFriction(const size_t _index, double staticFriction)
 {
     m_static_friction = staticFriction;
 

--- a/src/model/src/SolidShapes.cpp
+++ b/src/model/src/SolidShapes.cpp
@@ -137,7 +137,7 @@ namespace iDynTree
     {
     }
 
-    SolidShape* Sphere::clone()
+    SolidShape* Sphere::clone() const
     {
         return new Sphere(*this);
     }
@@ -150,7 +150,7 @@ namespace iDynTree
     {
     }
 
-    SolidShape* Box::clone()
+    SolidShape* Box::clone() const
     {
         return new Box(*this);
     }
@@ -171,7 +171,7 @@ namespace iDynTree
     {
     }
 
-    SolidShape* Cylinder::clone()
+    SolidShape* Cylinder::clone() const
     {
         return new Cylinder(*this);
     }
@@ -188,7 +188,7 @@ namespace iDynTree
     {
     }
 
-    SolidShape* ExternalMesh::clone()
+    SolidShape* ExternalMesh::clone() const
     {
         return new ExternalMesh(*this);
     }
@@ -385,6 +385,31 @@ namespace iDynTree
     bool ModelSolidShapes::isConsistent(const Model& model) const
     {
         return (this->linkSolidShapes.size() == model.getNrOfLinks());
+    }
+
+    void ModelSolidShapes::clearSingleLinkSolidShapes(LinkIndex linkIndex)
+    {
+        if (linkIndex >= linkSolidShapes.size())
+        {
+            return;
+        }
+
+        for (size_t geom = 0; geom < linkSolidShapes[linkIndex].size(); geom++)
+        {
+            delete linkSolidShapes[linkIndex][geom];
+            linkSolidShapes[linkIndex][geom] = 0;
+        }
+        linkSolidShapes[linkIndex].resize(0);
+    }
+
+    void ModelSolidShapes::addSingleLinkSolidShape(LinkIndex linkIndex, const SolidShape& shape)
+    {
+        if (linkIndex >= linkSolidShapes.size())
+        {
+            return;
+        }
+
+        linkSolidShapes[linkIndex].push_back(shape.clone());
     }
 
     std::vector<std::vector<SolidShape *>>& ModelSolidShapes::getLinkSolidShapes() {


### PR DESCRIPTION
This PR does the following:
- add some setter methods to ease the setting of the model visual solid shapes from the bindings
- removed the use of ``double&`` when setting the limits and the friction of a joint, as the values were effectively copied
- bumped the version (as the API has changed)
- removed some whitespace and included Visual Studio files in the gitignore