### PR TITLE
Force installing NumPy 2.0 in CI/CD when building PyPI wheels and drop Python 3.7 and 3.8 in pip packages

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -95,7 +95,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_BUILD: cp37-*manylinux*_x86_64 cp38-*manylinux*_x86_64 cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64 cp311-*manylinux*_x86_64 cp312-*manylinux*_x86_64
+          CIBW_BUILD: cp39-*manylinux*_x86_64 cp310-*manylinux*_x86_64 cp311-*manylinux*_x86_64 cp312-*manylinux*_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_28_x86_64
           CIBW_BEFORE_BUILD_LINUX: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -104,7 +104,7 @@ jobs:
             dnf update -y &&\
             dnf install -y eigen3-devel libxml2-devel
             # Pre-install NumPy > 2.0
-            pip install "numpy>2.0"
+            pip install "numpy>=2.0.0"
           CIBW_TEST_COMMAND: "python -c 'import idyntree.bindings'"
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -103,6 +103,8 @@ jobs:
             rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux &&\
             dnf update -y &&\
             dnf install -y eigen3-devel libxml2-devel
+            # Pre-install NumPy > 2.0
+            pip install "numpy>2.0"
           CIBW_TEST_COMMAND: "python -c 'import idyntree.bindings'"
 
       - uses: actions/upload-artifact@v3

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -14,6 +14,7 @@ swig_add_library(${target_name}
     OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR}
     OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/idyntree)
 
+message(STATUS "Linking SWIG Python bindings against NumPy '${Python3_NumPy_VERSION}'")
 target_link_libraries(${target_name} PUBLIC Python3::NumPy)
 
 set_target_properties(${target_name} PROPERTIES


### PR DESCRIPTION
- Enforces the installation of NumPy 2.0 when building PyPI wheels. Otherwise, downstream projects importing both `numpy >= 2.0.0` and `idyntree` built against NumPy 1.X would fail.
- Removes support for building wheels on Python 3.7 and 3.8. This is necessary since NumPy >= 2.0.0 is not packaged in PyPI for these Python versions.