### PR TITLE
Fix bug in DynamicsLinearization due to use of ; in place of +

### DIFF
--- a/src/model/src/DynamicsLinearization.cpp
+++ b/src/model/src/DynamicsLinearization.cpp
@@ -305,7 +305,7 @@ void ForwardDynamicsLinearizationWrtJointPos(const Model& model,
                double invD = 1/(bufs.aba.D(dofIndex));
                double d_invD = - invD * bufs.dPos[dofDeriv].D(dofIndex) * invD;
                double dPos_ddq =
-                    (bufs.aba.u(dofIndex)-bufs.aba.U(dofIndex).dot(bufs.aba.linksAccelerations(visitedLinkIndex)))*d_invD;
+                    (bufs.aba.u(dofIndex)-bufs.aba.U(dofIndex).dot(bufs.aba.linksAccelerations(visitedLinkIndex)))*d_invD+
                     (bufs.dPos[dofDeriv].u(dofIndex)
                         -bufs.dPos[dofDeriv].U(dofIndex).dot(bufs.aba.linksAccelerations(visitedLinkIndex))
                         -bufs.aba.U(dofIndex).dot(bufs.dPos[dofDeriv].linksAccelerations(visitedLinkIndex)))*invD;

--- a/src/tests/integration/CMakeLists.txt
+++ b/src/tests/integration/CMakeLists.txt
@@ -43,7 +43,6 @@ add_integration_test(Dynamics)
 add_integration_test(DenavitHartenberg)
 add_integration_test(ReducedModelWithFT)
 
-
 # See issue https://github.com/robotology/idyntree/issues/367
 add_integration_test_no_valgrind(iCubTorqueEstimation)
 

--- a/src/tests/integration/DynamicsLinearizationIntegrationTest.cpp
+++ b/src/tests/integration/DynamicsLinearizationIntegrationTest.cpp
@@ -505,8 +505,6 @@ int main()
     std::cerr << "Checking DynamicsLinearization test on a point mass model" << std::endl;
     checkABAandABALinearizationAreConsistent(doubleBodyModel);
 
-    return 0;
-
     // Then test random generated chains
     for(unsigned int joints =0; joints < 20; joints++)
     {


### PR DESCRIPTION
Back in January 2016, in a rush to avoid that the work I did during my secondment in Eindhoven diverged too much w.r.t. to iDynTree master, I merged https://github.com/robotology/idyntree/pull/129 . In it, I included my work on Dynamics linearization that eventually got published in https://www.aimsciences.org/article/doi/10.3934/jgm.2022009 / https://arxiv.org/pdf/2204.05092.pdf (Equations 22 and 23, if anyone is curious). 

Unfortunately, I remember that a test was not passing, so I disabled it as I was not able to fix it. Then, time passed and for linearization we started using almost uniquely autodiff system, so I did not turned back my attention to hand-written DynamicsLinearization functions in iDynTree. However, after some years (but still a few years ago) I started noticing a warning that only occured in Visual Studio/Windows-builds:
~~~
[105/308] Building CXX object src\model\CMakeFiles\idyntree-model.dir\src\DynamicsLinearization.cpp.obj
D:\a\idyntree\idyntree\src\model\src\DynamicsLinearization.cpp(311): warning C4552: '*': result of expression not used
~~~

I remember thinking that "result of expression not used" probably indicated a real bug, and that could be the reason why my test in Eindhoven  were not passing! Anyhow, I never actually looked into it. However, today @S-Dafarra noticed again the warning and pinged me about it, so I finally looked into it. The bug itself was quite trivial (a `;` instead of a `+` typo), but I was not able to find it back in 2015/2016. And after fixing it, ~indeed the test finally passed!~ the test have less failures, but unfortunately still fails. So, let's just fix the obvious error, and leave the test disabled.

