### PR TITLE
Visualize solid shapes and attach frames to model frames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 12.0.0
+project(iDynTree VERSION 11.1.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 11.0.0
+project(iDynTree VERSION 12.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 11.1.0
+project(iDynTree VERSION 12.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -18,6 +18,7 @@ if(IDYNTREE_USES_IRRLICHT)
                                                src/JetsVisualization.h
                                                src/VectorsVisualization.h
                                                src/FrameVisualization.h
+                                               src/ShapesVisualization.h
                                                src/Texture.h
                                                src/TexturesHandler.h
                                                src/Light.h
@@ -30,6 +31,7 @@ if(IDYNTREE_USES_IRRLICHT)
                                                src/JetsVisualization.cpp
                                                src/VectorsVisualization.cpp
                                                src/FrameVisualization.cpp
+                                               src/ShapesVisualization.cpp
                                                src/Texture.cpp
                                                src/TexturesHandler.cpp
                                                src/Light.cpp

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -657,7 +657,7 @@ public:
         /**
         * Get the parent of a shape.
         * Returns a pair with the first element being the model name, and the second the frame name.
-        * If the shape is attached to the world, the both elements are empty strings.
+        * If the shape is attached to the world, both elements are empty strings.
         */
         virtual std::pair<std::string, std::string> getShapeParent(size_t shapeIndex) const = 0;
 
@@ -665,6 +665,7 @@ public:
         * Set the parent of a shape.
         * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
         * If the modelName and frameName are empty strings, the shape is attached to the world.
+        * If the model name is specified, but not the frame name, it is attached to the root link of the model.
         */
         virtual bool setShapeParent(size_t shapeIndex, const std::string& modelName, const std::string& frameName) = 0;
 

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -13,6 +13,8 @@
 #include <iDynTree/JointState.h>
 #include <iDynTree/LinkState.h>
 
+#include <iDynTree/SolidShapes.h>
+
 namespace iDynTree
 {
 class Model;
@@ -149,6 +151,11 @@ public:
      * Build a color from a Vector4 rgba.
      */
     ColorViz(const Vector4 & rgba);
+
+    /**
+     * Return as a Vector4.
+     */
+    Vector4 toVector4() const;
 };
 
 /**
@@ -587,6 +594,71 @@ public:
     virtual ILabel* getFrameLabel(size_t frameIndex) = 0;
 };
 
+/**
+ * Interface to the visualization of generic solid shapes.
+ */
+ class IShapeVisualization
+ {
+public:
+        /**
+        * Destructor
+        */
+        virtual ~IShapeVisualization() = 0;
+
+        /**
+        * Add a shape in the visualization.
+        * If the modelName and linkName are specified, the shape is attached to the specific frame.
+        * If they are not specified, or cannot be found, the shape is attached to the world.
+        * The initial transform is specified by the shape itself (Link_H_geometry).
+        * Returns the shape index.
+        */
+        virtual size_t addShape(const iDynTree::SolidShape& shape,
+                                const std::string& modelName = "",
+                                const std::string& frameName = "") = 0;
+
+        /**
+        * Set the specified shape visible or not.
+        * Returns true in case of success, false otherwise (for example if the shape does not exists).
+        */
+        virtual bool setVisible(size_t shapeIndex, bool isVisible) = 0;
+
+        /**
+        * Get the number of visualized shapes.
+        *
+        */
+        virtual size_t getNrOfShapes() const = 0;
+
+        /**
+        * Get shape transform with respect the parent frame (world if the shape is attached to the world).
+        */
+        virtual bool getShapeTransform(size_t shapeIndex, Transform& currentTransform) const = 0;
+
+        /**
+        * Set the shape transform with respect the parent frame (world if the shape is attached to the world).
+        */
+        virtual bool setShapeTransform(size_t shapeIndex, const Transform& transformation) = 0;
+
+        /**
+        * Set the color of the shape.
+        * Returns true in case of success, false otherwise (for example if the shape does not exists).
+        */
+        virtual bool setShapeColor(size_t shapeIndex, const ColorViz& shapeColor) = 0;
+
+        /**
+        * Change the shape.
+        * The previous shape is removed.
+        * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
+        */
+        virtual bool changeShape(size_t shapeIndex, const iDynTree::SolidShape& newShape) = 0;
+
+        /**
+        * Get the label of a shape.
+        *
+        * Returns nullptr of the shape index is out of bounds.
+        */
+        virtual ILabel* getShapeLabel(size_t shapeIndex) = 0;
+    };
+
 
 /**
  * Interface to the visualization of a model istance.
@@ -942,6 +1014,11 @@ public:
      * Get a reference to the internal ITexturesHandler interface.
      */
     ITexturesHandler& textures();
+
+    /**
+     * Get a reference to the internal IShapeVisualization interface.
+     */
+    IShapeVisualization& shapes();
 
     /**
      * Get a label given a name. Note: this does not set the text in the label.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -578,14 +578,29 @@ public:
     virtual size_t getNrOfFrames() const = 0;
 
     /**
-     * Get frame transform.
+     * Get frame transform, relative to the parent frame (world if the frame is attached to the world).
      */
     virtual bool getFrameTransform(size_t frameIndex, Transform& currentTransform) const = 0;
 
     /**
-     * Update Frame
+     * Update Frame, the transformation is relative to the parent frame (world if the frame is attached to the world).
      */
     virtual bool updateFrame(size_t frameIndex, const Transform& transformation) = 0;
+
+    /**
+    * Get the parent of a frame.
+    * Returns a pair with the first element being the model name, and the second the frame name to which it is attached.
+    * If the frame is attached to the world, both elements are empty strings.
+    */
+    virtual std::pair<std::string, std::string> getFrameParent(size_t frameIndex) const = 0;
+
+    /**
+    * Set the parent of a frame.
+    * Returns true in case of success, false otherwise (for example if the frame index is out of bounds).
+    * If the modelName and frameName are empty strings, the frame is attached to the world.
+    * If the model name is specified, but not the frame name, it is attached to the root link of the model.
+    */
+    virtual bool setFrameParent(size_t frameIndex, const std::string& modelName, const std::string& frameName) = 0;
 
     /**
      * Get the label of a frame.

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -751,6 +751,22 @@ public:
     virtual bool setLinkColor(const LinkIndex& linkIndex, const ColorViz& linkColor) = 0;
 
     /**
+     * Set the transparency of a given link of the model.
+     *
+     * This will overwrite the material of the link, but it can be
+     * reset by resetLinkColor.
+     */
+    virtual bool setLinkTransparency(const LinkIndex& linkIndex, const double transparency) = 0;
+
+    /**
+     * Set the transparency of all the links of the model.
+     *
+     * This will overwrite the material of the links, but they can be
+     * reset by resetLinkColor.
+     */
+    virtual void setModelTransparency(const double transparency) = 0;
+
+    /**
      * Reset the colors of given link.
      */
     virtual bool resetLinkColor(const LinkIndex& linkIndex) = 0;

--- a/src/visualization/include/iDynTree/Visualizer.h
+++ b/src/visualization/include/iDynTree/Visualizer.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <iDynTree/Direction.h>
 #include <iDynTree/Position.h>
@@ -609,6 +610,7 @@ public:
         * Add a shape in the visualization.
         * If the modelName and linkName are specified, the shape is attached to the specific frame.
         * If they are not specified, or cannot be found, the shape is attached to the world.
+        * If the model name is specified, but not the frame name, it is attached to the root link of the model.
         * The initial transform is specified by the shape itself (Link_H_geometry).
         * Returns the shape index.
         */
@@ -650,6 +652,21 @@ public:
         * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
         */
         virtual bool changeShape(size_t shapeIndex, const iDynTree::SolidShape& newShape) = 0;
+
+
+        /**
+        * Get the parent of a shape.
+        * Returns a pair with the first element being the model name, and the second the frame name.
+        * If the shape is attached to the world, the both elements are empty strings.
+        */
+        virtual std::pair<std::string, std::string> getShapeParent(size_t shapeIndex) const = 0;
+
+        /**
+        * Set the parent of a shape.
+        * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
+        * If the modelName and frameName are empty strings, the shape is attached to the world.
+        */
+        virtual bool setShapeParent(size_t shapeIndex, const std::string& modelName, const std::string& frameName) = 0;
 
         /**
         * Get the label of a shape.

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -171,6 +171,8 @@ public:
     virtual void setModelColor(const ColorViz & ) {}
     virtual void resetModelColor() {}
     virtual bool setLinkColor(const LinkIndex &, const ColorViz &) { return false; }
+    virtual bool setLinkTransparency(const LinkIndex&, const double) { return false; }
+    virtual void setModelTransparency(const double ) {}
     virtual bool resetLinkColor(const LinkIndex &) { return false; }
     virtual std::vector< std::string > getLinkNames() { return std::vector<std::string>(); };
     virtual bool setLinkVisibility(const std::string &, bool) { return false; }

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -146,6 +146,8 @@ public:
     virtual size_t getNrOfFrames() const override {return 0; };
     virtual bool getFrameTransform(size_t , Transform& ) const override {return false;};
     virtual bool updateFrame(size_t, const Transform&) override {return false;};
+    virtual std::pair<std::string, std::string> getFrameParent(size_t frameIndex) const override { return std::pair<std::string, std::string>("", ""); };
+    virtual bool setFrameParent(size_t frameIndex, const std::string& modelName, const std::string& frameName) override { return false; };
     virtual ILabel* getFrameLabel(size_t) override {return nullptr;};
 };
 

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -130,6 +130,8 @@ public:
     virtual bool setShapeTransform(size_t, const Transform&) override { return false; };
     virtual bool setShapeColor(size_t, const ColorViz&) override { return false; };
     virtual bool changeShape(size_t, const iDynTree::SolidShape&) override { return false; };
+    virtual std::pair<std::string, std::string> getShapeParent(size_t shapeIndex) const override { return std::pair<std::string, std::string>("", ""); };
+    virtual bool setShapeParent(size_t shapeIndex, const std::string& modelName, const std::string& frameName) override { return false; };
     virtual ILabel* getShapeLabel(size_t) override { return nullptr; };
 };
 

--- a/src/visualization/src/DummyImplementations.h
+++ b/src/visualization/src/DummyImplementations.h
@@ -120,6 +120,20 @@ public:
     virtual ILabel* getVectorLabel(size_t ) override {return nullptr;}
 };
 
+class DummyShapeVisualization : public IShapeVisualization {
+public:
+    virtual ~DummyShapeVisualization() override { };
+    virtual size_t addShape(const iDynTree::SolidShape&, const std::string& = "", const std::string& = "") override { return 0; };
+    virtual bool setVisible(size_t, bool) override { return false; };
+    virtual size_t getNrOfShapes() const override { return 0; };
+    virtual bool getShapeTransform(size_t, Transform&) const override { return false; };
+    virtual bool setShapeTransform(size_t, const Transform&) override { return false; };
+    virtual bool setShapeColor(size_t, const ColorViz&) override { return false; };
+    virtual bool changeShape(size_t, const iDynTree::SolidShape&) override { return false; };
+    virtual ILabel* getShapeLabel(size_t) override { return nullptr; };
+};
+
+
 class DummyFrameVisualization : public IFrameVisualization
 {
 public:

--- a/src/visualization/src/FrameVisualization.cpp
+++ b/src/visualization/src/FrameVisualization.cpp
@@ -4,6 +4,8 @@
 #include "FrameVisualization.h"
 #include "IrrlichtUtils.h"
 
+#include <iDynTree/Model.h>
+
 
 void iDynTree::FrameVisualization::setFrameTransform(size_t index, const iDynTree::Transform &transformation)
 {
@@ -23,6 +25,7 @@ size_t iDynTree::FrameVisualization::addFrame(const iDynTree::Transform &transfo
     m_frames.emplace_back();
 
     m_frames.back().visualizationNode = addFrameAxes(m_smgr, 0, arrowLength);
+    m_frames.back().visualizationNode->grab();
     setFrameTransform(m_frames.size() - 1, transformation);
     m_frames.back().label.init(m_smgr, m_frames.back().visualizationNode);
 
@@ -54,7 +57,7 @@ bool iDynTree::FrameVisualization::getFrameTransform(size_t frameIndex, iDynTree
     }
 
     irr::scene::ISceneNode * frameSceneNode = m_frames[frameIndex].visualizationNode;
-    currentTransform.setPosition(irr2idyntree_pos(frameSceneNode->getAbsolutePosition()));
+    currentTransform.setPosition(irr2idyntree_pos(frameSceneNode->getPosition()));
     currentTransform.setRotation(irr2idyntree_rot(frameSceneNode->getRotation()));
 
     return true;
@@ -67,6 +70,72 @@ bool iDynTree::FrameVisualization::updateFrame(size_t frameIndex, const iDynTree
         return false;
     }
     setFrameTransform(frameIndex, transformation);
+    return true;
+}
+
+std::pair<std::string, std::string> iDynTree::FrameVisualization::getFrameParent(size_t frameIndex) const
+{
+    if (frameIndex >= m_frames.size())
+    {
+        reportError("FrameVisualization", "getFrameParent", "Frame index out of range");
+        return std::make_pair<std::string, std::string>("", "");
+    }
+    return std::make_pair(m_frames[frameIndex].parentModel, m_frames[frameIndex].parentFrame);
+}
+
+bool iDynTree::FrameVisualization::setFrameParent(size_t frameIndex, const std::string& modelName, const std::string& frameName)
+{
+    if (frameIndex >= m_frames.size())
+    {
+        reportError("FrameVisualization", "setFrameParent", "Frame index out of range");
+        return false;
+    }
+
+    irr::scene::ISceneNode* parent = nullptr;
+    std::string actualFrameName = "";
+
+    if (!modelName.empty())
+    {
+        bool found = false;
+        for (auto& model : *m_models)
+        {
+            if (model->getInstanceName() == modelName)
+            {
+                found = true;
+                if (frameName.empty())
+                {
+                    iDynTree::LinkIndex root_link_index = model->model().getDefaultBaseLink();
+                    actualFrameName = model->model().getLinkName(root_link_index);
+                    parent = model->getFrameSceneNode(actualFrameName);
+                }
+                else
+                {
+                    actualFrameName = frameName;
+                    parent = model->getFrameSceneNode(frameName);
+                }
+                break;
+            }
+        }
+        if (!parent)
+        {
+            std::string error;
+            if (!found)
+            {
+                error = "Model " + modelName + " not found";
+            }
+            else
+            {
+                error = "Frame " + frameName + " not found in model " + modelName;
+            }
+            reportError("FrameVisualization", "setFrameParent", error.c_str());
+            return false;
+        }
+    }
+
+    m_frames[frameIndex].visualizationNode->setParent(parent);
+    m_frames[frameIndex].parentModel = modelName;
+    m_frames[frameIndex].parentFrame = actualFrameName;
+
     return true;
 }
 
@@ -85,11 +154,12 @@ iDynTree::FrameVisualization::~FrameVisualization()
     close();
 }
 
-void iDynTree::FrameVisualization::init(irr::scene::ISceneManager *smgr)
+void iDynTree::FrameVisualization::init(irr::scene::ISceneManager* smgr, std::shared_ptr<std::vector<ModelVisualization*>> models)
 {
     assert(smgr);
     m_smgr = smgr;
     m_smgr->grab(); //Increment the reference count
+    m_models = models;
 }
 
 void iDynTree::FrameVisualization::close()
@@ -97,6 +167,8 @@ void iDynTree::FrameVisualization::close()
     for (auto& frames: m_frames) {
         if (frames.visualizationNode) {
             frames.visualizationNode->removeAll();
+            frames.visualizationNode->remove();
+            frames.visualizationNode->drop();
             frames.visualizationNode = nullptr;
         }
     }
@@ -107,4 +179,5 @@ void iDynTree::FrameVisualization::close()
         m_smgr->drop(); //Drop the element (dual of "grab")
         m_smgr = 0;
     }
+    m_models = nullptr;
 }

--- a/src/visualization/src/FrameVisualization.h
+++ b/src/visualization/src/FrameVisualization.h
@@ -5,9 +5,11 @@
 
 #include <iDynTree/Visualizer.h>
 #include "Label.h"
+#include "ModelVisualization.h"
 
 #include <vector>
 #include <irrlicht.h>
+#include <memory>
 
 namespace iDynTree
 {
@@ -17,10 +19,13 @@ namespace iDynTree
         {
             irr::scene::ISceneNode * visualizationNode = nullptr;
             Label label;
+            std::string parentModel;
+            std::string parentFrame;
         };
 
         std::vector<Frame> m_frames;
         irr::scene::ISceneManager* m_smgr;
+        std::shared_ptr<std::vector<ModelVisualization*>> m_models;
 
         void setFrameTransform(size_t index, const Transform& transformation);
 
@@ -30,7 +35,7 @@ namespace iDynTree
 
         ~FrameVisualization();
 
-        void init(irr::scene::ISceneManager* smgr);
+        void init(irr::scene::ISceneManager* smgr, std::shared_ptr<std::vector<ModelVisualization*>> models);
 
         void close();
 
@@ -47,6 +52,10 @@ namespace iDynTree
         virtual bool getFrameTransform(size_t frameIndex, Transform& currentTransform) const final;
 
         virtual bool updateFrame(size_t frameIndex, const Transform& transformation) final;
+
+        virtual std::pair<std::string, std::string> getFrameParent(size_t frameIndex) const final;
+
+        virtual bool setFrameParent(size_t frameIndex, const std::string& modelName, const std::string& frameName) final;
 
         virtual ILabel* getFrameLabel(size_t frameIndex) final;
 

--- a/src/visualization/src/ModelVisualization.cpp
+++ b/src/visualization/src/ModelVisualization.cpp
@@ -473,6 +473,18 @@ void ModelVisualization::close()
 
 }
 
+irr::scene::ISceneNode* ModelVisualization::getFrameSceneNode(const std::string& frameName)
+{
+    size_t frameIndex = pimpl->m_model.getFrameIndex(frameName);
+    if (frameIndex == FRAME_INVALID_INDEX)
+    {
+        std::string errorMsg = "Frame " + frameName + " not found";
+        reportError("ModelVisualization","getFrameSceneNode", errorMsg.c_str());
+        return nullptr;
+    }
+    return pimpl->frameNodes[frameIndex];
+}
+
 std::vector<std::string> ModelVisualization::getFeatures()
 {
     std::vector<std::string> ret;

--- a/src/visualization/src/ModelVisualization.cpp
+++ b/src/visualization/src/ModelVisualization.cpp
@@ -372,6 +372,16 @@ bool ModelVisualization::setLinkColor(const LinkIndex& linkIndex, const ColorViz
                 geomMat.SpecularColor.setAlpha(col.getAlpha());
                 geomMat.EmissiveColor.setAlpha(col.getAlpha());
 
+                if (linkColor.a < 1.0)
+                {
+                    geomMat.MaterialType = irr::video::EMT_TRANSPARENT_VERTEX_ALPHA;
+                }
+                else
+                {
+                    geomMat.MaterialType = irr::video::EMT_SOLID;
+                }
+
+
                 geomNode->getMaterial(mat) = geomMat;
             }
             geomNode->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
@@ -419,6 +429,8 @@ bool ModelVisualization::resetLinkColor(const LinkIndex& linkIndex)
                 geomMat.DiffuseColor.setBlue(materialCache[mat].DiffuseColor.getBlue());
                 geomMat.SpecularColor.setBlue(materialCache[mat].SpecularColor.getBlue());
                 geomMat.EmissiveColor.setBlue(materialCache[mat].EmissiveColor.getBlue());
+
+                geomMat.MaterialType = irr::video::EMT_SOLID;
 
                 geomNode->getMaterial(mat) = geomMat;
             }
@@ -539,6 +551,16 @@ bool ModelVisualization::setLinkTransparency(const LinkIndex& linkIndex, const d
                 geomMat.DiffuseColor.setAlpha(alphaValue);
                 geomMat.SpecularColor.setAlpha(alphaValue);
                 geomMat.EmissiveColor.setAlpha(alphaValue);
+
+                if (transparency < 1.0)
+                {
+                    geomMat.MaterialType = irr::video::EMT_TRANSPARENT_VERTEX_ALPHA;
+                }
+                else
+                {
+                    geomMat.MaterialType = irr::video::EMT_SOLID;
+                }
+
 
                 geomNode->getMaterial(mat) = geomMat;
             }

--- a/src/visualization/src/ModelVisualization.cpp
+++ b/src/visualization/src/ModelVisualization.cpp
@@ -367,8 +367,17 @@ bool ModelVisualization::setLinkColor(const LinkIndex& linkIndex, const ColorViz
                 geomMat.SpecularColor.setBlue(col.getBlue());
                 geomMat.EmissiveColor.setBlue(col.getBlue());
 
+                geomMat.AmbientColor.setAlpha(col.getAlpha());
+                geomMat.DiffuseColor.setAlpha(col.getAlpha());
+                geomMat.SpecularColor.setAlpha(col.getAlpha());
+                geomMat.EmissiveColor.setAlpha(col.getAlpha());
+
                 geomNode->getMaterial(mat) = geomMat;
             }
+            geomNode->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
+            geomNode->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
+            geomNode->setMaterialFlag(irr::video::EMF_COLOR_MATERIAL, false);
+            geomNode->setMaterialFlag(irr::video::EMF_BLEND_OPERATION, true);
         }
     }
     return true;
@@ -413,6 +422,10 @@ bool ModelVisualization::resetLinkColor(const LinkIndex& linkIndex)
 
                 geomNode->getMaterial(mat) = geomMat;
             }
+            geomNode->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
+            geomNode->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
+            geomNode->setMaterialFlag(irr::video::EMF_COLOR_MATERIAL, true);
+            geomNode->setMaterialFlag(irr::video::EMF_BLEND_OPERATION, false);
         }
     }
    return true;
@@ -492,6 +505,51 @@ std::vector<std::string> ModelVisualization::getFeatures()
     ret.push_back("transparent");
 
     return ret;
+}
+
+void ModelVisualization::setModelTransparency(const double transparency)
+{
+    for (size_t linkIdx = 0; linkIdx < pimpl->geomNodes.size(); linkIdx++)
+    {
+        setLinkTransparency(linkIdx, transparency);
+    }
+}
+
+bool ModelVisualization::setLinkTransparency(const LinkIndex& linkIndex, const double transparency)
+{
+    if (linkIndex < 0 || linkIndex >= pimpl->geomNodes.size())
+    {
+        reportError("ModelVisualization", "setLinkTransparency", "invalid link index");
+        return false;
+    }
+    irr::u32 alphaValue = static_cast<irr::u32>(255.0 * transparency);
+
+
+    for (size_t geom = 0; geom < pimpl->geomNodes[linkIndex].size(); geom++)
+    {
+        if (pimpl->geomNodes[linkIndex][geom])
+        {
+            irr::scene::ISceneNode* geomNode = pimpl->geomNodes[linkIndex][geom];
+
+            for (size_t mat = 0; mat < geomNode->getMaterialCount(); mat++)
+            {
+                irr::video::SMaterial geomMat = geomNode->getMaterial(mat);
+
+                geomMat.AmbientColor.setAlpha(alphaValue);
+                geomMat.DiffuseColor.setAlpha(alphaValue);
+                geomMat.SpecularColor.setAlpha(alphaValue);
+                geomMat.EmissiveColor.setAlpha(alphaValue);
+
+                geomNode->getMaterial(mat) = geomMat;
+            }
+            geomNode->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
+            geomNode->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
+            geomNode->setMaterialFlag(irr::video::EMF_COLOR_MATERIAL, false); //Do not use vertex color
+            geomNode->setMaterialFlag(irr::video::EMF_BLEND_OPERATION, true); //Blend colors to have the transparency effect
+        }
+    }
+
+    return true;
 }
 
 bool ModelVisualization::setFeatureVisibility(const std::string& elementKey, bool isVisible)

--- a/src/visualization/src/ModelVisualization.h
+++ b/src/visualization/src/ModelVisualization.h
@@ -40,6 +40,8 @@ public:
     virtual std::vector< std::string > getLinkNames();
     virtual bool setLinkVisibility(const std::string & linkName, bool isVisible);
     virtual std::vector<std::string> getFeatures();
+    virtual void setModelTransparency(const double transparency);
+    virtual bool setLinkTransparency(const LinkIndex& linkIndex, const double transparency);
     virtual bool setFeatureVisibility(const std::string & elementKey, bool isVisible);
     void setWireframeVisibility(bool isVisible);
     void setTransparent(bool isTransparent);

--- a/src/visualization/src/ModelVisualization.h
+++ b/src/visualization/src/ModelVisualization.h
@@ -26,6 +26,8 @@ public:
     bool init(const Model& model, const std::string instanceName, irr::scene::ISceneManager * sceneManager);
     void close();
 
+    irr::scene::ISceneNode * getFrameSceneNode(const std::string& frameName);
+
     virtual bool setPositions(const Transform & world_H_base, const VectorDynSize & jointPos);
     virtual bool setLinkPositions(const LinkPositions & linkPos);
     virtual Model & model();

--- a/src/visualization/src/ShapesVisualization.cpp
+++ b/src/visualization/src/ShapesVisualization.cpp
@@ -72,6 +72,7 @@ size_t iDynTree::ShapeVisualization::addShape(const iDynTree::SolidShape& shape,
 {
     m_shapes.emplace_back(shape, m_smgr);
     setShapeParent(m_shapes.size() - 1, modelName, frameName);
+    setShapeColor(m_shapes.size() - 1, shape.getMaterial().color());
     return m_shapes.size() - 1;
 }
 
@@ -127,8 +128,17 @@ bool iDynTree::ShapeVisualization::setShapeColor(size_t shapeIndex, const ColorV
     m_shapes[shapeIndex].shape->setMaterial(newMaterial);
     for (irr::u32 mat = 0; mat < m_shapes[shapeIndex].node->getMaterialCount(); mat++)
     {
-        m_shapes[shapeIndex].node->getMaterial(mat) = idyntree2irr(m_shapes[shapeIndex].shape->getMaterial().color());
+        irr::video::SMaterial& material = m_shapes[shapeIndex].node->getMaterial(mat);
+        material = idyntree2irr(m_shapes[shapeIndex].shape->getMaterial().color());
+        double alpha = m_shapes[shapeIndex].shape->getMaterial().color()[3];
+        material.MaterialType = irr::video::EMT_TRANSPARENT_ADD_COLOR;
+        material.AmbientColor.setAlpha(alpha);
+        material.DiffuseColor.setAlpha(alpha);
+        material.SpecularColor.setAlpha(alpha);
+        material.EmissiveColor.setAlpha(alpha);
     }
+    m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
+    m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
     return true;
 }
 
@@ -140,6 +150,7 @@ bool iDynTree::ShapeVisualization::changeShape(size_t shapeIndex, const iDynTree
         return false;
     }
     m_shapes[shapeIndex] = std::move(Shape(newShape, m_smgr));
+    setShapeColor(shapeIndex, newShape.getMaterial().color());
     return true;
 }
 

--- a/src/visualization/src/ShapesVisualization.cpp
+++ b/src/visualization/src/ShapesVisualization.cpp
@@ -131,7 +131,14 @@ bool iDynTree::ShapeVisualization::setShapeColor(size_t shapeIndex, const ColorV
     {
         irr::video::SMaterial& material = m_shapes[shapeIndex].node->getMaterial(mat);
         material = idyntree2irr(m_shapes[shapeIndex].shape->getMaterial().color());
-        material.MaterialType = irr::video::EMT_TRANSPARENT_VERTEX_ALPHA;
+        if (shapeColor.a < 1.0)
+        {
+            material.MaterialType = irr::video::EMT_TRANSPARENT_VERTEX_ALPHA;
+        }
+        else
+        {
+            material.MaterialType = irr::video::EMT_SOLID;
+        }
     }
     m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
     m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);

--- a/src/visualization/src/ShapesVisualization.cpp
+++ b/src/visualization/src/ShapesVisualization.cpp
@@ -56,6 +56,7 @@ void iDynTree::ShapeVisualization::init(irr::scene::ISceneManager* smgr, std::sh
 void iDynTree::ShapeVisualization::close()
 {
     m_shapes.clear();
+    m_models = nullptr;
     if (m_smgr)
     {
         m_smgr->drop(); //Decrement the reference count
@@ -217,7 +218,7 @@ bool iDynTree::ShapeVisualization::setShapeParent(size_t shapeIndex, const std::
     m_shapes[shapeIndex].modelName = modelName;
     m_shapes[shapeIndex].frameName = actualFrameName;
 
-    return false;
+    return true;
 }
 
 iDynTree::ILabel* iDynTree::ShapeVisualization::getShapeLabel(size_t shapeIndex)

--- a/src/visualization/src/ShapesVisualization.cpp
+++ b/src/visualization/src/ShapesVisualization.cpp
@@ -21,7 +21,6 @@ iDynTree::ShapeVisualization::Shape& iDynTree::ShapeVisualization::Shape::operat
     if (node)
     {
         node->remove();
-        node->drop();
     }
     node = other.node;
     other.node = nullptr;
@@ -35,7 +34,7 @@ iDynTree::ShapeVisualization::Shape::~Shape()
     if (node)
     {
         node->remove();
-        node->drop();
+        node = nullptr;
     }
 }
 

--- a/src/visualization/src/ShapesVisualization.cpp
+++ b/src/visualization/src/ShapesVisualization.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+#include "ShapesVisualization.h"
+#include "IrrlichtUtils.h"
+
+
+iDynTree::ShapeVisualization::Shape::Shape(const SolidShape& input_shape, irr::scene::ISceneNode* parent, irr::scene::ISceneManager* sceneManager)
+{
+    shape.reset(input_shape.clone());
+    node = addGeometryToSceneManager(shape.get(), parent, sceneManager);
+    label.init(sceneManager, node);
+}
+
+iDynTree::ShapeVisualization::Shape::Shape(Shape&& other)
+{
+    operator=(std::move(other));
+}
+
+iDynTree::ShapeVisualization::Shape& iDynTree::ShapeVisualization::Shape::operator=(Shape&& other)
+{
+    if (node)
+    {
+        node->remove();
+        node->drop();
+    }
+    node = other.node;
+    other.node = nullptr;
+    shape = std::move(other.shape);
+    label = std::move(other.label);
+    return *this;
+}
+
+iDynTree::ShapeVisualization::Shape::~Shape()
+{
+    if (node)
+    {
+        node->remove();
+        node->drop();
+    }
+}
+
+void iDynTree::ShapeVisualization::init(irr::scene::ISceneManager* smgr, std::shared_ptr<std::vector<ModelVisualization*>> models)
+{
+    assert(smgr);
+    m_smgr = smgr;
+    m_smgr->grab(); //Increment the reference count
+    m_models = models;
+}
+
+void iDynTree::ShapeVisualization::close()
+{
+    m_shapes.clear();
+    if (m_smgr)
+    {
+        m_smgr->drop(); //Decrement the reference count
+        m_smgr = nullptr;
+    }
+}
+
+iDynTree::ShapeVisualization::~ShapeVisualization()
+{
+    close();
+}
+
+size_t iDynTree::ShapeVisualization::addShape(const iDynTree::SolidShape& shape,const std::string& modelName, const std::string& frameName)
+{
+    irr::scene::ISceneNode* parent = nullptr;
+
+    if (!modelName.empty() && !frameName.empty())
+    {
+        bool found = false;
+        for (auto& model : *m_models)
+        {
+            if (model->getInstanceName() == modelName)
+            {
+                found = true;
+                parent = model->getFrameSceneNode(frameName);
+                break;
+            }
+        }
+        if (!parent)
+        {
+            std::string error;
+            if (!found)
+            {
+                error = "Model " + modelName + " not found";
+            }
+            else
+            {
+                error = "Frame " + frameName + " not found in model " + modelName;
+            }
+            reportError("ShapesVisualization", "addShape", error.c_str());
+            return -1;
+        }
+
+    }
+
+    m_shapes.emplace_back(shape, m_smgr->getRootSceneNode(), m_smgr);
+    return m_shapes.size() - 1;
+}
+
+bool iDynTree::ShapeVisualization::setVisible(size_t shapeIndex, bool isVisible)
+{
+    if (shapeIndex >= m_shapes.size())
+    {
+        reportError("ShapesVisualization", "setVisible", "Shape index out of range");
+        return false;
+    }
+    m_shapes[shapeIndex].node->setVisible(isVisible);
+    return true;
+}
+
+size_t iDynTree::ShapeVisualization::getNrOfShapes() const
+{
+    return m_shapes.size();
+}
+
+bool iDynTree::ShapeVisualization::getShapeTransform(size_t shapeIndex, Transform& currentTransform) const
+{
+    if (shapeIndex >= m_shapes.size())
+    {
+        reportError("ShapesVisualization", "getShapeTransform", "Shape index out of range");
+        return false;
+    }
+    currentTransform = m_shapes[shapeIndex].shape->getLink_H_geometry();
+    return true;
+}
+
+bool iDynTree::ShapeVisualization::setShapeTransform(size_t shapeIndex, const Transform& transformation)
+{
+    if (shapeIndex >= m_shapes.size())
+    {
+        reportError("ShapesVisualization", "setShapeTransform", "Shape index out of range");
+        return false;
+    }
+    m_shapes[shapeIndex].shape->setLink_H_geometry(transformation);
+    setWorldHNode(m_shapes[shapeIndex].node, transformation);
+
+    return true;
+}
+
+bool iDynTree::ShapeVisualization::setShapeColor(size_t shapeIndex, const ColorViz& shapeColor)
+{
+    if (shapeIndex >= m_shapes.size())
+    {
+        reportError("ShapesVisualization", "setShapeColor", "Shape index out of range");
+        return false;
+    }
+    iDynTree::Material newMaterial = m_shapes[shapeIndex].shape->getMaterial();
+    newMaterial.setColor(shapeColor.toVector4());
+    m_shapes[shapeIndex].shape->setMaterial(newMaterial);
+    for (irr::u32 mat = 0; mat < m_shapes[shapeIndex].node->getMaterialCount(); mat++)
+    {
+        m_shapes[shapeIndex].node->getMaterial(mat) = idyntree2irr(m_shapes[shapeIndex].shape->getMaterial().color());
+    }
+    return true;
+}
+
+bool iDynTree::ShapeVisualization::changeShape(size_t shapeIndex, const iDynTree::SolidShape& newShape)
+{
+    if (shapeIndex >= m_shapes.size())
+    {
+        reportError("ShapesVisualization", "changeShape", "Shape index out of range");
+        return false;
+    }
+    m_shapes[shapeIndex] = std::move(Shape(newShape, m_shapes[shapeIndex].node->getParent(), m_smgr));
+    return true;
+}
+
+iDynTree::ILabel* iDynTree::ShapeVisualization::getShapeLabel(size_t shapeIndex)
+{
+    if (shapeIndex >= m_shapes.size())
+    {
+        reportError("ShapesVisualization", "getShapeLabel", "Shape index out of range");
+        return nullptr;
+    }
+    return &m_shapes[shapeIndex].label;
+}

--- a/src/visualization/src/ShapesVisualization.cpp
+++ b/src/visualization/src/ShapesVisualization.cpp
@@ -131,15 +131,12 @@ bool iDynTree::ShapeVisualization::setShapeColor(size_t shapeIndex, const ColorV
     {
         irr::video::SMaterial& material = m_shapes[shapeIndex].node->getMaterial(mat);
         material = idyntree2irr(m_shapes[shapeIndex].shape->getMaterial().color());
-        double alpha = m_shapes[shapeIndex].shape->getMaterial().color()[3];
-        material.MaterialType = irr::video::EMT_TRANSPARENT_ADD_COLOR;
-        material.AmbientColor.setAlpha(alpha);
-        material.DiffuseColor.setAlpha(alpha);
-        material.SpecularColor.setAlpha(alpha);
-        material.EmissiveColor.setAlpha(alpha);
+        material.MaterialType = irr::video::EMT_TRANSPARENT_VERTEX_ALPHA;
     }
     m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_BACK_FACE_CULLING, false);
     m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
+    m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_COLOR_MATERIAL, false);
+    m_shapes[shapeIndex].node->setMaterialFlag(irr::video::EMF_BLEND_OPERATION, true);
     return true;
 }
 

--- a/src/visualization/src/ShapesVisualization.h
+++ b/src/visualization/src/ShapesVisualization.h
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+#ifndef IDYNTREE_SHAPESVISUALIZATION_H
+#define IDYNTREE_SHAPESVISUALIZATION_H
+
+#include <iDynTree/Visualizer.h>
+#include "ModelVisualization.h"
+#include "Label.h"
+#include <irrlicht.h>
+
+#include <vector>
+#include <memory>
+
+namespace iDynTree {
+
+    class ShapeVisualization : public IShapeVisualization
+    {
+
+        class Shape
+        {
+            public:
+            std::unique_ptr<SolidShape> shape;
+            irr::scene::ISceneNode* node{ nullptr };
+            Label label;
+
+            Shape() = delete;
+            Shape(const SolidShape& input_shape, irr::scene::ISceneNode* parent, irr::scene::ISceneManager* sceneManager);
+            Shape(const Shape& other) = delete;
+            Shape& operator=(const Shape& other) = delete;
+            Shape(Shape&& other);
+            Shape& operator=(Shape&& other);
+            ~Shape();
+
+
+        };
+        irr::scene::ISceneManager* m_smgr{0};
+        std::shared_ptr<std::vector<ModelVisualization*>> m_models;
+        std::vector<Shape> m_shapes;
+
+    public:
+        ShapeVisualization() = default;
+
+        ShapeVisualization(const ShapeVisualization&) = delete;
+        ShapeVisualization& operator=(const ShapeVisualization&) = delete;
+        ShapeVisualization(ShapeVisualization&&) = delete;
+        ShapeVisualization& operator=(ShapeVisualization&&) = delete;
+
+        void init(irr::scene::ISceneManager* smgr, std::shared_ptr<std::vector<ModelVisualization*>> models);
+
+        void close();
+
+
+        /**
+        * Destructor
+        */
+        ~ShapeVisualization();
+
+        /**
+        * Add a shape in the visualization
+        * Returns the shape index.
+        */
+        virtual size_t addShape(const iDynTree::SolidShape& shape,
+                                const std::string& modelName = "",
+                                const std::string& frameName = "") final;
+        /**
+        * Set the specified shape visible or not.
+        * Returns true in case of success, false otherwise (for example if the shape does not exists).
+        */
+        virtual bool setVisible(size_t shapeIndex, bool isVisible) final;
+
+        /**
+        * Get the number of visualized shapes.
+        *
+        */
+        virtual size_t getNrOfShapes() const final;
+
+        /**
+        * Get shape transform with respect the parent frame (world if the shape is attached to the world).
+        */
+        virtual bool getShapeTransform(size_t shapeIndex, Transform& currentTransform) const final;
+
+        /**
+        * Set shape transform with respect the parent frame (world if the shape is attached to the world).
+        */
+        virtual bool setShapeTransform(size_t shapeIndex, const Transform& transformation) final;
+
+        /**
+        * Set the color of the shape.
+        * Returns true in case of success, false otherwise (for example if the shape does not exists).
+        */
+        virtual bool setShapeColor(size_t shapeIndex, const ColorViz& shapeColor) final;
+
+        /**
+        * Change the shape.
+        * The previous shape is removed.
+        * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
+        */
+        virtual bool changeShape(size_t shapeIndex, const iDynTree::SolidShape& newShape) final;
+
+        /**
+        * Get the label of a shape.
+        *
+        * Returns nullptr of the shape index is out of bounds.
+        */
+        virtual ILabel* getShapeLabel(size_t shapeIndex) final;
+    };
+}
+
+#endif // IDYNTREE_SHAPESVISUALIZATION_H

--- a/src/visualization/src/ShapesVisualization.h
+++ b/src/visualization/src/ShapesVisualization.h
@@ -106,7 +106,7 @@ namespace iDynTree {
         /**
         * Get the parent of a shape.
         * Returns a pair with the first element being the model name, and the second the frame name.
-        * If the shape is attached to the world, the both elements are empty strings.
+        * If the shape is attached to the world, both elements are empty strings.
         */
         virtual std::pair<std::string, std::string> getShapeParent(size_t shapeIndex) const final;
 
@@ -114,6 +114,7 @@ namespace iDynTree {
         * Set the parent of a shape.
         * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
         * If the modelName and frameName are empty strings, the shape is attached to the world.
+        * If the model name is specified, but not the frame name, it is attached to the root link of the model.
         */
         virtual bool setShapeParent(size_t shapeIndex, const std::string& modelName, const std::string& frameName) final;
 

--- a/src/visualization/src/ShapesVisualization.h
+++ b/src/visualization/src/ShapesVisualization.h
@@ -22,9 +22,11 @@ namespace iDynTree {
             std::unique_ptr<SolidShape> shape;
             irr::scene::ISceneNode* node{ nullptr };
             Label label;
+            std::string modelName;
+            std::string frameName;
 
             Shape() = delete;
-            Shape(const SolidShape& input_shape, irr::scene::ISceneNode* parent, irr::scene::ISceneManager* sceneManager);
+            Shape(const SolidShape& input_shape, irr::scene::ISceneManager* sceneManager);
             Shape(const Shape& other) = delete;
             Shape& operator=(const Shape& other) = delete;
             Shape(Shape&& other);
@@ -56,7 +58,11 @@ namespace iDynTree {
         ~ShapeVisualization();
 
         /**
-        * Add a shape in the visualization
+        * Add a shape in the visualization.
+        * If the modelName and linkName are specified, the shape is attached to the specific frame.
+        * If they are not specified, or cannot be found, the shape is attached to the world.
+        * If the model name is specified, but not the frame name, it is attached to the root link of the model.
+        * The initial transform is specified by the shape itself (Link_H_geometry).
         * Returns the shape index.
         */
         virtual size_t addShape(const iDynTree::SolidShape& shape,
@@ -96,6 +102,20 @@ namespace iDynTree {
         * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
         */
         virtual bool changeShape(size_t shapeIndex, const iDynTree::SolidShape& newShape) final;
+
+        /**
+        * Get the parent of a shape.
+        * Returns a pair with the first element being the model name, and the second the frame name.
+        * If the shape is attached to the world, the both elements are empty strings.
+        */
+        virtual std::pair<std::string, std::string> getShapeParent(size_t shapeIndex) const final;
+
+        /**
+        * Set the parent of a shape.
+        * Returns true in case of success, false otherwise (for example if the shape index is out of bounds).
+        * If the modelName and frameName are empty strings, the shape is attached to the world.
+        */
+        virtual bool setShapeParent(size_t shapeIndex, const std::string& modelName, const std::string& frameName) final;
 
         /**
         * Get the label of a shape.

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -580,7 +580,7 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
 
     pimpl->m_vectors.init(pimpl->m_irrSmgr);
 
-    pimpl->m_frames.init(pimpl->m_irrSmgr);
+    pimpl->m_frames.init(pimpl->m_irrSmgr, pimpl->m_modelViz);
 
     pimpl->m_shapes.init(pimpl->m_irrSmgr, pimpl->m_modelViz);
 

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -293,7 +293,7 @@ void checkShapes()
     ok = viz.addModel(mdlLoader.model(), "model");
     ASSERT_IS_TRUE(ok);
 
-    viz.camera().setPosition(iDynTree::Position(4.0, 0.0, 4.0));
+    viz.camera().setPosition(iDynTree::Position(6.0, 0.0, 4.0));
 
     iDynTree::Sphere sphere;
     sphere.setRadius(0.8);
@@ -308,11 +308,15 @@ void checkShapes()
 
     color.r = 0.0;
     color.g = 1.0;
+    color.a = 0.1;
     material.setColor(color.toVector4());
     sphere.setMaterial(material);
-    size_t index2 = shapes.addShape(sphere, "model", mdlLoader.model().getFrameName(mdlLoader.model().getNrOfFrames() - 1));
+    std::string frameName = mdlLoader.model().getLinkName(mdlLoader.model().getNrOfLinks() - 1);
+    size_t index2 = shapes.addShape(sphere, "model", frameName);
     ASSERT_IS_TRUE(index2 == 1);
     ASSERT_IS_TRUE(shapes.getNrOfShapes() == 2);
+    ASSERT_IS_TRUE(shapes.getShapeParent(index2).first == "model");
+    ASSERT_IS_TRUE(shapes.getShapeParent(index2).second == frameName);
     color.g = 0;
     color.b = 1.0;
     ok = shapes.setShapeColor(index2, color);
@@ -320,6 +324,8 @@ void checkShapes()
     ok = shapes.setShapeTransform(index2, iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position(1.0, 0.0, 0.0)));
     ASSERT_IS_TRUE(ok);
     ok = shapes.changeShape(index, sphere);
+    ASSERT_IS_TRUE(ok);
+    ok = shapes.setVisible(index, true);
     ASSERT_IS_TRUE(ok);
 
     // Check if run is returning true

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -278,6 +278,64 @@ void checkDoubleViz()
     viz2.close();
 }
 
+void checkShapes()
+{
+    // Check visualizer of simple model
+    iDynTree::ModelLoader mdlLoader, mdlLoaderReduced;
+
+    // Load full model
+    bool ok = mdlLoader.loadModelFromFile(getAbsModelPath("threeLinks.urdf"));
+    ASSERT_IS_TRUE(ok);
+
+    // Open visualizer
+    iDynTree::Visualizer viz;
+
+    ok = viz.addModel(mdlLoader.model(), "model");
+    ASSERT_IS_TRUE(ok);
+
+    viz.camera().setPosition(iDynTree::Position(4.0, 0.0, 4.0));
+
+    iDynTree::Sphere sphere;
+    sphere.setRadius(0.8);
+    iDynTree::ColorViz color(1.0, 0.0, 0.0, 0.5);
+    iDynTree::Material material = sphere.getMaterial();
+    material.setColor(color.toVector4());
+    sphere.setMaterial(material);
+
+    iDynTree::IShapeVisualization& shapes = viz.shapes();
+    size_t index = shapes.addShape(sphere);
+    ASSERT_IS_TRUE(index == 0);
+
+    color.r = 0.0;
+    color.g = 1.0;
+    material.setColor(color.toVector4());
+    sphere.setMaterial(material);
+    size_t index2 = shapes.addShape(sphere, "model", mdlLoader.model().getFrameName(mdlLoader.model().getNrOfFrames() - 1));
+    ASSERT_IS_TRUE(index2 == 1);
+    ASSERT_IS_TRUE(shapes.getNrOfShapes() == 2);
+    color.g = 0;
+    color.b = 1.0;
+    ok = shapes.setShapeColor(index2, color);
+    ASSERT_IS_TRUE(ok);
+    ok = shapes.setShapeTransform(index2, iDynTree::Transform(iDynTree::Rotation::Identity(), iDynTree::Position(1.0, 0.0, 0.0)));
+    ASSERT_IS_TRUE(ok);
+    ok = shapes.changeShape(index, sphere);
+    ASSERT_IS_TRUE(ok);
+
+    // Check if run is returning true
+    // Regression test for https://github.com/robotology/idyntree/issues/986
+    ok = viz.run();
+    ASSERT_IS_TRUE(ok);
+
+
+    for (int i = 0; i < 5; i++)
+    {
+        viz.draw();
+    }
+
+    viz.close();
+}
+
 int main()
 {
     threeLinksReducedTest();
@@ -287,6 +345,7 @@ int main()
     checkLabelVisualization();
     checkViewPorts();
     checkDoubleViz();
+    checkShapes();
 
     return EXIT_SUCCESS;
 }

--- a/src/visualization/tests/VisualizerUnitTest.cpp
+++ b/src/visualization/tests/VisualizerUnitTest.cpp
@@ -342,6 +342,51 @@ void checkShapes()
     viz.close();
 }
 
+void checkFrameAttachedToModel()
+{
+    // Check visualizer of simple model
+    iDynTree::ModelLoader mdlLoader, mdlLoaderReduced;
+
+    // Load full model
+    bool ok = mdlLoader.loadModelFromFile(getAbsModelPath("threeLinks.urdf"));
+    ASSERT_IS_TRUE(ok);
+
+    // Open visualizer
+    iDynTree::Visualizer viz;
+
+    ok = viz.addModel(mdlLoader.model(), "model");
+    ASSERT_IS_TRUE(ok);
+
+    viz.camera().setPosition(iDynTree::Position(6.0, 0.0, 4.0));
+
+    iDynTree::IFrameVisualization& frames = viz.frames();
+    for (iDynTree::LinkIndex l = 0; l < mdlLoader.model().getNrOfLinks(); l++)
+    {
+        std::string linkName = mdlLoader.model().getLinkName(l);
+        size_t index = frames.addFrame(iDynTree::Transform::Identity());
+        ASSERT_IS_TRUE(index >= 0);
+        ok = frames.setFrameParent(index, "model", linkName);
+        ASSERT_IS_TRUE(ok);
+        iDynTree::ILabel* label = frames.getFrameLabel(index);
+        ASSERT_IS_TRUE(label != nullptr);
+        label->setText(linkName);
+        label->setPosition(iDynTree::Position(1.0, 1.0, 1.0));
+    }
+
+    // Check if run is returning true
+    // Regression test for https://github.com/robotology/idyntree/issues/986
+    ok = viz.run();
+    ASSERT_IS_TRUE(ok);
+
+
+    for (int i = 0; i < 5; i++)
+    {
+        viz.draw();
+    }
+
+    viz.close();
+}
+
 int main()
 {
     threeLinksReducedTest();
@@ -352,6 +397,7 @@ int main()
     checkViewPorts();
     checkDoubleViz();
     checkShapes();
+    checkFrameAttachedToModel();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR
- allows visualizing solid shapes, like spheres, boxes, meshes, in the iDynTree visualizer. The solid shapes can also be attached to a link of a model.
- Allows attaching a frame to a link (or a frame) of a model
- Modifies ``idyntree-model-view`` to visualize a set of frames
- Improves the transparency visualization of the models

cc @dariosortino 