### PR TITLE
Fix typo in sdist folder name in Python CI/CD

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Move sdist and wheels
         run: |
           mkdir -p dist/
-          mv dist/* dist/
+          mv sdist/* dist/
           mv wheels/* dist/
 
       - name: Inspect dist folder


### PR DESCRIPTION
#1206 was merged too early :) New fix.