### PR TITLE
Fix code to obtain Python relative install dir in Python 3.12

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -47,9 +47,13 @@ if(IDYNTREE_USES_PYTHON OR IDYNTREE_USES_PYTHON_PYBIND11)
        if(IDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES)
            set(IDYNTREE_PYTHON_INSTALL_DIR ${Python3_SITELIB})
        else()
-           execute_process(COMMAND ${Python3_EXECUTABLE}
-                           -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
-                           OUTPUT_VARIABLE _PYTHON_INSTDIR)
+           if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
+               execute_process(COMMAND ${Python3_EXECUTABLE} -c "import os;import sysconfig;relative_site_packages = sysconfig.get_path('purelib').replace(sysconfig.get_path('data'), '').lstrip(os.path.sep);print(relative_site_packages)"
+                               OUTPUT_VARIABLE _PYTHON_INSTDIR)
+           else()
+               execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+                               OUTPUT_VARIABLE _PYTHON_INSTDIR)
+           endif()
            string(STRIP ${_PYTHON_INSTDIR} IDYNTREE_PYTHON_INSTALL_DIR)
        endif()
     endif()


### PR DESCRIPTION
As the code in some cases return slightly different results then the previous version (see https://github.com/robotology/robotology-superbuild/issues/1238#issuecomment-1234165171), we only use it when Python >= 3.12. This is simar to https://github.com/robotology/robotology-superbuild/pull/1511