### PR TITLE
Release 11.0.0 and document that CHANGELOG is not going to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased Major]
-
-
-## [Unreleased]
+This file documents notable changes to this project done before February 2024. For changes after that date, plase refers to the release notes of each release at https://github.com/robotology/idyntree/releases .
 
 ## [10.3.0] - 2024-02-07
 


### PR DESCRIPTION
I think it is important to make the contribution and release process as smooth as possible, and the CHANGELOG file was complicating this. I think we can rely on the automatic process of GitHub to generate the list of the changes in a given release, and if necessary we can modify manually the automatically generated release changelog.