### PR TITLE
Fix access to first element of empty vector in estimateLinkContactWrenchesFromLinkNetExternalWrenches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,14 +103,6 @@ jobs:
         # See https://github.com/robotology/robotology-superbuild/issues/477
         micromamba install xorg-libx11 xorg-libxrandr freeglut mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
 
-    # Additional dependencies useful only on macos-12
-    - name: Dependencies [Conda/Linux]
-      if: contains(matrix.os, 'macos-12')
-      shell: bash -l {0}
-      run: |
-        # See https://github.com/robotology/idyntree/issues/1192
-        micromamba install libcxx==17.*
-
     - name: Print used environment [Conda]
       shell: bash -l {0}
       run: |

--- a/src/estimation/src/ExternalWrenchesEstimation.cpp
+++ b/src/estimation/src/ExternalWrenchesEstimation.cpp
@@ -840,6 +840,12 @@ bool estimateLinkContactWrenchesFromLinkNetExternalWrenches(const Model& model,
             continue;
         }
 
+        // If the link has no contact, we can just go to next link
+        if (unknownWrenches.getNrOfContactsForLink(lnkIdx) == 0)
+        {
+            continue;
+        }
+
         const UnknownWrenchContact& unknownWrench = unknownWrenches.contactWrench(lnkIdx, 0);
         outputContactWrenches.setNrOfContactsForLink(lnkIdx, unknownWrenches.getNrOfContactsForLink(lnkIdx));
         ContactWrench& knownWrench          = outputContactWrenches.contactWrench(lnkIdx, 0);


### PR DESCRIPTION
The actually fixes the problem in https://github.com/robotology/idyntree/issues/1192 . While the test started to crash only on macOS since the update to libcxx 18, it turns out that the problem was actually calling `vec[0]` in an element with `vec.size() == 0`. Interestingly, the problem was not detected by valgrind, probably as the data was then write in a second call to `vec2[0]`, in another vector which again had actually size 0.

Fortunately the problematic function `estimateLinkContactWrenchesFromLinkNetExternalWrenches` was just used in the tests.