### PR TITLE
Re-enable valgrind tests for IntegrationTestiCubTorqueEstimation

### DIFF
--- a/cmake/FindValgrind.cmake
+++ b/cmake/FindValgrind.cmake
@@ -19,7 +19,7 @@ find_path(VALGRIND_INCLUDE_DIR valgrind/memcheck.h
 find_program(VALGRIND_PROGRAM NAMES valgrind PATH ${VALGRIND_ROOT}/bin)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(VALGRIND DEFAULT_MSG
+find_package_handle_standard_args(Valgrind DEFAULT_MSG
   VALGRIND_INCLUDE_DIR
   VALGRIND_PROGRAM)
 

--- a/src/tests/integration/CMakeLists.txt
+++ b/src/tests/integration/CMakeLists.txt
@@ -43,9 +43,7 @@ add_integration_test(Dynamics)
 add_integration_test(DenavitHartenberg)
 add_integration_test(ReducedModelWithFT)
 add_integration_test(ModelTransformers)
-
-# See issue https://github.com/robotology/idyntree/issues/367
-add_integration_test_no_valgrind(iCubTorqueEstimation)
+add_integration_test(iCubTorqueEstimation)
 
 # Until we fix it, add DynamicsLinearization test but don't execute it
 add_integration_exe(DynamicsLinearization)


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/367 . 