### PR TITLE
Update Matlab high-level wrappers

### DIFF
--- a/bindings/matlab/+iDynTreeWrappers/README.md
+++ b/bindings/matlab/+iDynTreeWrappers/README.md
@@ -1,4 +1,4 @@
-# idyntree high-level-wrappers
+# iDynTree high-level-wrappers
 
 A collection of Matlab/Octave functions that wraps the functionalities of (mainly) the iDyntree class `KinDynComputations`. For further information on the single wrapper, refer to the description included in each function.
 
@@ -74,6 +74,8 @@ The purpose of the wrapper is therefore to provide a simpler and easy-to-use int
 
 Not proper wrappers, they wrap more than one method of the class each. **Requirements:** compile iDyntree with Irrlicht `(IDYNTREE_USES_IRRLICHT = ON)`.
 
+**Warning**: the visualizer class may be deprecated in a future release.
+
 - [initializeVisualizer](initializeVisualizer.m)
 - [visualizerSetup](visualizerSetup.m)
 - [updateVisualizer](updateVisualizer.m)
@@ -81,9 +83,11 @@ Not proper wrappers, they wrap more than one method of the class each. **Require
 ## Matlab Native visualization
 
 Not actual wrappers, they use the iDynTreeWrappers in combination with the MATLAB patch plotting functions to visualize the robot.
+
 **Disclaimers**:
-- This visualization **has not been tested** with Octave.
-- At the moment, there is **no support** for .dae mesh files.
+
+1) This visualization **has not been tested** with Octave.
+2) At the moment, there is **no support** for `.dae` mesh file format.
 
 - [prepareVisualization](prepareVisualization.m)
 - [updateVisualization](updateVisualization.m)

--- a/bindings/matlab/+iDynTreeWrappers/generalizedBiasForces.m
+++ b/bindings/matlab/+iDynTreeWrappers/generalizedBiasForces.m
@@ -1,7 +1,7 @@
 function h = generalizedBiasForces(KinDynModel)
 
     % GENERALIZEDBIASFORCES retrieves the generalized bias forces from 
-    %                            the reduced model. 
+    %                       the reduced model. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -19,11 +19,8 @@ function h = generalizedBiasForces(KinDynModel)
 
     %% ------------Initialization----------------
     
-    % create the vector that must be populated with the bias forces
-    h_iDyntree = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
-    
     % get the bias forces
-    ack = KinDynModel.kinDynComp.generalizedBiasForces(h_iDyntree);
+    ack = KinDynModel.kinDynComp.generalizedBiasForces(KinDynModel.dynamics.h_iDyntree);
     
     % check for errors
     if ~ack
@@ -32,7 +29,7 @@ function h = generalizedBiasForces(KinDynModel)
     
     % convert to Matlab format: compute the base bias acc (h_b) and the
     % joint bias acc (h_s) and concatenate them
-    h_b = h_iDyntree.baseWrench.toMatlab;
-    h_s = h_iDyntree.jointTorques.toMatlab;   
+    h_b = KinDynModel.dynamics.h_iDyntree.baseWrench.toMatlab;
+    h_s = KinDynModel.dynamics.h_iDyntree.jointTorques.toMatlab;   
     h   = [h_b;h_s];
 end

--- a/bindings/matlab/+iDynTreeWrappers/generalizedBiasForces.m
+++ b/bindings/matlab/+iDynTreeWrappers/generalizedBiasForces.m
@@ -1,9 +1,9 @@
 function h = generalizedBiasForces(KinDynModel)
 
-    % GENERALIZEDBIASFORCES retrieves the generalized bias forces from 
-    %                       the reduced model. 
+    % GENERALIZEDBIASFORCES retrieves the generalized bias forces from
+    %                       the reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  h = generalizedBiasForces(KinDynModel)
@@ -15,21 +15,21 @@ function h = generalizedBiasForces(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the bias forces
     ack = KinDynModel.kinDynComp.generalizedBiasForces(KinDynModel.dynamics.h_iDyntree);
-    
+
     % check for errors
     if ~ack
         error('[generalizedBiasForces]: unable to get the bias forces from the reduced model.')
     end
-    
+
     % convert to Matlab format: compute the base bias acc (h_b) and the
     % joint bias acc (h_s) and concatenate them
     h_b = KinDynModel.dynamics.h_iDyntree.baseWrench.toMatlab;
-    h_s = KinDynModel.dynamics.h_iDyntree.jointTorques.toMatlab;   
+    h_s = KinDynModel.dynamics.h_iDyntree.jointTorques.toMatlab;
     h   = [h_b;h_s];
 end

--- a/bindings/matlab/+iDynTreeWrappers/generalizedGravityForces.m
+++ b/bindings/matlab/+iDynTreeWrappers/generalizedGravityForces.m
@@ -1,9 +1,9 @@
 function g = generalizedGravityForces(KinDynModel)
 
-    % GENERALIZEDGRAVITYFORCES retrieves the generalized gravity forces 
+    % GENERALIZEDGRAVITYFORCES retrieves the generalized gravity forces
     %                          given the reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  g = generalizedGravityForces(KinDynModel)
@@ -15,21 +15,21 @@ function g = generalizedGravityForces(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the gravity forces
     ack = KinDynModel.kinDynComp.generalizedGravityForces(KinDynModel.dynamics.g_iDyntree);
-    
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[generalizedGravityForces]: unable to get the gravity forces from the reduced model.')
     end
-    
+
     % convert to Matlab format: compute the base gravity forces (g_b) and the
     % joint gravity forces (g_j) and concatenate them
     g_b = KinDynModel.dynamics.g_iDyntree.baseWrench.toMatlab;
-    g_s = KinDynModel.dynamics.g_iDyntree.jointTorques.toMatlab;   
+    g_s = KinDynModel.dynamics.g_iDyntree.jointTorques.toMatlab;
     g   = [g_b; g_s];
 end

--- a/bindings/matlab/+iDynTreeWrappers/generalizedGravityForces.m
+++ b/bindings/matlab/+iDynTreeWrappers/generalizedGravityForces.m
@@ -1,7 +1,7 @@
 function g = generalizedGravityForces(KinDynModel)
 
     % GENERALIZEDGRAVITYFORCES retrieves the generalized gravity forces 
-    %                               given the reduced model.
+    %                          given the reduced model.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -18,12 +18,9 @@ function g = generalizedGravityForces(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % create the vector that must be populated with the gravity forces
-    g_iDyntree = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
-    
+
     % get the gravity forces
-    ack = KinDynModel.kinDynComp.generalizedGravityForces(g_iDyntree);
+    ack = KinDynModel.kinDynComp.generalizedGravityForces(KinDynModel.dynamics.g_iDyntree);
     
     % check for errors
     if ~ack  
@@ -32,7 +29,7 @@ function g = generalizedGravityForces(KinDynModel)
     
     % convert to Matlab format: compute the base gravity forces (g_b) and the
     % joint gravity forces (g_j) and concatenate them
-    g_b = g_iDyntree.baseWrench.toMatlab;
-    g_s = g_iDyntree.jointTorques.toMatlab;   
+    g_b = KinDynModel.dynamics.g_iDyntree.baseWrench.toMatlab;
+    g_s = KinDynModel.dynamics.g_iDyntree.jointTorques.toMatlab;   
     g   = [g_b; g_s];
 end

--- a/bindings/matlab/+iDynTreeWrappers/getBaseTwist.m
+++ b/bindings/matlab/+iDynTreeWrappers/getBaseTwist.m
@@ -2,7 +2,7 @@ function baseVel = getBaseTwist(KinDynModel)
 
     % GETBASETWIST retrieves the robot base velocity from the reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  baseVel = getBaseTwist(KinDynModel)
@@ -14,13 +14,13 @@ function baseVel = getBaseTwist(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the base velocities
     baseVel_iDyntree = KinDynModel.kinDynComp.getBaseTwist();
-    
+
     % convert to Matlab format
     baseVel = baseVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCenterOfMassJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCenterOfMassJacobian.m
@@ -2,7 +2,7 @@ function J_CoM = getCenterOfMassJacobian(KinDynModel)
 
     % GETCENTEROFMASSJACOBIAN retrieves the CoM jacobian.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  J_CoM = getCenterOfMassJacobian(KinDynModel)
@@ -14,18 +14,18 @@ function J_CoM = getCenterOfMassJacobian(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the free floating jacobian
     ack = KinDynModel.kinDynComp.getCenterOfMassJacobian(KinDynModel.kinematics.J_CoM_iDyntree);
-    
+
     % check for errors
-    if ~ack    
+    if ~ack
         error('[getCenterOfMassJacobian]: unable to get the CoM Jacobian from the reduced model.')
     end
-    
+
     % convert to Matlab format
     J_CoM = KinDynModel.kinematics.J_CoM_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCenterOfMassJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCenterOfMassJacobian.m
@@ -17,12 +17,9 @@ function J_CoM = getCenterOfMassJacobian(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % create the matrix that must be populated with the jacobian map
-    J_CoM_iDyntree = iDynTree.MatrixDynSize(3,KinDynModel.NDOF+6);
-    
+
     % get the free floating jacobian
-    ack = KinDynModel.kinDynComp.getCenterOfMassJacobian(J_CoM_iDyntree);
+    ack = KinDynModel.kinDynComp.getCenterOfMassJacobian(KinDynModel.kinematics.J_CoM_iDyntree);
     
     % check for errors
     if ~ack    
@@ -30,5 +27,5 @@ function J_CoM = getCenterOfMassJacobian(KinDynModel)
     end
     
     % convert to Matlab format
-    J_CoM = J_CoM_iDyntree.toMatlab;
+    J_CoM = KinDynModel.kinematics.J_CoM_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCenterOfMassPosition.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCenterOfMassPosition.m
@@ -2,7 +2,7 @@ function posCoM = getCenterOfMassPosition(KinDynModel)
 
     % GETCENTEROFMASSPOSITION retrieves the CoM position in world coordinates.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  posCoM = getCenterOfMassPosition(KinDynModel)
@@ -14,13 +14,13 @@ function posCoM = getCenterOfMassPosition(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the CoM position
-    posCoM_iDyntree = KinDynModel.kinDynComp.getCenterOfMassPosition(); 
-    
+    posCoM_iDyntree = KinDynModel.kinDynComp.getCenterOfMassPosition();
+
     % covert to matlab
     posCoM = posCoM_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCenterOfMassVelocity.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCenterOfMassVelocity.m
@@ -2,7 +2,7 @@ function velCoM = getCenterOfMassVelocity(KinDynModel)
 
     % GETCENTEROFMASSVELOCITY retrieves the CoM velocity in world coordinates.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  velCoM = getCenterOfMassVelocity(KinDynModel)
@@ -14,13 +14,13 @@ function velCoM = getCenterOfMassVelocity(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
-    %% ------------Initialization----------------  
-    
+    %% ------------Initialization----------------
+
     % get the CoM velocity
-    velCoM_iDyntree = KinDynModel.kinDynComp.getCenterOfMassVelocity(); 
-    
+    velCoM_iDyntree = KinDynModel.kinDynComp.getCenterOfMassVelocity();
+
     % covert to matlab
     velCoM = velCoM_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCentroidalTotalMomentum.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCentroidalTotalMomentum.m
@@ -2,9 +2,9 @@ function totalMomentum = getCentroidalTotalMomentum(KinDynModel)
 
     % GETCENTROIDALTOTALMOMENTUM retrieves the centroidal momentum from the reduced
     %                            model. The quantity is expressed in a frame that depends
-    %                            on the 'FrameVelocityReperesentation' settings.                               
+    %                            on the 'FrameVelocityReperesentation' settings.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  totalMomentum = getCentroidalTotalMomentum(KinDynModel)
@@ -16,13 +16,13 @@ function totalMomentum = getCentroidalTotalMomentum(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the momentum
     totalMomentum_iDyntree = KinDynModel.kinDynComp.getCentroidalTotalMomentum();
-    
+
     % convert to Matlab format
     totalMomentum = totalMomentum_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getCentroidalTotalMomentum.m
+++ b/bindings/matlab/+iDynTreeWrappers/getCentroidalTotalMomentum.m
@@ -1,8 +1,8 @@
 function totalMomentum = getCentroidalTotalMomentum(KinDynModel)
 
     % GETCENTROIDALTOTALMOMENTUM retrieves the centroidal momentum from the reduced
-    %                                 model. The quantity is expressed in a frame that depends
-    %                                 on the 'FrameVelocityReperesentation' settings.                               
+    %                            model. The quantity is expressed in a frame that depends
+    %                            on the 'FrameVelocityReperesentation' settings.                               
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getFloatingBase.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFloatingBase.m
@@ -1,9 +1,9 @@
 function baseLinkName = getFloatingBase(KinDynModel)
 
-    % GETFLOATINGBASE retrieves the floating base link name from the 
+    % GETFLOATINGBASE retrieves the floating base link name from the
     %                 reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  baseLinkName = getFloatingBase(KinDynModel)
@@ -15,10 +15,10 @@ function baseLinkName = getFloatingBase(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the name of the floating base link
-    baseLinkName = KinDynModel.kinDynComp.getFloatingBase();  
+    baseLinkName = KinDynModel.kinDynComp.getFloatingBase();
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFloatingBase.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFloatingBase.m
@@ -1,7 +1,7 @@
 function baseLinkName = getFloatingBase(KinDynModel)
 
     % GETFLOATINGBASE retrieves the floating base link name from the 
-    %                      reduced model.
+    %                 reduced model.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getFrameBiasAcc.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameBiasAcc.m
@@ -1,28 +1,28 @@
 function JDot_nu_frame = getFrameBiasAcc(KinDynModel,frameName)
 
-    % GETFRAMEBIASACC gets the bias accelerations of a specified frame. 
+    % GETFRAMEBIASACC gets the bias accelerations of a specified frame.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  JDot_nu_frame = getFrameBiasAcc(KinDynModel,frameName)
     %
     % INPUTS:  - KinDynModel: a structure containing the loaded model and additional info.
-    %          - frameName: a string that specifies the frame w.r.t. compute the 
-    %                       bias accelerations, or the associated ID;     
+    %          - frameName: a string that specifies the frame w.r.t. compute the
+    %                       bias accelerations, or the associated ID;
     %
     % OUTPUTS: - JDot_nu_frame: [6 x 6+ndof] frame bias accelerations.
     %
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the bias acc
     JDot_nu_frame_iDyntree = KinDynModel.kinDynComp.getFrameBiasAcc(frameName);
-    
+
     % convert to Matlab format
     JDot_nu_frame = JDot_nu_frame_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameFreeFloatingJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameFreeFloatingJacobian.m
@@ -1,34 +1,34 @@
 function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
 
-    % GETFRAMEFREEFLOATINGJACOBIAN gets the free floating jacobian of a 
-    %                              specified frame. 
+    % GETFRAMEFREEFLOATINGJACOBIAN gets the free floating jacobian of a
+    %                              specified frame.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
     %
     % INPUTS:  - KinDynModel: a structure containing the loaded model and additional info.
-    %          - frameName: a string that specifies the frame w.r.t. compute the 
-    %                       jacobian matrix, or the associated ID;     
+    %          - frameName: a string that specifies the frame w.r.t. compute the
+    %                       jacobian matrix, or the associated ID;
     %
     % OUTPUTS: - J_frame: [6 x 6+ndof] frame free floating Jacobian.
     %
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the free floating jacobian
     ack = KinDynModel.kinDynComp.getFrameFreeFloatingJacobian(frameName,KinDynModel.kinematics.J_frame_iDyntree);
-    
+
     % check for errors
-    if ~ack   
+    if ~ack
         error('[getFrameFreeFloatingJacobian]: unable to get the Jacobian from the reduced model.')
     end
-    
+
     % convert to Matlab format
     J_frame = KinDynModel.kinematics.J_frame_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameFreeFloatingJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameFreeFloatingJacobian.m
@@ -1,7 +1,7 @@
 function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
 
     % GETFRAMEFREEFLOATINGJACOBIAN gets the free floating jacobian of a 
-    %                                   specified frame. 
+    %                              specified frame. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -20,12 +20,9 @@ function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % create the matrix that must be populated with the jacobian map
-    J_frame_iDyntree = iDynTree.MatrixDynSize(6,KinDynModel.NDOF+6);
-    
+
     % get the free floating jacobian
-    ack = KinDynModel.kinDynComp.getFrameFreeFloatingJacobian(frameName,J_frame_iDyntree);
+    ack = KinDynModel.kinDynComp.getFrameFreeFloatingJacobian(frameName,KinDynModel.kinematics.J_frame_iDyntree);
     
     % check for errors
     if ~ack   
@@ -33,5 +30,5 @@ function J_frame = getFrameFreeFloatingJacobian(KinDynModel,frameName)
     end
     
     % convert to Matlab format
-    J_frame = J_frame_iDyntree.toMatlab;
+    J_frame = KinDynModel.kinematics.J_frame_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameIndex.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameIndex.m
@@ -1,8 +1,8 @@
 function frameID = getFrameIndex(KinDynModel,frameName)
 
-    % GETFRAMEINDEX gets the index corresponding to a given frame name. 
+    % GETFRAMEINDEX gets the index corresponding to a given frame name.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  frameID = getFrameIndex(KinDynModel,frameName)
@@ -15,10 +15,10 @@ function frameID = getFrameIndex(KinDynModel,frameName)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the ID of the given frame
-    frameID = KinDynModel.kinDynComp.getFrameIndex(frameName); 
+    frameID = KinDynModel.kinDynComp.getFrameIndex(frameName);
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameName.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameName.m
@@ -2,7 +2,7 @@ function frameName = getFrameName(KinDynModel,frameID)
 
     % GETFRAMENAME gets the name corresponding to a given frame index.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  frameName = getFrameName(KinDynModel,frameID)
@@ -15,10 +15,10 @@ function frameName = getFrameName(KinDynModel,frameID)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the ID of the given frame
-    frameName = KinDynModel.kinDynComp.getFrameName(frameID);   
+    frameName = KinDynModel.kinDynComp.getFrameName(frameID);
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameVelocityRepresentation.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameVelocityRepresentation.m
@@ -1,9 +1,9 @@
 function frameVelRepr = getFrameVelocityRepresentation(KinDynModel)
 
     % GETFRAMEVELOCITYREPRESENTATION retrieves the current frame velocity
-    %                                representation. 
+    %                                representation.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  frameVelRepr = getFrameVelocityRepresentation(KinDynModel)
@@ -15,7 +15,7 @@ function frameVelRepr = getFrameVelocityRepresentation(KinDynModel)
     %
     % Possible frame velocity representations:
     %
-    %  0 = INERTIAL_FIXED_REPRESENTATION 	
+    %  0 = INERTIAL_FIXED_REPRESENTATION
     %
     %  1 = BODY_FIXED_REPRESENTATION
     %
@@ -24,28 +24,28 @@ function frameVelRepr = getFrameVelocityRepresentation(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    frameVelRepr_idyntree = KinDynModel.kinDynComp.getFrameVelocityRepresentation();   
-    
+
+    frameVelRepr_idyntree = KinDynModel.kinDynComp.getFrameVelocityRepresentation();
+
     % output the current frame velocity representation
-    switch frameVelRepr_idyntree  
-        
+    switch frameVelRepr_idyntree
+
         case 2
-            
+
             frameVelRepr = 'mixed';
-                    
+
         case 1
-            
+
             frameVelRepr = 'body';
-                    
+
         case 0
-            
+
             frameVelRepr = 'inertial';
-                    
-        otherwise        
+
+        otherwise
             error('[setFrameVelocityRepresentation]: frameVelRepr is not a valid string.')
-    end   
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getFrameVelocityRepresentation.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFrameVelocityRepresentation.m
@@ -1,7 +1,7 @@
 function frameVelRepr = getFrameVelocityRepresentation(KinDynModel)
 
     % GETFRAMEVELOCITYREPRESENTATION retrieves the current frame velocity
-    %                                     representation. 
+    %                                representation. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getFreeFloatingMassMatrix.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFreeFloatingMassMatrix.m
@@ -17,12 +17,9 @@ function M = getFreeFloatingMassMatrix(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % create the matrix that must be populated with the mass info
-    M_iDyntree = iDynTree.MatrixDynSize(KinDynModel.NDOF+6,KinDynModel.NDOF+6);
-    
+
     % get the mass matrix
-    ack = KinDynModel.kinDynComp.getFreeFloatingMassMatrix(M_iDyntree);
+    ack = KinDynModel.kinDynComp.getFreeFloatingMassMatrix(KinDynModel.dynamics.M_iDyntree);
     
     % check for errors
     if ~ack  
@@ -30,7 +27,7 @@ function M = getFreeFloatingMassMatrix(KinDynModel)
     end
     
     % convert to Matlab format
-    M = M_iDyntree.toMatlab;
+    M = KinDynModel.dynamics.M_iDyntree.toMatlab;
     
     % debug output
     if KinDynModel.DEBUG

--- a/bindings/matlab/+iDynTreeWrappers/getFreeFloatingMassMatrix.m
+++ b/bindings/matlab/+iDynTreeWrappers/getFreeFloatingMassMatrix.m
@@ -2,7 +2,7 @@ function M = getFreeFloatingMassMatrix(KinDynModel)
 
     % GETFREEFLOATINGMASSMATRIX retrieves the free floating mass matrix.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  M = getFreeFloatingMassMatrix(KinDynModel)
@@ -14,42 +14,42 @@ function M = getFreeFloatingMassMatrix(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the mass matrix
     ack = KinDynModel.kinDynComp.getFreeFloatingMassMatrix(KinDynModel.dynamics.M_iDyntree);
-    
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[getFreeFloatingMassMatrix]: unable to retrieve the mass matrix from the reduced model.')
     end
-    
+
     % convert to Matlab format
     M = KinDynModel.dynamics.M_iDyntree.toMatlab;
-    
+
     % debug output
     if KinDynModel.DEBUG
-        
+
         disp('[getFreeFloatingMassMatrix]: debugging outputs...')
-                
+
         % check mass matrix symmetry and positive definiteness
         M_symm_error = norm(M -(M + M')/2);
         M_symm_eig   = eig((M + M')/2);
- 
+
         if M_symm_error > 0.1
-            
+
             error('[getFreeFloatingMassMatrix]: M is not symmetric')
         end
-        
+
         for k = 1:length(M_symm_eig)
-            
+
             if M_symm_eig(k) < 0
-                
+
                 error('[getFreeFloatingMassMatrix]: M is not positive definite')
             end
-        end       
-        disp('[getFreeFloatingMassMatrix]: done.')     
-    end 
+        end
+        disp('[getFreeFloatingMassMatrix]: done.')
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getJointPos.m
+++ b/bindings/matlab/+iDynTreeWrappers/getJointPos.m
@@ -2,7 +2,7 @@ function jointPos = getJointPos(KinDynModel)
 
     % GETJOINTPOS retrieves the joints configuration from the reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  jointPos = getJointPos(KinDynModel)
@@ -14,18 +14,18 @@ function jointPos = getJointPos(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the joints positions
     ack = KinDynModel.kinDynComp.getJointPos(KinDynModel.kinematics.jointPos_iDyntree);
-    
+
     % check for errors
-    if ~ack   
+    if ~ack
         error('[getJointPos]: unable to retrieve the joint positions from the reduced model.')
     end
-    
+
     % convert to Matlab format
     jointPos = KinDynModel.kinematics.jointPos_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getJointPos.m
+++ b/bindings/matlab/+iDynTreeWrappers/getJointPos.m
@@ -17,12 +17,9 @@ function jointPos = getJointPos(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % create the vector that must be populated with the joint positions
-    jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+
     % get the joints positions
-    ack = KinDynModel.kinDynComp.getJointPos(jointPos_iDyntree);
+    ack = KinDynModel.kinDynComp.getJointPos(KinDynModel.kinematics.jointPos_iDyntree);
     
     % check for errors
     if ~ack   
@@ -30,5 +27,5 @@ function jointPos = getJointPos(KinDynModel)
     end
     
     % convert to Matlab format
-    jointPos = jointPos_iDyntree.toMatlab;
+    jointPos = KinDynModel.kinematics.jointPos_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getJointVel.m
+++ b/bindings/matlab/+iDynTreeWrappers/getJointVel.m
@@ -2,7 +2,7 @@ function jointVel = getJointVel(KinDynModel)
 
     % GETJOINTVEL retrieves joint velocities from the reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  jointVel = getJointVel(KinDynModel)
@@ -14,18 +14,18 @@ function jointVel = getJointVel(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the joints velocities
     ack = KinDynModel.kinDynComp.getJointVel(KinDynModel.kinematics.jointVel_iDyntree);
-    
+
     % check for errors
-    if ~ack   
+    if ~ack
         error('[getJointVel]: unable to retrieve the joint velocities from the reduced model.')
     end
-    
+
     % convert to Matlab format
     jointVel = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getJointVel.m
+++ b/bindings/matlab/+iDynTreeWrappers/getJointVel.m
@@ -17,12 +17,9 @@ function jointVel = getJointVel(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-
-    % create the vector that must be populated with the joint velocities
-    jointVel_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
     
     % get the joints velocities
-    ack = KinDynModel.kinDynComp.getJointVel(jointVel_iDyntree);
+    ack = KinDynModel.kinDynComp.getJointVel(KinDynModel.kinematics.jointVel_iDyntree);
     
     % check for errors
     if ~ack   
@@ -30,5 +27,5 @@ function jointVel = getJointVel(KinDynModel)
     end
     
     % convert to Matlab format
-    jointVel = jointVel_iDyntree.toMatlab;
+    jointVel = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -17,7 +17,7 @@ function [linkMeshInfo,map]=getMeshes(model,meshFilePrefix)
 % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
 % SPDX-License-Identifier: BSD-3-Clause
 
-
+    %% ------------Initialization----------------
 
 % get the linkSolidShapes containing the mesh information
 visual=model.visualSolidShapes;
@@ -91,32 +91,35 @@ end
 linkMeshInfo(link_with_no_visual)=[];
 
 end
-%% Create points and connectivity list for each geometry
 
-function [mesh_triangles]=calculateMeshFromSphere(radius)
-[X,Y,Z]=sphere;
-X = X * radius;
-Y = Y * radius;
-Z = Z * radius;
-[F,V]=mesh2tri(X,Y,Z,'f');
-mesh_triangles.Points=V;
-mesh_triangles.ConnectivityList = F;
+% Create points and connectivity list for each geometry
+function [mesh_triangles] = calculateMeshFromSphere(radius)
+    
+    [X,Y,Z] = sphere;
+    X       = X * radius;
+    Y       = Y * radius;
+    Z       = Z * radius;
+    [F,V]   = mesh2tri(X,Y,Z,'f');
+    mesh_triangles.Points           = V;
+    mesh_triangles.ConnectivityList = F;
 end
 
-function [mesh_triangles]=calculateMeshFromBox(box_dimensions)
-mesh_triangles.Points = [0 0 0;1 0 0;1 1 0;0 1 0;0 0 1;1 0 1;1 1 1;0 1 1];
-mesh_triangles.Points(:,1)=mesh_triangles.Points(:,1)*box_dimensions(1)-box_dimensions(1)/2;
-mesh_triangles.Points(:,2)=mesh_triangles.Points(:,2)*box_dimensions(2)-box_dimensions(2)/2;
-mesh_triangles.Points(:,3)=mesh_triangles.Points(:,3)*box_dimensions(3)-box_dimensions(3)/2;
-mesh_triangles.ConnectivityList = [1 2 6 5;2 3 7 6;3 4 8 7;4 1 5 8;1 2 3 4;5 6 7 8];
+function [mesh_triangles] = calculateMeshFromBox(box_dimensions)
+
+    mesh_triangles.Points           = [0 0 0;1 0 0;1 1 0;0 1 0;0 0 1;1 0 1;1 1 1;0 1 1];
+    mesh_triangles.Points(:,1)      = mesh_triangles.Points(:,1)*box_dimensions(1)-box_dimensions(1)/2;
+    mesh_triangles.Points(:,2)      = mesh_triangles.Points(:,2)*box_dimensions(2)-box_dimensions(2)/2;
+    mesh_triangles.Points(:,3)      = mesh_triangles.Points(:,3)*box_dimensions(3)-box_dimensions(3)/2;
+    mesh_triangles.ConnectivityList = [1 2 6 5;2 3 7 6;3 4 8 7;4 1 5 8;1 2 3 4;5 6 7 8];
 end
 
-function [mesh_triangles]=calculateMeshFromCylinder(length,radius)
-[X,Y,Z] = cylinder;
-X = X * radius;
-Y = Y * radius;
-Z = Z * length-length/2;
-[F,V]=mesh2tri(X,Y,Z,'f');
-mesh_triangles.Points=V;
-mesh_triangles.ConnectivityList = F;
+function [mesh_triangles] = calculateMeshFromCylinder(length,radius)
+
+    [X,Y,Z] = cylinder;
+    X       = X * radius;
+    Y       = Y * radius;
+    Z       = Z * length-length/2;
+    [F,V]   = mesh2tri(X,Y,Z,'f');
+    mesh_triangles.Points           = V;
+    mesh_triangles.ConnectivityList = F;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getMeshes.m
+++ b/bindings/matlab/+iDynTreeWrappers/getMeshes.m
@@ -1,125 +1,125 @@
 function [linkMeshInfo,map]=getMeshes(model,meshFilePrefix)
-% We use the iDyntree information to obtain the files containing the meshes
-% and we link them to their link names
-% Gets the mesh information for each link in the model.
-%     - Iputs:
-%         - `model` : iDyntree model loaded from a URDF.
-%         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-% `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
-%     - Outputs:
-%         - `map`        : Cell array having both the names of the meshes and the associated link
-%         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
-%
-% NOTE: at the moment only STL files are supported.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % We use the iDyntree information to obtain the files containing the meshes
+    % and we link them to their link names
+    % Gets the mesh information for each link in the model.
+    %     - Iputs:
+    %         - `model` : iDyntree model loaded from a URDF.
+    %         - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
+    % `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
+    %     - Outputs:
+    %         - `map`        : Cell array having both the names of the meshes and the associated link
+    %         - `linkMeshInfo` : Struct array that contain the link name and a struct (`meshInfo`) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.
+    %
+    % NOTE: at the moment only STL files are supported.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
-% get the linkSolidShapes containing the mesh information
-visual=model.visualSolidShapes;
-linkSolidShapesV=visual.getLinkSolidShapes;
-% get number of links
-numberOfLinks=linkSolidShapesV.size;
-linkMeshInfo=struct('meshInfo',{},'linkName',{});
-% get pointer to beggining of vector
-iterator=linkSolidShapesV.begin;
-% iterate getting the name of the mesh and the name of the link
-count=1;
-link_with_no_visual=[];
-for links=1:numberOfLinks
-    linkName=model.getLinkName(links-1);
-    linkMeshInfo(links).linkName=linkName;
-    solidarray=iterator.next;
-    solids_number=size(solidarray,2);
-    meshInfo=struct('meshFile',{},'mesh_triangles',{},'link_H_geom',{});
-    for solids=1:solids_number
-        if solidarray{solids}.isExternalMesh
-            externalMesh=solidarray{solids}.asExternalMesh;
-            scale=externalMesh.getScale.toMatlab;
-            if(meshFilePrefix == "")
-               meshFile = externalMesh.getFilename;
-               mesh_triangles = stlread(externalMesh.getFileLocationOnLocalFileSystem);
-            else
-                meshName=split(externalMesh.getFilename,':');
-                meshFile=meshName{2};
-                % Import an STL mesh, returning a PATCH-compatible face-vertex structure
-                if strcmp('package',meshName{1})
-                    mesh_triangles = stlread([meshFilePrefix meshFile]);
+    % get the linkSolidShapes containing the mesh information
+    visual=model.visualSolidShapes;
+    linkSolidShapesV=visual.getLinkSolidShapes;
+    % get number of links
+    numberOfLinks=linkSolidShapesV.size;
+    linkMeshInfo=struct('meshInfo',{},'linkName',{});
+    % get pointer to beggining of vector
+    iterator=linkSolidShapesV.begin;
+    % iterate getting the name of the mesh and the name of the link
+    count=1;
+    link_with_no_visual=[];
+    for links=1:numberOfLinks
+        linkName=model.getLinkName(links-1);
+        linkMeshInfo(links).linkName=linkName;
+        solidarray=iterator.next;
+        solids_number=size(solidarray,2);
+        meshInfo=struct('meshFile',{},'mesh_triangles',{},'link_H_geom',{});
+        for solids=1:solids_number
+            if solidarray{solids}.isExternalMesh
+                externalMesh=solidarray{solids}.asExternalMesh;
+                scale=externalMesh.getScale.toMatlab;
+                if(meshFilePrefix == "")
+                    meshFile = externalMesh.getFilename;
+                    mesh_triangles = stlread(externalMesh.getFileLocationOnLocalFileSystem);
                 else
-                    mesh_triangles = stlread(meshFile);
+                    meshName=split(externalMesh.getFilename,':');
+                    meshFile=meshName{2};
+                    % Import an STL mesh, returning a PATCH-compatible face-vertex structure
+                    if strcmp('package',meshName{1})
+                        mesh_triangles = stlread([meshFilePrefix meshFile]);
+                    else
+                        mesh_triangles = stlread(meshFile);
+                    end
+                end
+                meshInfo(solids).meshFile=meshFile;
+                meshInfo(solids).scale=scale';
+            else
+                meshInfo(solids).scale=[1,1,1];
+                if solidarray{solids}.isCylinder
+                    meshInfo(solids).meshFile='cylinder';
+                    length=solidarray{solids}.asCylinder.getLength;
+                    radius=solidarray{solids}.asCylinder.getRadius;
+                    mesh_triangles=calculateMeshFromCylinder(length,radius);
+                end
+                if solidarray{solids}.isBox
+                    meshInfo(solids).meshFile='box';
+                    box_dimensions(1)=solidarray{solids}.asBox.getX;
+                    box_dimensions(2)=solidarray{solids}.asBox.getY;
+                    box_dimensions(3)=solidarray{solids}.asBox.getZ;
+                    mesh_triangles=calculateMeshFromBox(box_dimensions);
+                end
+                if solidarray{solids}.isSphere
+                    meshInfo(solids).meshFile='sphere';
+                    radius=solidarray{solids}.asSphere.getRadius;
+                    mesh_triangles=calculateMeshFromSphere(radius);
                 end
             end
-            meshInfo(solids).meshFile=meshFile;
-            meshInfo(solids).scale=scale';
-        else
-            meshInfo(solids).scale=[1,1,1];
-            if solidarray{solids}.isCylinder
-                meshInfo(solids).meshFile='cylinder';
-                length=solidarray{solids}.asCylinder.getLength;
-                radius=solidarray{solids}.asCylinder.getRadius;
-                mesh_triangles=calculateMeshFromCylinder(length,radius);
-            end
-            if solidarray{solids}.isBox
-                meshInfo(solids).meshFile='box';
-                box_dimensions(1)=solidarray{solids}.asBox.getX;
-                box_dimensions(2)=solidarray{solids}.asBox.getY;
-                box_dimensions(3)=solidarray{solids}.asBox.getZ;
-                mesh_triangles=calculateMeshFromBox(box_dimensions);
-            end
-            if solidarray{solids}.isSphere
-                meshInfo(solids).meshFile='sphere';
-                radius=solidarray{solids}.asSphere.getRadius;
-                mesh_triangles=calculateMeshFromSphere(radius);
-            end
+            link_H_geom=solidarray{solids}.getLink_H_geometry.asHomogeneousTransform.toMatlab;
+            meshInfo(solids).link_H_geom=link_H_geom;
+            meshInfo(solids).mesh_triangles=mesh_triangles;
+            map(count,:)=[{meshInfo(solids).meshFile},{linkName}];
+            count=count+1;
         end
-        link_H_geom=solidarray{solids}.getLink_H_geometry.asHomogeneousTransform.toMatlab;
-        meshInfo(solids).link_H_geom=link_H_geom;
-        meshInfo(solids).mesh_triangles=mesh_triangles;
-        map(count,:)=[{meshInfo(solids).meshFile},{linkName}];
-        count=count+1;
+        linkMeshInfo(links).meshInfo=meshInfo;
+        if solids_number==0
+            link_with_no_visual=[ link_with_no_visual links];
+        end
     end
-    linkMeshInfo(links).meshInfo=meshInfo;
-    if solids_number==0
-       link_with_no_visual=[ link_with_no_visual links];
-    end
-end
-% clean links with no visuals
-linkMeshInfo(link_with_no_visual)=[];
+    % clean links with no visuals
+    linkMeshInfo(link_with_no_visual)=[];
 
 end
 
 % Create points and connectivity list for each geometry
 function [mesh_triangles] = calculateMeshFromSphere(radius)
-    
+
     [X,Y,Z] = sphere;
-    X       = X * radius;
-    Y       = Y * radius;
-    Z       = Z * radius;
-    [F,V]   = mesh2tri(X,Y,Z,'f');
-    mesh_triangles.Points           = V;
+    X = X * radius;
+    Y = Y * radius;
+    Z = Z * radius;
+    [F,V] = mesh2tri(X,Y,Z,'f');
+    mesh_triangles.Points = V;
     mesh_triangles.ConnectivityList = F;
 end
 
 function [mesh_triangles] = calculateMeshFromBox(box_dimensions)
 
-    mesh_triangles.Points           = [0 0 0;1 0 0;1 1 0;0 1 0;0 0 1;1 0 1;1 1 1;0 1 1];
-    mesh_triangles.Points(:,1)      = mesh_triangles.Points(:,1)*box_dimensions(1)-box_dimensions(1)/2;
-    mesh_triangles.Points(:,2)      = mesh_triangles.Points(:,2)*box_dimensions(2)-box_dimensions(2)/2;
-    mesh_triangles.Points(:,3)      = mesh_triangles.Points(:,3)*box_dimensions(3)-box_dimensions(3)/2;
+    mesh_triangles.Points = [0 0 0;1 0 0;1 1 0;0 1 0;0 0 1;1 0 1;1 1 1;0 1 1];
+    mesh_triangles.Points(:,1) = mesh_triangles.Points(:,1)*box_dimensions(1)-box_dimensions(1)/2;
+    mesh_triangles.Points(:,2) = mesh_triangles.Points(:,2)*box_dimensions(2)-box_dimensions(2)/2;
+    mesh_triangles.Points(:,3) = mesh_triangles.Points(:,3)*box_dimensions(3)-box_dimensions(3)/2;
     mesh_triangles.ConnectivityList = [1 2 6 5;2 3 7 6;3 4 8 7;4 1 5 8;1 2 3 4;5 6 7 8];
 end
 
 function [mesh_triangles] = calculateMeshFromCylinder(length,radius)
 
     [X,Y,Z] = cylinder;
-    X       = X * radius;
-    Y       = Y * radius;
-    Z       = Z * length-length/2;
-    [F,V]   = mesh2tri(X,Y,Z,'f');
-    mesh_triangles.Points           = V;
+    X = X * radius;
+    Y = Y * radius;
+    Z = Z * length-length/2;
+    [F,V] = mesh2tri(X,Y,Z,'f');
+    mesh_triangles.Points = V;
     mesh_triangles.ConnectivityList = F;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getModelVel.m
+++ b/bindings/matlab/+iDynTreeWrappers/getModelVel.m
@@ -1,7 +1,7 @@
 function stateVel = getModelVel(KinDynModel)
 
     % GETMODELVEL gets the joints and floating base velocities from the 
-    %                  reduced model.
+    %             reduced model.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -18,12 +18,9 @@ function stateVel = getModelVel(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % create the vector that must be populated with the stae velocities
-    stateVel_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+ 
     % get the joints velocities
-    ack = KinDynModel.kinDynComp.getModelVel(stateVel_iDyntree);
+    ack = KinDynModel.kinDynComp.getModelVel(KinDynModel.kinematics.stateVel_iDyntree);
     
     % check for errors
     if ~ack  
@@ -31,5 +28,5 @@ function stateVel = getModelVel(KinDynModel)
     end
     
     % convert to Matlab format
-    stateVel = stateVel_iDyntree.toMatlab;
+    stateVel = KinDynModel.kinematics.stateVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getModelVel.m
+++ b/bindings/matlab/+iDynTreeWrappers/getModelVel.m
@@ -1,9 +1,9 @@
 function stateVel = getModelVel(KinDynModel)
 
-    % GETMODELVEL gets the joints and floating base velocities from the 
+    % GETMODELVEL gets the joints and floating base velocities from the
     %             reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  stateVel = getModelVel(KinDynModel)
@@ -15,18 +15,18 @@ function stateVel = getModelVel(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
- 
+
     % get the joints velocities
     ack = KinDynModel.kinDynComp.getModelVel(KinDynModel.kinematics.stateVel_iDyntree);
-    
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[getModelVel]: unable to retrieve the state velocities from the reduced model.')
     end
-    
+
     % convert to Matlab format
     stateVel = KinDynModel.kinematics.stateVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getNrOfDegreesOfFreedom.m
+++ b/bindings/matlab/+iDynTreeWrappers/getNrOfDegreesOfFreedom.m
@@ -29,7 +29,7 @@ function nDof = getNrOfDegreesOfFreedom(KinDynModel)
         % check nDof is not empty
         if isempty(nDof)
             
-            error('[getNrOfDegreesOfFreedom]: nDof is empty.')
+            warning('[getNrOfDegreesOfFreedom]: nDof is empty.')
         end
                
         disp('[getNrOfDegreesOfFreedom]: done.')     

--- a/bindings/matlab/+iDynTreeWrappers/getNrOfDegreesOfFreedom.m
+++ b/bindings/matlab/+iDynTreeWrappers/getNrOfDegreesOfFreedom.m
@@ -1,8 +1,8 @@
 function nDof = getNrOfDegreesOfFreedom(KinDynModel)
 
-    % GETNROFDEGREESOFFREEDOM gets the dimension of the joint space. 
+    % GETNROFDEGREESOFFREEDOM gets the dimension of the joint space.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  nDof = getNrOfDegreesOfFreedom(KinDynModel)
@@ -14,24 +14,24 @@ function nDof = getNrOfDegreesOfFreedom(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the number of DoF
-    nDof = KinDynModel.kinDynComp.getNrOfDegreesOfFreedom(); 
-    
+    nDof = KinDynModel.kinDynComp.getNrOfDegreesOfFreedom();
+
     % Debug output
     if KinDynModel.DEBUG
-        
+
         disp('[getNrOfDegreesOfFreedom]: debugging outputs...')
-        
+
         % check nDof is not empty
         if isempty(nDof)
-            
+
             warning('[getNrOfDegreesOfFreedom]: nDof is empty.')
         end
-               
-        disp('[getNrOfDegreesOfFreedom]: done.')     
+
+        disp('[getNrOfDegreesOfFreedom]: done.')
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getRelativeJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRelativeJacobian.m
@@ -2,9 +2,9 @@ function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
 
     % GETRELATIVEJACOBIAN gets the relative jacobian, i.e. the matrix that
     %                     maps the velocity of frameVel expressed w.r.t.
-    %                     frameRef, to the joint velocity. 
+    %                     frameRef, to the joint velocity.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
@@ -20,18 +20,18 @@ function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % get the relative jacobian
-    ack = KinDynModel.kinDynComp.getRelativeJacobian(frameVelID,frameRefID,KinDynModel.kinematics.J_frameVel_iDyntree);  
-    
+    ack = KinDynModel.kinDynComp.getRelativeJacobian(frameVelID,frameRefID,KinDynModel.kinematics.J_frameVel_iDyntree);
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[getRelativeJacobian]: unable to get the relative jacobian from the reduced model.')
     end
-    
+
     % covert to Matlab format
-    J_frameVel = KinDynModel.kinematics.J_frameVel_iDyntree.toMatlab; 
+    J_frameVel = KinDynModel.kinematics.J_frameVel_iDyntree.toMatlab;
 end

--- a/bindings/matlab/+iDynTreeWrappers/getRelativeJacobian.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRelativeJacobian.m
@@ -1,8 +1,8 @@
 function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
 
     % GETRELATIVEJACOBIAN gets the relative jacobian, i.e. the matrix that
-    %                          maps the velocity of frameVel expressed w.r.t.
-    %                          frameRef, to the joint velocity. 
+    %                     maps the velocity of frameVel expressed w.r.t.
+    %                     frameRef, to the joint velocity. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -24,11 +24,8 @@ function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
 
     %% ------------Initialization----------------
 
-    % create the matrix that must be populated with the jacobian map
-    J_frameVel_iDyntree = iDynTree.MatrixDynSize(6,KinDynModel.NDOF);
-    
     % get the relative jacobian
-    ack = KinDynModel.kinDynComp.getRelativeJacobian(frameVelID,frameRefID,J_frameVel_iDyntree);  
+    ack = KinDynModel.kinDynComp.getRelativeJacobian(frameVelID,frameRefID,KinDynModel.kinematics.J_frameVel_iDyntree);  
     
     % check for errors
     if ~ack  
@@ -36,5 +33,5 @@ function J_frameVel = getRelativeJacobian(KinDynModel,frameVelID,frameRefID)
     end
     
     % covert to Matlab format
-    J_frameVel = J_frameVel_iDyntree.toMatlab; 
+    J_frameVel = KinDynModel.kinematics.J_frameVel_iDyntree.toMatlab; 
 end

--- a/bindings/matlab/+iDynTreeWrappers/getRelativeTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRelativeTransform.m
@@ -1,17 +1,17 @@
 function frame1_H_frame2 = getRelativeTransform(KinDynModel,frame1Name,frame2Name)
 
-    % GETRELATIVETRANSFORM gets the transformation matrix between two specified 
+    % GETRELATIVETRANSFORM gets the transformation matrix between two specified
     %                      frames.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  frame1_H_frame2 = getRelativeTransform(KinDynModel,frame1Name,frame2Name)
     %
-    % INPUTS:  - frame1Name: a string that specifies the frame w.r.t. compute the 
-    %                        transfomation matrix, or the associated ID;  
-    %          - frame2Name: a string that specifies the frame w.r.t. compute the 
-    %                        transfomation matrix, or the associated ID;   
+    % INPUTS:  - frame1Name: a string that specifies the frame w.r.t. compute the
+    %                        transfomation matrix, or the associated ID;
+    %          - frame2Name: a string that specifies the frame w.r.t. compute the
+    %                        transfomation matrix, or the associated ID;
     %          - KinDynModel: a structure containing the loaded model and additional info.
     %
     % OUTPUTS: - frame1_H_frame2: [4 x 4] from frame2 to frame1 transformation matrix.
@@ -19,74 +19,74 @@ function frame1_H_frame2 = getRelativeTransform(KinDynModel,frame1Name,frame2Nam
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the transformation between the frame 1 and 2
-    frame1_H_frame2_iDyntree = KinDynModel.kinDynComp.getRelativeTransform(frame1Name,frame2Name);  
+    frame1_H_frame2_iDyntree = KinDynModel.kinDynComp.getRelativeTransform(frame1Name,frame2Name);
     frame1_R_frame2_iDyntree = frame1_H_frame2_iDyntree.getRotation;
     framePos_iDyntree        = frame1_H_frame2_iDyntree.getPosition;
-    
+
     % covert to Matlab format
     frame1_R_frame2          = frame1_R_frame2_iDyntree.toMatlab;
     framePos                 = framePos_iDyntree.toMatlab;
     frame1_H_frame2          = [frame1_R_frame2,framePos;
-                                    0,   0,   0,   1];  
-                              
+        0,   0,   0,   1];
+
     % Debug output
     if KinDynModel.DEBUG
-        
+
         disp('[getRelativeTransform]: debugging outputs...')
 
         % frame1_H_frame2 must be a valid transformation matrix
         if size(frame1_H_frame2,1) ~= 4 || size(frame1_H_frame2,2) ~= 4
-            
-           error('[getRelativeTransform]: frame1_H_frame2 is not a 4x4 matrix.')
+
+            error('[getRelativeTransform]: frame1_H_frame2 is not a 4x4 matrix.')
         end
-        
+
         for ii = 1:4
-                    
-           if ii < 4
-                        
-               if abs(frame1_H_frame2(4,ii)) > 0.0001 
-            
-                   error('[getRelativeTransform]: the last line of frame1_H_frame2 is not [0,0,0,1].')
-               end
-           else
-               if abs(frame1_H_frame2(4,ii)) > 1.0001 || abs(frame1_H_frame2(4,ii)) < 0.9999
-            
-                   error('[getRelativeTransform]: the last line of frame1_H_frame2 is not [0,0,0,1].')
-               end
-           end
+
+            if ii < 4
+
+                if abs(frame1_H_frame2(4,ii)) > 0.0001
+
+                    error('[getRelativeTransform]: the last line of frame1_H_frame2 is not [0,0,0,1].')
+                end
+            else
+                if abs(frame1_H_frame2(4,ii)) > 1.0001 || abs(frame1_H_frame2(4,ii)) < 0.9999
+
+                    error('[getRelativeTransform]: the last line of frame1_H_frame2 is not [0,0,0,1].')
+                end
+            end
         end
-        
+
         % frame1_R_frame2 = frame1_H_frame2(1:3,1:3) must be a valid rotation matrix
         if det(frame1_H_frame2(1:3,1:3)) < 0.9 || det(frame1_H_frame2(1:3,1:3)) > 1.1
-            
+
             error('[getRelativeTransform]: frame1_R_frame2 is not a valid rotation matrix.')
         end
-       
+
         IdentityMatr = frame1_H_frame2(1:3,1:3)*frame1_H_frame2(1:3,1:3)';
-        
+
         for kk = 1:size(IdentityMatr, 1)
-            
+
             for jj = 1:size(IdentityMatr, 1)
-                
+
                 if jj == kk
-                    
+
                     if abs(IdentityMatr(kk,jj)) < 0.9 || abs(IdentityMatr(kk,jj)) > 1.1
-                        
+
                         error('[getRelativeTransform]: frame1_R_frame2 is not a valid rotation matrix.')
                     end
                 else
                     if abs(IdentityMatr(kk,jj)) > 0.01
-                        
+
                         error('[getRelativeTransform]: frame1_R_frame2 is not a valid rotation matrix.')
                     end
                 end
-            end   
-        end                                       
-        disp('[getRelativeTransform]: done.')     
+            end
+        end
+        disp('[getRelativeTransform]: done.')
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getRelativeTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRelativeTransform.m
@@ -1,7 +1,7 @@
 function frame1_H_frame2 = getRelativeTransform(KinDynModel,frame1Name,frame2Name)
 
     % GETRELATIVETRANSFORM gets the transformation matrix between two specified 
-    %                           frames.
+    %                      frames.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRobotState.m
@@ -20,29 +20,24 @@ function [basePose,jointPos,baseVel,jointVel] = getRobotState(KinDynModel)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-
-    % define all the iDyntree required quantities
-    basePose_iDyntree   = iDynTree.Transform();
-    jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    baseVel_iDyntree    = iDynTree.Twist();
-    jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    gravityVec_iDyntree = iDynTree.Vector3();
     
     % get the floating base state
-    KinDynModel.kinDynComp.getRobotState(basePose_iDyntree,jointPos_iDyntree,baseVel_iDyntree,jointVel_iDyntree,gravityVec_iDyntree);
+    KinDynModel.kinDynComp.getRobotState(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree, ...
+                                         KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                                         KinDynModel.kinematics.gravityVec_iDyntree);
    
     % get the base position and orientation
-    baseRotation_iDyntree = basePose_iDyntree.getRotation;
-    baseOrigin_iDyntree   = basePose_iDyntree.getPosition;
+    baseRotation_iDyntree = KinDynModel.kinematics.basePose_iDyntree.getRotation;
+    baseOrigin_iDyntree   = KinDynModel.kinematics.basePose_iDyntree.getPosition;
     
     % covert to Matlab format
     baseRotation = baseRotation_iDyntree.toMatlab;
     baseOrigin   = baseOrigin_iDyntree.toMatlab;
     basePose     = [baseRotation, baseOrigin;
                        0,  0,  0,  1]; 
-    jointPos     = jointPos_iDyntree.toMatlab;
-    baseVel      = baseVel_iDyntree.toMatlab;
-    jointVel     = jointVel_iDyntree.toMatlab;   
+    jointPos     = KinDynModel.kinematics.jointPos_iDyntree.toMatlab;
+    baseVel      = KinDynModel.kinematics.baseVel_iDyntree.toMatlab;
+    jointVel     = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;   
     
     % Debug output
     if KinDynModel.DEBUG

--- a/bindings/matlab/+iDynTreeWrappers/getRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/getRobotState.m
@@ -2,7 +2,7 @@ function [basePose,jointPos,baseVel,jointVel] = getRobotState(KinDynModel)
 
     % GETROBOTSTATE gets the floating base system state from the reduced model.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  [basePose,jointPos,baseVel,jointVel] = getRobotState(KinDynModel)
@@ -17,59 +17,59 @@ function [basePose,jointPos,baseVel,jointVel] = getRobotState(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the floating base state
     KinDynModel.kinDynComp.getRobotState(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree, ...
-                                         KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
-                                         KinDynModel.kinematics.gravityVec_iDyntree);
-   
+        KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+        KinDynModel.kinematics.gravityVec_iDyntree);
+
     % get the base position and orientation
     baseRotation_iDyntree = KinDynModel.kinematics.basePose_iDyntree.getRotation;
     baseOrigin_iDyntree   = KinDynModel.kinematics.basePose_iDyntree.getPosition;
-    
+
     % covert to Matlab format
     baseRotation = baseRotation_iDyntree.toMatlab;
     baseOrigin   = baseOrigin_iDyntree.toMatlab;
     basePose     = [baseRotation, baseOrigin;
-                       0,  0,  0,  1]; 
+        0,  0,  0,  1];
     jointPos     = KinDynModel.kinematics.jointPos_iDyntree.toMatlab;
     baseVel      = KinDynModel.kinematics.baseVel_iDyntree.toMatlab;
-    jointVel     = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;   
-    
+    jointVel     = KinDynModel.kinematics.jointVel_iDyntree.toMatlab;
+
     % Debug output
     if KinDynModel.DEBUG
-        
+
         disp('[getRobotState]: debugging outputs...')
-        
+
         % baseRotation = basePose(1:3,1:3) must be a valid rotation matrix
         if det(basePose(1:3,1:3)) < 0.9 || det(basePose(1:3,1:3)) > 1.1
-            
+
             error('[getRobotState]: baseRotation is not a valid rotation matrix.')
         end
-        
+
         IdentityMatr = basePose(1:3,1:3)*basePose(1:3,1:3)';
-        
+
         for kk = 1:size(IdentityMatr, 1)
-            
+
             for jj = 1:size(IdentityMatr, 1)
-                
+
                 if jj == kk
-                    
+
                     if abs(IdentityMatr(kk,jj)) < 0.9 || abs(IdentityMatr(kk,jj)) > 1.1
-                        
+
                         error('[getRobotState]: baseRotation is not a valid rotation matrix.')
                     end
                 else
                     if abs(IdentityMatr(kk,jj)) > 0.01
-                        
+
                         error('[getRobotState]: baseRotation is not a valid rotation matrix.')
                     end
                 end
-            end   
-        end    
-        disp('[getRobotState]: done.')     
+            end
+        end
+        disp('[getRobotState]: done.')
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getWorldBaseTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldBaseTransform.m
@@ -1,9 +1,9 @@
 function basePose = getWorldBaseTransform(KinDynModel)
 
     % GETWORLDBASETRANSFORM gets the transformation matrix between the base
-    %                       frame and the inertial reference frame. 
+    %                       frame and the inertial reference frame.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  basePose = getWorldBaseTransform(KinDynModel)
@@ -15,52 +15,52 @@ function basePose = getWorldBaseTransform(KinDynModel)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    % get the transformation between the base and the world frames 
-    basePose_iDyntree     = KinDynModel.kinDynComp.getWorldBaseTransform();  
+
+    % get the transformation between the base and the world frames
+    basePose_iDyntree     = KinDynModel.kinDynComp.getWorldBaseTransform();
     baseRotation_iDyntree = basePose_iDyntree.getRotation;
     baseOrigin_iDyntree   = basePose_iDyntree.getPosition;
-    
+
     % covert to Matlab format
     baseRotation          = baseRotation_iDyntree.toMatlab;
     baseOrigin            = baseOrigin_iDyntree.toMatlab;
     basePose              = [baseRotation, baseOrigin;
-                                0,   0,   0,   1];                  
-   % Debug output
+        0,   0,   0,   1];
+    % Debug output
     if KinDynModel.DEBUG
-        
+
         disp('[getWorldBaseTransform]: debugging outputs...')
-        
+
         % baseRotation = basePose(1:3,1:3) must be a valid rotation matrix
         if det(basePose(1:3,1:3)) < 0.9 || det(basePose(1:3,1:3)) > 1.1
-            
+
             error('[getWorldBaseTransform]: baseRotation is not a valid rotation matrix.')
         end
-        
+
         IdentityMatr = basePose(1:3,1:3)*basePose(1:3,1:3)';
-        
+
         for kk = 1:size(IdentityMatr, 1)
-            
+
             for jj = 1:size(IdentityMatr, 1)
-                
+
                 if jj == kk
-                    
+
                     if abs(IdentityMatr(kk,jj)) < 0.9 || abs(IdentityMatr(kk,jj)) > 1.1
-                        
+
                         error('[getWorldBaseTransform]: baseRotation is not a valid rotation matrix.')
                     end
                 else
                     if abs(IdentityMatr(kk,jj)) > 0.01
-                        
+
                         error('[getWorldBaseTransform]: baseRotation is not a valid rotation matrix.')
                     end
                 end
-            end   
-        end       
-             
-        disp('[getWorldBaseTransform]: done.')     
-    end   
+            end
+        end
+
+        disp('[getWorldBaseTransform]: done.')
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getWorldBaseTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldBaseTransform.m
@@ -1,7 +1,7 @@
 function basePose = getWorldBaseTransform(KinDynModel)
 
-    % GETWORLDBASETRANSFORM gets the transformation matrix between the base frame
-    %                            and the inertial reference frame. 
+    % GETWORLDBASETRANSFORM gets the transformation matrix between the base
+    %                       frame and the inertial reference frame. 
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree

--- a/bindings/matlab/+iDynTreeWrappers/getWorldTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldTransform.m
@@ -1,7 +1,7 @@
 function w_H_frame = getWorldTransform(KinDynModel,frameName)
 
     % GETWORLDTRANSFORM gets the transformation matrix between a specified 
-    %                        frame and the inertial reference frame.
+    %                   frame and the inertial reference frame.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -22,8 +22,7 @@ function w_H_frame = getWorldTransform(KinDynModel,frameName)
 
     %% ------------Initialization----------------
     
-    % get the transformation between the frame and the world in Matlab
-    % format
+    % get the transformation between the frame and the world in Matlab format
     w_H_frame = KinDynModel.kinDynComp.getWorldTransform(frameName).asHomogeneousTransform.toMatlab;  
 
     % Debug output

--- a/bindings/matlab/+iDynTreeWrappers/getWorldTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldTransform.m
@@ -1,15 +1,15 @@
 function w_H_frame = getWorldTransform(KinDynModel,frameName)
 
-    % GETWORLDTRANSFORM gets the transformation matrix between a specified 
+    % GETWORLDTRANSFORM gets the transformation matrix between a specified
     %                   frame and the inertial reference frame.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  w_H_frame = getWorldTransform(KinDynModel,frameName)
     %
-    % INPUTS:  - frameName: a string that specifies the frame w.r.t. compute the 
-    %                       transfomation matrix, or the associated ID;     
+    % INPUTS:  - frameName: a string that specifies the frame w.r.t. compute the
+    %                       transfomation matrix, or the associated ID;
     %          - KinDynModel: a structure containing the loaded model and additional info.
     %
     % OUTPUTS: - w_H_frame: [4 x 4] from frame to world transformation matrix.
@@ -18,45 +18,45 @@ function w_H_frame = getWorldTransform(KinDynModel,frameName)
     % (franciscojavier.andradechavez@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % get the transformation between the frame and the world in Matlab format
-    w_H_frame = KinDynModel.kinDynComp.getWorldTransform(frameName).asHomogeneousTransform.toMatlab;  
+    w_H_frame = KinDynModel.kinDynComp.getWorldTransform(frameName).asHomogeneousTransform.toMatlab;
 
     % Debug output
     if KinDynModel.DEBUG
         w_R_frame          = w_H_frame(1:3,1:3);
-    
+
         disp('[getWorldTransform]: debugging outputs...')
-        
-         % w_R_frame must be a valid rotation matrix
-         if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
-            
-             error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-         end
-        
-         IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
-        
-         for kk = 1:size(IdentityMatr, 1)
-            
-             for jj = 1:size(IdentityMatr, 1)
-                
-                 if jj == kk
-                    
-                     if abs(IdentityMatr(kk,jj)-1) > 0.9
-                        
-                         error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-                     end
-                 else
-                     if abs(IdentityMatr(kk,jj)) > 0.1
-                        
-                          error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-                     end
-                 end
-             end   
-         end                          
-         disp('[getWorldTransform]: done.')     
+
+        % w_R_frame must be a valid rotation matrix
+        if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
+
+            error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
+        end
+
+        IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
+
+        for kk = 1:size(IdentityMatr, 1)
+
+            for jj = 1:size(IdentityMatr, 1)
+
+                if jj == kk
+
+                    if abs(IdentityMatr(kk,jj)-1) > 0.9
+
+                        error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
+                    end
+                else
+                    if abs(IdentityMatr(kk,jj)) > 0.1
+
+                        error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
+                    end
+                end
+            end
+        end
+        disp('[getWorldTransform]: done.')
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getWorldTransformsAsHomogeneous.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldTransformsAsHomogeneous.m
@@ -1,69 +1,68 @@
 function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 
-% GETWORLDTRANSFORMASHOMOGENEOUS gets the transformation matrices between the specified
-%                                frames and the inertial reference frame.
-%
-% This matlab function wraps a functionality of the iDyntree library.
-% For further info see also: https://github.com/robotology/idyntree
-%
-% FORMAT:  w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameName)
-%
-% INPUTS:  - frameNames: a string vector that specifies the frames w.r.t. compute the
-%                        transfomation matrix;
-%
-%          - KinDynModel: a structure containing the loaded model and additional info.
-%
-% OUTPUTS: - w_H_frames: [size(frameNames) x 4 x 4] from frame to world transformation matrices.
-%
-% Author : Francisco Andrade(franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % GETWORLDTRANSFORMASHOMOGENEOUS gets the transformation matrices between the specified
+    %                                frames and the inertial reference frame.
+    %
+    % This matlab function wraps a functionality of the iDyntree library.
+    % For further info see also: https://github.com/robotology/idyntree
+    %
+    % FORMAT:  w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameName)
+    %
+    % INPUTS:  - frameNames: a string vector that specifies the frames w.r.t. compute the
+    %                        transfomation matrix;
+    %
+    %          - KinDynModel: a structure containing the loaded model and additional info.
+    %
+    % OUTPUTS: - w_H_frames: [size(frameNames) x 4 x 4] from frame to world transformation matrices.
+    %
+    % Author : Francisco Andrade(franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
 
-%% ------------Initialization----------------
+    %% ------------Initialization----------------
 
     % get the transformation between the frame and the world in Matlab format
     transforms_iDyntree = KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(frameNames);
-    w_H_frames          = transforms_iDyntree.toMatlab();
+    w_H_frames = transforms_iDyntree.toMatlab();
 
     for i = 1:frameNames.size
-    
+
         w_H_frame = squeeze(w_H_frames(i,:,:));
-    
+
         % Debug output
         if KinDynModel.DEBUG
-        
             w_R_frame = w_H_frame(1:3,1:3);
-        
+
             disp('[getWorldTransformsAsHomogeneous]: debugging outputs...')
-        
+
             % w_R_frame must be a valid rotation matrix
             if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
-            
+
                 error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
             end
-        
+
             IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
-        
+
             for kk = 1:size(IdentityMatr, 1)
-            
+
                 for jj = 1:size(IdentityMatr, 1)
-                
+
                     if jj == kk
-                    
+
                         if abs(IdentityMatr(kk,jj)-1) > 0.9
-                        
+
                             error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
                         end
                     else
                         if abs(IdentityMatr(kk,jj)) > 0.1
-                            
+
                             error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
                         end
                     end
                 end
             end
             disp('[getWorldTransformsAsHomogeneous]: done.')
-        end   
+        end
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/getWorldTransformsAsHomogeneous.m
+++ b/bindings/matlab/+iDynTreeWrappers/getWorldTransformsAsHomogeneous.m
@@ -1,7 +1,7 @@
 function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 
 % GETWORLDTRANSFORMASHOMOGENEOUS gets the transformation matrices between the specified
-%                        frames and the inertial reference frame.
+%                                frames and the inertial reference frame.
 %
 % This matlab function wraps a functionality of the iDyntree library.
 % For further info see also: https://github.com/robotology/idyntree
@@ -9,7 +9,8 @@ function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 % FORMAT:  w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameName)
 %
 % INPUTS:  - frameNames: a string vector that specifies the frames w.r.t. compute the
-%                       transfomation matrix;
+%                        transfomation matrix;
+%
 %          - KinDynModel: a structure containing the loaded model and additional info.
 %
 % OUTPUTS: - w_H_frames: [size(frameNames) x 4 x 4] from frame to world transformation matrices.
@@ -21,48 +22,48 @@ function w_H_frames = getWorldTransformsAsHomogeneous(KinDynModel,frameNames)
 
 %% ------------Initialization----------------
 
-% get the transformation between the frame and the world in Matlab
-% format
-transforms_idyn=KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(frameNames);
-w_H_frames= transforms_idyn.toMatlab();
-for it=1:frameNames.size
-    w_H_frame=squeeze(w_H_frames(it,:,:));
+    % get the transformation between the frame and the world in Matlab format
+    transforms_iDyntree = KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(frameNames);
+    w_H_frames          = transforms_iDyntree.toMatlab();
+
+    for i = 1:frameNames.size
     
-    % Debug output
-    if KinDynModel.DEBUG
-        w_R_frame          = w_H_frame(1:3,1:3);
+        w_H_frame = squeeze(w_H_frames(i,:,:));
+    
+        % Debug output
+        if KinDynModel.DEBUG
         
-        disp('[getWorldTransform]: debugging outputs...')
+            w_R_frame = w_H_frame(1:3,1:3);
         
-        % w_R_frame must be a valid rotation matrix
-        if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
+            disp('[getWorldTransformsAsHomogeneous]: debugging outputs...')
+        
+            % w_R_frame must be a valid rotation matrix
+            if det(w_R_frame) < 0.9 || det(w_R_frame) > 1.1
             
-            error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-        end
+                error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
+            end
         
-        IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
+            IdentityMatr = w_H_frame(1:3,1:3)*w_H_frame(1:3,1:3)';
         
-        for kk = 1:size(IdentityMatr, 1)
+            for kk = 1:size(IdentityMatr, 1)
             
-            for jj = 1:size(IdentityMatr, 1)
+                for jj = 1:size(IdentityMatr, 1)
                 
-                if jj == kk
+                    if jj == kk
                     
-                    if abs(IdentityMatr(kk,jj)-1) > 0.9
+                        if abs(IdentityMatr(kk,jj)-1) > 0.9
                         
-                        error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
-                    end
-                else
-                    if abs(IdentityMatr(kk,jj)) > 0.1
-                        
-                        error('[getWorldTransform]: w_R_frame is not a valid rotation matrix.')
+                            error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
+                        end
+                    else
+                        if abs(IdentityMatr(kk,jj)) > 0.1
+                            
+                            error('[getWorldTransformsAsHomogeneous]: w_R_frame is not a valid rotation matrix.')
+                        end
                     end
                 end
             end
-        end
-        disp('[getWorldTransform]: done.')
+            disp('[getWorldTransformsAsHomogeneous]: done.')
+        end   
     end
-    
-end
-
 end

--- a/bindings/matlab/+iDynTreeWrappers/initializeVisualizer.m
+++ b/bindings/matlab/+iDynTreeWrappers/initializeVisualizer.m
@@ -5,7 +5,7 @@ function Visualizer = initializeVisualizer(KinDynModel,debugMode)
     %
     % WARNING! This function is deprecated! Use prepareVisualization instead.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % REQUIREMENTS: compile iDyntree with Irrlicht (IDYNTREE_USES_IRRLICHT = ON).
@@ -16,28 +16,28 @@ function Visualizer = initializeVisualizer(KinDynModel,debugMode)
     %          - debugMode: if TRUE, the visualizer is used in "debug" mode;
     %
     % OUTPUTS: - Visualizer: a structure containing the visualizer and its options.
-    % 
+    %
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     Visualizer.viz = iDynTree.Visualizer();
-    
+
     % load the model in the visualizer
     ack = Visualizer.viz.addModel(KinDynModel.kinDynComp.model(),'viz1');
-    
+
     % check for errors
-    if ~ack   
+    if ~ack
         error('[initializeVisualizer]: unable to load the model in the visualizer.')
-    end  
+    end
 
     % draw the model
     Visualizer.viz.draw();
-    
+
     % if DEBUG option is set to TRUE, all the wrappers related to the
     % iDyntree visualizer will be run in DEBUG mode.
-    Visualizer.DEBUG = debugMode;    
+    Visualizer.DEBUG = debugMode;
 end

--- a/bindings/matlab/+iDynTreeWrappers/initializeVisualizer.m
+++ b/bindings/matlab/+iDynTreeWrappers/initializeVisualizer.m
@@ -1,7 +1,9 @@
 function Visualizer = initializeVisualizer(KinDynModel,debugMode)
 
     % INITIALIZEVISUALIZER opens the iDyntree visualizer and loads the reduced
-    %                           model into the visualizer.
+    %                      model into the visualizer.
+    %
+    % WARNING! This function is deprecated! Use prepareVisualization instead.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -21,8 +23,8 @@ function Visualizer = initializeVisualizer(KinDynModel,debugMode)
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
-    Visualizer.viz   = iDynTree.Visualizer();
+
+    Visualizer.viz = iDynTree.Visualizer();
     
     % load the model in the visualizer
     ack = Visualizer.viz.addModel(KinDynModel.kinDynComp.model(),'viz1');

--- a/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
+++ b/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
@@ -1,8 +1,8 @@
 function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelName,debugMode)
 
     % LOADREDUCEDMODEL loads the urdf model of the rigid multi-body system.
-    %                     
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    %
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT:  KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelName,debugMode)
@@ -20,23 +20,23 @@ function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelNa
     % Author: Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
     disp(['[loadReducedModel]: loading the following model: ',fullfile(modelPath,modelName)]);
-        
+
     % if DEBUG option is set to TRUE, all the wrappers will be run in debug
     % mode. Wrappers concerning iDyntree simulator have their own debugger
     KinDynModel.DEBUG      = debugMode;
-    
+
     % retrieve the link that will be used as the floating base
     KinDynModel.BASE_LINK  = baseLinkName;
-        
+
     % load the list of joints to be used in the reduced model
     jointList_idyntree     = iDynTree.StringVector();
-    
+
     for k = 1:length(jointList)
-        
+
         jointList_idyntree.push_back(jointList{k});
     end
 
@@ -54,9 +54,9 @@ function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelNa
     KinDynModel.kinDynComp = iDynTree.KinDynComputations();
 
     KinDynModel.kinDynComp.loadRobotModel(reducedModel);
-    
+
     % set the floating base link
     KinDynModel.kinDynComp.setFloatingBase(KinDynModel.BASE_LINK);
-    
+
     disp(['[loadReducedModel]: loaded model: ',fullfile(modelPath,modelName),', number of joints: ',num2str(KinDynModel.NDOF)]);
 end

--- a/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
+++ b/bindings/matlab/+iDynTreeWrappers/loadReducedModel.m
@@ -59,4 +59,22 @@ function KinDynModel = loadReducedModel(jointList,baseLinkName,modelPath,modelNa
     KinDynModel.kinDynComp.setFloatingBase(KinDynModel.BASE_LINK);
 
     disp(['[loadReducedModel]: loaded model: ',fullfile(modelPath,modelName),', number of joints: ',num2str(KinDynModel.NDOF)]);
+
+    % initialize all dynamics and kinematics quantities used inside the
+    % wrappers. This procedure optimizes the wrappers speed, as the
+    % iDyntree objects are created only once and then updated runtime
+    KinDynModel.kinematics.baseRotation_iDyntree = iDynTree.Rotation();
+    KinDynModel.kinematics.baseOrigin_iDyntree = iDynTree.Position();
+    KinDynModel.kinematics.basePose_iDyntree = iDynTree.Transform();
+    KinDynModel.kinematics.baseVel_iDyntree = iDynTree.Twist();
+    KinDynModel.kinematics.jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
+    KinDynModel.kinematics.jointVel_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
+    KinDynModel.kinematics.stateVel_iDyntree = iDynTree.VectorDynSize(6+KinDynModel.NDOF);
+    KinDynModel.kinematics.gravityVec_iDyntree = iDynTree.Vector3();
+    KinDynModel.kinematics.J_CoM_iDyntree = iDynTree.MatrixDynSize(3,KinDynModel.NDOF+6);
+    KinDynModel.kinematics.J_frame_iDyntree = iDynTree.MatrixDynSize(6,KinDynModel.NDOF+6);
+    KinDynModel.kinematics.J_frameVel_iDyntree = iDynTree.MatrixDynSize(6,KinDynModel.NDOF);
+    KinDynModel.dynamics.M_iDyntree = iDynTree.MatrixDynSize(KinDynModel.NDOF+6,KinDynModel.NDOF+6);
+    KinDynModel.dynamics.h_iDyntree = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
+    KinDynModel.dynamics.g_iDyntree = iDynTree.FreeFloatingGeneralizedTorques(KinDynModel.kinDynComp.model);
 end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
@@ -1,101 +1,91 @@
 function []=modifyLinkVisual(meshHandle,varargin)
-% Modifies a single `meshHandle` with the specified changes.
-%     - Inputs:
-%         - `meshHandle` : Struct containing the patch type of variable ( `modelMesh` field ) and the original information of the mesh in `fullMesh_bckup` field.
-%     - Optional Inputs:
-%         - `color` : Selects the color of the meshes.
-%         - `transparency` : Sets the alpha value of the patch. Is the
-%         level of transparency between 0 fully transparent and 1 solid.
-%         - `wireframe_rendering` : the reduction ratio of faces to
-%         wireframe. Follows convention of reducepatch.
-%         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
-%     - Outputs:
-%         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
-%         - `transform`    : The transform object for the link
-%         - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
-%         - `useDefault`  : Enables the use of the default values instead of ignoring non specified changes.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_color= [0.1843    0.3098    0.3098];
-default_transparency=0.5;
-default_style='fullMesh';
-default_wireframe_rendering=0.08;
-default_material='dull';
-default_useDefault=false;
-% accepted values
-expected_materials={'dull','metal','shiny'};
-expected_styles={'fullMesh','wireframe','invisible'};
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
-addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
-addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
-addParameter(p,'useDefault',default_useDefault);
+    % Modifies a single `meshHandle` with the specified changes.
+    %     - Inputs:
+    %         - `meshHandle` : Struct containing the patch type of variable ( `modelMesh` field ) and the original information of the mesh in `fullMesh_bckup` field.
+    %     - Optional Inputs:
+    %         - `color` : Selects the color of the meshes.
+    %         - `transparency` : Sets the alpha value of the patch. Is the
+    %         level of transparency between 0 fully transparent and 1 solid.
+    %         - `wireframe_rendering` : the reduction ratio of faces to
+    %         wireframe. Follows convention of reducepatch.
+    %         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
+    %     - Outputs:
+    %         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
+    %         - `transform`    : The transform object for the link
+    %         - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
+    %         - `useDefault`  : Enables the use of the default values instead of ignoring non specified changes.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
+    %% input parser section
+    p = inputParser;
+    p.StructExpand = false;
+    p.KeepUnmatched= true;
+    % Default values
+    default_color= [0.1843    0.3098    0.3098];
+    default_transparency=0.5;
+    default_style='fullMesh';
+    default_wireframe_rendering=0.08;
+    default_material='dull';
+    default_useDefault=false;
+    % accepted values
+    expected_materials={'dull','metal','shiny'};
+    expected_styles={'fullMesh','wireframe','invisible'};
+    % add parameters and validity funcitons
+    addRequired(p,'structInput');
+    addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+    addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
+    addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
+    addParameter(p,'useDefault',default_useDefault);
 
     % Parse inputs
     parse(p,meshHandle,varargin{:});
     options = p.Results;
-    
+
     for nMeshes = 1:length(meshHandle.modelMesh)
-        
         modelMesh = meshHandle.modelMesh(nMeshes);
-        
+
         if ~any(ismember(p.UsingDefaults,'color')) || options.useDefault
-            
             changeColor(modelMesh,options.color);
         end
         if ~any(ismember(p.UsingDefaults,'transparency')) || options.useDefault
-            
             alpha(modelMesh,options.transparency);
         end
         if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
-            
             material(modelMesh,options.material);
         end
         if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
-            
+
             [isWF,noColor] = isWireframe(modelMesh);
 
             if strcmpi(options.style,'wireframe') && ~isWF
-                
                 if noColor
-                    
                     color = options.color;
                 else
                     color = modelMesh.FaceColor;
                 end
-                
                 reducepatch(modelMesh,options.wireframe_rendering);
                 modelMesh.FaceColor = 'none';
                 modelMesh.EdgeColor = color;
             end
             if strcmpi(options.style,'fullMesh') && isWF
-            
+
                 if noColor
-                
                     color = options.color;
-            
-                else                  
+                else
                     color = modelMesh.EdgeColor;
                 end
-                
-                modelMesh.Vertices  =  meshHandle.fullMesh_bckup(nMeshes).vertices;          
-                modelMesh.Faces     =  meshHandle.fullMesh_bckup(nMeshes).faces;
-                modelMesh.FaceColor =  color;
+
+                modelMesh.Vertices = meshHandle.fullMesh_bckup(nMeshes).vertices;
+                modelMesh.Faces = meshHandle.fullMesh_bckup(nMeshes).faces;
+                modelMesh.FaceColor = color;
                 modelMesh.EdgeColor = 'none';
             end
             if strcmpi(options.style,'invisible')
-                
                 % make invisible
                 modelMesh.Visible = 'off';
             else
@@ -105,12 +95,11 @@ addParameter(p,'useDefault',default_useDefault);
     end
 end
 
-% Utilities 
+% Utilities
 function [] = changeColor(modelMesh,color)
-        
+
     if isWireframe(modelMesh)
-      
-        modelMesh.EdgeColor = color;    
+        modelMesh.EdgeColor = color;
     else
         modelMesh.FaceColor = color;
     end
@@ -121,21 +110,18 @@ function [isIt, noColor] = isWireframe(meshHandle)
     % If there is a numeric value in edges and a char ('none') in faces
     % then is wireframe
     noColor = false;
-    
+
     if ischar(meshHandle.FaceColor) && ~ischar(meshHandle.EdgeColor)
-       
         isIt = true;
     end
-    
+
     % As long as there is a color in faces is not wireframe
     if ~ischar(meshHandle.FaceColor) && ischar(meshHandle.EdgeColor)
-      
         isIt = false;
     end
     % The mesh is invisble and not on purpose. Make it wireframe.
     if ~exist('isIt','var')
-         
-        isIt    = true;
+        isIt = true;
         noColor = true;
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinkVisual.m
@@ -42,77 +42,100 @@ addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles))
 addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
 addParameter(p,'useDefault',default_useDefault);
 
-% parse inputs
-parse(p,meshHandle,varargin{:});
-options=p.Results;
-for nMeshes=1:length(meshHandle.modelMesh)
-    modelMesh=meshHandle.modelMesh(nMeshes);
-    if ~any(ismember(p.UsingDefaults,'color')) || options.useDefault
-        changeColor(modelMesh,options.color);
-    end
-    if ~any(ismember(p.UsingDefaults,'transparency')) || options.useDefault
-        alpha(modelMesh,options.transparency);
-    end
-    if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
-        material(modelMesh,options.material);
-    end
-
-
-    if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
-        [isWF,noColor]=isWireframe(modelMesh);
-
-        if strcmpi(options.style,'wireframe') && ~isWF
-            if noColor
-                color=options.color;
-            else
-                color=modelMesh.FaceColor;
-            end
-            reducepatch(modelMesh,options.wireframe_rendering);
-            modelMesh.FaceColor='none';
-            modelMesh.EdgeColor=color;
+    % Parse inputs
+    parse(p,meshHandle,varargin{:});
+    options = p.Results;
+    
+    for nMeshes = 1:length(meshHandle.modelMesh)
+        
+        modelMesh = meshHandle.modelMesh(nMeshes);
+        
+        if ~any(ismember(p.UsingDefaults,'color')) || options.useDefault
+            
+            changeColor(modelMesh,options.color);
         end
-        if strcmpi(options.style,'fullMesh') && isWF % means full mesh
-            if noColor
-                color=options.color;
-            else
-                color=modelMesh.EdgeColor;
-            end
-            modelMesh.Vertices=meshHandle.fullMesh_bckup(nMeshes).vertices;
-            modelMesh.Faces=meshHandle.fullMesh_bckup(nMeshes).faces;
-            modelMesh.FaceColor=color;
-            modelMesh.EdgeColor='none';
+        if ~any(ismember(p.UsingDefaults,'transparency')) || options.useDefault
+            
+            alpha(modelMesh,options.transparency);
         end
-        if strcmpi(options.style,'invisible')% make invisible
-            modelMesh.Visible='off';
-        else
-            modelMesh.Visible='on';
+        if ~any(ismember(p.UsingDefaults,'material')) || options.useDefault
+            
+            material(modelMesh,options.material);
+        end
+        if ~any(ismember(p.UsingDefaults,'style')) || options.useDefault
+            
+            [isWF,noColor] = isWireframe(modelMesh);
+
+            if strcmpi(options.style,'wireframe') && ~isWF
+                
+                if noColor
+                    
+                    color = options.color;
+                else
+                    color = modelMesh.FaceColor;
+                end
+                
+                reducepatch(modelMesh,options.wireframe_rendering);
+                modelMesh.FaceColor = 'none';
+                modelMesh.EdgeColor = color;
+            end
+            if strcmpi(options.style,'fullMesh') && isWF
+            
+                if noColor
+                
+                    color = options.color;
+            
+                else                  
+                    color = modelMesh.EdgeColor;
+                end
+                
+                modelMesh.Vertices  =  meshHandle.fullMesh_bckup(nMeshes).vertices;          
+                modelMesh.Faces     =  meshHandle.fullMesh_bckup(nMeshes).faces;
+                modelMesh.FaceColor =  color;
+                modelMesh.EdgeColor = 'none';
+            end
+            if strcmpi(options.style,'invisible')
+                
+                % make invisible
+                modelMesh.Visible = 'off';
+            else
+                modelMesh.Visible = 'on';
+            end
         end
     end
 end
 
-    function []=changeColor(modelMesh,color)
-        if isWireframe(modelMesh)
-            modelMesh.EdgeColor=color;
-        else
-            modelMesh.FaceColor=color;
-        end
+% Utilities 
+function [] = changeColor(modelMesh,color)
+        
+    if isWireframe(modelMesh)
+      
+        modelMesh.EdgeColor = color;    
+    else
+        modelMesh.FaceColor = color;
     end
+end
 
-    function [isIt,noColor]=isWireframe(meshHandle)
-        % if there is a numeric value in edges and a char ('none') in faces
-        % then is wireframe
-        noColor=false;
-        if ischar(meshHandle.FaceColor) && ~ischar(meshHandle.EdgeColor)
-            isIt=true;
-        end
-        % As long as there is a color in faces is not wireframe
-        if ~ischar(meshHandle.FaceColor) && ischar(meshHandle.EdgeColor)
-            isIt=false;
-        end
-        % The mesh is invisble and not on purpose. Make it wireframe.
-        if ~exist('isIt','var')
-            isIt=true;
-            noColor=true;
-        end
+function [isIt, noColor] = isWireframe(meshHandle)
+
+    % If there is a numeric value in edges and a char ('none') in faces
+    % then is wireframe
+    noColor = false;
+    
+    if ischar(meshHandle.FaceColor) && ~ischar(meshHandle.EdgeColor)
+       
+        isIt = true;
+    end
+    
+    % As long as there is a color in faces is not wireframe
+    if ~ischar(meshHandle.FaceColor) && ischar(meshHandle.EdgeColor)
+      
+        isIt = false;
+    end
+    % The mesh is invisble and not on purpose. Make it wireframe.
+    if ~exist('isIt','var')
+         
+        isIt    = true;
+        noColor = true;
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
@@ -27,28 +27,34 @@ addRequired(p,'structInput');
 addParameter(p,'linksToModify',default_linksToModify,@(x) iscell(x));
 addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) && ~any(x>Visualizer.NOBJ));
 
-% parse inputs
-parse(p,Visualizer,varargin{:});
-options=p.Results;
+    % Parse inputs
+    parse(p,Visualizer,varargin{:});
+    options = p.Results;
 
-if ~any(ismember(p.UsingDefaults,'linksToModify'))  || ~any(ismember(p.UsingDefaults,'linksIndices'))
-    % select the indices of the links to modify
-    if ~any(ismember(p.UsingDefaults,'linksIndices'))
-        indices=options.linksIndices;
-    else
-        [~,indices_temp]=ismember(options.linksToModify,Visualizer.linkNames);
-        indices=nonzeros(indices_temp);
-        if length(indices_temp)~=length(indices)
-            notInModel=length(indices_temp)-length(indices);
-            indices_notInModel=find(indices_temp==0);
-            warndlg(sprintf('The list of links to modify contains %d names (positions [ %s ] ) that are not in the list of links of the model',notInModel,num2str(indices_notInModel')));
+    if ~any(ismember(p.UsingDefaults,'linksToModify')) || ~any(ismember(p.UsingDefaults,'linksIndices'))
+    
+        % Select the indices of the links to modify
+        if ~any(ismember(p.UsingDefaults,'linksIndices'))
+        
+            indices = options.linksIndices;
+        else
+            [~,indices_temp] = ismember(options.linksToModify,Visualizer.linkNames);
+            indices = nonzeros(indices_temp);
+            
+            if length(indices_temp) ~= length(indices)
+                
+                notInModel         = length(indices_temp)-length(indices);
+                indices_notInModel = find(indices_temp==0);
+                warndlg(sprintf('The list of links to modify contains %d names (positions [ %s ] ) that are not in the list of links of the model',notInModel,num2str(indices_notInModel')));
+            end
         end
+    else
+        % By default modify all links
+        indices = 1:Visualizer.NOBJ;
     end
-else
-    % by default modify all links
-    indices=1:Visualizer.NOBJ;
-end
 
-for it=1:length(indices)
-    iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});
+    for it = 1:length(indices)
+    
+        iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/modifyLinksVisualization.m
@@ -1,49 +1,47 @@
 function []=modifyLinksVisualization(Visualizer,varargin)
-% Allows the modifications of the meshes of the selected links. By default it will modify all objects in the Visualizer variable
-%   - `modifyLinksVisualization` : Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
-%       - Inputs:
-%             - `Visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables `linkNames`,`transforms` and `NOBJ`.
-%                 - `linkNames`  : variable that contains the link names.
-%                 - `meshHandles` : variable that has the handles of the mesh objects.
-%                 - `NOBJ` : variable that contains the number of visual objects to update.
-%       - Optional Inputs:
-%             - `linksToModify`  : Cell array containing the names of the links to modify
-%             - `linksIndices`   : array containing the indices of the links to modify
-% :exclamation:   Note: all extra variables are sent to `modifyLinkVisual`
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_linksToModify={'all'};
-default_linksIndices=-99;
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addParameter(p,'linksToModify',default_linksToModify,@(x) iscell(x));
-addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) && ~any(x>Visualizer.NOBJ));
+    % Allows the modifications of the meshes of the selected links. By default it will modify all objects in the Visualizer variable
+    %   - `modifyLinksVisualization` : Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
+    %       - Inputs:
+    %             - `Visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables `linkNames`,`transforms` and `NOBJ`.
+    %                 - `linkNames`  : variable that contains the link names.
+    %                 - `meshHandles` : variable that has the handles of the mesh objects.
+    %                 - `NOBJ` : variable that contains the number of visual objects to update.
+    %       - Optional Inputs:
+    %             - `linksToModify`  : Cell array containing the names of the links to modify
+    %             - `linksIndices`   : array containing the indices of the links to modify
+    % :exclamation:   Note: all extra variables are sent to `modifyLinkVisual`
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
+    %% input parser section
+    p = inputParser;
+    p.StructExpand = false;
+    p.KeepUnmatched= true;
+    % Default values
+    default_linksToModify={'all'};
+    default_linksIndices=-99;
+    % add parameters and validity funcitons
+    addRequired(p,'structInput');
+    addParameter(p,'linksToModify',default_linksToModify,@(x) iscell(x));
+    addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) && ~any(x>Visualizer.NOBJ));
 
     % Parse inputs
     parse(p,Visualizer,varargin{:});
     options = p.Results;
 
     if ~any(ismember(p.UsingDefaults,'linksToModify')) || ~any(ismember(p.UsingDefaults,'linksIndices'))
-    
+
         % Select the indices of the links to modify
         if ~any(ismember(p.UsingDefaults,'linksIndices'))
-        
             indices = options.linksIndices;
         else
             [~,indices_temp] = ismember(options.linksToModify,Visualizer.linkNames);
             indices = nonzeros(indices_temp);
-            
+
             if length(indices_temp) ~= length(indices)
-                
-                notInModel         = length(indices_temp)-length(indices);
+                notInModel = length(indices_temp)-length(indices);
                 indices_notInModel = find(indices_temp==0);
                 warndlg(sprintf('The list of links to modify contains %d names (positions [ %s ] ) that are not in the list of links of the model',notInModel,num2str(indices_notInModel')));
             end
@@ -54,7 +52,6 @@ addParameter(p,'linksIndices',default_linksIndices,@(x)isnumeric(x) && all(x>0) 
     end
 
     for it = 1:length(indices)
-    
         iDynTreeWrappers.modifyLinkVisual(Visualizer.meshHandles(indices(it)),varargin{:});
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/plotFrame.m
+++ b/bindings/matlab/+iDynTreeWrappers/plotFrame.m
@@ -1,44 +1,44 @@
 function frame = plotFrame(transform, axisDimension, lineWidth)
 
-%% plotFrame 
-% plotFrame adds a 3D frame in the current figure
-% Inputs:
-%    - transform: The transform of the frame (4x4 matrix)
-%    - axisDimension: The dimension of the axes
-%    - lineWidth: The linewidth of the axes
-% Outputs:
-%    - A struct that can be used with updateFrame to update the
-%    visualization
-%
-% Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-% This software may be modified and distributed under the terms of the
-% GNU Lesser General Public License v2.1 or any later version.
+    %% plotFrame
+    % plotFrame adds a 3D frame in the current figure
+    % Inputs:
+    %    - transform: The transform of the frame (4x4 matrix)
+    %    - axisDimension: The dimension of the axes
+    %    - lineWidth: The linewidth of the axes
+    % Outputs:
+    %    - A struct that can be used with updateFrame to update the
+    %    visualization
+    %
+    % Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+    % This software may be modified and distributed under the terms of the
+    % GNU Lesser General Public License v2.1 or any later version.
 
-hold on
-parent=gca;
+    hold on
+    parent=gca;
 
-frame = struct();
+    frame = struct();
 
-R = transform(1:3, 1:3);
+    R = transform(1:3, 1:3);
 
-or = transform(1:3, 4);
+    or = transform(1:3, 4);
 
-p = [or, or, or] + axisDimension * R;
+    p = [or, or, or] + axisDimension * R;
 
-frame.axisDimension = axisDimension;
-frame.lineWidth = lineWidth;
+    frame.axisDimension = axisDimension;
+    frame.lineWidth = lineWidth;
 
-frame.x = plot3(parent, [or(1) p(1,1)], [or(2) p(2,1)], [or(3) p(3,1)], 'r', 'linewidth', lineWidth);
-frame.y = plot3(parent, [or(1) p(1,2)], [or(2) p(2,2)], [or(3) p(3,2)], 'g', 'linewidth', lineWidth);
-frame.z = plot3(parent, [or(1) p(1,3)], [or(2) p(2,3)], [or(3) p(3,3)], 'b', 'linewidth', lineWidth);
+    frame.x = plot3(parent, [or(1) p(1,1)], [or(2) p(2,1)], [or(3) p(3,1)], 'r', 'linewidth', lineWidth);
+    frame.y = plot3(parent, [or(1) p(1,2)], [or(2) p(2,2)], [or(3) p(3,2)], 'g', 'linewidth', lineWidth);
+    frame.z = plot3(parent, [or(1) p(1,3)], [or(2) p(2,3)], [or(3) p(3,3)], 'b', 'linewidth', lineWidth);
 
-p_text = [or, or, or] + axisDimension * 1.25 * R;
+    p_text = [or, or, or] + axisDimension * 1.25 * R;
 
-frame.labels = struct();
+    frame.labels = struct();
 
-frame.labels.x = text(parent, p_text(1,1), p_text(2,1), p_text(3,1), 'x', 'color', 'r');
-frame.labels.y = text(parent, p_text(1,2), p_text(2,2), p_text(3,2), 'y', 'color', 'g');
-frame.labels.z = text(parent, p_text(1,3), p_text(2,3), p_text(3,3), 'z', 'color', 'b');
+    frame.labels.x = text(parent, p_text(1,1), p_text(2,1), p_text(3,1), 'x', 'color', 'r');
+    frame.labels.y = text(parent, p_text(1,2), p_text(2,2), p_text(3,2), 'y', 'color', 'g');
+    frame.labels.z = text(parent, p_text(1,3), p_text(2,3), p_text(3,3), 'z', 'color', 'b');
 
 end
 

--- a/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
+++ b/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
@@ -1,53 +1,53 @@
 function [meshHandles,transform]=plotMeshInWorld(linkMeshInfo,w_H_link,varargin)
-% Gets the mesh information for each link in the model.
-%     - Iputs:
-%         - `linkMeshInfo` : An individual `linkMeshInfo` from the array output variable from `getMeshes` function.
-%         - `w_H_link` : Homogeneous transform from the world to the link
-%     - Optional Inputs:
-%         - `color` : Selects the color of the meshes.
-%         - `transparency` : Sets the alpha value of the patch. Is the
-%         level of transparency between 0 fully transparent and 1 solid.
-%         - `wireframe_rendering` : the reduction ratio of faces to
-%         wireframe. Follows convention of reducepatch.
-%         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
-%     - Outputs:
-%         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
-%         - `transform`    : The transform object for the link
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_color= [0.1843    0.3098    0.3098];
-default_transparency=0.5;
-default_style='fullMesh';
-default_wireframe_rendering=0.08;
-% accepted values
-expected_styles={'fullMesh','wireframe'};
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addRequired(p,'w_H_link',@(x)validateattributes(x,{'numeric'},{'size',[4,4]}));
-addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
-addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
-% parse inputs
-parse(p,linkMeshInfo,w_H_link,varargin{:});
-options=p.Results;
+    % Gets the mesh information for each link in the model.
+    %     - Iputs:
+    %         - `linkMeshInfo` : An individual `linkMeshInfo` from the array output variable from `getMeshes` function.
+    %         - `w_H_link` : Homogeneous transform from the world to the link
+    %     - Optional Inputs:
+    %         - `color` : Selects the color of the meshes.
+    %         - `transparency` : Sets the alpha value of the patch. Is the
+    %         level of transparency between 0 fully transparent and 1 solid.
+    %         - `wireframe_rendering` : the reduction ratio of faces to
+    %         wireframe. Follows convention of reducepatch.
+    %         - `style` : Selects the style of display of meshes, either fullMesh or wireframe.
+    %     - Outputs:
+    %         - `meshHandles`  : Struct that contains all the created handles for the meshes. There can be more than one mesh for each link.
+    %         - `transform`    : The transform object for the link
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
+    %% input parser section
+    p = inputParser;
+    p.StructExpand = false;
+    p.KeepUnmatched= true;
+    % Default values
+    default_color= [0.1843    0.3098    0.3098];
+    default_transparency=0.5;
+    default_style='fullMesh';
+    default_wireframe_rendering=0.08;
+    % accepted values
+    expected_styles={'fullMesh','wireframe'};
+    % add parameters and validity funcitons
+    addRequired(p,'structInput');
+    addRequired(p,'w_H_link',@(x)validateattributes(x,{'numeric'},{'size',[4,4]}));
+    addParameter(p,'color',default_color,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+    addParameter(p,'transparency',default_transparency,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'wireframe_rendering',default_wireframe_rendering,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles)));
+    % parse inputs
+    parse(p,linkMeshInfo,w_H_link,varargin{:});
+    options=p.Results;
 
     %% Create a transform object
     transform = hgtransform('Parent',gca);
-    
+
     for mesh_number = 1:length(linkMeshInfo.meshInfo)
 
         mesh_triangles = linkMeshInfo.meshInfo(mesh_number).mesh_triangles;
-        link_H_geom    = linkMeshInfo.meshInfo(mesh_number).link_H_geom;
-        scale          = linkMeshInfo.meshInfo(mesh_number).scale;
+        link_H_geom = linkMeshInfo.meshInfo(mesh_number).link_H_geom;
+        scale = linkMeshInfo.meshInfo(mesh_number).scale;
 
         % Scale the STL mesh
         corrected_vertices = mesh_triangles.Points.*scale;
@@ -59,20 +59,19 @@ options=p.Results;
 
         % Plot in the figure using patch
         modelMesh(mesh_number) = patch('Faces',mesh_triangles.ConnectivityList, ...
-                                       'Vertices',corrected_vertices, ...
-                                       'FaceColor',options.color , ...
-                                       'EdgeColor','none', ...
-                                       'FaceLighting','gouraud', ...
-                                       'AmbientStrength', 0.25);
+            'Vertices',corrected_vertices, ...
+            'FaceColor',options.color , ...
+            'EdgeColor','none', ...
+            'FaceLighting','gouraud', ...
+            'AmbientStrength', 0.25);
 
-        faces_bckup    = modelMesh(mesh_number).Faces;
+        faces_bckup = modelMesh(mesh_number).Faces;
         vertices_bckup = modelMesh(mesh_number).Vertices;
-        
-        meshHandles.fullMesh_bckup(mesh_number).faces    = faces_bckup;
+
+        meshHandles.fullMesh_bckup(mesh_number).faces = faces_bckup;
         meshHandles.fullMesh_bckup(mesh_number).vertices = vertices_bckup;
 
         if strcmp(options.style,'wireframe')
-       
             reducepatch(modelMesh(mesh_number),options.wireframe_rendering);
             modelMesh(mesh_number).FaceColor = 'none';
             modelMesh(mesh_number).EdgeColor = options.color;
@@ -84,7 +83,7 @@ options=p.Results;
         % Set the object transparency
         alpha(modelMesh(mesh_number),options.transparency);
     end
-    
+
     set(transform,'Matrix',w_H_link);
     meshHandles.modelMesh = modelMesh;
 end

--- a/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
+++ b/bindings/matlab/+iDynTreeWrappers/plotMeshInWorld.m
@@ -40,49 +40,51 @@ addParameter(p,'style',default_style,@(x) any(validatestring(x,expected_styles))
 parse(p,linkMeshInfo,w_H_link,varargin{:});
 options=p.Results;
 
-%% Create a transform object %
-transform = hgtransform('Parent',gca);
-for mesh_number=1:length(linkMeshInfo.meshInfo)
+    %% Create a transform object
+    transform = hgtransform('Parent',gca);
+    
+    for mesh_number = 1:length(linkMeshInfo.meshInfo)
 
-    mesh_triangles=linkMeshInfo.meshInfo(mesh_number).mesh_triangles;
-    link_H_geom=linkMeshInfo.meshInfo(mesh_number).link_H_geom;
-    scale=linkMeshInfo.meshInfo(mesh_number).scale;
+        mesh_triangles = linkMeshInfo.meshInfo(mesh_number).mesh_triangles;
+        link_H_geom    = linkMeshInfo.meshInfo(mesh_number).link_H_geom;
+        scale          = linkMeshInfo.meshInfo(mesh_number).scale;
 
-    % Change scale
-    % Scale the STL mesh
-    corrected_vertices=mesh_triangles.Points.*scale;
+        % Scale the STL mesh
+        corrected_vertices = mesh_triangles.Points.*scale;
 
-    % Applying transform to link frame to stl file  :
-    corrected_vertices=link_H_geom*[corrected_vertices';ones(1,size(corrected_vertices,1))];
-    corrected_vertices=corrected_vertices';
-    corrected_vertices=corrected_vertices(:,1:3);
+        % Applying transform to link frame to stl file:
+        corrected_vertices = link_H_geom*[corrected_vertices';ones(1,size(corrected_vertices,1))];
+        corrected_vertices = corrected_vertices';
+        corrected_vertices = corrected_vertices(:,1:3);
 
-    % plot in figureusing patch
-    modelMesh(mesh_number) = ...
-        patch('Faces',mesh_triangles.ConnectivityList,'Vertices',corrected_vertices,...
-        'FaceColor',options.color , ...
-        'EdgeColor',  'none',        ...
-        'FaceLighting',    'gouraud',     ...
-        'AmbientStrength', 0.25);
+        % Plot in the figure using patch
+        modelMesh(mesh_number) = patch('Faces',mesh_triangles.ConnectivityList, ...
+                                       'Vertices',corrected_vertices, ...
+                                       'FaceColor',options.color , ...
+                                       'EdgeColor','none', ...
+                                       'FaceLighting','gouraud', ...
+                                       'AmbientStrength', 0.25);
 
-    faces_bckup=modelMesh(mesh_number).Faces;
-    vertices_bckup=modelMesh(mesh_number).Vertices;
-    meshHandles.fullMesh_bckup(mesh_number).faces=faces_bckup;
-    meshHandles.fullMesh_bckup(mesh_number).vertices=vertices_bckup;
+        faces_bckup    = modelMesh(mesh_number).Faces;
+        vertices_bckup = modelMesh(mesh_number).Vertices;
+        
+        meshHandles.fullMesh_bckup(mesh_number).faces    = faces_bckup;
+        meshHandles.fullMesh_bckup(mesh_number).vertices = vertices_bckup;
 
-    if strcmp(options.style,'wireframe')
-        reducepatch(modelMesh(mesh_number),options.wireframe_rendering);
-        modelMesh(mesh_number).FaceColor='none';
-        modelMesh(mesh_number).EdgeColor=options.color;
+        if strcmp(options.style,'wireframe')
+       
+            reducepatch(modelMesh(mesh_number),options.wireframe_rendering);
+            modelMesh(mesh_number).FaceColor = 'none';
+            modelMesh(mesh_number).EdgeColor = options.color;
+        end
+
+        % Parent transform as parent to the mesh
+        set(modelMesh(mesh_number),'Parent',transform);
+
+        % Set the object transparency
+        alpha(modelMesh(mesh_number),options.transparency);
     end
-
-    %parent transform as parent to the mesh
-    set(modelMesh(mesh_number),'Parent',transform);
-
-    % Set the object transparency
-    alpha(modelMesh(mesh_number),options.transparency);
-
-end
-set(transform,'Matrix',w_H_link);
-meshHandles.modelMesh=modelMesh;
+    
+    set(transform,'Matrix',w_H_link);
+    meshHandles.modelMesh = modelMesh;
 end

--- a/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/prepareVisualization.m
@@ -1,116 +1,108 @@
 function [Visualizer,Objects]=prepareVisualization(KinDynModel,meshFilePrefix,varargin)
-% Creates the figures, loads the meshes, handles some visual effects, and creates the transform objects
-% - Inputs:
-%   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
-%   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
-%   `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
-% - Optional Inputs:
-%     - `view` : Selects the angle in which the figure is seen.
-%     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
-%     - `debug` : Enables having extra information for debugging purposes.
-%     - `groundOn` : Enables showing a plane as the ground.
-%     - `groundColor` : Selects the color of the ground.
-%     - `groundTransparency` : Selects the transparency of the ground.
-%     - `groundFrame` : Selects the frame in which the ground is attached.
-%     - `name` : The name of the figure 
-%     - `reuseFigure` : Enable the reuse of an already open figure. It can be the following values:
-%         - 'name': Reuse the figure with the same name (the figure is cleared before reusing it). The name must be set.
-%         - 'gcf': Reuse the figure returned by gcf.
-%         - 'none': Do not reuse the figure (Default).
-%     Note: all extra variables are sent to `plotMeshInWorld`
-%   - Outputs:
-%       - `Visualizer` : Struct containing the following fields
-%           - `transforms` : Is the transform objects array. There is one transform for each link
-%           - `linkNames`  : The name of the links in the same order of the transforms
-%           - `linkNames_idyn`  : The idyntree string vector equivalent to `linkNames`
-%           - `NOBJ` : Contains the number of visual objects in the visualizer
-%           - `meshHandles` : Has the handles of the mesh objects.
-%           - `parent`     : Contains the axes object of the parent figure.
-%           - `mainHandler`: Is the handle of the overall figure.
-%           - `DEBUG` : Flag stating if the debug mode was set or not.
-%           Fields included if debug mode is on:
-%           - `map`       : Cell array having both the names of the meshes and the associated link
-%           - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
-%% input parser section
-p = inputParser;
-p.StructExpand = false;
-p.KeepUnmatched= true;
-% Default values
-default_view=[128.0181 16.8000];
-default_material='dull';
-default_debug=false;
-default_groundOn=false;
-default_groundColor=[0 0.5 0.5];
-default_groundTransparency=0.8;
-default_groundFrame='none';
-default_name='iDynTreeVisualizer';
-default_reuseFigure='none';
-% accepted values
-expected_materials={'dull','metal','shiny'};
-expected_reuseFigure={'name', 'gcf', 'none'};
-% add parameters and validity funcitons
-addRequired(p,'structInput');
-addRequired(p,'meshFilePrefix',@(x) isstring(x) || ischar(x));
-addParameter(p,'view',default_view,@isnumeric);
-addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
-addParameter(p,'debug',default_debug,@(x) islogical(x));
-addParameter(p,'groundOn',default_groundOn,@(x) islogical(x));
-addParameter(p,'groundColor',default_groundColor,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
-addParameter(p,'groundTransparency',default_groundTransparency,@(x) isnumeric(x) && isscalar(x));
-addParameter(p,'groundFrame',default_groundFrame,@(x) isstring(x) || ischar(x));
-addParameter(p,'name',default_name,@(x) isstring(x) || ischar(x));
-addParameter(p,'reuseFigure',default_reuseFigure,@(x) any(validatestring(x,expected_reuseFigure)));
+    % Creates the figures, loads the meshes, handles some visual effects, and creates the transform objects
+    % - Inputs:
+    %   - `KinDynModel` : iDyntreewrappers main variable. Contains the model.
+    %   - `meshFilePrefix` : Path in which we can find the meshes. As an example the path to the mesh in a iCub urdf is `'package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl'
+    %   `. `meshFilePrefix` should replace package to allow to find the rest of the path. If the value is "", the standard iDynTree workflow of locating the mesh via the ExternalMesh.getFileLocationOnLocalFileSystem method is used.
+    % - Optional Inputs:
+    %     - `view` : Selects the angle in which the figure is seen.
+    %     - `material` : Selects effect with which the patch is rendered. Options are : 'dull','metal','shiny';
+    %     - `debug` : Enables having extra information for debugging purposes.
+    %     - `groundOn` : Enables showing a plane as the ground.
+    %     - `groundColor` : Selects the color of the ground.
+    %     - `groundTransparency` : Selects the transparency of the ground.
+    %     - `groundFrame` : Selects the frame in which the ground is attached.
+    %     - `name` : The name of the figure
+    %     - `reuseFigure` : Enable the reuse of an already open figure. It can be the following values:
+    %         - 'name': Reuse the figure with the same name (the figure is cleared before reusing it). The name must be set.
+    %         - 'gcf': Reuse the figure returned by gcf.
+    %         - 'none': Do not reuse the figure (Default).
+    %     Note: all extra variables are sent to `plotMeshInWorld`
+    %   - Outputs:
+    %       - `Visualizer` : Struct containing the following fields
+    %           - `transforms` : Is the transform objects array. There is one transform for each link
+    %           - `linkNames`  : The name of the links in the same order of the transforms
+    %           - `linkNames_idyn`  : The idyntree string vector equivalent to `linkNames`
+    %           - `NOBJ` : Contains the number of visual objects in the visualizer
+    %           - `meshHandles` : Has the handles of the mesh objects.
+    %           - `parent`     : Contains the axes object of the parent figure.
+    %           - `mainHandler`: Is the handle of the overall figure.
+    %           - `DEBUG` : Flag stating if the debug mode was set or not.
+    %           Fields included if debug mode is on:
+    %           - `map`       : Cell array having both the names of the meshes and the associated link
+    %           - `linkMeshInfo` : Contains the link name and a struct (meshInfo) that contains the name of file or if is a simple geometry, the triangulation ( edges and vertices of the mesh ) and the link to geometry transform.% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
+    %% input parser section
+    p = inputParser;
+    p.StructExpand = false;
+    p.KeepUnmatched= true;
+    % Default values
+    default_view=[128.0181 16.8000];
+    default_material='dull';
+    default_debug=false;
+    default_groundOn=false;
+    default_groundColor=[0 0.5 0.5];
+    default_groundTransparency=0.8;
+    default_groundFrame='none';
+    default_name='iDynTreeVisualizer';
+    default_reuseFigure='none';
+    % accepted values
+    expected_materials={'dull','metal','shiny'};
+    expected_reuseFigure={'name', 'gcf', 'none'};
+    % add parameters and validity funcitons
+    addRequired(p,'structInput');
+    addRequired(p,'meshFilePrefix',@(x) isstring(x) || ischar(x));
+    addParameter(p,'view',default_view,@isnumeric);
+    addParameter(p,'material',default_material,@(x) any(validatestring(x,expected_materials)));
+    addParameter(p,'debug',default_debug,@(x) islogical(x));
+    addParameter(p,'groundOn',default_groundOn,@(x) islogical(x));
+    addParameter(p,'groundColor',default_groundColor,@(x)validateattributes(x,{'numeric'},{'numel', 3}));
+    addParameter(p,'groundTransparency',default_groundTransparency,@(x) isnumeric(x) && isscalar(x));
+    addParameter(p,'groundFrame',default_groundFrame,@(x) isstring(x) || ischar(x));
+    addParameter(p,'name',default_name,@(x) isstring(x) || ischar(x));
+    addParameter(p,'reuseFigure',default_reuseFigure,@(x) any(validatestring(x,expected_reuseFigure)));
 
     % Parse inputs
     parse(p,KinDynModel,meshFilePrefix,varargin{:});
-    options   =  p.Results;
+    options = p.Results;
     isNameSet = ~any(strcmp(p.UsingDefaults, 'name'));
-    
+
     %% Get meshes from the model variable
-    model              = KinDynModel.kinDynComp.model;
+    model = KinDynModel.kinDynComp.model;
     [linkMeshInfo,map] = iDynTreeWrappers.getMeshes(model,meshFilePrefix);
-    numberOfLinks      = length(linkMeshInfo);
-    linkNames          = cell(numberOfLinks,1);
-    
+    numberOfLinks = length(linkMeshInfo);
+    linkNames = cell(numberOfLinks,1);
+
     switch options.reuseFigure
-    
         case 'gcf'
-            
             mainHandler = gcf;
             cla(mainHandler.Children);
-    
         case 'name'
-        
             figHandles = findobj('Type', 'figure', 'Name', options.name);
-        
             if isNameSet && ~isempty(figHandles)
-            
                 mainHandler = figHandles(1,1);
                 cla(mainHandler.Children);
             else
                 mainHandler = figure;
-            end  
-            
-        otherwise           
+            end
+        otherwise
             mainHandler = figure;
     end
-    
+
     if isNameSet
-        
         set(mainHandler,'Name', options.name,'numbertitle','off')
     end
-    
+
     % Set the figure as current figure such that gca works
-    set(0, 'CurrentFigure', mainHandler) 
+    set(0, 'CurrentFigure', mainHandler)
     parent = gca;
     hold on
     linkNames_idyn = iDynTree.StringVector();
 
     for it=1:numberOfLinks
-        
+
         w_H_link = iDynTreeWrappers.getWorldTransform(KinDynModel,linkMeshInfo(it).linkName);
         [meshHandles(it,:),transforms(it)] = iDynTreeWrappers.plotMeshInWorld(linkMeshInfo(it),w_H_link,varargin{:});
         linkNames{it} = linkMeshInfo(it).linkName;
@@ -129,15 +121,15 @@ addParameter(p,'reuseFigure',default_reuseFigure,@(x) any(validatestring(x,expec
     % Apply views
     view(parent,options.view);
 
-% Add world reference frame
-hold on;
-currentAxisValues=axis;
-axisRange=currentAxisValues([2,4,6])-currentAxisValues([1,3,5]);
-frameAxisSize = min(axisRange)/4;
-% linewidth value 1 = to 0.35mm. It is better if we increase the linewidth
-% in proportion to the axisSize of the frame.c
-linewidthSize=frameAxisSize*50;
-iDynTreeWrappers.plotFrame(eye(4), frameAxisSize, linewidthSize);
+    % Add world reference frame
+    hold on;
+    currentAxisValues=axis;
+    axisRange=currentAxisValues([2,4,6])-currentAxisValues([1,3,5]);
+    frameAxisSize = min(axisRange)/4;
+    % linewidth value 1 = to 0.35mm. It is better if we increase the linewidth
+    % in proportion to the axisSize of the frame.c
+    linewidthSize=frameAxisSize*50;
+    iDynTreeWrappers.plotFrame(eye(4), frameAxisSize, linewidthSize);
 
     % Axis labels
     title('Robot Visualizer ');
@@ -147,31 +139,31 @@ iDynTreeWrappers.plotFrame(eye(4), frameAxisSize, linewidthSize);
 
     % Draw the ground
     if options.groundOn
-    
+
         % Create plane on x-y axis
-        normal_vector  = [0,0,1];
+        normal_vector = [0,0,1];
         point_on_plane = [0,0,0];
-        d              = normal_vector*point_on_plane';
-        
+        d = normal_vector*point_on_plane';
+
         x = [1 -1 -1  1]*max(axisRange(1:2)); % Generate data for x vertices
         y = [1  1 -1 -1]*max(axisRange(1:2)); % Generate data for y vertices
         z = 1/normal_vector(3)*(normal_vector(1)*x + normal_vector(2)*y + d); % Solve for z vertices data
-        
-        groundHandle   = patch('XData',x,'YData',y,'ZData',z,'FaceColor', options.groundColor);
+
+        groundHandle = patch('XData',x,'YData',y,'ZData',z,'FaceColor', options.groundColor);
         alpha(groundHandle,options.groundTransparency);
-        
+
         % apply transform
         groundTransform = hgtransform('Parent',parent);
         set(groundHandle,'Parent',groundTransform);
-        
+
         if any(ismember(p.UsingDefaults,'groundFrame'))
-            
-            w_H_plane           = eye(4,4);
+
+            w_H_plane = eye(4,4);
             options.groundFrame = linkNames{1};
         else
-            w_H_plane_idyn      = KinDynModel.kinDynComp.getWorldTransform(options.groundFrame);
-            w_H_plane           = w_H_plane_idyn.asHomogeneousTransform.toMatlab();
-            w_H_plane(1:2,4)    = 0;
+            w_H_plane_idyn = KinDynModel.kinDynComp.getWorldTransform(options.groundFrame);
+            w_H_plane = w_H_plane_idyn.asHomogeneousTransform.toMatlab();
+            w_H_plane(1:2,4) = 0;
         end
         set(groundTransform,'Matrix',w_H_plane);
 
@@ -180,11 +172,11 @@ iDynTreeWrappers.plotFrame(eye(4), frameAxisSize, linewidthSize);
 
         % Build Object struct
         Objects.frames_idyn = objectFrames_idyn;
-        Objects.transform   = groundTransform;
-        Objects.frames      = options.groundFrame;
-        Objects.types       = {'plane'};
-        Objects.names       = {'ground'};
-        Objects.handle      = groundHandle;
+        Objects.transform = groundTransform;
+        Objects.frames = options.groundFrame;
+        Objects.types = {'plane'};
+        Objects.names = {'ground'};
+        Objects.handle = groundHandle;
 
         if options.debug
             Objects.map = [Objects.names',Objects.frames'];
@@ -194,16 +186,16 @@ iDynTreeWrappers.plotFrame(eye(4), frameAxisSize, linewidthSize);
     end
 
     % Build Output struct
-    Visualizer.transforms     = transforms;
+    Visualizer.transforms = transforms;
     Visualizer.linkNames_idyn = linkNames_idyn;
-    Visualizer.linkNames      = linkNames;
-    Visualizer.NOBJ           = length(transforms);
-    Visualizer.meshHandles    = meshHandles;
-    Visualizer.mainHandler    = mainHandler;
-    Visualizer.parent         = parent;
-    Visualizer.DEBUG          = options.debug;
+    Visualizer.linkNames = linkNames;
+    Visualizer.NOBJ = length(transforms);
+    Visualizer.meshHandles = meshHandles;
+    Visualizer.mainHandler = mainHandler;
+    Visualizer.parent = parent;
+    Visualizer.DEBUG = options.debug;
 
-    if options.debug      
+    if options.debug
         Visualizer.map = map;
         Visualizer.linkMeshInfo = linkMeshInfo;
     end

--- a/bindings/matlab/+iDynTreeWrappers/setFloatingBase.m
+++ b/bindings/matlab/+iDynTreeWrappers/setFloatingBase.m
@@ -2,7 +2,7 @@ function [] = setFloatingBase(KinDynModel,floatBaseLinkName)
 
     % SETFLOATINGBASE sets the link that is used as floating base.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT: [] = setFloatingBase(KinDynModel,floatBaseLinkName)
@@ -14,15 +14,15 @@ function [] = setFloatingBase(KinDynModel,floatBaseLinkName)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % set the floating base link
     ack = KinDynModel.kinDynComp.setFloatingBase(floatBaseLinkName);
-    
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[setFloatingBase]: unable to set the floating base link.')
-    end  
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/setFrameVelocityRepresentation.m
+++ b/bindings/matlab/+iDynTreeWrappers/setFrameVelocityRepresentation.m
@@ -2,7 +2,7 @@ function [] = setFrameVelocityRepresentation(KinDynModel,frameVelRepr)
 
     % SETFRAMEVELOCITYREPRESENTATION sets the frame velocity representation.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT: [] = setFrameVelocityRepresentation(KinDynModel,frameVelRepr)
@@ -22,33 +22,33 @@ function [] = setFrameVelocityRepresentation(KinDynModel,frameVelRepr)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     switch frameVelRepr
-        
+
         case 'mixed'
-            
+
             frameVelRepr_idyntree = iDynTree.MIXED_REPRESENTATION;
-                    
+
         case 'body'
-            
+
             frameVelRepr_idyntree = iDynTree.BODY_FIXED_REPRESENTATION;
-                    
+
         case 'inertial'
-            
+
             frameVelRepr_idyntree = iDynTree.INERTIAL_FIXED_REPRESENTATION;
-                    
-        otherwise        
+
+        otherwise
             error('[setFrameVelocityRepresentation]: frameVelRepr is not a valid string.')
     end
-             
+
     % set the desired frameVelRepr
     ack = KinDynModel.kinDynComp.setFrameVelocityRepresentation(frameVelRepr_idyntree);
-    
+
     % check for errors
-    if ~ack    
+    if ~ack
         error('[setFrameVelocityRepresentation]: unable to set the frame velocity representation.')
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/setJointPos.m
+++ b/bindings/matlab/+iDynTreeWrappers/setJointPos.m
@@ -1,7 +1,6 @@
 function [] = setJointPos(KinDynModel,jointPos)
 
-    % SETJOINTPOS sets the joints configuration for kino-dynamic 
-    %                  computations.
+    % SETJOINTPOS sets the joints configuration for kino-dynamic computations.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -32,17 +31,14 @@ function [] = setJointPos(KinDynModel,jointPos)
             
         disp('[setJointPos]: done.')     
     end
-    
-    % convert the joint position to a dynamic size vector
-    jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+
     for k = 0:length(jointPos)-1
         
-        jointPos_iDyntree.setVal(k,jointPos(k+1));
+        KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
     
     % set the current joint positions
-    ack = KinDynModel.kinDynComp.setJointPos(jointPos_iDyntree);
+    ack = KinDynModel.kinDynComp.setJointPos(KinDynModel.kinematics.jointPos_iDyntree);
     
     % check for errors
     if ~ack  

--- a/bindings/matlab/+iDynTreeWrappers/setJointPos.m
+++ b/bindings/matlab/+iDynTreeWrappers/setJointPos.m
@@ -2,46 +2,46 @@ function [] = setJointPos(KinDynModel,jointPos)
 
     % SETJOINTPOS sets the joints configuration for kino-dynamic computations.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT: [] = setJointPos(KinDynModel,jointPos)
     %
-    % INPUTS: - jointPos: [ndof x 1] vector representing the joints 
+    % INPUTS: - jointPos: [ndof x 1] vector representing the joints
     %                     configuration in radians;
     %         - KinDynModel: a structure containing the loaded model and additional info.
     %
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % Debug input
     if KinDynModel.DEBUG
-        
+
         disp('[setJointPos]: debugging inputs...')
-        
+
         % check joints position vector size
         if length(jointPos) ~= KinDynModel.NDOF
-            
+
             error('[setJointPos]: the length of jointPos is not KinDynModel.NDOF')
         end
-            
-        disp('[setJointPos]: done.')     
+
+        disp('[setJointPos]: done.')
     end
 
     for k = 0:length(jointPos)-1
-        
+
         KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
-    
+
     % set the current joint positions
     ack = KinDynModel.kinDynComp.setJointPos(KinDynModel.kinematics.jointPos_iDyntree);
-    
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[setJointPos]: unable to set the joint positions.')
-    end  
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/setRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/setRobotState.m
@@ -1,16 +1,16 @@
 function [] = setRobotState(varargin)
 
     % SETROBOTSTATE sets the system state. The system state is composed of:
-    %                   
-    %                    - joints configuration and velocity plus gravity vector 
-    %                      for fixed-base systems; 
-    %                    - base pose and velocity, joints configuration and 
-    %                      velocity plus gravity vector for floating-base systems. 
     %
-    %                    The gravity vector expresses the gravity acceleration 
-    %                    in the inertial frame. 
+    %                    - joints configuration and velocity plus gravity vector
+    %                      for fixed-base systems;
+    %                    - base pose and velocity, joints configuration and
+    %                      velocity plus gravity vector for floating-base systems.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    %                    The gravity vector expresses the gravity acceleration
+    %                    in the inertial frame.
+    %
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT: Floating base system:
@@ -23,7 +23,7 @@ function [] = setRobotState(varargin)
     %
     % INPUTS:  - KinDynModel: a structure containing the loaded model and additional info.
     %          - basePose: [4 x 4] from base frame to world frame transform;
-    %          - jointPos: [nDof x 1] vector representing the joints configuration 
+    %          - jointPos: [nDof x 1] vector representing the joints configuration
     %                      in radians;
     %          - baseVel: [6 x 1] vector of base velocities [lin, ang];
     %          - jointVel: [ndof x 1] vector of joints velocities;
@@ -33,192 +33,192 @@ function [] = setRobotState(varargin)
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     KinDynModel = varargin{1};
-    
+
     % check the number of inputs
     switch nargin
-       
+
         case 6
-            
+
             basePose = varargin{2};
             jointPos = varargin{3};
             baseVel  = varargin{4};
             jointVel = varargin{5};
             gravAcc  = varargin{6};
-            
+
             % Debug inputs
             if KinDynModel.DEBUG
-        
+
                 disp('[setRobotState]: debugging inputs...')
-        
+
                 % basePose must be a valid transformation matrix
                 if size(basePose,1) ~= 4 || size(basePose,2) ~= 4
-            
+
                     error('[setRobotState]: basePose is not a 4x4 matrix.')
                 end
-        
+
                 for ii = 1:4
-                    
+
                     if ii < 4
-                        
-                        if abs(basePose(4,ii)) > 0.0001 
-            
+
+                        if abs(basePose(4,ii)) > 0.0001
+
                             error('[setRobotState]: the last line of basePose is not [0,0,0,1].')
                         end
                     else
                         if abs(basePose(4,ii)) > 1.0001 || abs(basePose(4,ii)) < 0.9999
-            
+
                             error('[setRobotState]: the last line of basePose is not [0,0,0,1].')
                         end
                     end
                 end
-        
+
                 % baseRotation = basePose(1:3,1:3) must be a valid rotation matrix
                 if det(basePose(1:3,1:3)) < 0.9 || det(basePose(1:3,1:3)) > 1.1
-            
+
                     error('[setRobotState]: baseRotation is not a valid rotation matrix.')
                 end
-        
+
                 IdentityMatr = basePose(1:3,1:3)*basePose(1:3,1:3)';
-        
+
                 for kk = 1:size(IdentityMatr, 1)
-            
+
                     for jj = 1:size(IdentityMatr, 1)
-                
+
                         if jj == kk
-                    
+
                             if abs(IdentityMatr(kk,jj)) < 0.9 || abs(IdentityMatr(kk,jj)) > 1.1
-                        
+
                                 error('[setRobotState]: baseRotation is not a valid rotation matrix.')
                             end
                         else
                             if abs(IdentityMatr(kk,jj)) > 0.01
-                        
+
                                 error('[setRobotState]: baseRotation is not a valid rotation matrix.')
                             end
                         end
-                    end   
-                end   
-            
+                    end
+                end
+
                 % debug gravity vector size
                 if length(gravAcc) ~= 3
-            
-                     error('[setRobotState]: the length of gravAcc vector is not 3.')
-                end 
-                
+
+                    error('[setRobotState]: the length of gravAcc vector is not 3.')
+                end
+
                 % check base velocity vector size
                 if length(baseVel) ~= 6
-            
-                     error('[setRobotState]: the length of baseVel is not 6.')
+
+                    error('[setRobotState]: the length of baseVel is not 6.')
                 end
-                
+
                 % check joints position vector size
                 if length(jointPos) ~= KinDynModel.NDOF
-            
+
                     error('[setRobotState]: the length of jointPos is not KinDynModel.NDOF')
                 end
-                
+
                 % check joints velocity vector size
                 if length(jointVel) ~= KinDynModel.NDOF
-            
+
                     error('[setRobotState]: the length of jointVel is not KinDynModel.NDOF')
                 end
-                
-                disp('[setRobotState]: done.')     
+
+                disp('[setRobotState]: done.')
             end
 
             % set the element of the rotation matrix and of the base
             % position vector
             for k = 0:2
-                
+
                 KinDynModel.kinematics.baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
-                
+
                 for j = 0:2
-                    
-                    KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+
+                    KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));
                 end
-            end      
-            
+            end
+
             % add the rotation matrix and the position to basePose_iDyntree
             KinDynModel.kinematics.basePose_iDyntree.setRotation(KinDynModel.kinematics.baseRotation_iDyntree);
             KinDynModel.kinematics.basePose_iDyntree.setPosition(KinDynModel.kinematics.baseOrigin_iDyntree);
-            
+
             % set the base velocities
             for k = 0:5
-                
+
                 KinDynModel.kinematics.baseVel_iDyntree.setVal(k,baseVel(k+1));
             end
-            
+
         case 4
-            
-            jointPos = varargin{2}; 
+
+            jointPos = varargin{2};
             jointVel = varargin{3};
             gravAcc  = varargin{4};
-            
+
             % Debug inputs
             if KinDynModel.DEBUG
-        
+
                 disp('[setRobotState]: debugging inputs...')
-                    
+
                 % debug gravity vector
                 if length(gravAcc) ~= 3
-            
-                     error('[setRobotState]: the length of gravAcc vector is not 3.')
+
+                    error('[setRobotState]: the length of gravAcc vector is not 3.')
                 end
-                
+
                 % check joints position vector size
                 if length(jointPos) ~= KinDynModel.NDOF
-            
+
                     error('[setRobotState]: the length of jointPos is not KinDynModel.NDOF')
                 end
-                
+
                 % check joints velocity vector size
                 if length(jointVel) ~= KinDynModel.NDOF
-            
+
                     error('[setRobotState]: the length of jointVel is not KinDynModel.NDOF')
                 end
-                
-                disp('[setRobotState]: done.')     
+
+                disp('[setRobotState]: done.')
             end
-            
-        otherwise        
+
+        otherwise
             error('[setRobotState]: wrong number of inputs.')
     end
-    
+
     % set joints position and velocity
     for k = 0:length(jointPos)-1
-        
+
         KinDynModel.kinematics.jointVel_iDyntree.setVal(k,jointVel(k+1));
         KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
-    
+
     % set the gravity vector
     for k = 0:2
-        
-       KinDynModel.kinematics.gravityVec_iDyntree.setVal(k,gravAcc(k+1));       
+
+        KinDynModel.kinematics.gravityVec_iDyntree.setVal(k,gravAcc(k+1));
     end
-    
+
     % set the current robot state
     switch nargin
-        
+
         case 4
-            
+
             ack = KinDynModel.kinDynComp.setRobotState(KinDynModel.kinematics.jointPos_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
-                                                       KinDynModel.kinematics.gravityVec_iDyntree);
-            
+                KinDynModel.kinematics.gravityVec_iDyntree);
+
         case 6
-            
+
             ack = KinDynModel.kinDynComp.setRobotState(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree, ...
-                                                       KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
-                                                       KinDynModel.kinematics.gravityVec_iDyntree);
+                KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                KinDynModel.kinematics.gravityVec_iDyntree);
     end
-    
+
     % check for errors
-    if ~ack   
+    if ~ack
         error('[setRobotState]: unable to set the robot state.')
-    end  
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/setRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/setRobotState.m
@@ -37,6 +37,10 @@ function [] = setRobotState(varargin)
 
     %% ------------Initialization----------------
 
+    persistent baseRotation_iDyntree baseOrigin_iDyntree ...
+               basePose_iDyntree baseVel_iDyntree jointPos_iDyntree ...
+               jointVel_iDyntree gravityVec_iDyntree
+        
     KinDynModel = varargin{1};
     
     % check the number of inputs
@@ -132,11 +136,15 @@ function [] = setRobotState(varargin)
             end
             
             % define the quantities required to set the floating base
-            baseRotation_iDyntree = iDynTree.Rotation();
-            baseOrigin_iDyntree   = iDynTree.Position();
-            basePose_iDyntree     = iDynTree.Transform();
-            baseVel_iDyntree      = iDynTree.Twist();
             
+            if isempty(baseRotation_iDyntree)
+                
+                baseRotation_iDyntree = iDynTree.Rotation();
+                baseOrigin_iDyntree   = iDynTree.Position();
+                basePose_iDyntree     = iDynTree.Transform();
+                baseVel_iDyntree      = iDynTree.Twist();
+            end
+         
             % set the element of the rotation matrix and of the base
             % position vector
             for k = 0:2
@@ -196,9 +204,12 @@ function [] = setRobotState(varargin)
     end
     
     % define all the remaining quantities required for setting the system state
-    jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    gravityVec_iDyntree = iDynTree.Vector3();
+    if isempty(jointPos_iDyntree)
+        
+        jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
+        jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
+        gravityVec_iDyntree = iDynTree.Vector3();
+    end
          
     % set joints position and velocity
     for k = 0:length(jointPos)-1

--- a/bindings/matlab/+iDynTreeWrappers/setRobotState.m
+++ b/bindings/matlab/+iDynTreeWrappers/setRobotState.m
@@ -37,10 +37,6 @@ function [] = setRobotState(varargin)
 
     %% ------------Initialization----------------
 
-    persistent baseRotation_iDyntree baseOrigin_iDyntree ...
-               basePose_iDyntree baseVel_iDyntree jointPos_iDyntree ...
-               jointVel_iDyntree gravityVec_iDyntree
-        
     KinDynModel = varargin{1};
     
     % check the number of inputs
@@ -134,37 +130,27 @@ function [] = setRobotState(varargin)
                 
                 disp('[setRobotState]: done.')     
             end
-            
-            % define the quantities required to set the floating base
-            
-            if isempty(baseRotation_iDyntree)
-                
-                baseRotation_iDyntree = iDynTree.Rotation();
-                baseOrigin_iDyntree   = iDynTree.Position();
-                basePose_iDyntree     = iDynTree.Transform();
-                baseVel_iDyntree      = iDynTree.Twist();
-            end
-         
+
             % set the element of the rotation matrix and of the base
             % position vector
             for k = 0:2
                 
-                baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
+                KinDynModel.kinematics.baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
                 
                 for j = 0:2
                     
-                    baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+                    KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
                 end
             end      
             
             % add the rotation matrix and the position to basePose_iDyntree
-            basePose_iDyntree.setRotation(baseRotation_iDyntree);
-            basePose_iDyntree.setPosition(baseOrigin_iDyntree);
+            KinDynModel.kinematics.basePose_iDyntree.setRotation(KinDynModel.kinematics.baseRotation_iDyntree);
+            KinDynModel.kinematics.basePose_iDyntree.setPosition(KinDynModel.kinematics.baseOrigin_iDyntree);
             
             % set the base velocities
             for k = 0:5
                 
-                baseVel_iDyntree.setVal(k,baseVel(k+1));
+                KinDynModel.kinematics.baseVel_iDyntree.setVal(k,baseVel(k+1));
             end
             
         case 4
@@ -203,25 +189,17 @@ function [] = setRobotState(varargin)
             error('[setRobotState]: wrong number of inputs.')
     end
     
-    % define all the remaining quantities required for setting the system state
-    if isempty(jointPos_iDyntree)
-        
-        jointPos_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-        jointVel_iDyntree   = iDynTree.VectorDynSize(KinDynModel.NDOF);
-        gravityVec_iDyntree = iDynTree.Vector3();
-    end
-         
     % set joints position and velocity
     for k = 0:length(jointPos)-1
         
-        jointVel_iDyntree.setVal(k,jointVel(k+1));
-        jointPos_iDyntree.setVal(k,jointPos(k+1));
+        KinDynModel.kinematics.jointVel_iDyntree.setVal(k,jointVel(k+1));
+        KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
     
     % set the gravity vector
     for k = 0:2
         
-       gravityVec_iDyntree.setVal(k,gravAcc(k+1));       
+       KinDynModel.kinematics.gravityVec_iDyntree.setVal(k,gravAcc(k+1));       
     end
     
     % set the current robot state
@@ -229,11 +207,14 @@ function [] = setRobotState(varargin)
         
         case 4
             
-            ack = KinDynModel.kinDynComp.setRobotState(jointPos_iDyntree,jointVel_iDyntree,gravityVec_iDyntree);
+            ack = KinDynModel.kinDynComp.setRobotState(KinDynModel.kinematics.jointPos_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                                                       KinDynModel.kinematics.gravityVec_iDyntree);
             
         case 6
             
-            ack = KinDynModel.kinDynComp.setRobotState(basePose_iDyntree,jointPos_iDyntree,baseVel_iDyntree,jointVel_iDyntree,gravityVec_iDyntree);
+            ack = KinDynModel.kinDynComp.setRobotState(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree, ...
+                                                       KinDynModel.kinematics.baseVel_iDyntree,KinDynModel.kinematics.jointVel_iDyntree, ...
+                                                       KinDynModel.kinematics.gravityVec_iDyntree);
     end
     
     % check for errors

--- a/bindings/matlab/+iDynTreeWrappers/setWorldBaseTransform.m
+++ b/bindings/matlab/+iDynTreeWrappers/setWorldBaseTransform.m
@@ -1,9 +1,9 @@
 function [] = setWorldBaseTransform(KinDynModel,basePose)
 
-    % SETWORLDBASETRANSFORM sets the joints configuration for kino-dynamic 
+    % SETWORLDBASETRANSFORM sets the joints configuration for kino-dynamic
     %                       computations.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % FORMAT: [] = setWorldBaseTransform(KinDynModel,basePose)
@@ -20,87 +20,87 @@ function [] = setWorldBaseTransform(KinDynModel,basePose)
 
     % Debug input
     if KinDynModel.DEBUG
-        
+
         disp('[setWorldBaseTransform]: debugging inputs...')
-        
+
         % basePose must be a valid transformation matrix
         if size(basePose,1) ~= 4 || size(basePose,2) ~= 4
-        
+
             error('[setWorldBaseTransform]: basePose is not a 4x4 matrix.')
         end
-    
+
         for ii = 1:4
-            
+
             if ii < 4
-                
-                if abs(basePose(4,ii)) > 0.0001 
-        
+
+                if abs(basePose(4,ii)) > 0.0001
+
                     error('[setWorldBaseTransform]: the last line of basePose is not [0,0,0,1].')
                 end
             else
                 if abs(basePose(4,ii)) > 1.0001 || abs(basePose(4,ii)) < 0.9999
-        
+
                     error('[setWorldBaseTransform]: the last line of basePose is not [0,0,0,1].')
                 end
             end
         end
-    
+
         % baseRotation = basePose(1:3,1:3) must be a valid rotation matrix
         if det(basePose(1:3,1:3)) < 0.9 || det(basePose(1:3,1:3)) > 1.1
-        
+
             error('[setWorldBaseTransform]: baseRotation is not a valid rotation matrix.')
         end
-    
+
         IdentityMatr = basePose(1:3,1:3)*basePose(1:3,1:3)';
-    
+
         for kk = 1:size(IdentityMatr, 1)
-        
+
             for jj = 1:size(IdentityMatr, 1)
-        
+
                 if jj == kk
-            
+
                     if abs(IdentityMatr(kk,jj)) < 0.9 || abs(IdentityMatr(kk,jj)) > 1.1
-                
+
                         error('[setWorldBaseTransform]: baseRotation is not a valid rotation matrix.')
                     end
                 else
                     if abs(IdentityMatr(kk,jj)) > 0.01
-                
+
                         error('[setWorldBaseTransform]: baseRotation is not a valid rotation matrix.')
                     end
                 end
-            end   
-        end   
-            
-        disp('[setWorldBaseTransform]: done.')     
+            end
+        end
+
+        disp('[setWorldBaseTransform]: done.')
     end
-    
+
     % define the quantities required to set the floating base
     baseRotation_iDyntree = iDynTree.Rotation();
     baseOrigin_iDyntree   = iDynTree.Position();
     basePose_iDyntree     = iDynTree.Transform();
-    
+
     % set the element of the rotation matrix and of the base
     % position vector
     for k = 0:2
-        
+
         baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
-        
+
         for j = 0:2
-            
-            baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+
+            baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));
         end
-    end      
-    
+    end
+
     % add the rotation matrix and the position to basePose_iDyntree
     basePose_iDyntree.setRotation(baseRotation_iDyntree);
     basePose_iDyntree.setPosition(baseOrigin_iDyntree);
 
     % set the world base transform
     ack = KinDynModel.kinDynComp.setWorldBaseTransform(basePose_iDyntree);
-    
+
     % check for errors
-    if ~ack  
+    if ~ack
         error('[setWorldBaseTransform]: unable to set the world base transform.')
-    end  
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/updateFrame.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateFrame.m
@@ -1,29 +1,29 @@
 function updateFrame(frame, newTransform)
 
-%% updateFrame 
-% updateFrame updates a 3D frame added with the plotFrame function
-% Inputs:
-%    - frame: The struct output by plotFrame
-%    - newTransform : The new 3D transformation (4x4 matrix)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    %% updateFrame
+    % updateFrame updates a 3D frame added with the plotFrame function
+    % Inputs:
+    %    - frame: The struct output by plotFrame
+    %    - newTransform : The new 3D transformation (4x4 matrix)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
 
-R = newTransform(1:3, 1:3);
+    R = newTransform(1:3, 1:3);
 
-or = newTransform(1:3, 4);
+    or = newTransform(1:3, 4);
 
-p = [or, or, or] + frame.axisDimension * R;
+    p = [or, or, or] + frame.axisDimension * R;
 
-set(frame.x, 'XData', [or(1) p(1,1)], 'YData', [or(2) p(2,1)], 'ZData', [or(3) p(3,1)]);
-set(frame.y, 'XData', [or(1) p(1,2)], 'YData', [or(2) p(2,2)], 'ZData', [or(3) p(3,2)]);
-set(frame.z, 'XData', [or(1) p(1,3)], 'YData', [or(2) p(2,3)], 'ZData', [or(3) p(3,3)]);
+    set(frame.x, 'XData', [or(1) p(1,1)], 'YData', [or(2) p(2,1)], 'ZData', [or(3) p(3,1)]);
+    set(frame.y, 'XData', [or(1) p(1,2)], 'YData', [or(2) p(2,2)], 'ZData', [or(3) p(3,2)]);
+    set(frame.z, 'XData', [or(1) p(1,3)], 'YData', [or(2) p(2,3)], 'ZData', [or(3) p(3,3)]);
 
-p_text = [or, or, or] + frame.axisDimension * 1.25 * R;
+    p_text = [or, or, or] + frame.axisDimension * 1.25 * R;
 
-set(frame.labels.x, 'Position', p_text(1:3,1));
-set(frame.labels.y, 'Position', p_text(1:3,2));
-set(frame.labels.z, 'Position', p_text(1:3,3));
+    set(frame.labels.x, 'Position', p_text(1:3,1));
+    set(frame.labels.y, 'Position', p_text(1:3,2));
+    set(frame.labels.z, 'Position', p_text(1:3,3));
 
 end
 

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
@@ -1,25 +1,25 @@
 function []=updateVisualization(KinDynModel,Visualizer)
-% We use the transform handlers to update the robot image using the
-% iDyntree kinematics
-% Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
-%     - Inputs:
-%           - `KinDynModel`: iDyntreewrappers main variable. Contains the model.
-%           - `visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables linkNames,transforms and NOBJ
-%               - `linkNames`  : variable that contains the link names.
-%               - `transforms` : variable that contains transform objects that are parent of the meshes.
-%               - `NOBJ` : variable that contains the number of visual objects to update.
-%
-% Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
-%
-% SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % We use the transform handlers to update the robot image using the
+    % iDyntree kinematics
+    % Updates the figure image with the new robot state. To be launched after `setRobotState` has been used.
+    %     - Inputs:
+    %           - `KinDynModel`: iDyntreewrappers main variable. Contains the model.
+    %           - `visualizer` : variable output from the `prepareVisualization` function. It contains the relevant variables linkNames,transforms and NOBJ
+    %               - `linkNames`  : variable that contains the link names.
+    %               - `transforms` : variable that contains transform objects that are parent of the meshes.
+    %               - `NOBJ` : variable that contains the number of visual objects to update.
+    %
+    % Author : Francisco Andrade (franciscojavier.andradechavez@iit.it)
+    %
+    % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
     transforms_idyn = KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(Visualizer.linkNames_idyn);
-    w_H_links       = transforms_idyn.toMatlab();
-    
+    w_H_links = transforms_idyn.toMatlab();
+
     for it = 1:Visualizer.NOBJ
-     
+
         Visualizer.transforms(it).Matrix = squeeze(w_H_links(it,:,:));
     end
 end

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualization.m
@@ -14,8 +14,12 @@ function []=updateVisualization(KinDynModel,Visualizer)
 % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
 % SPDX-License-Identifier: BSD-3-Clause
 
-transforms_idyn=KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(Visualizer.linkNames_idyn);
-w_H_links= transforms_idyn.toMatlab();
-for it=1:Visualizer.NOBJ
-    Visualizer.transforms(it).Matrix=squeeze(w_H_links(it,:,:));
+    %% ------------Initialization----------------
+    transforms_idyn = KinDynModel.kinDynComp.getWorldTransformsAsHomogeneous(Visualizer.linkNames_idyn);
+    w_H_links       = transforms_idyn.toMatlab();
+    
+    for it = 1:Visualizer.NOBJ
+     
+        Visualizer.transforms(it).Matrix = squeeze(w_H_links(it,:,:));
+    end
 end

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualizer.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualizer.m
@@ -5,7 +5,7 @@ function [] = updateVisualizer(Visualizer,KinDynModel,jointPos,basePose)
     %
     % WARNING! This function is deprecated! Use updateVisualization instead.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % REQUIREMENTS: compile iDyntree with Irrlicht (IDYNTREE_USES_IRRLICHT = ON).
@@ -17,104 +17,104 @@ function [] = updateVisualizer(Visualizer,KinDynModel,jointPos,basePose)
     %          - jointPos: [ndof x 1] vector representing the joints
     %                      configuration in radians;
     %          - basePose: [4 x 4] from base frame to world frame transform.
-    % 
+    %
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
     % Debug input
     if Visualizer.DEBUG
-        
+
         disp('[updateVisualizer]: debugging inputs...')
-        
+
         % basePose must be a valid transformation matrix
         if size(basePose,1) ~= 4 || size(basePose,2) ~= 4
-            
+
             error('[updateVisualizer]: basePose is not a 4x4 matrix.')
         end
-        
+
         for ii = 1:4
-                    
+
             if ii < 4
-                        
-                if abs(basePose(4,ii)) > 0.0001 
-            
+
+                if abs(basePose(4,ii)) > 0.0001
+
                     error('[updateVisualizer]: the last line of basePose is not [0,0,0,1].')
                 end
             else
                 if abs(basePose(4,ii)) > 1.0001 || abs(basePose(4,ii)) < 0.9999
-            
+
                     error('[updateVisualizer]: the last line of basePose is not [0,0,0,1].')
                 end
             end
         end
-        
+
         % baseRotation = basePose(1:3,1:3) must be a valid rotation matrix
         if det(basePose(1:3,1:3)) < 0.9 || det(basePose(1:3,1:3)) > 1.1
-            
+
             error('[updateVisualizer]: baseRotation is not a valid rotation matrix.')
         end
-        
+
         IdentityMatr = basePose(1:3,1:3)*basePose(1:3,1:3)';
-        
+
         for kk = 1:size(IdentityMatr, 1)
-            
+
             for jj = 1:size(IdentityMatr, 1)
-                
+
                 if jj == kk
-                    
+
                     if abs(IdentityMatr(kk,jj)) < 0.9 || abs(IdentityMatr(kk,jj)) > 1.1
-                        
+
                         error('[updateVisualizer]: baseRotation is not a valid rotation matrix.')
                     end
                 else
                     if abs(IdentityMatr(kk,jj)) > 0.01
-                        
+
                         error('[updateVisualizer]: baseRotation is not a valid rotation matrix.')
                     end
                 end
-            end   
-        end   
-        
+            end
+        end
+
         % check joint position vector size
         if length(jointPos) ~= KinDynModel.NDOF
-            
+
             error('[updateVisualizer]: the length of jointPos is not KinDynModel.NDOF')
         end
-            
-        disp('[updateVisualizer]: done.')     
+
+        disp('[updateVisualizer]: done.')
     end
 
     for k = 0:length(jointPos)-1
-        
+
         KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
-            
+
     % set the elements of the rotation matrix and of the base position vector
     for k = 0:2
-                
+
         KinDynModel.kinematics.baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
-                
+
         for j = 0:2
-                    
-            KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+
+            KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));
         end
     end
-            
+
     % add the rotation matrix and the position to w_H_b_iDyntree
     KinDynModel.kinematics.basePose_iDyntree.setRotation(KinDynModel.kinematics.baseRotation_iDyntree);
     KinDynModel.kinematics.basePose_iDyntree.setPosition(KinDynModel.kinematics.baseOrigin_iDyntree);
 
     % set the current joints position and world-to-base transform
     ack = Visualizer.viz.modelViz(0).setPositions(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree);
-       
+
     % check for errors
-    if ~ack    
+    if ~ack
         error('[updateVisualizer]: unable to update the visualizer.')
     end
-    
+
     Visualizer.viz.draw();
 end

--- a/bindings/matlab/+iDynTreeWrappers/updateVisualizer.m
+++ b/bindings/matlab/+iDynTreeWrappers/updateVisualizer.m
@@ -3,6 +3,8 @@ function [] = updateVisualizer(Visualizer,KinDynModel,jointPos,basePose)
     % UPDATEVISUALIZER updates the iDyntree visualizer with the current
     %                  base pose and joints position.
     %
+    % WARNING! This function is deprecated! Use updateVisualization instead.
+    %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
     %
@@ -85,37 +87,29 @@ function [] = updateVisualizer(Visualizer,KinDynModel,jointPos,basePose)
             
         disp('[updateVisualizer]: done.')     
     end
-    
-    % convert joints position to a dynamic size vector
-    jointPos_iDyntree = iDynTree.VectorDynSize(KinDynModel.NDOF);
-    
+
     for k = 0:length(jointPos)-1
         
-        jointPos_iDyntree.setVal(k,jointPos(k+1));
+        KinDynModel.kinematics.jointPos_iDyntree.setVal(k,jointPos(k+1));
     end
-    
-    % define the quantities required to set the floating base pose
-    baseRotation_iDyntree = iDynTree.Rotation();
-    baseOrigin_iDyntree   = iDynTree.Position();
-    basePose_iDyntree     = iDynTree.Transform();
             
     % set the elements of the rotation matrix and of the base position vector
     for k = 0:2
                 
-        baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
+        KinDynModel.kinematics.baseOrigin_iDyntree.setVal(k,basePose(k+1,4));
                 
         for j = 0:2
                     
-            baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
+            KinDynModel.kinematics.baseRotation_iDyntree.setVal(k,j,basePose(k+1,j+1));                   
         end
     end
             
     % add the rotation matrix and the position to w_H_b_iDyntree
-    basePose_iDyntree.setRotation(baseRotation_iDyntree);
-    basePose_iDyntree.setPosition(baseOrigin_iDyntree);
+    KinDynModel.kinematics.basePose_iDyntree.setRotation(KinDynModel.kinematics.baseRotation_iDyntree);
+    KinDynModel.kinematics.basePose_iDyntree.setPosition(KinDynModel.kinematics.baseOrigin_iDyntree);
 
     % set the current joints position and world-to-base transform
-    ack = Visualizer.viz.modelViz(0).setPositions(basePose_iDyntree,jointPos_iDyntree);
+    ack = Visualizer.viz.modelViz(0).setPositions(KinDynModel.kinematics.basePose_iDyntree,KinDynModel.kinematics.jointPos_iDyntree);
        
     % check for errors
     if ~ack    

--- a/bindings/matlab/+iDynTreeWrappers/visualizerSetup.m
+++ b/bindings/matlab/+iDynTreeWrappers/visualizerSetup.m
@@ -1,11 +1,11 @@
 function [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,cameraPos,cameraTarget)
 
-    % VISUALIZERSETUP modifies the visualization environment according to the 
+    % VISUALIZERSETUP modifies the visualization environment according to the
     %                 user specifications.
     %
     % WARNING! This function is deprecated! Use prepareVisualization instead.
     %
-    % This matlab function wraps a functionality of the iDyntree library.                     
+    % This matlab function wraps a functionality of the iDyntree library.
     % For further info see also: https://github.com/robotology/idyntree
     %
     % REQUIREMENTS: compile iDyntree with Irrlicht (IDYNTREE_USES_IRRLICHT = ON).
@@ -13,42 +13,42 @@ function [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,camer
     % FORMAT:  [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,cameraPos,cameraTarget)
     %
     % INPUTS:  - Visualizer: a structure containing the visualizer and its options.
-    %          - disableViewInertialFrame: boolean for disabling the view of the 
+    %          - disableViewInertialFrame: boolean for disabling the view of the
     %                                      inertial frame;
     %          - lightDir: [3 x 1] vector describing the light direction;
     %          - cameraPos: [3 x 1] vector describing the camera position;
     %          - cameraTarget: [3 x 1] vector describing the camera target;
-    % 
+    %
     % Author : Gabriele Nava (gabriele.nava@iit.it)
     %
     % SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
-% SPDX-License-Identifier: BSD-3-Clause
+    % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
 
-    % disable environmental features  
+    % disable environmental features
     if disableViewInertialFrame
-        
-        enviroment = Visualizer.viz.enviroment();  
-        ack        = enviroment.setElementVisibility('root_frame',false);   
-        
+
+        enviroment = Visualizer.viz.enviroment();
+        ack        = enviroment.setElementVisibility('root_frame',false);
+
         % check for errors
         if ~ack
             error('[visualizerSetup]: unable to disable the inertial frame view.')
-        end         
+        end
     end
-    
+
     % set lights
-    sun = Visualizer.viz.enviroment().lightViz('sun');     
-    lightDir_idyntree = iDynTree.Direction();     
-    lightDir_idyntree.fromMatlab(lightDir); 
+    sun = Visualizer.viz.enviroment().lightViz('sun');
+    lightDir_idyntree = iDynTree.Direction();
+    lightDir_idyntree.fromMatlab(lightDir);
     sun.setDirection(lightDir_idyntree);
 
-    % set camera     
-    cam = Visualizer.viz.camera();     
-    cam.setPosition(iDynTree.Position(cameraPos(1),cameraPos(2),cameraPos(3)));     
-    cam.setTarget(iDynTree.Position(cameraTarget(1),cameraTarget(2),cameraTarget(3)));    
-    
+    % set camera
+    cam = Visualizer.viz.camera();
+    cam.setPosition(iDynTree.Position(cameraPos(1),cameraPos(2),cameraPos(3)));
+    cam.setTarget(iDynTree.Position(cameraTarget(1),cameraTarget(2),cameraTarget(3)));
+
     % draw the model
     Visualizer.viz.draw();
 end

--- a/bindings/matlab/+iDynTreeWrappers/visualizerSetup.m
+++ b/bindings/matlab/+iDynTreeWrappers/visualizerSetup.m
@@ -1,7 +1,9 @@
 function [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,cameraPos,cameraTarget)
 
     % VISUALIZERSETUP modifies the visualization environment according to the 
-    %                      user specifications.
+    %                 user specifications.
+    %
+    % WARNING! This function is deprecated! Use prepareVisualization instead.
     %
     % This matlab function wraps a functionality of the iDyntree library.                     
     % For further info see also: https://github.com/robotology/idyntree
@@ -23,7 +25,7 @@ function [] = visualizerSetup(Visualizer,disableViewInertialFrame,lightDir,camer
 % SPDX-License-Identifier: BSD-3-Clause
 
     %% ------------Initialization----------------
-    
+
     % disable environmental features  
     if disableViewInertialFrame
         


### PR DESCRIPTION
Hello @traversaro, I have realized that in the end we never merged the optimization of the [iDynTree high level Matlab wrappers](https://github.com/robotology/idyntree/tree/master/bindings/matlab/%2BiDynTreeWrappers) in `master`. Following the old PR https://github.com/robotology/idyntree/pull/744 I have:

- rebased the modifications done back in time on the current `master`;
- fixed a bug related to a missing initialization of variables in `loadReducedModel.m`:
- formatted all files using the smart-indent functionality of MATLAB (ctrl+i) so that they all have the same style
- tested the code with iRonCub Matlab-based controllers and seems they work fine.

Besides the alignment of formatting style and the removal of trailing spaces, the main change is that every time the iDynTree wrappers are called, instead of creating a new object of the corresponding iDynTree class, updating it, then returning its content to matlab, they now directly update an already existing object which is created when `loadReducedModel.m` is called. This can save some computation time especially if a wrapper is called many times in the code. The change should not require any update of existing applications that use the wrappers.

We may try again to merge this changes in master! Let me know what you think about it.