### PR TITLE
Switch from macos-latest to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, windows-2019, macos-latest]
+        os: [ubuntu-20.04, windows-2019, macos-12]
         matlab_version: [R2022a, R2022b, R2023a]
 
     steps:


### PR DESCRIPTION
Workaround for the problem still present with macos-latest/`osx-arm64` builds, see:
* Missing `icub-main` package on `osx-arm64` (blocked by https://github.com/conda-forge/ace-feedstock/issues/29)
* https://github.com/robotology/idyntree/pull/1181