### PR TITLE
Add moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink function

### DIFF
--- a/src/core/include/iDynTree/Axis.h
+++ b/src/core/include/iDynTree/Axis.h
@@ -133,6 +133,11 @@ namespace iDynTree
         Axis reverse() const;
 
         /**
+         * Compute the point on the axis that is closest to a given opoint
+         */
+        Position getPointOnAxisClosestToGivenPoint(const iDynTree::Position& point) const;
+
+        /**
          * Compute distance between the axis and a given point
          */
         double getDistanceBetweenAxisAndPoint(const iDynTree::Position& point) const;

--- a/src/core/src/Axis.cpp
+++ b/src/core/src/Axis.cpp
@@ -261,21 +261,29 @@ namespace iDynTree
 
     double Axis::getDistanceBetweenAxisAndPoint(const iDynTree::Position& point) const
     {
-        Eigen::Vector3d direction = iDynTree::toEigen(this->getDirection()).normalized();
-
-        // Vector from the offset point of the to the given point
-        Eigen::Vector3d axisOrigin_p_point = iDynTree::toEigen(point) - iDynTree::toEigen(this->getOrigin());
-
-        // Project the axisOrigin_p_point onto the axis direction
-        Eigen::Vector3d projection = direction * axisOrigin_p_point.dot(direction);
-
         // Calculate the closest point on the axis to the given point
-        Eigen::Vector3d closestPointOnAxis = iDynTree::toEigen(this->getOrigin()) + projection;
+        iDynTree::Position closestPointOnAxis = getPointOnAxisClosestToGivenPoint(point);
 
         // Calculate the distance between the closest point on the axis and the given point
-        return (closestPointOnAxis - iDynTree::toEigen(point)).norm();
+        return (iDynTree::toEigen(closestPointOnAxis) - iDynTree::toEigen(point)).norm();
     }
 
+    iDynTree::Position Axis::getPointOnAxisClosestToGivenPoint(const iDynTree::Position& point) const
+    {
+            Eigen::Vector3d direction = iDynTree::toEigen(this->getDirection()).normalized();
+
+            // Vector from the offset point of the to the given point
+            Eigen::Vector3d axisOrigin_p_point = iDynTree::toEigen(point) - iDynTree::toEigen(this->getOrigin());
+
+            // Project the axisOrigin_p_point onto the axis direction
+            Eigen::Vector3d projection = direction * axisOrigin_p_point.dot(direction);
+
+            // Calculate the closest point on the axis to the given point
+            iDynTree::Position closestPointOnAxis;
+            iDynTree::toEigen(closestPointOnAxis) = iDynTree::toEigen(this->getOrigin()) + projection;
+
+            return closestPointOnAxis;
+    }
 
     std::string Axis::toString() const
     {

--- a/src/model/include/iDynTree/ModelTransformers.h
+++ b/src/model/include/iDynTree/ModelTransformers.h
@@ -145,6 +145,25 @@ bool extractSubModel(const iDynTree::Model& fullModel, const iDynTree::Traversal
 bool addValidNamesToAllSolidShapes(const iDynTree::Model& inputModel,
                                    iDynTree::Model& outputModel);
 
+/**
+ * Transform the input model in model that can be exported as URDF with the given base link.
+ *
+ * In iDynTree, the link frame can be placed without constraint w.r.t. to the joints to which
+ * the link is connected. On the other hand, in the URDF format, the origin of the frame of the child link
+ * connected to its parent with a non-fixed joint **must** lay on the axis of the joint.
+ *
+ * That means that if you want to export a model with an arbitrary base link, some link frame will need
+ * to be moved to respect the constraint given by the URDF format. This function perform exactly this
+ * transformation, ensuring that inertia, visual and collision information is probably accounted for,
+ * and leaving the original link frames in the model as "additional frames" with the naming scheme
+ * <linkName>_original_frame .
+ *
+ * @return true if all went well, false if there was an error in creating the sub model.
+ */
+bool moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(const iDynTree::Model& inputModel,
+                                                           const std::string& baseLink,
+                                                           iDynTree::Model& outputModel);
+
 }
 
 

--- a/src/model/include/iDynTree/ModelTransformers.h
+++ b/src/model/include/iDynTree/ModelTransformers.h
@@ -158,10 +158,12 @@ bool addValidNamesToAllSolidShapes(const iDynTree::Model& inputModel,
  * and leaving the original link frames in the model as "additional frames" with the naming scheme
  * <linkName>_original_frame .
  *
+ * Note that the operation done depends on the base link used, if you want to use a different
+ * base link, change the default base link of the model via inputModel.setDefaultBaseLink method.
+ *
  * @return true if all went well, false if there was an error in creating the sub model.
  */
 bool moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(const iDynTree::Model& inputModel,
-                                                           const std::string& baseLink,
                                                            iDynTree::Model& outputModel);
 
 }

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -917,4 +917,11 @@ bool addValidNamesToAllSolidShapes(const iDynTree::Model& inputModel,
     return true;
 }
 
+bool moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(const iDynTree::Model& inputModel,
+                                                           const std::string& baseLink,
+                                                           iDynTree::Model& outputModel)
+{
+    return false;
+}
+
 }

--- a/src/tests/integration/CMakeLists.txt
+++ b/src/tests/integration/CMakeLists.txt
@@ -42,6 +42,7 @@ endmacro()
 add_integration_test(Dynamics)
 add_integration_test(DenavitHartenberg)
 add_integration_test(ReducedModelWithFT)
+add_integration_test(ModelTransformers)
 
 # See issue https://github.com/robotology/idyntree/issues/367
 add_integration_test_no_valgrind(iCubTorqueEstimation)

--- a/src/tests/integration/ModelTransformersIntegrationTest.cpp
+++ b/src/tests/integration/ModelTransformersIntegrationTest.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <iDynTree/ModelTransformers.h>
+
+#include <iDynTree/Model.h>
+#include <iDynTree/Link.h>
+
+#include <iDynTree/TestUtils.h>
+#include <iDynTree/ModelTestUtils.h>
+
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/ModelExporter.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace iDynTree;
+
+double random_double()
+{
+    return 1.0*((double)rand()-RAND_MAX/2)/((double)RAND_MAX);
+}
+
+double real_random_double()
+{
+    return 1.0*((double)rand()-RAND_MAX/2)/((double)RAND_MAX);
+}
+
+int real_random_int(int initialValue, int finalValue)
+{
+    int length = finalValue - initialValue;
+    return initialValue + rand() % length;
+}
+
+void setRandomState(iDynTree::KinDynComputations & originalKinDyn, iDynTree::KinDynComputations & transformedKinDyn)
+{
+    size_t dofs = originalKinDyn.getNrOfDegreesOfFreedom();
+    Transform    worldTbase;
+    Twist        baseVel;
+    Vector3 gravity;
+
+    iDynTree::VectorDynSize qj(dofs), dqj(dofs), ddqj(dofs);
+
+    worldTbase = iDynTree::Transform(Rotation::RPY(random_double(),random_double(),random_double()),
+            Position(random_double(),random_double(),random_double()));
+
+    for(int i=0; i < 3; i++)
+    {
+        gravity(i) = random_double();
+    }
+
+    for(int i=0; i < 6; i++)
+    {
+        baseVel(i) = real_random_double();
+    }
+
+    for(size_t dof=0; dof < dofs; dof++)
+
+    {
+        qj(dof) = random_double();
+        dqj(dof) = random_double();
+        ddqj(dof) = random_double();
+    }
+
+    ASSERT_IS_TRUE(originalKinDyn.setRobotState(worldTbase,qj,baseVel,dqj,gravity));
+    ASSERT_IS_TRUE(transformedKinDyn.setRobotState(worldTbase,qj,baseVel,dqj,gravity));
+}
+
+
+// This test ensures that moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink transform the
+// models in a way that does not modify its inertial, visual and collision properties
+void checkThatMoveLinkFramesToBeCompatibleWithURDFWithGivenBaseLinkIsConsistent()
+{
+
+    for (size_t i=0; i < 20; i++)
+    {
+        // Generate random model
+        size_t nrOfJoints = 10;
+        size_t nrOFAdditionalFrames = 10;
+
+        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames);
+
+        // Get random base link
+        iDynTree::LinkIndex baseLinkIndex = static_cast<iDynTree::LinkIndex>(rand() % originalModel.getNrOfLinks());
+        originalModel.setDefaultBaseLink(baseLinkIndex);
+        std::string baseLink = originalModel.getLinkName(baseLinkIndex);
+
+        iDynTree::Model transformedModel;
+        ASSERT_IS_TRUE(moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(originalModel, baseLink, transformedModel));
+
+        // Check that the default base link is propagated
+        ASSERT_IS_TRUE(originalModel.getDefaultBaseLink() == transformedModel.getDefaultBaseLink());
+
+        // Check consistency
+        ASSERT_IS_TRUE(originalModel.getNrOfJoints() == transformedModel.getNrOfJoints());
+        ASSERT_IS_TRUE(originalModel.getNrOfLinks() == transformedModel.getNrOfLinks());
+        // The transformed model has more frames, as it stores the original_frames as <linkName>_original_frame
+        ASSERT_IS_TRUE(originalModel.getNrOfFrames() <= transformedModel.getNrOfFrames());
+
+        // Check that joint serialization remains the same
+        for(iDynTree::JointIndex jntIdx=0; jntIdx < originalModel.getNrOfJoints(); jntIdx++)
+        {
+            ASSERT_IS_TRUE(originalModel.getJointName(jntIdx) == transformedModel.getJointName(jntIdx));
+        }
+
+        // Create a kindyn object for each model, and assign a random state
+        iDynTree::KinDynComputations originalKinDyn;
+        ASSERT_IS_TRUE(originalKinDyn.loadRobotModel(originalModel));
+        ASSERT_IS_TRUE(originalKinDyn.setFloatingBase(baseLink));
+        iDynTree::KinDynComputations transformedKinDyn;
+        ASSERT_IS_TRUE(transformedKinDyn.loadRobotModel(transformedModel));
+        ASSERT_IS_TRUE(transformedKinDyn.setFloatingBase(baseLink));
+        setRandomState(originalKinDyn, transformedKinDyn);
+
+        // Check kinematics: make sure that the kinematics between additional frames remain consistent
+        // (as only the link frame can be moved by the function)
+        std::string firstAdditionalFrame = originalModel.getFrameName(originalModel.getNrOfLinks());
+        for(iDynTree::FrameIndex frameIndex = originalModel.getNrOfLinks(); frameIndex < originalModel.getNrOfFrames(); frameIndex++)
+        {
+            std::string secondAdditionalFrame = originalModel.getFrameName(frameIndex);
+
+            ASSERT_EQUAL_TRANSFORM(originalKinDyn.getRelativeTransform(firstAdditionalFrame, secondAdditionalFrame),
+                                   transformedKinDyn.getRelativeTransform(firstAdditionalFrame, secondAdditionalFrame));
+        }
+
+        // Check inertia: make sure that mass matrix is the same
+        iDynTree::FreeFloatingMassMatrix originalMassMatrix(originalMassMatrix);
+        iDynTree::FreeFloatingMassMatrix transformedMassMatrix(transformedModel);
+        ASSERT_IS_TRUE(originalKinDyn.getFreeFloatingMassMatrix(originalMassMatrix));
+        ASSERT_IS_TRUE(transformedKinDyn.getFreeFloatingMassMatrix(transformedMassMatrix));
+        ASSERT_EQUAL_MATRIX(originalMassMatrix, transformedMassMatrix);
+
+        // Check collision and visual: check that transform between the visual and collision element w.r.t. to a given additional
+        // frame is always the same
+
+        for(iDynTree::LinkIndex lnkIdx=0; lnkIdx < originalModel.getNrOfLinks(); lnkIdx++)
+        {
+            auto& originalVisual = originalModel.visualSolidShapes().getLinkSolidShapes();
+            auto& transformedVisual = transformedModel.visualSolidShapes().getLinkSolidShapes();
+            for(int shapeIdx=0; shapeIdx < originalVisual[lnkIdx].size(); shapeIdx++)
+            {
+                // Check that link index remains constant
+                ASSERT_IS_TRUE(originalModel.getLinkName(lnkIdx) == transformedModel.getLinkName(lnkIdx));
+
+                // Get firstAdditionalFrame_H_visual in original model and transformed model
+                iDynTree::Transform original_frame_H_visual =
+                    originalKinDyn.getRelativeTransform(firstAdditionalFrame, originalModel.getLinkName(lnkIdx))*
+                    originalVisual[lnkIdx][shapeIdx]->getLink_H_geometry();
+
+                iDynTree::Transform transformed_frame_H_visual =
+                    transformedKinDyn.getRelativeTransform(firstAdditionalFrame, transformedModel.getLinkName(lnkIdx))*
+                    transformedVisual[lnkIdx][shapeIdx]->getLink_H_geometry();
+
+                ASSERT_EQUAL_TRANSFORM(original_frame_H_visual, transformed_frame_H_visual);
+            }
+
+            auto& originalCollision = originalModel.collisionSolidShapes().getLinkSolidShapes();
+            auto& transformedCollision = transformedModel.collisionSolidShapes().getLinkSolidShapes();
+            for(int shapeIdx=0; shapeIdx < originalCollision[lnkIdx].size(); shapeIdx++)
+            {
+                // Check that link index remains constant
+                ASSERT_IS_TRUE(originalModel.getLinkName(lnkIdx) == transformedModel.getLinkName(lnkIdx));
+
+                // Get firstAdditionalFrame_H_collision in original model and transformed model
+                iDynTree::Transform original_frame_H_visual =
+                    originalKinDyn.getRelativeTransform(firstAdditionalFrame, originalModel.getLinkName(lnkIdx))*
+                    originalCollision[lnkIdx][shapeIdx]->getLink_H_geometry();
+
+                iDynTree::Transform transformed_frame_H_visual =
+                    transformedKinDyn.getRelativeTransform(firstAdditionalFrame, transformedModel.getLinkName(lnkIdx))*
+                    transformedCollision[lnkIdx][shapeIdx]->getLink_H_geometry();
+
+                ASSERT_EQUAL_TRANSFORM(original_frame_H_visual, transformed_frame_H_visual);
+            }
+        }
+
+        // Verify that the original model can't be exported to URDF, while the transformed yes
+        iDynTree::ModelExporter originalModelExporter;
+        originalModelExporter.init(originalModel);
+        std::string originalURDFStringExported;
+        ASSERT_IS_FALSE(originalModelExporter.exportModelToString(originalURDFStringExported));
+        iDynTree::ModelExporter transformedModelExporter;
+        transformedModelExporter.init(transformedModel);
+        std::string transformedURDFStringExported;
+        ASSERT_IS_TRUE(originalModelExporter.exportModelToString(transformedURDFStringExported));
+    }
+}
+
+int main()
+{
+    checkThatMoveLinkFramesToBeCompatibleWithURDFWithGivenBaseLinkIsConsistent();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Until now, if you exported a `iDynTree::Model` that did not respected the URDF constraint of the child link frame origin being on the joint axis, you only got an error during the URDF export process, something like:

~~~
[ERROR] URDFModelExport: Impossible to convert joint torso_pitch to a URDF joint without moving the link frame of link torso_1 , because its origin is 1.90735e-10 -0.032 -0.0364
~~~

This PR does not modify this behaviour to avoid confusion in the export of URDF, but it adds a new `iDynTree::moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink` function to generate a URDF compatible model from a non-URDF compatible model, so for example if a code like:

~~~cxx
iDynTree::Model modelToExport;

// ... modelToExport is created

iDynTree::ModelExporter modelExporter;
modelExporter.init(modelToExport);
bool ok = transformedModelExporter.exportModelToFile("/file/name.urdf");
~~~

was reporting an error, you can modify it like:

~~~cxx
iDynTree::Model modelToExport;

// ... modelToExport is created

// Convert modelToExport in a URDF-compatible model (using the default base link)
iDynTree::Model modelToExportURDFCompatible;

bool ok = iDynTree::moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(modelToExport, modelToExportURDFCompatible);

iDynTree::ModelExporter modelExporter;
modelExporter.init(modelToExportURDFCompatible);
ok = ok && transformedModelExporter.exportModelToFile("/file/name.urdf");
~~~

to actually export a model that is identical to the original one, but with the link frames moved to comply with URDF constraints.

Fix https://github.com/robotology/idyntree/issues/847 .