### PR TITLE
Bump version to 13.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 12.5.0
+project(iDynTree VERSION 13.0.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used


### PR DESCRIPTION
The ABI was changed by https://github.com/robotology/idyntree/pull/1203 and https://github.com/robotology/idyntree/pull/1195 .