### PR TITLE
Fix bug preventing export of iDynTree::Model with non-zero axis offset to URDF and bump version to 12.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 12.3.0
+project(iDynTree VERSION 12.3.1
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/core/include/iDynTree/Axis.h
+++ b/src/core/include/iDynTree/Axis.h
@@ -133,6 +133,11 @@ namespace iDynTree
         Axis reverse() const;
 
         /**
+         * Compute distance between the axis and a given point
+         */
+        double getDistanceBetweenAxisAndPoint(const iDynTree::Position& point) const;
+
+        /**
          * @name Output helpers.
          *  Output helpers.
          */

--- a/src/core/src/Axis.cpp
+++ b/src/core/src/Axis.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <iDynTree/Axis.h>
+#include <iDynTree/EigenHelpers.h>
 #include <iDynTree/Transform.h>
 #include <iDynTree/TransformDerivative.h>
 #include <iDynTree/Twist.h>
@@ -257,6 +258,24 @@ namespace iDynTree
         return Axis(this->getDirection().reverse(),
                     this->getOrigin());
     }
+
+    double Axis::getDistanceBetweenAxisAndPoint(const iDynTree::Position& point) const
+    {
+        Eigen::Vector3d direction = iDynTree::toEigen(this->getDirection()).normalized();
+
+        // Vector from the offset point of the to the given point
+        Eigen::Vector3d axisOrigin_p_point = iDynTree::toEigen(point) - iDynTree::toEigen(this->getOrigin());
+
+        // Project the axisOrigin_p_point onto the axis direction
+        Eigen::Vector3d projection = direction * axisOrigin_p_point.dot(direction);
+
+        // Calculate the closest point on the axis to the given point
+        Eigen::Vector3d closestPointOnAxis = iDynTree::toEigen(this->getOrigin()) + projection;
+
+        // Calculate the distance between the closest point on the axis and the given point
+        return (closestPointOnAxis - iDynTree::toEigen(point)).norm();
+    }
+
 
     std::string Axis::toString() const
     {

--- a/src/model_io/codecs/src/URDFModelExport.cpp
+++ b/src/model_io/codecs/src/URDFModelExport.cpp
@@ -357,13 +357,16 @@ bool exportJoint(IJointConstPtr joint, LinkConstPtr parentLink, LinkConstPtr chi
             return false;
         }
 
-        // Check that the axis is URDF-compatible
-        if (toEigen(axis.getOrigin()).norm() > 1e-7)
+        // Check that the axis is URDF-compatible, i.e. that the distance between the
+        // axis and the child link origin is zero
+        double distanceBetweenAxisAndOrigin = axis.getDistanceBetweenAxisAndPoint(iDynTree::Position::Zero());
+        if (distanceBetweenAxisAndOrigin > 1e-7)
         {
             std::cerr << "[ERROR] URDFModelExport: Impossible to convert joint "
                       <<   model.getJointName(joint->getIndex()) << " to a URDF joint without moving the link frame of link "
-                      << model.getLinkName(childLink->getIndex()) << " , because its origin is "
-                      << axis.getOrigin().toString()  << std::endl;
+                      << model.getLinkName(childLink->getIndex()) << " , because the axis origin is "
+                      << axis.getOrigin().toString() << " the axis direction is " << axis.getDirection().toString() 
+                      << " and the distance between the axis and (0,0,0) is " << distanceBetweenAxisAndOrigin << std::endl;
             return false;
         }
 


### PR DESCRIPTION
I noticed this today in https://github.com/icub-tech-iit/creo2urdf/issues/97#issuecomment-2163188586 .


Basically in iDynTree the joint axis can have any direction and offset, while for URDF the joint axis must pass through the child link frame origin. However, the check to ensure this in the URDF exported had a bug, as it checked the origin of the axis was 0,0,0, but it is perfectly fine for the axis to have a non-zero offset, as long as the axis still passes through the origin of the frame. For example, if you have an axis defined as (direction: [1,0,0], offset: [1,0,0]), that is ok for URDF as it passes through the origin, but it was rejected before this PR. 

This PR fixes the problem by actually checking the distance between the axis (expressed in the child link frame) and the origin of the child link frame (that is simply `[0 0 0]`) is different from zero, rather then simply checking that the axis offset is different from zero.

Furthermore, tests have been added to ensure that the new check works as expected.