### PR TITLE
Align versions of upload/download artifact in Python workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -107,7 +107,7 @@ jobs:
             pip install "numpy>=2.0.0"
           CIBW_TEST_COMMAND: "python -c 'import idyntree.bindings'"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./wheelhouse/*.whl

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: sdist
           path: dist/*.tar.gz
 
   build_wheels:
@@ -109,7 +109,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: wheels
           path: ./wheelhouse/*.whl
 
   upload_pypi:
@@ -124,7 +124,6 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: dist
           path: dist
 
       - name: Inspect dist folder


### PR DESCRIPTION
I noticed this morning that the CI pipeline of a downstream project was failing because it tried to compile from scratch the idyntree wheel starting from its sdist. I realized that yesterday iDynTree 13 was released, and I investigated what happened. It turnes out that PyPI only had the sdist, the wheels were not there, and this is the reason of the failure in the  downstream.

The CI/CD pipeline of the tagged release is [this one](https://github.com/robotology/idyntree/actions/runs/10912040848) and, as you can notice, there are two different artifacts with the same name. I inspected the [Python workflow](https://github.com/robotology/idyntree/blob/48ffea2e203d917c59503f58c4d113fc2b052134/.github/workflows/python.yml) and I realized that the wheels were uploaded with the v3 action, while the upload of the sdist and the download of the artifact were done with the v4 versions. This was changed recently by a bot PR in https://github.com/robotology/idyntree/pull/1202.

Probably the different majors are not compatible with each other. In this PR, I aligned all of them. While I'm not sure this solves the problem (I don't exclude a change of behavior in which the artifacts are not merged when multiple jobs try to upload them using the same name), let's keep an eye on it.