### PR TITLE
ModelUnitTest: Add checkReducedModel call to the tests

### DIFF
--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -294,6 +294,7 @@ void checkAll(const Model & model)
     createCopyAndDestroy(model);
     checkNeighborSanity(model,false);
     checkComputeTraversal(model);
+    checkReducedModel(model);
     checkExtractSubModel(model);
 }
 


### PR DESCRIPTION
As emerged in https://github.com/robotology/idyntree/pull/1174, the test was always there but was not actually called.