### PR TITLE
Fix compilation with SWIG 4.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 13.1.0
+project(iDynTree VERSION 13.1.1
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -20,6 +20,8 @@ target_link_libraries(${target_name} PUBLIC Python3::NumPy)
 set_target_properties(${target_name} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/idyntree)
 
+# numpy.i is copied from
+# https://raw.githubusercontent.com/numpy/numpy/65d5b867cd1045bbc007cce8780e088142770b88/tools/swig/numpy.i
 set_property(
     TARGET ${target_name}
     PROPERTY SWIG_DEPENDS python.i numpy.i)

--- a/bindings/python/numpy.i
+++ b/bindings/python/numpy.i
@@ -48,7 +48,7 @@
 
 %fragment("NumPy_Backward_Compatibility", "header")
 {
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
 %#define NPY_ARRAY_DEFAULT NPY_DEFAULT
 %#define NPY_ARRAY_FARRAY  NPY_FARRAY
 %#define NPY_FORTRANORDER  NPY_FORTRAN
@@ -69,7 +69,7 @@
 {
 /* Macros to extract array attributes.
  */
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
 %#define is_array(a)            ((a) && PyArray_Check((PyArrayObject*)a))
 %#define array_type(a)          (int)(PyArray_TYPE((PyArrayObject*)a))
 %#define array_numdims(a)       (((PyArrayObject*)a)->nd)
@@ -114,8 +114,8 @@
     if (py_obj == NULL          ) return "C NULL value";
     if (py_obj == Py_None       ) return "Python None" ;
     if (PyCallable_Check(py_obj)) return "callable"    ;
-    if (PyString_Check(  py_obj)) return "string"      ;
-    if (PyInt_Check(     py_obj)) return "int"         ;
+    if (PyBytes_Check(   py_obj)) return "string"      ;
+    if (PyLong_Check(    py_obj)) return "int"         ;
     if (PyFloat_Check(   py_obj)) return "float"       ;
     if (PyDict_Check(    py_obj)) return "dict"        ;
     if (PyList_Check(    py_obj)) return "list"        ;
@@ -165,13 +165,11 @@
     return PyArray_EquivTypenums(actual_type, desired_type);
   }
 
-%#ifdef SWIGPY_USE_CAPSULE
-  void free_cap(PyObject * cap)
+void free_cap(PyObject * cap)
   {
     void* array = (void*) PyCapsule_GetPointer(cap,SWIGPY_CAPSULE_NAME);
     if (array != NULL) free(array);
   }
-%#endif
 
 
 }
@@ -293,7 +291,7 @@
       Py_INCREF(array_descr(ary));
       result = (PyArrayObject*) PyArray_FromArray(ary,
                                                   array_descr(ary),
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
                                                   NPY_FORTRANORDER);
 %#else
                                                   NPY_ARRAY_F_CONTIGUOUS);
@@ -524,7 +522,7 @@
     return success;
   }
 
-  /* Require the given PyArrayObject to to be Fortran ordered.  If the
+  /* Require the given PyArrayObject to be Fortran ordered.  If the
    * the PyArrayObject is already Fortran ordered, do nothing.  Else,
    * set the Fortran ordering flag and recompute the strides.
    */
@@ -1991,7 +1989,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY1[ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = SWIG_AppendOutput($result,(PyObject*)array$argnum);
 }
 
 /* Typemap suite for (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
@@ -2002,7 +2000,7 @@
   (PyObject* array = NULL)
 {
   npy_intp dims[1];
-  if (!PyInt_Check($input))
+  if (!PyLong_Check($input))
   {
     const char* typestring = pytype_string($input);
     PyErr_Format(PyExc_TypeError,
@@ -2010,7 +2008,8 @@
                  typestring);
     SWIG_fail;
   }
-  $2 = (DIM_TYPE) PyInt_AsLong($input);
+  $2 = (DIM_TYPE) PyLong_AsSsize_t($input);
+  if ($2 == -1 && PyErr_Occurred()) SWIG_fail;
   dims[0] = (npy_intp) $2;
   array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
   if (!array) SWIG_fail;
@@ -2019,7 +2018,7 @@
 %typemap(argout)
   (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = SWIG_AppendOutput($result,(PyObject*)array$argnum);
 }
 
 /* Typemap suite for (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
@@ -2030,7 +2029,7 @@
   (PyObject* array = NULL)
 {
   npy_intp dims[1];
-  if (!PyInt_Check($input))
+  if (!PyLong_Check($input))
   {
     const char* typestring = pytype_string($input);
     PyErr_Format(PyExc_TypeError,
@@ -2038,7 +2037,8 @@
                  typestring);
     SWIG_fail;
   }
-  $1 = (DIM_TYPE) PyInt_AsLong($input);
+  $1 = (DIM_TYPE) PyLong_AsSsize_t($input);
+  if ($1 == -1 && PyErr_Occurred()) SWIG_fail;
   dims[0] = (npy_intp) $1;
   array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
   if (!array) SWIG_fail;
@@ -2047,7 +2047,7 @@
 %typemap(argout)
   (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = SWIG_AppendOutput($result,(PyObject*)array$argnum);
 }
 
 /* Typemap suite for (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
@@ -2065,7 +2065,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = SWIG_AppendOutput($result,(PyObject*)array$argnum);
 }
 
 /* Typemap suite for (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
@@ -2083,7 +2083,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = SWIG_AppendOutput($result,(PyObject*)array$argnum);
 }
 
 /* Typemap suite for (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
@@ -2101,7 +2101,7 @@
 %typemap(argout)
   (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
 {
-  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+  $result = SWIG_AppendOutput($result,(PyObject*)array$argnum);
 }
 
 /*****************************/
@@ -2126,7 +2126,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEW_ARRAY1)
@@ -2147,7 +2147,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2169,7 +2169,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_ARRAY2)
@@ -2191,7 +2191,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2213,7 +2213,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_FARRAY2)
@@ -2235,7 +2235,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2259,7 +2259,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2283,7 +2283,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2307,7 +2307,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2331,7 +2331,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2356,7 +2356,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2381,7 +2381,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2406,7 +2406,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2431,7 +2431,7 @@
   PyArrayObject* array = (PyArrayObject*) obj;
 
   if (!array || !require_fortran(array)) SWIG_fail;
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /*************************************/
@@ -2457,19 +2457,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEWM_ARRAY1)
@@ -2491,19 +2487,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$2), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2526,19 +2518,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_ARRAY2)
@@ -2561,19 +2549,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$3), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
@@ -2596,19 +2580,15 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_FARRAY2)
@@ -2631,19 +2611,15 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$3), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2668,19 +2644,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2705,19 +2677,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$4), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2742,19 +2710,15 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
@@ -2779,19 +2743,15 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$4), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -2817,19 +2777,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -2855,171 +2811,15 @@
 
   if (!array) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$5), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
-                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
- */
-%typemap(in,numinputs=0)
-  (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
-  (DATA_TYPE* data_temp = NULL    , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
-{
-  $1 = &data_temp;
-  $2 = &dim1_temp;
-  $3 = &dim2_temp;
-  $4 = &dim3_temp;
-  $5 = &dim4_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
-  (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
-{
-  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array || !require_fortran(array)) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
-                      DATA_TYPE** ARGOUTVIEWM_FARRAY4)
- */
-%typemap(in,numinputs=0)
-  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEWM_FARRAY4)
-  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL    )
-{
-  $1 = &dim1_temp;
-  $2 = &dim2_temp;
-  $3 = &dim3_temp;
-  $4 = &dim4_temp;
-  $5 = &data_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
-  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_FARRAY4)
-{
-  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array || !require_fortran(array)) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
-                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
- */
-%typemap(in,numinputs=0)
-  (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
-  (DATA_TYPE* data_temp = NULL   , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
-{
-  $1 = &data_temp;
-  $2 = &dim1_temp;
-  $3 = &dim2_temp;
-  $4 = &dim3_temp;
-  $5 = &dim4_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
-  (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
-{
-  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
-}
-
-/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
-                      DATA_TYPE** ARGOUTVIEWM_ARRAY4)
- */
-%typemap(in,numinputs=0)
-  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEWM_ARRAY4)
-  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL   )
-{
-  $1 = &dim1_temp;
-  $2 = &dim2_temp;
-  $3 = &dim3_temp;
-  $4 = &dim4_temp;
-  $5 = &data_temp;
-}
-%typemap(argout,
-         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
-  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_ARRAY4)
-{
-  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
-  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
-  PyArrayObject* array = (PyArrayObject*) obj;
-
-  if (!array) SWIG_fail;
-
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
-
-%#if NPY_API_VERSION < 0x00000007
-  PyArray_BASE(array) = cap;
-%#else
-  PyArray_SetBaseObject(array,cap);
-%#endif
-
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
@@ -3045,19 +2845,15 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
@@ -3083,19 +2879,15 @@
 
   if (!array || !require_fortran(array)) SWIG_fail;
 
-%#ifdef SWIGPY_USE_CAPSULE
-    PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
-%#else
-    PyObject* cap = PyCObject_FromVoidPtr((void*)(*$1), free);
-%#endif
+PyObject* cap = PyCapsule_New((void*)(*$5), SWIGPY_CAPSULE_NAME, free_cap);
 
-%#if NPY_API_VERSION < 0x00000007
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
   PyArray_BASE(array) = cap;
 %#else
   PyArray_SetBaseObject(array,cap);
 %#endif
 
-  $result = SWIG_Python_AppendOutput($result,obj);
+  $result = SWIG_AppendOutput($result,obj);
 }
 
 /**************************************/

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -6,957 +6,957 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ace-7.1.3-h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.3.1-h8343317_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.29.2-hcfe8598_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.30.5-hf9cb763_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h38e077a_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_he2fd91e_702.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h95e488c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.0-hf2295e7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.0-hde27a5a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-hfa15dee_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h95e488c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h4a1b8e8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.11-hfc55251_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.14-h04b96a2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-h2a6caf8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.3-he6dfbbe_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-hcce6d95_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-h8013b2b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.2-default_h127d8a8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.2-default_h5d6823c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.2-default_hb5137d0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.2-default_h9c6a7e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.48-h71f35ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.3-hcb278e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.2-h2448989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.2-ha7bfdaf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-qt6_py39h8add8c0_612.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.0.0-h2e90f83_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.0.0-hd5fc58b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.0.0-hd5fc58b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.0.0-h3ecfda7_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.0.0-h2e90f83_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.0.0-h2e90f83_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.0.0-h3ecfda7_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.0.0-h757c851_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.0.0-h757c851_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.0.0-h59595ed_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.0.0-hca94c1a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h59595ed_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py39h5cac152_610.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.5-h27087fc_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h91e35bf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.7-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2023.09.07-h6aa6db2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h831f25b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.49.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.0-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-h564f6a6_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.2-h024ca30_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.4-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.6.2-ha770c72_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.6.2-hfef103a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.3.0-hf1915f5_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.3.0-hca2cd23_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.8-hc50e24c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.2-py311h71ddf71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-haf962dd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h36c2ea0_1008.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.12.0-py312h8572e83_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.12.0-py312h8572e83_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h112747c_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.6.3-hd0aab4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scotch-7.0.4-h23d43cc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.2-hdbcbe63_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.2.1-hc9a1274_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.2.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.3.0-heed6a68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.22.0-h8c25dac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.4-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py312hebe80a8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-hca90a2c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h328aa9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-7.1.3-h787c7f5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.11-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.2-h0425590_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.3.1-h0b8f51a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-h64c2a2e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h95d2017_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.28.1-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.29.2-hef020d8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.7.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.8.0-h6561dab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.30.5-hbb72600_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.8.0-heb6c788_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.3.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.2-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_h991a198_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.3-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.2-gpl_h4bdba66_705.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-hf4b6fbe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-he80d746_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-hcdea9b6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.0-h9d8fbc1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.0-hfbcf09e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h0a86eba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-he80d746_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.11-hd84c7bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.14-h64a9e3f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-h962fdfd_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.3-h381c573_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h1211b58_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-hc10942e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240116.1-cxx17_h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-h1fed05a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-21_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp15-15.0.7-default_hb368394_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp18.1-18.1.2-default_hb368394_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-18.1.2-default_hf9b4efe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.2-default_he324ac1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.2-default_h4390ef5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.7.1-h4e8248e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.20-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.120-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.0-h9d8fbc1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.48-h5ce24db_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.3-hd600fc2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.1-default_h3030c0e_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.4-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-21_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-21_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm18-18.1.2-hbfe100b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-25_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.2-h2edbd07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.4-h3557bc0_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.26-pthreads_h5a5ec62_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-qt6_py312h0bce51b_612.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.0.0-h3e0449b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.0.0-h3e0449b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.0.0-hd429f41_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.0.0-hd429f41_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.0.0-hc6dd956_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.0.0-hc6dd956_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.0.0-h81208d3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.0.0-h81208d3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.0.0-h2f0025b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.0.0-h5177828_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.0.0-h2f0025b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-openmp_h1a8b088_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312h127a95d_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-he59a552_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-he59a552_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-h7d3acce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.3-h648ac29_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.5-h4de3ea5_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h16908e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.27.5-h029595c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.7-hd600fc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2023.09.07-h98a5362_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-h2fd7c63_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-hf980d43_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.48.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.49.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.0-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.6-h3091e33_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h00a45b3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h31b8c72_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-19.1.2-h013ceaa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h2f0025b_1007.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.4-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.6.2-h8af1aa0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.6.2-hae18a20_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.3.0-hb6794ad_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.3.0-hf629957_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4.20240210-h0425590_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.98-hc5a5cc2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-hdf561d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h670dfbf_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.8-h65af167_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.12.1-h70be974_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.2-py312h2eb110b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-h78594a9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-2.12.0-py312h8f0b210_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-global-2.12.0-py312h8f0b210_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.2-h43d1f9e_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5d96f70_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.6.3-h993b442_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.7-h5d932e8_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.4-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.5-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scotch-7.0.4-habe6132_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.2-hd75414b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.2.1-h089f89f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.2.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.3.0-h2f4baa9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.13.0-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.22.0-hce5310f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-cursor-0.1.4-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.41-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-fixesproto-5.0-h3557bc0_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-inputproto-2.3.2-h3557bc0_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h3557bc0_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h7935292_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-5.0.3-h3557bc0_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h3557bc0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h7935292_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-renderproto-0.11.1-h3557bc0_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h2a766a3_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-hf897c2e_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h6a62f5c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.2-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-hded75bf_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h53f4ca0_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ace-7.1.3-h73e2aa4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ace-8.0.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.2-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.3.1-h3e74f17_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-986-ha1c5b94_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.29.2-h7c85d92_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.7.0-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.4.3-hf9fe5ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.8.0-hfc4bf79_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h5b2de21_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-h98e843e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-17-17.0.6-default_hb173f14_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-17.0.6-default_he371ed4_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-17.0.6-h1af8efd_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-17.0.6-hb91bd55_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-17.0.6-default_he371ed4_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-17.0.6-hc3430b7_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-17.0.6-hb91bd55_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.30.5-h7243fc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-17.0.6-h1020d70_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-17.0.6-hf2b8a54_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.8.0-h385f146_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h71b6f88_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.3-hac325c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.2-gpl_h63732f7_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.4-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-2.80.0-h81c1438_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.80.0-h49a7eea_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-2.82.2-hbe7352d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.82.2-h8a9f880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.22.9-h3fb38fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.22.9-hf63bbb8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.3.0-hf45c392_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.11-h2d185b6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.14-h09c0c07_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.3-h6ff19ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.24.7-h0ee1d58_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.24.7-h3271b85_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h098a298_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h57e3b00_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.12-h2016aa1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.16-h43feef9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-hc01355b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-711-ha02d983_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-711-ha20a434_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-h0a3eb4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h38c89e5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-h6ebd1c4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp15-15.0.7-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-18.1.2-default_h0edc4dd_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.3-h5386a9e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.86.0-hbe88bda_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp17-17.0.6-default_hb173f14_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-19.1.2-default_h0c68bdf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.2-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-17.0.6-h8f8a49f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-hb6ef654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.11.1-default_h456cccd_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm18-18.1.2-hbcf5fad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.4-h35c211d_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-headless_py39h1cbcdfd_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.0.0-h113ac47_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.0.0-h9adb129_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.0.0-h9adb129_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.0.0-hfe2fe54_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.0.0-h113ac47_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.0.0-hfe2fe54_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.0.0-h1a3ed6a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.0.0-h1a3ed6a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.0.0-hd427752_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.0.0-h7d3639a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.0.0-hd427752_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm19-19.1.2-h1e63acb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_h8869122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.10.0-headless_py310hedf1e49_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.4.0-h7bc525e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.4.0-h904f6e8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.4.0-h904f6e8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.4.0-h364e3e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.4.0-h7bc525e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.4.0-h364e3e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.4.0-h9381666_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.4.0-h9381666_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.4.0-h4398f7a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.4.0-hd55e6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h4398f7a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-he965462_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.5-hf0c8a7f_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.4-hc2ac6e5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-h97d8b74_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.4-h365486b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.27.5-h62b0dff_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.7-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.5-h8e19eb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.49.2-hd79239c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.0-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.6.2-h694c41f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.6.2-he3629b0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-8.3.0-hfd7a639_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-8.3.0-ha9146f8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h3f0570e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h0ed339e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-h3023b02_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.7.3-h694c41f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.7.3-h3416ed2_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-9.0.1-h918ca22_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-9.0.1-h502887b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.12.1-h3c5361c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.36-h97d8b74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.106-hbde9d96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.2-py311h394b0bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h2627bef_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.1-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hb7bbaee_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-ha3d46e9_1008.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/portaudio-19.6.0-he965462_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.12.0-py312h9230928_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.12.0-py312h9230928_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-h98f5cd4_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.15-h07d6d3d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.5-ha44c9a9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/robot-testing-framework-2.0.1-hf0c8a7f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scotch-7.0.4-h52a132a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.7-hac325c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/soxr-0.1.3-hbf74d83_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.8.0-h93d8f39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/swig-4.2.1-hc959ec8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.2.1-hac325c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/swig-4.3.0-h05d4bff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-h37c8870_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml-2.6.2-h65a07b1_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/unixodbc-2.3.12-he8a5cf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-kbproto-1.0.7-h35c211d_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.7-hbd0b022_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.4-hb7f2c08_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xextproto-7.3.0-hb7f2c08_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.10-ha6c16c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.6-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xorgproto-2024.1-h00291cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py312h013081d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.2-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h7013b1f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h7a96f56_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.9-hac325c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.2-h078ce10_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.3.1-h8e95e21_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-986-h62378fb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.29.2-h50fd54c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.7.0-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4208deb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h54d7cd3_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h54d7cd3_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.30.5-hfbcbe4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-h18dbf2f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_haa72bd2_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.2-gpl_he9820c9_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.80.0-hfc324ee_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.80.0-hb9a4d99_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.2-hb1db9eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h25d4a46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.22.9-h09b4b5e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.22.9-h551c6ff_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h5bb55e9_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.11-h1059232_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.14-h6639f4a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.3-h7c0e182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_h99fbd1e_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-711-h634c8be_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-711-ha4bd21c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-hc81425b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.1-cxx17_hebf3989_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-h8e0f962_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_he012953_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-18.1.2-default_h83d0a53_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.2-default_h5f28f6d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.2-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.0-hfc324ee_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.1-default_h7685b71_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.2-h30cc82d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.4-h27ca646_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.26-openmp_h6c19121_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-headless_py312h52052b3_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.0.0-he6dadac_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.0.0-he6dadac_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.0.0-hc9f00d9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.0.0-hc9f00d9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.0.0-hf483cef_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.0.0-hf483cef_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.0.0-h298fcef_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.0.0-h298fcef_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.0.0-hebf3989_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.0.0-h356fca3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.0.0-hebf3989_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.2-haf57ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_h517c56d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312he31edb6_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-h49f535f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-h49f535f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-h8a2fcec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-h8a2fcec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h868cbb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h868cbb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-h56b1c3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-h56b1c3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h0b17760_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h13dd4ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.5-hb7217d7_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.4-hc938e73_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h5833ebf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-hfb0b52a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.27.5-h53f8970_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.7-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-h07db509_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.49.2-h7ab814d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.0-h078ce10_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.2-hcd81f8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.6.2-hce30654_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.6.2-hbbab245_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-8.3.0-hd1853d3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-8.3.0-hf036fc4_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.98-h5ce2875_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-h2c51e1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h01dff8b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h35b7655_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h15f6cfe_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h0887d5e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-he9bc4e1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.106-h6f44f80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.2-py312h801f5e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-hab01212_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.12.0-py312h0fef576_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.12.0-py312h0fef576_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-h07f8ed4_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h7d33341_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.5-h7ab814d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scotch-7.0.4-heaa5b5c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.8.0-h463b476_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.2.1-hfe15c3f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.2.1-ha39b806_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.3.0-h051d1ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-kbproto-1.0.7-h27ca646_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.7-hfd9643e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.4-h1a8c8d9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-h1a8c8d9_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312h293aecf_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.2-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-h7176fba_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312hd1b4365_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ace-7.1.3-h63175ca_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.3.1-h0dbab56_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.29.2-hf0feee3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.5-h400e5d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.3-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h9673905_705.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.0-h39d0aa6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.0-h0a98069_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.3.0-h7ab893a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.14-h1709daf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.3-h28f2b1a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-hcc118f5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.2-default_hf64faad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.2-default_ha5278ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-qt6_py312hd35d245_612.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.0.0-hc2557fa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.0.0-h002f227_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.0.0-h002f227_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.0.0-h7e3b17c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.0.0-hc2557fa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.0.0-hc2557fa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.0.0-h7e3b17c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.0.0-h55b4db4_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.0.0-h55b4db4_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.0.0-h63175ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.0.0-ha362bc9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h63175ca_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py311h5a8f696_608.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-h5707d70_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-h5707d70_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-hf4e5e90_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.5-h63175ca_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.27.5-hcaed137_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.7-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.49.2-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-h71b8b94_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/metis-5.1.0-h63175ca_1007.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.6.2-h1f49738_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.2-py312hf10105a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h9aba623_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.12.0-py312h0d7def4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.12.0-py312h0d7def4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.6.3-h5dee92f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.8.0-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.2.1-hb8d0685_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.0-h51fbe9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h0a24697_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-hcac4619_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h3ccbe7c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
 packages:
 - kind: conda
   name: _libgcc_mutex
@@ -972,142 +972,134 @@ packages:
 - kind: conda
   name: _openmp_mutex
   version: '4.5'
-  build: 2_gnu
-  build_number: 16
+  build: 2_kmp_llvm
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+  sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
+  md5: 562b26ba2e19059551a811e72ab7f793
   depends:
   - _libgcc_mutex 0.1 conda_forge
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
+  - llvm-openmp >=9.0.1
   license: BSD-3-Clause
   license_family: BSD
-  size: 23621
-  timestamp: 1650670423406
+  size: 5744
+  timestamp: 1650742457817
 - kind: conda
   name: _openmp_mutex
   version: '4.5'
-  build: 2_gnu
-  build_number: 16
+  build: 2_kmp_llvm
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
-  md5: 6168d71addc746e8f2b8d57dfd2edcea
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+  sha256: 7ef8a15d19133d82014945d3b7fd3bb4202b51c06a5522bf99e13c731f2396c3
+  md5: 98a1185182fec3c434069fa74e6473d6
   depends:
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
+  - llvm-openmp >=9.0.1
   license: BSD-3-Clause
   license_family: BSD
-  size: 23712
-  timestamp: 1650670790230
-- kind: conda
-  name: _sysroot_linux-aarch64_curr_repodata_hack
-  version: '4'
-  build: h57d6b7b_14
-  build_number: 14
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
-  sha256: edac93a8e3beb9383abf508f66085505950bc89962116ef149558350a6213749
-  md5: 18f0bdf689b6f345fecddbebaed945d6
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
-  license_family: GPL
-  size: 21238
-  timestamp: 1708000885951
+  size: 5802
+  timestamp: 1650742448370
 - kind: conda
   name: ace
-  version: 7.1.3
-  build: h59595ed_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ace-7.1.3-h59595ed_2.conda
-  sha256: ffe53a66b9a164e57b7482758f9c5f30fe11d0da72cca29e61369b34f6b216e4
-  md5: 417cf3a2ff5b3335777c31f73a42f19d
+  version: 8.0.1
+  build: h00cdb27_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
+  sha256: 48df3d15ec38ca23e09bf0f15f1852c9646c26880ca2ddec8437e196ef1d1870
+  md5: 2eb7794e38928e7a4fe8cfcf0bb52e1b
   depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: DOC
+  size: 1824080
+  timestamp: 1722623136969
+- kind: conda
+  name: ace
+  version: 8.0.1
+  build: he02047a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
+  sha256: 287025e0deee445b3e6fc849852466a153dcdceba81824536647e75d64b22017
+  md5: 8cbfcc4b8e11a401ed8400c4d0145fea
+  depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: DOC
-  size: 5472312
-  timestamp: 1707130255299
+  size: 5449099
+  timestamp: 1722622759964
 - kind: conda
   name: ace
-  version: 7.1.3
-  build: h63175ca_2
-  build_number: 2
+  version: 8.0.1
+  build: he0c23c2_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ace-7.1.3-h63175ca_2.conda
-  sha256: 263ef6e06e6cd75e5c426e19da0933192ed6ca85454ae93055c9c6431cbfd48d
-  md5: e1142f08cb44c9ed2d2b876859a61367
+  url: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
+  sha256: 7bdd85ba11690416f29200421a7b546884896c4bdff0a4f9e2fbe24292e692d6
+  md5: 0382a1b8ce5bc60a11a8510dc20c44f8
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: DOC
-  size: 2041944
-  timestamp: 1707130991728
+  size: 2005656
+  timestamp: 1722623567537
 - kind: conda
   name: ace
-  version: 7.1.3
-  build: h73e2aa4_2
-  build_number: 2
+  version: 8.0.1
+  build: hf036a51_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ace-7.1.3-h73e2aa4_2.conda
-  sha256: 0c862552e321d2be1e1ca91541ea05c0c5fa76731d9af95e9891d16717227215
-  md5: 3599788d7debc200ff2ce71a5e6c9a13
+  url: https://conda.anaconda.org/conda-forge/osx-64/ace-8.0.1-hf036a51_0.conda
+  sha256: ac3a301d5bd4dd0dbc04884f7f8dda21281ca4677a5730eefec2e0182846c4b4
+  md5: 2b5e5281bef8d92713ae911697628a8a
   depends:
+  - __osx >=10.13
   - libcxx >=16
   license: DOC
-  size: 1799511
-  timestamp: 1707130916668
+  size: 1796328
+  timestamp: 1722622941798
 - kind: conda
   name: ace
-  version: 7.1.3
-  build: h787c7f5_2
-  build_number: 2
+  version: 8.0.1
+  build: hf9b3779_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-7.1.3-h787c7f5_2.conda
-  sha256: f1e0643e5c9c9124d434138bf8e39c0ee7f9e568d46923ce22ebce8709cbee23
-  md5: 8f6b4a15696eb9d4a7e1dd1b874972c5
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
+  sha256: d60b603ac170c8907623252792ff3cfa5e75b2bff0e7378243d74527da645e7a
+  md5: c9db7894fbe35f235d75aded931010ac
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: DOC
-  size: 5364970
-  timestamp: 1707133447836
+  size: 5338955
+  timestamp: 1722626386604
 - kind: conda
   name: alsa-lib
-  version: 1.2.11
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.11-h31becfc_1.conda
-  sha256: d062bc712dd307714dfdb0f7da095a510c138c5db76321494a516ac127f9e5cf
-  md5: 76bf292a85a0556cef4f500420cabe6c
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  license_family: GPL
-  size: 584152
-  timestamp: 1709396718705
-- kind: conda
-  name: alsa-lib
-  version: 1.2.11
-  build: hd590300_1
-  build_number: 1
+  version: 1.2.12
+  build: h4ab18f5_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
-  sha256: 0e2b75b9834a6e520b13db516f7cf5c9cea8f0bbc9157c978444173dacb98fec
-  md5: 0bb492cca54017ea314b809b1ee3a176
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
+  sha256: 64b95dd06d7ca6b54cea03b02da8f1657b9899ca376d0ca7b47823064f55fb16
+  md5: 7ed427f0871fd41cb1d9c17727c17589
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
   license_family: GPL
-  size: 554699
-  timestamp: 1709396557528
+  size: 555868
+  timestamp: 1718118368236
+- kind: conda
+  name: alsa-lib
+  version: 1.2.12
+  build: h68df207_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
+  sha256: 40328d34c61f6e37873828566c9b4f704a11223a0577511226b5287803e69661
+  md5: 65448d015f05afb3c68ea92d0483a466
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  size: 585566
+  timestamp: 1718118473054
 - kind: conda
   name: ampl-mp
   version: 3.1.0
@@ -1180,176 +1172,172 @@ packages:
   timestamp: 1645057976681
 - kind: conda
   name: aom
-  version: 3.8.2
-  build: h0425590_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.2-h0425590_0.conda
-  sha256: 04458a9a9b3dd71ac201c9570948f31dedbd7b336b9c66a047e1f3c79b830de3
-  md5: 20efd6f87ac241a7d9fd551cd4e26203
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 3221283
-  timestamp: 1710388193204
-- kind: conda
-  name: aom
-  version: 3.8.2
-  build: h078ce10_0
+  version: 3.9.1
+  build: h7bae524_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.2-h078ce10_0.conda
-  sha256: d3a6cb707373a8d2d219259ad017a35c20fc3618e39c87db0d6200af0f984379
-  md5: 3c5057d1d4494caab891ed6f276c3f63
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2204439
-  timestamp: 1710388305837
-- kind: conda
-  name: aom
-  version: 3.8.2
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
-  sha256: 49b1352e2b9710b7b5400c0f2a86c0bb805091ecfc6c84d3dbf064effe33bfbf
-  md5: 625e1fed28a5139aed71b3a76117ef84
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2696998
-  timestamp: 1710388229587
-- kind: conda
-  name: aom
-  version: 3.8.2
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.2-h63175ca_0.conda
-  sha256: dd79f4e3660ab169f4e2d9bf2d9e74001dcf6dfaa8d1168373b3450af5282286
-  md5: 6691dd6833a29c95e3a16e08841a0f43
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1968537
-  timestamp: 1710388705950
-- kind: conda
-  name: aom
-  version: 3.8.2
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.2-h73e2aa4_0.conda
-  sha256: 967d05b46e0a8153c57070a94262d38ffc03378803c1faa0bad258e8635d3775
-  md5: a519a6b9f8f0e2ce1b4ee77cbc6a0a09
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2922373
-  timestamp: 1710388791338
-- kind: conda
-  name: assimp
-  version: 5.3.1
-  build: h0b8f51a_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.3.1-h0b8f51a_3.conda
-  sha256: e9b7ff8465b87c443371a03b7a9d1a070c116e77af88a06ae78cdd8e3ad03338
-  md5: 08795b10fa95adb689c448e9ccb760c0
-  depends:
-  - libboost >=1.84.0,<1.85.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3441125
-  timestamp: 1711437629441
-- kind: conda
-  name: assimp
-  version: 5.3.1
-  build: h0dbab56_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/assimp-5.3.1-h0dbab56_3.conda
-  sha256: dc52088754e17cb7ec765cd7012f8082247454ecb79fe0bdd014defe9b6a8fd6
-  md5: f4221549a429e040d715a4d946ae2e6b
-  depends:
-  - libboost >=1.84.0,<1.85.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc >=14.3,<15
-  - vc14_runtime >=14.29.30139
-  - vc14_runtime >=14.38.33130
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3038126
-  timestamp: 1711438208764
-- kind: conda
-  name: assimp
-  version: 5.3.1
-  build: h3e74f17_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.3.1-h3e74f17_3.conda
-  sha256: 0eb8dbe8b65aa503d14a734d5a1343be0b1acd753eb6116bcb568ce1b96c2484
-  md5: f0dc69293801ae8826a9f239d4f2e3ef
-  depends:
-  - __osx >=10.9
-  - libboost >=1.84.0,<1.85.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2734859
-  timestamp: 1711438376366
-- kind: conda
-  name: assimp
-  version: 5.3.1
-  build: h8343317_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.3.1-h8343317_3.conda
-  sha256: 2889e1e68d8845b3d655510bc98e9962ee286643ebc65a7c628982ce63413489
-  md5: 647d7acf33bbbeb2715261893036a5f6
-  depends:
-  - libboost >=1.84.0,<1.85.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3508729
-  timestamp: 1711437526358
-- kind: conda
-  name: assimp
-  version: 5.3.1
-  build: h8e95e21_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.3.1-h8e95e21_3.conda
-  sha256: 94650d1e8ae9cd7247fa76b3669081411f8b45c1b334142e160888ce24ff57bd
-  md5: b5bfbb08400473e2719e5d4c07eeab4a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
+  md5: 7adba36492a1bb22d98ffffe4f6fc6de
   depends:
   - __osx >=11.0
-  - libboost >=1.84.0,<1.85.0a0
   - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2235747
+  timestamp: 1718551382432
+- kind: conda
+  name: aom
+  version: 3.9.1
+  build: hac33072_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
+  md5: 346722a0be40f6edc53f12640d301338
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2706396
+  timestamp: 1718551242397
+- kind: conda
+  name: aom
+  version: 3.9.1
+  build: hcccb83c_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+  sha256: ac438ce5d3d3673a9188b535fc7cda413b479f0d52536aeeac1bd82faa656ea0
+  md5: cc744ac4efe5bcaa8cca51ff5b850df0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3250813
+  timestamp: 1718551360260
+- kind: conda
+  name: aom
+  version: 3.9.1
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+  sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
+  md5: 3d7c14285d3eb3239a76ff79063f27a5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1958151
+  timestamp: 1718551737234
+- kind: conda
+  name: aom
+  version: 3.9.1
+  build: hf036a51_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+  sha256: 3032f2f55d6eceb10d53217c2a7f43e1eac83603d91e21ce502e8179e63a75f5
+  md5: 3f17bc32cb7fcb2b4bf3d8d37f656eb8
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2749186
+  timestamp: 1718551450314
+- kind: conda
+  name: assimp
+  version: 5.4.3
+  build: h8943939_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+  sha256: c9022ee34f756847f48907472514da3395a8c0549679cfd2a1b4f6833dd6298c
+  md5: 5546062a59566def2fa6482acf531841
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   - zlib
   license: BSD-3-Clause
   license_family: BSD
-  size: 2476405
-  timestamp: 1711438303236
+  size: 3535704
+  timestamp: 1725086969417
+- kind: conda
+  name: assimp
+  version: 5.4.3
+  build: ha9c0b8d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
+  sha256: d5c348d697abbb824f12bebb8da4de960e0ca2d62350745cfc08da3b984491c4
+  md5: 4f6abafa61c3c6d3ff9a1b012fe2e9fa
+  depends:
+  - __osx >=11.0
+  - libboost >=1.86.0,<1.87.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2478543
+  timestamp: 1725087172579
+- kind: conda
+  name: assimp
+  version: 5.4.3
+  build: hdc325bc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+  sha256: e791fd005b413d1fc7aa7f84d8c83343c64b53ab02e7bd410cb1f2f61789baf9
+  md5: 553a8f53d6d599fa15dcbdd95c3c8cee
+  depends:
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3476475
+  timestamp: 1725087034438
+- kind: conda
+  name: assimp
+  version: 5.4.3
+  build: hf1e84b2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
+  sha256: b3a651af288b4ef41323d1931a3042a050935096575a75e6e0df7f4bb974903a
+  md5: af71c63135f00fd8522d5aa729996f98
+  depends:
+  - libboost >=1.86.0,<1.87.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11937899
+  timestamp: 1725087701414
+- kind: conda
+  name: assimp
+  version: 5.4.3
+  build: hf9fe5ce_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.4.3-hf9fe5ce_0.conda
+  sha256: 305e318014db5e6873bd94bfb14d675cbb209cc9b196743e73d1e0dc55df527b
+  md5: 8cc9a947c9e41d03600f8aa7eec34e42
+  depends:
+  - __osx >=10.13
+  - libboost >=1.86.0,<1.87.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2719322
+  timestamp: 1725087116119
 - kind: conda
   name: attr
   version: 2.5.1
@@ -1382,1062 +1370,1108 @@ packages:
   timestamp: 1660065534958
 - kind: conda
   name: binutils
-  version: '2.40'
-  build: h64c2a2e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-h64c2a2e_0.conda
-  sha256: 624f6e9dd9cf651d9fd6ed3a7c1af38ea60aaa3213b35f14c088d8de37ffda5e
-  md5: 50083e4c6e024fcb0b0dd195204276a3
+  version: '2.43'
+  build: h4852527_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
+  sha256: 92be0f8ccd501ceeb3c782e2182e6ea04dca46799038176de40a57bca45512c5
+  md5: 348619f90eee04901f4a70615efff35b
   depends:
-  - binutils_impl_linux-aarch64 >=2.40,<2.41.0a0
+  - binutils_impl_linux-64 >=2.43,<2.44.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 30742
-  timestamp: 1674833883570
+  size: 33876
+  timestamp: 1729655402186
 - kind: conda
   name: binutils
-  version: '2.40'
-  build: hdd6e379_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
-  sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
-  md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
+  version: '2.43'
+  build: hf1166c9_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_2.conda
+  sha256: 50962dd8b4de41c9dcd2d19f37683aff1a7c3fc01e6b1617dd250940f2b83055
+  md5: 4afcab775fe2288fce420514cd92ae37
   depends:
-  - binutils_impl_linux-64 >=2.40,<2.41.0a0
+  - binutils_impl_linux-aarch64 >=2.43,<2.44.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 30469
-  timestamp: 1674833987166
+  size: 33870
+  timestamp: 1729655405026
 - kind: conda
   name: binutils_impl_linux-64
-  version: '2.40'
-  build: hf600244_0
+  version: '2.43'
+  build: h4bf12b8_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
-  sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
-  md5: 33084421a8c0af6aef1b439707f7662a
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
+  sha256: 267e78990247369b13234bda270f31beb56a600b4851a8244e31dd9ad85b3b17
+  md5: cf0c5521ac2a20dfa6c662a4009eeef6
   depends:
-  - ld_impl_linux-64 2.40 h41732ed_0
+  - ld_impl_linux-64 2.43 h712a8e2_2
   - sysroot_linux-64
   license: GPL-3.0-only
   license_family: GPL
-  size: 5414922
-  timestamp: 1674833958334
+  size: 5682777
+  timestamp: 1729655371045
 - kind: conda
   name: binutils_impl_linux-aarch64
-  version: '2.40'
-  build: h870a726_0
+  version: '2.43'
+  build: h4c662bb_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
-  sha256: 43a69e65a7d66fe9f6f17f71814eef807c94f2bc60c7892e6658498cb3759e13
-  md5: 1945203dbddc28b0080c5129a3a704b1
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_2.conda
+  sha256: 0bb8058bdb662e085f844f803a98e89314268c3e7aa79d495529992a8f41ecf1
+  md5: 2eb09e329ee7030a4cab0269eeea97d4
   depends:
-  - ld_impl_linux-aarch64 2.40 h2d8c526_0
+  - ld_impl_linux-aarch64 2.43 h80caac9_2
   - sysroot_linux-aarch64
   license: GPL-3.0-only
   license_family: GPL
-  size: 5535072
-  timestamp: 1674833858298
+  size: 6722685
+  timestamp: 1729655379343
 - kind: conda
   name: binutils_linux-64
-  version: '2.40'
-  build: hdade7a5_3
-  build_number: 3
+  version: '2.43'
+  build: h4852527_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
-  sha256: d114b825acef51c1d065ca0a17f97e0e856c48765aecf2f8f164935635013dd2
-  md5: 2d9a60578bc28469d9aeef9aea5520c3
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
+  sha256: df52bd8b8b2a20a0c529d9ad08aaf66093ac318aa8a33d270f18274341a77062
+  md5: 18aba879ddf1f8f28145ca6fcb873d8c
   depends:
-  - binutils_impl_linux-64 2.40.*
-  - sysroot_linux-64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28868
-  timestamp: 1710259805994
+  - binutils_impl_linux-64 2.43 h4bf12b8_2
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 34945
+  timestamp: 1729655404893
 - kind: conda
   name: binutils_linux-aarch64
-  version: '2.40'
-  build: h95d2017_3
-  build_number: 3
+  version: '2.43'
+  build: hf1166c9_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h95d2017_3.conda
-  sha256: cd839ad41a573ebd84552b9ed946ea99ae48f8a07f4e38b8725022ff881f767c
-  md5: 561a4c45334781c962db079457e6f0f0
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_2.conda
+  sha256: 97fe7c2023fdbef453a2a05d53d81037a7e18c4b3946dd68a7ea122747e7d1fa
+  md5: 5c308468fe391f32dc3bb57a4b4622aa
   depends:
-  - binutils_impl_linux-aarch64 2.40.*
-  - sysroot_linux-aarch64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28888
-  timestamp: 1710259827989
+  - binutils_impl_linux-aarch64 2.43 h4c662bb_2
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 34879
+  timestamp: 1729655407691
 - kind: conda
   name: bzip2
   version: 1.0.8
-  build: h10d778d_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
-  sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
-  md5: 6097a6ca9ada32699b5fc4312dd6ef18
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 127885
-  timestamp: 1699280178474
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h31becfc_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
-  sha256: b9f170990625cb1eeefaca02e091dc009a64264b077166d8ed7aeb7a09e923b0
-  md5: a64e35f01e0b7a2a152eca87d33b9c87
-  depends:
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 189668
-  timestamp: 1699280060686
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h93a5062_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
-  sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
-  md5: 1bbc659ca658bfd49a481b5ef7a0f40f
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 122325
-  timestamp: 1699280294368
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: hcfcfb64_5
-  build_number: 5
+  build: h2466b09_7
+  build_number: 7
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
-  sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
-  md5: 26eb8ca6ea332b675e11704cce84a3be
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: bzip2-1.0.6
   license_family: BSD
-  size: 124580
-  timestamp: 1699280668742
+  size: 54927
+  timestamp: 1720974860185
 - kind: conda
   name: bzip2
   version: 1.0.8
-  build: hd590300_5
-  build_number: 5
+  build: h4bc722e_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-  sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
-  md5: 69b8b6202a07720f448be700e300ccf4
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h68df207_7
+  build_number: 7
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+  sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
+  md5: 56398c28220513b9ea13d7b450acfb20
   depends:
   - libgcc-ng >=12
   license: bzip2-1.0.6
   license_family: BSD
-  size: 254228
-  timestamp: 1699279927352
+  size: 189884
+  timestamp: 1720974504976
 - kind: conda
-  name: c-ares
-  version: 1.28.1
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
-  sha256: fccd7ad7e3dfa6b19352705b33eb738c4c55f79f398e106e6cf03bab9415595a
-  md5: d5eb7992227254c0e9a0ce71151f0079
-  license: MIT
-  license_family: MIT
-  size: 152607
-  timestamp: 1711819681694
-- kind: conda
-  name: c-ares
-  version: 1.28.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.28.1-h31becfc_0.conda
-  sha256: 0d7b310411f069975053ee5ce750fc6d8c368607164ce2a921a7a1a068dc137b
-  md5: a8da75795c853c5fe6d8d1947e16eea8
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 176103
-  timestamp: 1711819570996
-- kind: conda
-  name: c-ares
-  version: 1.28.1
-  build: h93a5062_0
+  name: bzip2
+  version: 1.0.8
+  build: h99b78c6_7
+  build_number: 7
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
-  sha256: 2fc553d7a75e912efbdd6b82cd7916cc9cb2773e6cd873b77e02d631dd7be698
-  md5: 04f776a6139f7eafc2f38668570eb7db
-  license: MIT
-  license_family: MIT
-  size: 150488
-  timestamp: 1711819630164
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: hfdf4475_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
 - kind: conda
   name: c-ares
-  version: 1.28.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
-  sha256: cb25063f3342149c7924b21544109696197a9d774f1407567477d4f3026bf38a
-  md5: dcde58ff9a1f30b0037a2315d1846d1f
+  version: 1.34.2
+  build: h32b1619_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
+  sha256: 972d0403c92c9cd1d1c60e34d80991258125ee880cf5a9289ae83a443d8970cd
+  md5: 724edfea6dde646c1faf2ce1423e0faa
   depends:
-  - libgcc-ng >=12
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 168875
-  timestamp: 1711819445938
+  size: 182342
+  timestamp: 1729006698430
 - kind: conda
-  name: c-compiler
-  version: 1.7.0
-  build: h282daa2_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_0.conda
-  sha256: c32fdb29dac5e1a01aa486aba1f7b21cff5c1c7748c0cf9b6c9475888b61eb17
-  md5: 4652f33fe8d895f61177e2783b289377
+  name: c-ares
+  version: 1.34.2
+  build: h7ab814d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
+  sha256: 24d53d27397f9c2f0c168992690b5ec1bd62593fb4fc1f1e906ab91b10fd06c3
+  md5: 8a8cfc11064b521bc54bd2d8591cb137
   depends:
-  - cctools >=949.0.1
-  - clang_osx-64 16.*
-  - ld64 >=530
-  - llvm-openmp
-  license: BSD
-  size: 6409
-  timestamp: 1701505468495
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 177487
+  timestamp: 1729006763496
+- kind: conda
+  name: c-ares
+  version: 1.34.2
+  build: ha64f414_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
+  sha256: 06f67e6b2c18f1ff79391ffb032c752fcbbf754f6f6e7a786edde6cca1c92791
+  md5: 588af5337614cece17e61b6ac907f812
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 214916
+  timestamp: 1729006632022
+- kind: conda
+  name: c-ares
+  version: 1.34.2
+  build: heb4867d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+  sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
+  md5: 2b780c0338fc0ffa678ac82c54af51fd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 205797
+  timestamp: 1729006575652
 - kind: conda
   name: c-compiler
-  version: 1.7.0
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_0.conda
-  sha256: d669377ff234838216e3bbd32b46872fe6f19c40c9477c8119305d2204168829
-  md5: 4df75f282f5841cc6dc6126a6d281268
+  version: 1.8.0
+  build: h2b85faf_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
+  sha256: 009fced27be14e5ac750a04111a07eda79d73f80009300c1538cb83d5da71879
+  md5: fa7b3bf2965b9d74a81a0702d9bb49ee
   depends:
   - binutils
   - gcc
-  - gcc_linux-aarch64 12.*
-  license: BSD
-  size: 6282
-  timestamp: 1701505282730
+  - gcc_linux-64 13.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6085
+  timestamp: 1728985300402
 - kind: conda
   name: c-compiler
-  version: 1.7.0
-  build: h6aa9301_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_0.conda
-  sha256: 1d5992140eef7c4df1a479767f8430367c2b856627dc6f84e2f6fc62d919bc37
-  md5: 1d3e1f0096f791944c07a9ca5e0a92c5
+  version: 1.8.0
+  build: h6561dab_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.8.0-h6561dab_1.conda
+  sha256: f1b894a87a9bd8446de2ebd1820cc965e1fe2d5462e8c7df43a0b108732597a2
+  md5: 715a2eea9897fb01de5dd6ba82728935
   depends:
-  - cctools >=949.0.1
-  - clang_osx-arm64 16.*
-  - ld64 >=530
-  - llvm-openmp
-  license: BSD
-  size: 6422
-  timestamp: 1701505466835
+  - binutils
+  - gcc
+  - gcc_linux-aarch64 13.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6190
+  timestamp: 1728985292548
 - kind: conda
   name: c-compiler
-  version: 1.7.0
-  build: hcfcfb64_0
+  version: 1.8.0
+  build: hcfcfb64_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_0.conda
-  sha256: 8abfef37bfebf05b5412dabb7908c7b07263b373c37442ebec13cfb7eddd0e08
-  md5: 32d42233276c87fc1b774a3f17014611
+  url: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_1.conda
+  sha256: 3fc7b2ceb03cc024e5f91f70fb576da71ff9cec787f3c481f3372d311ecc04f3
+  md5: 33c106164044a19c4e8d13277ae97c3f
   depends:
   - vs2019_win-64
-  license: BSD
-  size: 6493
-  timestamp: 1701505478619
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6513
+  timestamp: 1728985389589
 - kind: conda
   name: c-compiler
-  version: 1.7.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_0.conda
-  sha256: 19343f6cdefd0a2e36c4f0da81ed9ea964e5b4e82a2304809afd8f151bf2ac8c
-  md5: fad1d0a651bf929c6c16fbf1f6ccfa7c
+  version: 1.8.0
+  build: hf48404e_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
+  sha256: 64245f90755c314f61d48b38fc7b82270b709f88204789895f7c4b2b84204992
+  md5: 429476dcb80c4f9087cd8ac1fa2183d1
   depends:
-  - binutils
-  - gcc
-  - gcc_linux-64 12.*
-  license: BSD
-  size: 6287
-  timestamp: 1701505302633
+  - cctools >=949.0.1
+  - clang_osx-arm64 17.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6220
+  timestamp: 1728985386241
+- kind: conda
+  name: c-compiler
+  version: 1.8.0
+  build: hfc4bf79_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.8.0-hfc4bf79_1.conda
+  sha256: b5bff50c0792933c19bdf4c18b77c5aedabce4b01f86d3b68815534f3e9e3640
+  md5: d6e3cf55128335736c8d4bb86e73c191
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-64 17.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6210
+  timestamp: 1728985474611
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.8.30
   build: h56e8100_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-  sha256: 4d587088ecccd393fec3420b64f1af4ee1a0e6897a45cfd5ef38055322cea5d0
-  md5: 63da060240ab8087b60d1357051ea7d6
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
   license: ISC
-  size: 155886
-  timestamp: 1706843918052
+  size: 158773
+  timestamp: 1725019107649
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.8.30
   build: h8857fd0_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
-  sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
-  md5: f2eacee8c33c43692f1ccfd33d0f50b1
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
   license: ISC
-  size: 155665
-  timestamp: 1706843838227
+  size: 158665
+  timestamp: 1725019059295
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.8.30
   build: hbcca054_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
-  sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
-  md5: 2f4327a1cbe7f022401b236e915a5fef
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
   license: ISC
-  size: 155432
-  timestamp: 1706843687645
+  size: 159003
+  timestamp: 1725018903918
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.8.30
   build: hcefe29a_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
-  sha256: 0f6b34d835e26e5fa97cca4985dc46f0aba551a3a23f07c6f13cca2542b8c642
-  md5: 57c226edb90c4e973b9b7503537dd339
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
+  sha256: 2a2d827bee3775a85f0f1b2f2089291475c4416336d1b3a8cbce2964db547af8
+  md5: 70e57e8f59d2c98f86b49c69e5074be5
   license: ISC
-  size: 155738
-  timestamp: 1706845723412
+  size: 159106
+  timestamp: 1725020043153
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.8.30
   build: hf0a4a13_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
-  sha256: 49bc3439816ac72d0c0e0f144b8cc870fdcc4adec2e861407ec818d8116b2204
-  md5: fb416a1795f18dcc5a038bc2dc54edf9
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
   license: ISC
-  size: 155725
-  timestamp: 1706844034242
+  size: 158482
+  timestamp: 1725019034582
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: h1fef639_0
+  build: h32b962e_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
-  sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
-  md5: b3fe2c6381ec74afe8128e16a11eee02
+  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
+  md5: 8f43723a4925c51e55c2d81725a97db4
   depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zlib
   license: LGPL-2.1-only or MPL-1.1
-  size: 1520159
-  timestamp: 1697029136038
+  size: 1516680
+  timestamp: 1721139332360
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: h3faef2a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
-  sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
-  md5: f907bb958910dc404647326ca80c263e
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  size: 982351
-  timestamp: 1697028423052
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: h99e66fa_0
+  build: h37bd5c4_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
-  sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
-  md5: 13f830b1bf46018f7062d1b798d53eca
+  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+  sha256: 8d70fbca4887b9b580de0f3715026e05f9e74fad8a652364aa0bccd795b1fa87
+  md5: 448aad56614db52338dc4fd4c758cfb6
   depends:
-  - __osx >=10.9
+  - __osx >=10.13
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
-  - libcxx >=16.0.6
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
-  size: 885311
-  timestamp: 1697028802967
+  size: 892544
+  timestamp: 1721139116538
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: ha13f110_0
+  build: hb4a6bf7_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+  sha256: f7603b7f6ee7c6e07c23d77302420194f4ec1b8e8facfff2b6aab17c7988a102
+  md5: 08bd0752f3de8a2d8a35fd012f09531f
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 899126
+  timestamp: 1721139203735
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: hdb1a16f_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
-  sha256: 79b6323661b535d90aaec0eac0e91ccda88cc5917d9e597a03d7de183bc22f26
-  md5: 425111f8cc6945c5d1307357dd819b9b
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
+  sha256: 8a747ad6ce32228a85c80bef8ec7387d71f8d2b0bf637edb56ff33e09794c616
+  md5: 080659f02bf2202c57f1cda4f9e51f21
   depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
+  - icu >=75.1,<76.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
   - xorg-libice >=1.1.1,<2.0a0
   - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
-  size: 983779
-  timestamp: 1697028424329
+  size: 966709
+  timestamp: 1721138947987
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: hd1e100b_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
-  sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
-  md5: 3fa6eebabb77f65e82f86b72b95482db
+  build: hebfffa5_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+  sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
+  md5: fceaedf1cdbcb02df9699a0d9b005292
   depends:
-  - __osx >=10.9
+  - __glibc >=2.17,<3.0.a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
-  - libcxx >=16.0.6
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
-  size: 897919
-  timestamp: 1697028755150
+  size: 983604
+  timestamp: 1721138900054
 - kind: conda
   name: cctools
-  version: '986'
-  build: h40f6528_0
+  version: '1010.6'
+  build: h5b2de21_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_0.conda
-  sha256: 4eac1d10ddafb1dc277ddff304a7d314607c7dc99d7a77d69ed75f8fcbdf93d4
-  md5: b7a2ca0062a6ee8bc4e83ec887bef942
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h5b2de21_1.conda
+  sha256: 3881b38dcb1e6a129617a270396e85a65b4202cf5e02a2d133caaff8643ae489
+  md5: 5a08ae55869b0b1eb7fbee910aa30d19
   depends:
-  - cctools_osx-64 986 ha1c5b94_0
-  - ld64 711 ha02d983_0
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - cctools_osx-64 1010.6 h98e843e_1
+  - ld64 951.9 h0a3eb4e_1
+  - libllvm17 >=17.0.6,<17.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 21663
-  timestamp: 1710466476542
+  size: 21528
+  timestamp: 1726771688744
 - kind: conda
   name: cctools
-  version: '986'
-  build: h4faf515_0
+  version: '1010.6'
+  build: hf67d63f_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_0.conda
-  sha256: 505471dfa37dc42ba1a2c4cf65d4c4abe4c36164c8fcb0a375e3c4f3550ab3ee
-  md5: d81c4480e8445b13129024191231e6c5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_1.conda
+  sha256: b85469a1277da76dbbc71639b03014143cec96fe2e86dc11b1c3e299b9d29e2f
+  md5: f9138a6ffe696dadea9374101856747b
   depends:
-  - cctools_osx-arm64 986 h62378fb_0
-  - ld64 711 h634c8be_0
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - cctools_osx-arm64 1010.6 h4208deb_1
+  - ld64 951.9 h39a299f_1
+  - libllvm17 >=17.0.6,<17.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 21683
-  timestamp: 1710466813384
+  size: 21681
+  timestamp: 1726771723258
 - kind: conda
   name: cctools_osx-64
-  version: '986'
-  build: ha1c5b94_0
+  version: '1010.6'
+  build: h98e843e_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-986-ha1c5b94_0.conda
-  sha256: 16ef6a8dd367d7d4d7b3446f73ed95b07603d6b5b3256c3acab9b3a9006ef7eb
-  md5: a8951de2506df5649f5a3295fdfd9f2c
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-h98e843e_1.conda
+  sha256: e28e55f55af27b66fbf4afc45f521f9a869e4495bd260c7c721dd2ac51e017a1
+  md5: ed757b98aaa22a9e38c5a76191fb477c
   depends:
-  - ld64_osx-64 >=711,<712.0a0
+  - __osx >=10.13
+  - ld64_osx-64 >=951.9,<951.10.0a0
   - libcxx
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 17.0.*
   - sigtool
   constrains:
-  - ld64 711.*
-  - cctools 986.*
-  - clang 16.0.*
+  - ld64 951.9.*
+  - cctools 1010.6.*
+  - clang 17.0.*
   license: APSL-2.0
   license_family: Other
-  size: 1118961
-  timestamp: 1710466421642
+  size: 1096895
+  timestamp: 1726771657226
 - kind: conda
   name: cctools_osx-arm64
-  version: '986'
-  build: h62378fb_0
+  version: '1010.6'
+  build: h4208deb_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-986-h62378fb_0.conda
-  sha256: 35907653456fdd854b426060980025689670784c677e2bbecd2fcaf983cfa37c
-  md5: cb85035a5eceb3a0d3becc1026dbb31d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4208deb_1.conda
+  sha256: 7122430e69ab8e38d382553bf7225b0887158341fe6879be4220e4e495b93aac
+  md5: bca79601bdb3a3dfa4c3917701a79f81
   depends:
-  - ld64_osx-arm64 >=711,<712.0a0
+  - __osx >=11.0
+  - ld64_osx-arm64 >=951.9,<951.10.0a0
   - libcxx
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 17.0.*
   - sigtool
   constrains:
-  - clang 16.0.*
-  - ld64 711.*
-  - cctools 986.*
+  - clang 17.0.*
+  - cctools 1010.6.*
+  - ld64 951.9.*
   license: APSL-2.0
   license_family: Other
-  size: 1127544
-  timestamp: 1710466751857
+  size: 1089821
+  timestamp: 1726771687683
 - kind: conda
   name: clang
-  version: 16.0.6
-  build: h30cc82d_6
-  build_number: 6
+  version: 17.0.6
+  build: default_h360f5da_7
+  build_number: 7
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_6.conda
-  sha256: 7002fd391945934f6679863de5e22bd1cd329c626511355d943b83b1860162c3
-  md5: 7b09b50fbcd7e154e45e05cf2f81d7f7
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
+  sha256: 3caeb933e74561c834074ef1617aa721c10e6b08c1fed9d5180c82a9ba18b5f2
+  md5: c98bdbd4985530fac68ea4831d053ba1
   depends:
-  - clang-16 16.0.6 default_he012953_6
-  constrains:
-  - clang-tools 16.0.6.*
-  - llvm 16.0.6.*
-  - llvm-tools 16.0.6.*
-  - llvmdev 16.0.6.*
+  - clang-17 17.0.6 default_h146c034_7
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21987
-  timestamp: 1711067164939
+  size: 24105
+  timestamp: 1725505775351
 - kind: conda
   name: clang
-  version: 16.0.6
-  build: hdae98eb_6
-  build_number: 6
+  version: 17.0.6
+  build: default_he371ed4_7
+  build_number: 7
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_6.conda
-  sha256: 71d2fa8174aedf549313fccf6fbc63ef08fdc898891ffba56dd376226649fa13
-  md5: 884e7b24306e4f21b7ee08dabadb2ecc
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-17.0.6-default_he371ed4_7.conda
+  sha256: 0bcc3fa29482ac32847bd5baac89563e285978fdc3f9d0c5d0844d647ecba821
+  md5: fd6888f26c44ddb10c9954a2df5765c7
   depends:
-  - clang-16 16.0.6 default_h7151d67_6
-  constrains:
-  - clang-tools 16.0.6.*
-  - llvm 16.0.6.*
-  - llvm-tools 16.0.6.*
-  - llvmdev 16.0.6.*
+  - clang-17 17.0.6 default_hb173f14_7
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21919
-  timestamp: 1711067981416
+  size: 23890
+  timestamp: 1725506037908
 - kind: conda
-  name: clang-16
-  version: 16.0.6
-  build: default_h7151d67_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_6.conda
-  sha256: 5a8dcab3b23552c6e93967ecc7e13c0e40c3f8e96ba26a4d942fa528ed5b449e
-  md5: 1c298568c30efe7d9369c7c15b748461
-  depends:
-  - libclang-cpp16 16.0.6 default_h7151d67_6
-  - libcxx >=16.0.6
-  - libllvm16 >=16.0.6,<16.1.0a0
-  constrains:
-  - clang-tools 16.0.6
-  - clangxx 16.0.6
-  - llvm-tools 16.0.6
-  - clangdev 16.0.6
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 694124
-  timestamp: 1711067822905
-- kind: conda
-  name: clang-16
-  version: 16.0.6
-  build: default_he012953_6
-  build_number: 6
+  name: clang-17
+  version: 17.0.6
+  build: default_h146c034_7
+  build_number: 7
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_6.conda
-  sha256: 7742b35001e7d81534a3ed63ce55da12998d1037d5ad594cf478d9fbabec8f7e
-  md5: 87c53ef6d2f5fe1427a9ef448dff1d09
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
+  sha256: f9e40e5402ab78543553e7bc0437dfeed42d43f486395b66dd55ea0fd819b789
+  md5: 585064b6856cb3e719343e3362ea828b
   depends:
-  - libclang-cpp16 16.0.6 default_he012953_6
-  - libcxx >=16.0.6
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - __osx >=11.0
+  - libclang-cpp17 17.0.6 default_h146c034_7
+  - libcxx >=17.0.6
+  - libllvm17 >=17.0.6,<17.1.0a0
   constrains:
-  - clangdev 16.0.6
-  - llvm-tools 16.0.6
-  - clang-tools 16.0.6
-  - clangxx 16.0.6
+  - clangxx 17.0.6
+  - clang-tools 17.0.6
+  - clangdev 17.0.6
+  - llvm-tools 17.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 693018
-  timestamp: 1711067020001
+  size: 715930
+  timestamp: 1725505694198
+- kind: conda
+  name: clang-17
+  version: 17.0.6
+  build: default_hb173f14_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-17-17.0.6-default_hb173f14_7.conda
+  sha256: 95cb7cc541e45757b2cc586b1db6fb2f27796316723fe07c8c225f7ea12f6c9b
+  md5: 809e36447b1bfb87ed1b7fb46339561a
+  depends:
+  - __osx >=10.13
+  - libclang-cpp17 17.0.6 default_hb173f14_7
+  - libcxx >=17.0.6
+  - libllvm17 >=17.0.6,<17.1.0a0
+  constrains:
+  - llvm-tools 17.0.6
+  - clangxx 17.0.6
+  - clang-tools 17.0.6
+  - clangdev 17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 719083
+  timestamp: 1725505951220
 - kind: conda
   name: clang_impl_osx-64
-  version: 16.0.6
-  build: h8787910_11
-  build_number: 11
+  version: 17.0.6
+  build: h1af8efd_21
+  build_number: 21
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_11.conda
-  sha256: 2174b2a01fb60da87b383405100bb6d5eac54fb8e84d2ce5f6a0488627c055fc
-  md5: ed9c90270c77481fc4cfccd0891d62a8
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-17.0.6-h1af8efd_21.conda
+  sha256: 739050856565443f5568370f9a0a28f803579eb5dbee635c65b83056e52e42c9
+  md5: 6ef491cbc462aae64eaa0213e7ae6222
   depends:
   - cctools_osx-64
-  - clang 16.0.6.*
-  - compiler-rt 16.0.6.*
+  - clang 17.0.6.*
+  - compiler-rt 17.0.6.*
   - ld64_osx-64
-  - llvm-tools 16.0.6.*
+  - llvm-tools 17.0.6.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 17384
-  timestamp: 1711079620447
+  size: 17526
+  timestamp: 1728550487882
 - kind: conda
   name: clang_impl_osx-arm64
-  version: 16.0.6
-  build: hc421ffc_11
-  build_number: 11
+  version: 17.0.6
+  build: he47c785_21
+  build_number: 21
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_11.conda
-  sha256: b414939c7cdd4575429db2678651b370348561417162dd2dd1570d7afeac267e
-  md5: c211c6998c1d79131a82455abc70c0f7
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_21.conda
+  sha256: e3e2038b22b425f4fd4bae6d50c15be1a6da2075c3ff5072c7f98bff14072b4a
+  md5: 2417a85d8d37df3df2bd37b6ae0514aa
   depends:
   - cctools_osx-arm64
-  - clang 16.0.6.*
-  - compiler-rt 16.0.6.*
+  - clang 17.0.6.*
+  - compiler-rt 17.0.6.*
   - ld64_osx-arm64
-  - llvm-tools 16.0.6.*
+  - llvm-tools 17.0.6.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 17559
-  timestamp: 1711079687149
+  size: 17585
+  timestamp: 1728550578755
 - kind: conda
   name: clang_osx-64
-  version: 16.0.6
-  build: hb91bd55_11
-  build_number: 11
+  version: 17.0.6
+  build: hb91bd55_21
+  build_number: 21
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_11.conda
-  sha256: 86b4928261c21546b9bae5a58975a5ade6256be0aacd8d0f7a3126150bad3967
-  md5: 24123b15e9c0dad9c0d5fd9da0b4c7a9
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-17.0.6-hb91bd55_21.conda
+  sha256: 446ff91c60c6266e4e5bcaab20377116ef59e1e3b712da7aa37faad644ae8065
+  md5: d94a0f2c03e7a50203d2b78d7dd9fa25
   depends:
-  - clang_impl_osx-64 16.0.6 h8787910_11
+  - clang_impl_osx-64 17.0.6 h1af8efd_21
   license: BSD-3-Clause
   license_family: BSD
-  size: 20419
-  timestamp: 1711079628326
+  size: 20624
+  timestamp: 1728550493227
 - kind: conda
   name: clang_osx-arm64
-  version: 16.0.6
-  build: h54d7cd3_11
-  build_number: 11
+  version: 17.0.6
+  build: h54d7cd3_21
+  build_number: 21
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_11.conda
-  sha256: e5b2f86b89fd0b84fbf9d8eac628110d32fcd6cda0b5858f697033ffd67bdce8
-  md5: df62131bebfb7d6d086610373926aeb4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h54d7cd3_21.conda
+  sha256: f71a0285bba6695a3d1693563d43b4b3f31f611dccf2b8c3be2a480cf1da2b7a
+  md5: 83a80f491ac81d81f28cb9a46d3f5439
   depends:
-  - clang_impl_osx-arm64 16.0.6 hc421ffc_11
+  - clang_impl_osx-arm64 17.0.6 he47c785_21
   license: BSD-3-Clause
   license_family: BSD
-  size: 20564
-  timestamp: 1711079695189
+  size: 20608
+  timestamp: 1728550586726
 - kind: conda
   name: clangxx
-  version: 16.0.6
-  build: default_h4cf2255_6
-  build_number: 6
+  version: 17.0.6
+  build: default_h360f5da_7
+  build_number: 7
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_6.conda
-  sha256: e0d5a68e361853221257d2842d431c45e61d0e41597087f7f311b4fc5fe13fa5
-  md5: 2c724daf018dc99394fdbb43d93bb23c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
+  sha256: 73a87fe4a31494cdc5d74aacf9d08f560e4468795547f06290ee6a7bb128f61c
+  md5: 0bb5cea65ab3457812707537603a3619
   depends:
-  - clang 16.0.6 h30cc82d_6
+  - clang 17.0.6 default_h360f5da_7
+  - libcxx-devel 17.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 22080
-  timestamp: 1711067198960
+  size: 24168
+  timestamp: 1725505786435
 - kind: conda
   name: clangxx
-  version: 16.0.6
-  build: default_h7151d67_6
-  build_number: 6
+  version: 17.0.6
+  build: default_he371ed4_7
+  build_number: 7
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_6.conda
-  sha256: 422e471cb572b977c7ff3aec6c89fc6af365c5e5a4e29feaa780519c9a20e84d
-  md5: cc8c007a529a7cfaa5d29d8599df3fe6
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-17.0.6-default_he371ed4_7.conda
+  sha256: 8f7e1d2759b5bd33577054cd72631dc7a4154e7a2b92880040b37c5be0a38255
+  md5: 4f110486af1272f0d4dee6adc5041fbf
   depends:
-  - clang 16.0.6 hdae98eb_6
+  - clang 17.0.6 default_he371ed4_7
+  - libcxx-devel 17.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 22112
-  timestamp: 1711068021002
+  size: 23975
+  timestamp: 1725506051851
 - kind: conda
   name: clangxx_impl_osx-64
-  version: 16.0.6
-  build: h6d92fbe_11
-  build_number: 11
+  version: 17.0.6
+  build: hc3430b7_21
+  build_number: 21
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_11.conda
-  sha256: 944d9cb8052eefec3182380454bf8a3f1b2a93c5ea992f8681ef45e975492983
-  md5: a658c595675bde00373347b22a974810
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-17.0.6-hc3430b7_21.conda
+  sha256: 68bfcd5f17945497582cb91a44737a94a2600a0dab7f0ef6c9118e1d5fb089de
+  md5: 9dbdec57445cac0f0c39aefe3d3900bc
   depends:
-  - clang_osx-64 16.0.6 hb91bd55_11
-  - clangxx 16.0.6.*
-  - libcxx >=16
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - clang_osx-64 17.0.6 hb91bd55_21
+  - clangxx 17.0.6.*
+  - libcxx >=17
+  - libllvm17 >=17.0.6,<17.1.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 17481
-  timestamp: 1711079694850
+  size: 17588
+  timestamp: 1728550507978
 - kind: conda
   name: clangxx_impl_osx-arm64
-  version: 16.0.6
-  build: hcd7bac0_11
-  build_number: 11
+  version: 17.0.6
+  build: h50f59cd_21
+  build_number: 21
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_11.conda
-  sha256: 8c34bfd000ead5989535ce60b01471e1c008915fd12f23c364b9665a84d5c160
-  md5: 3dbd1a1276d73e09de7f0f047a8a661b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_21.conda
+  sha256: bfdf0b768b36694707fab931ccbe9971bd1b9a258c0806c62596d5c93167e972
+  md5: a78eb1ab3aad5251ff9c6da5a99d59be
   depends:
-  - clang_osx-arm64 16.0.6 h54d7cd3_11
-  - clangxx 16.0.6.*
-  - libcxx >=16
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - clang_osx-arm64 17.0.6 h54d7cd3_21
+  - clangxx 17.0.6.*
+  - libcxx >=17
+  - libllvm17 >=17.0.6,<17.1.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 17670
-  timestamp: 1711079761701
+  size: 17648
+  timestamp: 1728550606508
 - kind: conda
   name: clangxx_osx-64
-  version: 16.0.6
-  build: hb91bd55_11
-  build_number: 11
+  version: 17.0.6
+  build: hb91bd55_21
+  build_number: 21
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_11.conda
-  sha256: 664e769eecf1d07d07729f4902ef07f2f5b11bc033adfd84637ce9742f3267a1
-  md5: e49aad30263abdcb785e610981b7c2c7
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-17.0.6-hb91bd55_21.conda
+  sha256: 780cd56526c835bb5ca867939b3a8613af4ea67c9c37cc952bfaad438974b098
+  md5: cfcbb6790123280b5be7992d392e8194
   depends:
-  - clang_osx-64 16.0.6 hb91bd55_11
-  - clangxx_impl_osx-64 16.0.6 h6d92fbe_11
+  - clang_osx-64 17.0.6 hb91bd55_21
+  - clangxx_impl_osx-64 17.0.6 hc3430b7_21
   license: BSD-3-Clause
   license_family: BSD
-  size: 19169
-  timestamp: 1711079704320
+  size: 19261
+  timestamp: 1728550514642
 - kind: conda
   name: clangxx_osx-arm64
-  version: 16.0.6
-  build: h54d7cd3_11
-  build_number: 11
+  version: 17.0.6
+  build: h54d7cd3_21
+  build_number: 21
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_11.conda
-  sha256: b3b96d2f7edde88548c29514fef327e7f72e2497d07d649e079ac1ecaa0511dc
-  md5: 6ec1b04f1f9a907794d3b42f326343f1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h54d7cd3_21.conda
+  sha256: 02bc5ed5f37a6e3d4e244d09e4e5db7bfc9ad2b7342f14a68f2b971511b7afc7
+  md5: 594c1db6262e284e928c9d4f28dc8846
   depends:
-  - clang_osx-arm64 16.0.6 h54d7cd3_11
-  - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_11
+  - clang_osx-arm64 17.0.6 h54d7cd3_21
+  - clangxx_impl_osx-arm64 17.0.6 h50f59cd_21
   license: BSD-3-Clause
   license_family: BSD
-  size: 19268
-  timestamp: 1711079770802
+  size: 19257
+  timestamp: 1728550613321
 - kind: conda
   name: cmake
-  version: 3.29.2
-  build: h50fd54c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.29.2-h50fd54c_0.conda
-  sha256: 0afaad91b7904eef0dd290a336c80b282aec587a282531eb957d62c627e90892
-  md5: 502bac755e3ac970ccb810562a2db195
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.7.1,<9.0a0
-  - libcxx >=16
-  - libexpat >=2.6.2,<3.0a0
-  - libuv >=1.48.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15705651
-  timestamp: 1712874999888
-- kind: conda
-  name: cmake
-  version: 3.29.2
-  build: h7c85d92_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.29.2-h7c85d92_0.conda
-  sha256: edaa39e26ef7c7ebb6490a7582b912f261b667b37430be4408723927c94d70d4
-  md5: 3275d174bef409a613c3b7fbcda4c298
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.7.1,<9.0a0
-  - libcxx >=16
-  - libexpat >=2.6.2,<3.0a0
-  - libuv >=1.48.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 16875463
-  timestamp: 1712875334643
-- kind: conda
-  name: cmake
-  version: 3.29.2
-  build: hcfe8598_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.29.2-hcfe8598_0.conda
-  sha256: a5de599a96b090fdad9041aa0fdc8ef546b2e36200edb72324e349d4ae01365e
-  md5: 7b7ea31d312b491b814f4e7f67de7886
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.7.1,<9.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libuv >=1.48.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18993196
-  timestamp: 1712872720090
-- kind: conda
-  name: cmake
-  version: 3.29.2
-  build: hef020d8_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.29.2-hef020d8_0.conda
-  sha256: 0d74cd82d7c2bb0b3af446aa033127250747fd184ae9d1143779f9c64e7b05a5
-  md5: 9a5f90575faf65988e4d6423307d34bf
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.7.1,<9.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libuv >=1.48.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18303315
-  timestamp: 1712872672452
-- kind: conda
-  name: cmake
-  version: 3.29.2
-  build: hf0feee3_0
+  version: 3.30.5
+  build: h400e5d1_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.29.2-hf0feee3_0.conda
-  sha256: 0db2c09d86be20bbe4746582efb8b53b4f4cefb8effc11f90152f4ffd7c16d3a
-  md5: 6f314f81b0265c79e2c7effae0e42fa0
+  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.5-h400e5d1_0.conda
+  sha256: f1df2ab533ffed1a544ab0672bd09abeaee36cadf59c12f8564b03237779b3d3
+  md5: 4b84d88fe13e33dd1cad2deaac3fbcf4
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.7.1,<9.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libuv >=1.48.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 14085009
-  timestamp: 1712873626985
+  size: 14357142
+  timestamp: 1728417628536
 - kind: conda
-  name: compiler-rt
-  version: 16.0.6
-  build: h3808999_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
-  sha256: 67f6883f37ea720f97d016c3384962d86ec8853e5f4b0065aa77e335ca80193e
-  md5: 517f18b3260bb7a508d1f54a96e6285b
+  name: cmake
+  version: 3.30.5
+  build: h7243fc2_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.30.5-h7243fc2_0.conda
+  sha256: 09aa49a9f068233e4d98688268465f431426a338c115c56517c3c3193198d07b
+  md5: 826e05dc51e8a9e4d10680f37e267b68
   depends:
-  - clang 16.0.6.*
-  - clangxx 16.0.6.*
-  - compiler-rt_osx-arm64 16.0.6.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  size: 93724
-  timestamp: 1701467327657
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libexpat >=2.6.3,<3.0a0
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17507220
+  timestamp: 1728417253023
+- kind: conda
+  name: cmake
+  version: 3.30.5
+  build: hbb72600_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.30.5-hbb72600_0.conda
+  sha256: 6127125b954ae5115d67234218a6482724517ba35e0cd33ccaf211b77d51448d
+  md5: c60805ad9292ba829ba61ff6c9b8789d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19150524
+  timestamp: 1728416996527
+- kind: conda
+  name: cmake
+  version: 3.30.5
+  build: hf9cb763_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.30.5-hf9cb763_0.conda
+  sha256: 9b775bbdee337d67b180b6fbc6c93fa1ba73a18b167c242d792dee2797245148
+  md5: b3b88a7ec6372b6f2c0ddb31ee009ebd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19606674
+  timestamp: 1728416480376
+- kind: conda
+  name: cmake
+  version: 3.30.5
+  build: hfbcbe4a_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.30.5-hfbcbe4a_0.conda
+  sha256: a6df9f06a5f7037c80782b9dc16ff2eceb24348f665beaca1ce9de7041cfe4e5
+  md5: 22394eb25181c0dcadd3ccd473f6b90a
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libexpat >=2.6.3,<3.0a0
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16345134
+  timestamp: 1728417146512
 - kind: conda
   name: compiler-rt
-  version: 16.0.6
-  build: ha38d28d_2
+  version: 17.0.6
+  build: h1020d70_2
   build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
-  sha256: de0e2c94d9a04f60ec9aedde863d6c1fad3f261bdb63ec8adc70e2d9ecdb07bb
-  md5: 3b9e8c5c63b8e86234f499490acd85c2
+  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-17.0.6-h1020d70_2.conda
+  sha256: 463107bc5ac7ebe925cded4412fb7158bd2c1a2b062a4a2e691aab8b1ff6ccf3
+  md5: be4cb4531d4cee9df94bf752455d68de
   depends:
-  - clang 16.0.6.*
-  - clangxx 16.0.6.*
-  - compiler-rt_osx-64 16.0.6.*
+  - __osx >=10.13
+  - clang 17.0.6.*
+  - clangxx 17.0.6.*
+  - compiler-rt_osx-64 17.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 94198
-  timestamp: 1701467261175
+  size: 94907
+  timestamp: 1725251294237
+- kind: conda
+  name: compiler-rt
+  version: 17.0.6
+  build: h856b3c1_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
+  sha256: 91f4a6b80b7802432146a399944c20410e058dfb57ca6d738c0affb79cbdebbb
+  md5: 2d00ff8e98c163de45a7c85774094012
+  depends:
+  - __osx >=11.0
+  - clang 17.0.6.*
+  - clangxx 17.0.6.*
+  - compiler-rt_osx-arm64 17.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 94878
+  timestamp: 1725251190741
 - kind: conda
   name: compiler-rt_osx-64
-  version: 16.0.6
-  build: ha38d28d_2
+  version: 17.0.6
+  build: hf2b8a54_2
   build_number: 2
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
-  sha256: 75270bd8e306967f6e1a8c17d14f2dfe76602a5c162088f3ea98034fe3d71e0c
-  md5: 7a46507edc35c6c8818db0adaf8d787f
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-17.0.6-hf2b8a54_2.conda
+  sha256: bab564aff76e0c55a681f687dffb64282d643aa501c6848789071b1e29fdbce1
+  md5: 98e6d83e484e42f6beebba4276e38145
   depends:
-  - clang 16.0.6.*
-  - clangxx 16.0.6.*
+  - clang 17.0.6.*
+  - clangxx 17.0.6.*
   constrains:
-  - compiler-rt 16.0.6
+  - compiler-rt 17.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 9895261
-  timestamp: 1701467223753
+  size: 10450866
+  timestamp: 1725251223089
 - kind: conda
   name: compiler-rt_osx-arm64
-  version: 16.0.6
-  build: h3808999_2
+  version: 17.0.6
+  build: h832e737_2
   build_number: 2
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
-  sha256: 61f1a10e6e8ec147f17c5e36cf1c2fe77ac6d1907b05443fa319fd59be20fa33
-  md5: 8c7d77d888e1a218cccd9e82b1458ec6
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
+  sha256: 74d63f7f91a9482262d80490fafd39275121f4cb273f293e7d9fe91934837666
+  md5: 58fd1fa30d8b0795f33a7e79893b11cc
   depends:
-  - clang 16.0.6.*
-  - clangxx 16.0.6.*
+  - clang 17.0.6.*
+  - clangxx 17.0.6.*
   constrains:
-  - compiler-rt 16.0.6
+  - compiler-rt 17.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 9829914
-  timestamp: 1701467293179
+  size: 10369238
+  timestamp: 1725251155195
 - kind: conda
   name: cxx-compiler
-  version: 1.7.0
-  build: h00ab1b0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_0.conda
-  sha256: 9278c12ed455a39a50d908381786540c9fd1627e4489dca9638b3e222c86d3f7
-  md5: b4537c98cb59f8725b0e1e65816b4a28
-  depends:
-  - c-compiler 1.7.0 hd590300_0
-  - gxx
-  - gxx_linux-64 12.*
-  license: BSD
-  size: 6262
-  timestamp: 1701505307165
-- kind: conda
-  name: cxx-compiler
-  version: 1.7.0
-  build: h2a328a1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.7.0-h2a328a1_0.conda
-  sha256: 56176ede436f5fad7b43c5876c977a30c885de1e755d71f5bee53177559a26f9
-  md5: 51797a0f32e945d0ecb2406b6a576157
-  depends:
-  - c-compiler 1.7.0 h31becfc_0
-  - gxx
-  - gxx_linux-aarch64 12.*
-  license: BSD
-  size: 6277
-  timestamp: 1701505285388
-- kind: conda
-  name: cxx-compiler
-  version: 1.7.0
-  build: h2ffa867_0
+  version: 1.8.0
+  build: h18dbf2f_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.7.0-h2ffa867_0.conda
-  sha256: 654d70c5a57002fbd6f567236cf6a354597631e9256d21fad6937f08de5ec00a
-  md5: cfc5dbb08e4808fe647493fd911724a7
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-h18dbf2f_1.conda
+  sha256: bcadda695b13087920650adf43a599b66745dfb4bfc3b425169547d76082dcf2
+  md5: a1bc5417ab20b451ee141ca3290df479
   depends:
-  - c-compiler 1.7.0 h6aa9301_0
-  - clangxx_osx-arm64 16.*
-  license: BSD
-  size: 6454
-  timestamp: 1701505505979
+  - c-compiler 1.8.0 hf48404e_1
+  - clangxx_osx-arm64 17.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6261
+  timestamp: 1728985417226
 - kind: conda
   name: cxx-compiler
-  version: 1.7.0
-  build: h7728843_0
+  version: 1.8.0
+  build: h1a2810e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_1.conda
+  sha256: cca0450bbc0d19044107d0f90fa36126a11b007fbfb62bd2a1949b2bb59a21a4
+  md5: 3bb4907086d7187bf01c8bec397ffa5e
+  depends:
+  - c-compiler 1.8.0 h2b85faf_1
+  - gxx
+  - gxx_linux-64 13.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059
+  timestamp: 1728985302835
+- kind: conda
+  name: cxx-compiler
+  version: 1.8.0
+  build: h385f146_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.7.0-h7728843_0.conda
-  sha256: fe198da9a3ea1f3d1c9f18cceff633594549ef80c20bdb9522beb4b4446be09c
-  md5: 8abaa2694c1fba2b6bd3753d00a60415
+  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.8.0-h385f146_1.conda
+  sha256: bbb8097e20601a1c78b3ad4aba165dbfe9a61f27e0b42475ba6177222825adad
+  md5: b72f72f89de328cc907bcdf88b85447d
   depends:
-  - c-compiler 1.7.0 h282daa2_0
-  - clangxx_osx-64 16.*
-  license: BSD
-  size: 6428
-  timestamp: 1701505479181
+  - c-compiler 1.8.0 hfc4bf79_1
+  - clangxx_osx-64 17.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6235
+  timestamp: 1728985479382
 - kind: conda
   name: cxx-compiler
-  version: 1.7.0
-  build: h91493d7_0
+  version: 1.8.0
+  build: h91493d7_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_0.conda
-  sha256: f16dc990c284d704c43d28822c6153ccb63ef9716d5d7a47d3125b767f72a6d8
-  md5: 3949c652bedb193a39fa637d03f93150
+  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_1.conda
+  sha256: c6065df2e055a0392207f512bfa12d7a0e849f5e1a5435a3db9c60ae20bded9b
+  md5: 54d722a127a10b59596b5640d58f7ae6
   depends:
   - vs2019_win-64
-  license: BSD
-  size: 6517
-  timestamp: 1701505483027
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6549
+  timestamp: 1728985390855
+- kind: conda
+  name: cxx-compiler
+  version: 1.8.0
+  build: heb6c788_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.8.0-heb6c788_1.conda
+  sha256: 92cd5ba51d0d450cd69ae934107932d2b28cfbb652b1d5f5c0b8e2773ae90491
+  md5: d655e8bc7e615b6965afe20522e4ed1a
+  depends:
+  - c-compiler 1.8.0 h6561dab_1
+  - gxx
+  - gxx_linux-aarch64 13.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6154
+  timestamp: 1728985293216
 - kind: conda
   name: dav1d
   version: 1.2.1
@@ -2540,21 +2574,6 @@ packages:
   license_family: GPL
   size: 618596
   timestamp: 1640112124844
-- kind: conda
-  name: double-conversion
-  version: 3.3.0
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.3.0-h2f0025b_0.conda
-  sha256: a60f4223b0c090873ab029bf350e54da590d855cefe4ae15f727f3db93d24ac0
-  md5: 3b34b29f68d60abc1ce132b87f5a213c
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 78230
-  timestamp: 1686485872718
 - kind: conda
   name: double-conversion
   version: 3.3.0
@@ -2662,303 +2681,323 @@ packages:
   timestamp: 1690273089254
 - kind: conda
   name: expat
-  version: 2.6.2
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.2-h2f0025b_0.conda
-  sha256: a7a998faf6b9ed71d8c5c67f996e7faa52a7b9b02ed2d2f2ab6cfa1db8e5aca4
-  md5: 6d31100ba1e12773b4f1ef0693fb0169
-  depends:
-  - libexpat 2.6.2 h2f0025b_0
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 128302
-  timestamp: 1710362329008
-- kind: conda
-  name: expat
-  version: 2.6.2
-  build: h59595ed_0
+  version: 2.6.3
+  build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
-  sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
-  md5: 53fb86322bdb89496d7579fe3f02fd61
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+  sha256: 65bd479c75ce876f26600cb230d6ebc474086e31fa384af9b4282b36842ed7e2
+  md5: 6595440079bed734b113de44ffd3cd0a
   depends:
-  - libexpat 2.6.2 h59595ed_0
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libexpat 2.6.3 h5888daf_0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 137627
-  timestamp: 1710362144873
+  size: 137891
+  timestamp: 1725568750673
 - kind: conda
   name: expat
-  version: 2.6.2
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
-  sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
-  md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
-  depends:
-  - libexpat 2.6.2 h63175ca_0
-  license: MIT
-  license_family: MIT
-  size: 229627
-  timestamp: 1710362661692
-- kind: conda
-  name: expat
-  version: 2.6.2
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
-  sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
-  md5: dc0882915da2ec74696ad87aa2350f27
-  depends:
-  - libexpat 2.6.2 h73e2aa4_0
-  license: MIT
-  license_family: MIT
-  size: 126612
-  timestamp: 1710362607162
-- kind: conda
-  name: expat
-  version: 2.6.2
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
-  sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
-  md5: de0cff0ec74f273c4b6aa281479906c3
-  depends:
-  - libexpat 2.6.2 hebf3989_0
-  license: MIT
-  license_family: MIT
-  size: 124594
-  timestamp: 1710362455984
-- kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_h38e077a_106
-  build_number: 106
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h38e077a_106.conda
-  sha256: 394dbcac10a6d65c8dae456bc4a2a2717005f598f86a423fe11235392a9d00ea
-  md5: 23fe0f8b47e7b5527bcc1dfb6087dba6
-  depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libva >=2.20.0,<3.0a0
-  - libvpx >=1.14.0,<1.15.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9776719
-  timestamp: 1710227916961
-- kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_h71b6f88_106
-  build_number: 106
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h71b6f88_106.conda
-  sha256: 240fcb6b0b5b65902b909f87947ae189e9719404da64432f7cea7cb9e226678d
-  md5: 1f6fb99fff1e82f0cc33f32a7ae40914
-  depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libcxx >=16
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.14.0,<1.15.0a0
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9675951
-  timestamp: 1710228627269
-- kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_h991a198_106
-  build_number: 106
+  version: 2.6.3
+  build: h5ad3122_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_h991a198_106.conda
-  sha256: cdd638f5117ec0c77a62c793b09b466c2d8f4cc9ac42386c91a12b99dfd5ef77
-  md5: c777652f97e1fbba79b32e7f5e678ffa
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.3-h5ad3122_0.conda
+  sha256: c827521e080d0f3395655924f1c364d48a1eac1ff3e193a12d0441e9c3b51e91
+  md5: 901a44b341632b0c233756ed5abcd78b
   depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libvpx >=1.14.0,<1.15.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9354599
-  timestamp: 1710227859206
+  - libexpat 2.6.3 h5ad3122_0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 130283
+  timestamp: 1725568848182
 - kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_haa72bd2_106
-  build_number: 106
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_haa72bd2_106.conda
-  sha256: 6d63b78f000c1d295bacc3b154e5e458ef7f72abdcd5dfe6a74d7e3da414d34e
-  md5: fec1e360e205190389623f7bc62852f6
+  name: expat
+  version: 2.6.3
+  build: hac325c4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.3-hac325c4_0.conda
+  sha256: 79b0da6ca997f7a939bfb9631356afbc519343944fc81cc4261c6b3a85f6db32
+  md5: 474cd8746e9f896fc5ae84af3c951796
   depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libcxx >=16
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.14.0,<1.15.0a0
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 8636253
-  timestamp: 1710228709761
+  - __osx >=10.13
+  - libexpat 2.6.3 hac325c4_0
+  license: MIT
+  license_family: MIT
+  size: 128253
+  timestamp: 1725568880679
 - kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_hb766fab_106
-  build_number: 106
+  name: expat
+  version: 2.6.3
+  build: he0c23c2_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_106.conda
-  sha256: b64e111bb95c157eb6d5a442257147e85c1abbbd1c2ea1d3bf7fd56d09e3fdfc
-  md5: ae0ba1265579555268923e2b993845de
+  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.3-he0c23c2_0.conda
+  sha256: 627651a36fe659ce08d79e8bcad00dc5fc35c6e63eb51e5d15a30a7605251998
+  md5: a85588222941f75577eb39711058e1de
   depends:
-  - aom >=3.8.1,<3.9.0a0
+  - libexpat 2.6.3 he0c23c2_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 230615
+  timestamp: 1725569133557
+- kind: conda
+  name: expat
+  version: 2.6.3
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
+  sha256: 4d52ad7a7eb39f71a38bbf2b6377183024bd3bf4cfb5dcd33b31636a6f9a7abc
+  md5: 726bbcf3549fe22b4556285d946fed2d
+  depends:
+  - __osx >=11.0
+  - libexpat 2.6.3 hf9b8971_0
+  license: MIT
+  license_family: MIT
+  size: 125005
+  timestamp: 1725568799108
+- kind: conda
+  name: ffmpeg
+  version: 6.1.2
+  build: gpl_h4bdba66_705
+  build_number: 705
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.2-gpl_h4bdba66_705.conda
+  sha256: 3a2875e6a33bcbbf6b3a2f26e5d4d5fcb7d32c51cf6fced31b3565407d98ed68
+  md5: 2742d883dbffa1cb433c4a5d73fb744e
+  depends:
+  - aom >=3.9.1,<3.10.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=8.3.0,<9.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx >=13
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9513369
+  timestamp: 1726961395082
+- kind: conda
+  name: ffmpeg
+  version: 6.1.2
+  build: gpl_h63732f7_105
+  build_number: 105
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.2-gpl_h63732f7_105.conda
+  sha256: 7f7616b01e16c71cd58e359699083c21cf367357189269885b77bb8525cc917f
+  md5: 8afe2b968ea735af23203a7aaf272503
+  depends:
+  - __osx >=10.13
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9735061
+  timestamp: 1726961267052
+- kind: conda
+  name: ffmpeg
+  version: 6.1.2
+  build: gpl_h9673905_705
+  build_number: 705
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h9673905_705.conda
+  sha256: 493fdf46d0ef24adb5bf8870a2f957ca5e0f6c44d488d016cfd105d860c139c3
+  md5: 3106e26566f230104d83312fc1fb9b17
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
   - libiconv >=1.17,<2.0a0
   - libopus >=1.3.1,<2.0a0
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
   - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 9704858
-  timestamp: 1710228932901
+  size: 9560526
+  timestamp: 1726962540565
+- kind: conda
+  name: ffmpeg
+  version: 6.1.2
+  build: gpl_he9820c9_105
+  build_number: 105
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.2-gpl_he9820c9_105.conda
+  sha256: e80371364f6bcd9d81fba51635201521bfcb766e345cb2f9d7d3dbbc94973bf8
+  md5: 5c1fb06044be6587e043804fa2c559e3
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 8656928
+  timestamp: 1726961188053
+- kind: conda
+  name: ffmpeg
+  version: 7.1.0
+  build: gpl_he2fd91e_702
+  build_number: 702
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_he2fd91e_702.conda
+  sha256: 9799acf36bad3b3feca722872430b26da908abcb5df30333b661afb03844fbde
+  md5: fc3e332855b9124c7ea71218985037c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-npu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libva >=2.22.0,<3.0a0
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 10323945
+  timestamp: 1729893831196
 - kind: conda
   name: font-ttf-dejavu-sans-mono
   version: '2.37'
@@ -3001,17 +3040,17 @@ packages:
 - kind: conda
   name: font-ttf-ubuntu
   version: '0.83'
-  build: h77eed37_1
-  build_number: 1
+  build: h77eed37_3
+  build_number: 3
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-  sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
-  md5: 6185f640c43843e5ad6fd1c5372c3f80
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
-  size: 1619820
-  timestamp: 1700944216729
+  size: 1620504
+  timestamp: 1727511233259
 - kind: conda
   name: fontconfig
   version: 2.14.2
@@ -3025,7 +3064,7 @@ packages:
   - freetype >=2.12.1,<3.0a0
   - libgcc-ng >=12
   - libuuid >=2.32.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
   size: 272010
@@ -3041,7 +3080,7 @@ packages:
   depends:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
   size: 237068
@@ -3057,7 +3096,7 @@ packages:
   depends:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
   size: 237668
@@ -3075,7 +3114,7 @@ packages:
   - freetype >=2.12.1,<3.0a0
   - libgcc-ng >=12
   - libuuid >=2.32.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
   size: 280375
@@ -3092,7 +3131,7 @@ packages:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
@@ -3136,64 +3175,64 @@ packages:
 - kind: conda
   name: freeglut
   version: 3.2.2
-  build: h63175ca_2
-  build_number: 2
+  build: h5eeb66e_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+  sha256: 22a2104d5d6573e8445b7f264533bcd7595cff36d2b356cb1925af5ea62b6a47
+  md5: c6c65566e07fec709e1ea4bc95fc56e4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 144992
+  timestamp: 1719014317113
+- kind: conda
+  name: freeglut
+  version: 3.2.2
+  build: ha6d2627_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+  sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
+  md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 144010
+  timestamp: 1719014356708
+- kind: conda
+  name: freeglut
+  version: 3.2.2
+  build: he0c23c2_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
-  sha256: 42fd40d97dab1adb63ff0bb001e4ed9b3eef377a2de5e572bf989c6db79262c8
-  md5: e2d290a0159d485932abed83878e6952
+  url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
+  sha256: 8b41913ed6c8c0dadda463a649bc16f45e88faa58553efc6830f4de1138c97f2
+  md5: 5872031ef7cba8435ff24af056777473
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 111787
-  timestamp: 1684688787619
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: hac7e632_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
-  sha256: 6dc7be5d0853ea5bcbb2b1921baf7d069605594c207e8ce36a662f447cd81a3f
-  md5: 6e553df297f6e64668efb54302e0f139
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-libx11 >=1.8.4,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes
-  - xorg-libxi
-  license: MIT
-  license_family: MIT
-  size: 142933
-  timestamp: 1684688443008
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: hf4b6fbe_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-hf4b6fbe_2.conda
-  sha256: 7765eb701b7e0644a856c962f55f241098c09e4a9bf721aad7dad6f2e2fabb50
-  md5: c604494e2f7fd2df83bd6491fdc2c6ca
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-libx11 >=1.8.4,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes
-  - xorg-libxi
-  license: MIT
-  license_family: MIT
-  size: 144350
-  timestamp: 1684688403035
+  size: 111956
+  timestamp: 1719014753462
 - kind: conda
   name: freetype
   version: 2.12.1
@@ -3206,7 +3245,7 @@ packages:
   depends:
   - libgcc-ng >=12
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
@@ -3221,7 +3260,7 @@ packages:
   md5: 25152fce119320c980e5470e64834b50
   depends:
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
   size: 599300
   timestamp: 1694616137838
@@ -3236,7 +3275,7 @@ packages:
   md5: e6085e516a3e304ce41a8ee08b9b89ad
   depends:
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
   size: 596430
   timestamp: 1694616332835
@@ -3251,7 +3290,7 @@ packages:
   md5: 3761b23693f768dc75a8fd0a73ca053f
   depends:
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -3270,7 +3309,7 @@ packages:
   depends:
   - libgcc-ng >=12
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
   size: 642092
   timestamp: 1694617858496
@@ -3324,175 +3363,200 @@ packages:
   timestamp: 1604417213
 - kind: conda
   name: gcc
-  version: 12.3.0
-  build: h95e488c_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h95e488c_3.conda
-  sha256: 60669bb79c79d6f6929c67b334acd9dc885dccfb7371e41de7626090dc06e408
-  md5: 413e326f8a01d041ffbfbb51cea46a93
+  version: 13.3.0
+  build: h8a56e6e_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_1.conda
+  sha256: a65247a97374d871f12490aed847d975e513b70a1ba056c0908e9909e9a1945f
+  md5: 9548c9d315f1894dc311d56433e05e28
   depends:
-  - gcc_impl_linux-64 12.3.0.*
+  - gcc_impl_linux-aarch64 13.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 27727
-  timestamp: 1710259826549
+  size: 54122
+  timestamp: 1724802233653
 - kind: conda
   name: gcc
-  version: 12.3.0
-  build: he80d746_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-he80d746_3.conda
-  sha256: b85e2482a76145f01932513304ee1eca58115f48a4d02107035272c2a2c4bed2
-  md5: fe4071326b5c555a0c87081bb0427724
+  version: 13.3.0
+  build: h9576a4e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
+  sha256: d0161362430183cbdbc3db9cf95f9a1af1793027f3ab8755b3d3586deb28bf84
+  md5: 606924335b5bcdf90e9aed9a2f5d22ed
   depends:
-  - gcc_impl_linux-aarch64 12.3.0.*
+  - gcc_impl_linux-64 13.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 27793
-  timestamp: 1710259900584
+  size: 53864
+  timestamp: 1724801360210
 - kind: conda
   name: gcc_impl_linux-64
-  version: 12.3.0
-  build: he2b93b0_5
-  build_number: 5
+  version: 13.3.0
+  build: hfea6d02_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
-  sha256: a87826c55e6aa2ed5d17f267e6a583f7951658afaa4bf45cd5ba97f5583608b9
-  md5: e89827619e73df59496c708b94f6f3d5
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
+  sha256: 998ade1d487e93fc8a7a16b90e2af69ebb227355bf4646488661f7ae5887873c
+  md5: 0d043dbc126b64f79d915a0e96d3a1d5
   depends:
-  - binutils_impl_linux-64 >=2.39
-  - libgcc-devel_linux-64 12.3.0 h8bca6fd_105
-  - libgcc-ng >=12.3.0
-  - libgomp >=12.3.0
-  - libsanitizer 12.3.0 h0f45ef3_5
-  - libstdcxx-ng >=12.3.0
+  - binutils_impl_linux-64 >=2.40
+  - libgcc >=13.3.0
+  - libgcc-devel_linux-64 13.3.0 h84ea5a7_101
+  - libgomp >=13.3.0
+  - libsanitizer 13.3.0 heb74ff8_1
+  - libstdcxx >=13.3.0
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 51856676
-  timestamp: 1706820019081
+  size: 67464415
+  timestamp: 1724801227937
 - kind: conda
   name: gcc_impl_linux-aarch64
-  version: 12.3.0
-  build: hcde2664_5
-  build_number: 5
+  version: 13.3.0
+  build: hcdea9b6_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
-  sha256: c9d333af50695a002173fbfd906278b7709993139e65523c484853a70e769d06
-  md5: 07e2aacd52ad96db11f72558be9ad6ab
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-hcdea9b6_1.conda
+  sha256: cefdf28ab9639e0caa1ff50ec9c67911a5a22b216b685a56fcb82036b11f8758
+  md5: 05d767292bb95666ecfacea481f8ca64
   depends:
-  - binutils_impl_linux-aarch64 >=2.39
-  - libgcc-devel_linux-aarch64 12.3.0 h8b5ab12_105
-  - libgcc-ng >=12.3.0
-  - libgomp >=12.3.0
-  - libsanitizer 12.3.0 h8ebda82_5
-  - libstdcxx-ng >=12.3.0
+  - binutils_impl_linux-aarch64 >=2.40
+  - libgcc >=13.3.0
+  - libgcc-devel_linux-aarch64 13.3.0 h0c07274_101
+  - libgomp >=13.3.0
+  - libsanitizer 13.3.0 ha58e236_1
+  - libstdcxx >=13.3.0
   - sysroot_linux-aarch64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 47107717
-  timestamp: 1706820306980
+  size: 62293677
+  timestamp: 1724802082737
 - kind: conda
   name: gcc_linux-64
-  version: 12.3.0
-  build: h6477408_3
-  build_number: 3
+  version: 13.3.0
+  build: hc28eda2_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
-  sha256: 836692c3d4948f25a19f9071db40f7788edcb342d771786a206a6a122f92365d
-  md5: 7a53f84c45bdf4656ba27b9e9ed68b3d
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_5.conda
+  sha256: 6778f93159cfd967320f60473447b19e320f303378d4c9da0784caa40073fafa
+  md5: ffbadbbc3345d9a315ba31c8a9188d4c
   depends:
-  - binutils_linux-64 2.40 hdade7a5_3
-  - gcc_impl_linux-64 12.3.0.*
+  - binutils_linux-64
+  - gcc_impl_linux-64 13.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 30977
-  timestamp: 1710260096918
+  size: 31909
+  timestamp: 1729281963691
 - kind: conda
   name: gcc_linux-aarch64
-  version: 12.3.0
-  build: h9622932_3
-  build_number: 3
+  version: 13.3.0
+  build: h1cd514b_5
+  build_number: 5
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_3.conda
-  sha256: fabd666508f2c814d9372a46e5abb19bd5f53b66e67c9fee0d577fc0bdc292f2
-  md5: 0f77e0c3b8902a8c44b9814701e6f0a5
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_5.conda
+  sha256: 5bea73704a3fa24c89c3f0f259740b897125ac62fcff7e7e7668ec3562595a23
+  md5: ab35bdc9218e9f00161268237547a98c
   depends:
-  - binutils_linux-aarch64 2.40 h95d2017_3
-  - gcc_impl_linux-aarch64 12.3.0.*
+  - binutils_linux-aarch64
+  - gcc_impl_linux-aarch64 13.3.0.*
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
-  size: 30943
-  timestamp: 1710260225977
+  size: 31972
+  timestamp: 1729281808212
 - kind: conda
-  name: gettext
-  version: 0.21.1
-  build: h0186832_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
-  sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
-  md5: 63d2ff6fddfa74e5458488fd311bf635
-  depends:
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4021036
-  timestamp: 1665674192347
-- kind: conda
-  name: gettext
-  version: 0.21.1
-  build: h27087fc_0
+  name: gdk-pixbuf
+  version: 2.42.12
+  build: hb9ae30d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
-  md5: 14947d8770185e5153fdd04d4673ed37
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
+  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
   depends:
   - libgcc-ng >=12
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4320628
-  timestamp: 1665673494324
+  - libglib >=2.80.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 528149
+  timestamp: 1715782983957
 - kind: conda
   name: gettext
-  version: 0.21.1
-  build: h5728263_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
-  sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
-  md5: 299d4fd6798a45337042ff5a48219e5f
-  depends:
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 5579416
-  timestamp: 1665676022441
-- kind: conda
-  name: gettext
-  version: 0.21.1
-  build: h8a4c099_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
-  sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
-  md5: 1e3aff29ce703d421c43f371ad676cc5
-  depends:
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4153781
-  timestamp: 1665674106245
-- kind: conda
-  name: gettext
-  version: 0.21.1
-  build: ha18d298_0
+  version: 0.22.5
+  build: h0a1ffab_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
-  sha256: b1d8ee80b7577661a8cebdfd21dd1676ba73b676d106c458d4ecdbe4a6d9c2eb
-  md5: b109f1a4d22966793d61fd7f75b744c3
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+  sha256: 25b0b40329537f374a7394474376b01fd226e31f3ff3aa9254e8d328b23c2145
+  md5: be78ccdd273e43e27e66fc1629df6576
+  depends:
+  - gettext-tools 0.22.5 h0a1ffab_3
+  - libasprintf 0.22.5 h87f4aca_3
+  - libasprintf-devel 0.22.5 h87f4aca_3
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h0a1ffab_3
+  - libgettextpo-devel 0.22.5 h0a1ffab_3
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 481962
+  timestamp: 1723626297896
+- kind: conda
+  name: gettext
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+  sha256: c3d9a453f523acbf2b3e1c82a42edfc7c7111b4686a2180ab48cb9b51a274218
+  md5: c7f243bbaea97cd6ea1edd693270100e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext-tools 0.22.5 he02047a_3
+  - libasprintf 0.22.5 he8f35ee_3
+  - libasprintf-devel 0.22.5 he8f35ee_3
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 he02047a_3
+  - libgettextpo-devel 0.22.5 he02047a_3
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 479452
+  timestamp: 1723626088190
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h0a1ffab_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
+  sha256: 9846b9d2e3d081cc8cb9ac7800c7e02a7b63bceea8619e0c51cfa271f89afdb2
+  md5: 5fc8dfe3163ead62e0af82d97ce6b486
   depends:
   - libgcc-ng >=12
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4671428
-  timestamp: 1665673486488
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2954814
+  timestamp: 1723626262722
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
+  sha256: 0fd003953ce1ce9f4569458aab9ffaa397e3be2bc069250e2f05fd93b0ad2976
+  md5: fcd2016d1d299f654f81021e27496818
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2750908
+  timestamp: 1723626056740
 - kind: conda
   name: glfw
   version: '3.4'
@@ -3566,304 +3630,234 @@ packages:
   timestamp: 1708788896752
 - kind: conda
   name: glib
-  version: 2.80.0
-  build: h39d0aa6_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.0-h39d0aa6_1.conda
-  sha256: a76ad2d20164be5425269ac9c65dc8a071ea6dbd5ac3090f9b16dc29a7af1dbc
-  md5: 0384fcbea19fea38cdbf4b3b8924e436
+  version: 2.82.2
+  build: h44428e9_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
+  sha256: f89540cbca9d981fd65d2f3913e8aaa3fe30bc76aa0f70015be4a2169539025b
+  md5: f19f985ab043e8843045410f3b99de8a
   depends:
-  - glib-tools 2.80.0 h0a98069_1
-  - libglib 2.80.0 h39d0aa6_1
+  - glib-tools 2.82.2 h4833e2c_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 h2ff4ddf_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 602771
+  timestamp: 1729191500463
+- kind: conda
+  name: glib
+  version: 2.82.2
+  build: h7025463_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
+  sha256: 68632bb5aec001fcd09b7f9ea415fab09ad479eb640fb667141cbb747a8d48b5
+  md5: c295bf0ccb6823efdf40ebc5992384c4
+  depends:
+  - glib-tools 2.82.2 h4394cf3_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 h7025463_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
   - python *
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
-  size: 491857
-  timestamp: 1710939590211
+  size: 573556
+  timestamp: 1729192350624
 - kind: conda
   name: glib
-  version: 2.80.0
-  build: h81c1438_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.80.0-h81c1438_1.conda
-  sha256: 9bf57bc4cb0cfe72fe37dd01de41d74f5761fb21bd6bb76e11bb44adacfeeb99
-  md5: 5a6fd8f9e20c7e18edec5bbab75565c3
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.80.0 h49a7eea_1
-  - libglib 2.80.0 h81c1438_1
-  - python *
-  license: LGPL-2.1-or-later
-  size: 503338
-  timestamp: 1710939853223
-- kind: conda
-  name: glib
-  version: 2.80.0
-  build: h9d8fbc1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.0-h9d8fbc1_1.conda
-  sha256: 6560c165eadee8a1c5ca77f23e787d125662ddd636b4d4dfb3d4fbb7ab594afd
-  md5: 84be9b2d2d447b856ab0c6b8b913b506
-  depends:
-  - glib-tools 2.80.0 hfbcf09e_1
-  - libgcc-ng >=12
-  - libglib 2.80.0 h9d8fbc1_1
-  - python *
-  license: LGPL-2.1-or-later
-  size: 511720
-  timestamp: 1710938879461
-- kind: conda
-  name: glib
-  version: 2.80.0
-  build: hf2295e7_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.0-hf2295e7_1.conda
-  sha256: 92e0344072050dafd9f478498a2662cb6e309697b58283793145fd05c413a921
-  md5: d3bcc5c186f78feba6f39ea047c35950
-  depends:
-  - glib-tools 2.80.0 hde27a5a_1
-  - libgcc-ng >=12
-  - libglib 2.80.0 hf2295e7_1
-  - python *
-  license: LGPL-2.1-or-later
-  size: 503830
-  timestamp: 1710939217743
-- kind: conda
-  name: glib
-  version: 2.80.0
-  build: hfc324ee_1
-  build_number: 1
+  version: 2.82.2
+  build: hb1db9eb_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.80.0-hfc324ee_1.conda
-  sha256: e0259eaa28f47dd266a43b428f75cc450e9e37eb8065c14ec294ff936819b581
-  md5: 5d751a74ba034a7e2e5be201a00d5758
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.2-hb1db9eb_0.conda
+  sha256: 14efe746ba95154a89208e8478b71fb12ba5f25815029803d30196e561b9d94a
+  md5: 0642d868967b66fc7f0a5fda24bd7ac2
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.80.0 hb9a4d99_1
-  - libglib 2.80.0 hfc324ee_1
+  - glib-tools 2.82.2 h25d4a46_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 h07bd6cf_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
   - python *
   license: LGPL-2.1-or-later
-  size: 503216
-  timestamp: 1710939538458
+  size: 585193
+  timestamp: 1729191888264
+- kind: conda
+  name: glib
+  version: 2.82.2
+  build: hbe7352d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.82.2-hbe7352d_0.conda
+  sha256: e8ff53ffd56974e99f344b8def5afbb038ee1c24e245078d51c2d5218779c718
+  md5: c78d6046de0379875d4df402452a1292
+  depends:
+  - glib-tools 2.82.2 h8a9f880_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 hb6ef654_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 588914
+  timestamp: 1729191809622
+- kind: conda
+  name: glib
+  version: 2.82.2
+  build: hc486b8e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
+  sha256: 5735b3f53735ea78c0d7e98b112488576f03bcbf85fb7e5b0deb05dd35ea08b1
+  md5: 395da692fd81ebafd8c969683bb2bf41
+  depends:
+  - glib-tools 2.82.2 h78ca943_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 hc486b8e_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 616163
+  timestamp: 1729191610267
 - kind: conda
   name: glib-tools
-  version: 2.80.0
-  build: h0a98069_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.0-h0a98069_1.conda
-  sha256: 079b56c014b5f70381924db7a70000676e616079045e7a70081e2f3cf69bc969
-  md5: b6a4948e65ee42739ce14967e4cacdca
+  version: 2.82.2
+  build: h25d4a46_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h25d4a46_0.conda
+  sha256: e9855cc94eb05894255811e070adefe158acf7e03e62b223cc27615a5b7bfcbd
+  md5: a2a75ed0bf49f94478d356424f158c61
   depends:
-  - libglib 2.80.0 h39d0aa6_1
+  - __osx >=11.0
+  - libglib 2.82.2 h07bd6cf_0
+  - libintl >=0.22.5,<1.0a0
+  license: LGPL-2.1-or-later
+  size: 99919
+  timestamp: 1729191855779
+- kind: conda
+  name: glib-tools
+  version: 2.82.2
+  build: h4394cf3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
+  sha256: 2c502b66fb68ed3dd4ce9f8121ae8f613df08a83c354c55435994dd9a8ee780a
+  md5: 5aa50df298dca67e20ad24c622d1a27c
+  depends:
+  - libglib 2.82.2 h7025463_0
+  - libintl >=0.22.5,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
-  size: 94114
-  timestamp: 1710939517930
+  size: 96434
+  timestamp: 1729192296587
 - kind: conda
   name: glib-tools
-  version: 2.80.0
-  build: h49a7eea_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.80.0-h49a7eea_1.conda
-  sha256: 3174f5169a75abebba34de48f5f1ba44ae875abd9abefc0116792d2d13cb9e59
-  md5: 3d9331d7bb0435d1a054aa50b513f9ac
+  version: 2.82.2
+  build: h4833e2c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
+  sha256: 4d6d7175a841be9dd25f5041c9b9419b25f4f5e8de8f289b3c7914a76f5a24d4
+  md5: 12859f91830f58b1803e32846651c6f6
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libglib 2.80.0 h81c1438_1
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libglib 2.82.2 h2ff4ddf_0
   license: LGPL-2.1-or-later
-  size: 97279
-  timestamp: 1710939727447
+  size: 114038
+  timestamp: 1729191458625
 - kind: conda
   name: glib-tools
-  version: 2.80.0
-  build: hb9a4d99_1
-  build_number: 1
+  version: 2.82.2
+  build: h78ca943_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
+  sha256: 4f8eaa6d7fe07a6e6bc06787256a416b14d4ed424474b11875d0ca7aeff1256c
+  md5: 3053283d0c0e78ab5935c9e17f803358
+  depends:
+  - libgcc >=13
+  - libglib 2.82.2 hc486b8e_0
+  license: LGPL-2.1-or-later
+  size: 126325
+  timestamp: 1729191584153
+- kind: conda
+  name: glib-tools
+  version: 2.82.2
+  build: h8a9f880_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.82.2-h8a9f880_0.conda
+  sha256: 6ae574c24a9dd89b2361953e5cbb1d279c8462b6cc490f25f8b0f47b4e0c591e
+  md5: 23f4ee9e0e50445006507249bd39581b
+  depends:
+  - __osx >=10.13
+  - libglib 2.82.2 hb6ef654_0
+  - libintl >=0.22.5,<1.0a0
+  license: LGPL-2.1-or-later
+  size: 100613
+  timestamp: 1729191743410
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h0a1ffab_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+  sha256: a5e341cbf797c65d2477b27d99091393edbaa5178c7d69b7463bb105b0488e69
+  md5: 7cbfb3a8bb1b78a7f5518654ac6725ad
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 417323
+  timestamp: 1718980707330
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h7bae524_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.80.0-hb9a4d99_1.conda
-  sha256: 80c474aa2214b57bff6ed61e6906ed9c09e2b64ac2c367534804e59d287b892b
-  md5: 31519ccdedc9a30d6752fbbf0ac2a18e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
+  md5: eed7278dfbab727b56f2c0b64330814b
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libglib 2.80.0 hfc324ee_1
-  license: LGPL-2.1-or-later
-  size: 97756
-  timestamp: 1710939468243
-- kind: conda
-  name: glib-tools
-  version: 2.80.0
-  build: hde27a5a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.0-hde27a5a_1.conda
-  sha256: 8d736e120bb1fe3b57f957d8f6b90c9bb035ee1dac167714c9afba395af6878c
-  md5: 939ddd853b1d98bf6fd22cc0adeda317
-  depends:
-  - libgcc-ng >=12
-  - libglib 2.80.0 hf2295e7_1
-  license: LGPL-2.1-or-later
-  size: 112852
-  timestamp: 1710939161164
-- kind: conda
-  name: glib-tools
-  version: 2.80.0
-  build: hfbcf09e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.0-hfbcf09e_1.conda
-  sha256: 0d43a765b0a01591a93206a6c147142236ed7ea46d58871f00746738b5400955
-  md5: 823b03c3c671b0ab75de3cf0bc8fc34f
-  depends:
-  - libgcc-ng >=12
-  - libglib 2.80.0 h9d8fbc1_1
-  license: LGPL-2.1-or-later
-  size: 122487
-  timestamp: 1710938839342
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h2f0025b_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_1.conda
-  sha256: a839590a28ea9938e01e4a7fcf6d240611ef9a645c7b4cb6767c7b1397d06f22
-  md5: 0fdc64cdb43430acdca4d54fdfc64317
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 517903
-  timestamp: 1710169423575
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h59595ed_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
-  sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
-  md5: e358c7c5f6824c272b5034b3816438a7
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 569852
-  timestamp: 1710169507479
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h73e2aa4_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
-  sha256: 1a5b117908deb5a12288aba84dd0cb913f779c31c75f5a57d1a00e659e8fa3d3
-  md5: 92f8d748d95d97f92fc26cfac9bb5b6e
-  depends:
+  - __osx >=11.0
   - libcxx >=16
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 519804
-  timestamp: 1710170159201
+  size: 365188
+  timestamp: 1718981343258
 - kind: conda
   name: gmp
   version: 6.3.0
-  build: hebf3989_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
-  sha256: 0ed5aff70675dc0ed5c2f39bb02b908b864e8eee4ceb56e1c798ba8d7509551f
-  md5: 64f45819921ba710398706e1a6404eb5
+  build: hac33072_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
   depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 460055
+  timestamp: 1718980856608
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: hf036a51_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
+  sha256: 75aa5e7a875afdcf4903b7dc98577672a3dc17b528ac217b915f9528f93c85fc
+  md5: 427101d13f19c4974552a4e5b072eef1
+  depends:
+  - __osx >=10.13
   - libcxx >=16
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 448714
-  timestamp: 1710169869298
-- kind: conda
-  name: gnutls
-  version: 3.7.9
-  build: h1951705_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
-  sha256: 6754e835f78733ddded127e0a044c476be466f67f6b5881b685730590bf8436f
-  md5: b43bd7c59ff7f7163106a58a493b51f9
-  depends:
-  - __osx >=10.9
-  - gettext >=0.21.1,<1.0a0
-  - libcxx >=16.0.6
-  - libidn2 >=2,<3.0a0
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.9.1,<3.10.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 1980037
-  timestamp: 1701111603786
-- kind: conda
-  name: gnutls
-  version: 3.7.9
-  build: hb077bed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
-  sha256: 52d824a5d2b8a5566cd469cae6ad6920469b5a15b3e0ddc609dd29151be71be2
-  md5: 33eded89024f21659b1975886a4acf70
-  depends:
-  - libgcc-ng >=12
-  - libidn2 >=2,<3.0a0
-  - libstdcxx-ng >=12
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.9.1,<3.10.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 1974935
-  timestamp: 1701111180127
-- kind: conda
-  name: gnutls
-  version: 3.7.9
-  build: hb309da9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
-  sha256: 8c69e7e8073e3a9c5c4c4e0cd77e406abcf2a41b0cd3b98edbb5c6d612fd4562
-  md5: 324ec92c368d1ae5f40fe93470ec0317
-  depends:
-  - libgcc-ng >=12
-  - libidn2 >=2,<3.0a0
-  - libstdcxx-ng >=12
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.9.1,<3.10.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 2021021
-  timestamp: 1701110217449
-- kind: conda
-  name: gnutls
-  version: 3.7.9
-  build: hd26332c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
-  sha256: 800eceea27032e6d3edbb0186a76d62ed4e4c05963a7d43b35c2ced9ce27ba68
-  md5: 64af58bb3f2a635471dfbe798a1b81f5
-  depends:
-  - __osx >=10.9
-  - gettext >=0.21.1,<1.0a0
-  - libcxx >=16.0.6
-  - libidn2 >=2,<3.0a0
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.9.1,<3.10.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 1829713
-  timestamp: 1701110534084
+  size: 428919
+  timestamp: 1718981041839
 - kind: conda
   name: graphite2
   version: 1.3.13
@@ -3945,940 +3939,1012 @@ packages:
   timestamp: 1711634444608
 - kind: conda
   name: gst-plugins-base
-  version: 1.22.9
-  build: h001b923_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
-  sha256: e2c37128de5bdc12e3656c9c50e7b1459d8890ea656b866e68293e334356b652
-  md5: ef961ec5b46ac75cebd3d68460691c27
+  version: 1.24.7
+  build: h0a52356_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
+  sha256: 6606a2686c0aed281a60fb546703e62c66ea9afa1e46adcca5eb428a3ff67f9e
+  md5: d368425fbd031a2f8e801a40c3415c72
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.9 hb4038d2_1
-  - libglib >=2.78.4,<3.0a0
-  - libogg >=1.3.4,<1.4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.12,<1.3.0a0
+  - gstreamer 1.24.7 hf3bb09a_0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx >=13
   - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2822378
+  timestamp: 1725536496791
+- kind: conda
+  name: gst-plugins-base
+  version: 1.24.7
+  build: h0ee1d58_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.24.7-h0ee1d58_0.conda
+  sha256: ed8a4e9f0918957e8c9d3983b91e8ab9f20643aadb8f3aa9ed3343964d8945fd
+  md5: f012d1ef168db3b601031bcef1c47343
+  depends:
+  - __osx >=10.13
+  - gstreamer 1.24.7 h3271b85_0
+  - libcxx >=17
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2409409
+  timestamp: 1725536929071
+- kind: conda
+  name: gst-plugins-base
+  version: 1.24.7
+  build: h570c1df_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
+  sha256: d6db93e096d0213dd14004a0bd084f11b2d5af4a35a7ac319611c2885f87dc28
+  md5: 8d35b3a3d8b4a85ab93ab40314c9246a
+  depends:
+  - alsa-lib >=1.2.12,<1.3.0a0
+  - gstreamer 1.24.7 h37d20eb_0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx >=13
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2761700
+  timestamp: 1725540779840
+- kind: conda
+  name: gst-plugins-base
+  version: 1.24.7
+  build: hb0a98b8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
+  sha256: c8951e6af014cdeff2de740d1e6e4781ac6813853739c56c6e07266e7aefcf28
+  md5: 92edfae477856e97db6c2610dea95bb1
+  depends:
+  - gstreamer 1.24.7 h5006eae_0
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2035564
-  timestamp: 1711211913043
+  size: 2061727
+  timestamp: 1725537068521
 - kind: conda
   name: gst-plugins-base
-  version: 1.22.9
-  build: h09b4b5e_1
-  build_number: 1
+  version: 1.24.7
+  build: hb49d354_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.22.9-h09b4b5e_1.conda
-  sha256: e55277c44e7a55cd710438fe18d36816ea74570280863830b48706b793c26583
-  md5: 2e32f4b46cf8c2adef7e3ca6ad9c4e3c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
+  sha256: 56b84bf80b6301e715312e6c1b8c44b2e2f0821854b1d05ec065b59bf38adad1
+  md5: 3dfb86c12a1bc38d03be9f52225b8ef7
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.9 h551c6ff_1
-  - libcxx >=16
-  - libglib >=2.80.0,<3.0a0
-  - libogg >=1.3.4,<1.4.0a0
+  - __osx >=11.0
+  - gstreamer 1.24.7 hc3f5269_0
+  - libcxx >=17
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libogg >=1.3.5,<1.4.0a0
   - libopus >=1.3.1,<2.0a0
   - libpng >=1.6.43,<1.7.0a0
   - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1919868
-  timestamp: 1711211932350
+  size: 1962829
+  timestamp: 1725536921391
 - kind: conda
-  name: gst-plugins-base
-  version: 1.22.9
-  build: h0a86eba_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h0a86eba_1.conda
-  sha256: 8c52521d7a8f91e5f39e8f42fd4a68915066fd1812adc28640100a9d4e9f3ae2
-  md5: d67244c28840822a60bb1a3cb976acbd
-  depends:
-  - alsa-lib >=1.2.11,<1.3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.9 hed71854_1
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2668212
-  timestamp: 1711215891592
-- kind: conda
-  name: gst-plugins-base
-  version: 1.22.9
-  build: h3fb38fc_1
-  build_number: 1
+  name: gstreamer
+  version: 1.24.7
+  build: h3271b85_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.22.9-h3fb38fc_1.conda
-  sha256: 5f82f59f3bab51d44629cee8932b83a4f61a4438095a6e8195a6ad80f5ccfa4a
-  md5: 7bc7cdc3d7e58558c3986108d5840645
+  url: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.24.7-h3271b85_0.conda
+  sha256: e492fd4cd89ae8aede95134373dd43568386039c0e6b152de061935cfaabeea0
+  md5: 9605eae5ac683af5aeb0aef5dc7871fb
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.9 hf63bbb8_1
-  - libcxx >=16
-  - libglib >=2.80.0,<3.0a0
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2342680
-  timestamp: 1711211838219
-- kind: conda
-  name: gst-plugins-base
-  version: 1.22.9
-  build: hfa15dee_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-hfa15dee_1.conda
-  sha256: 58fda05d33182b29e0524d684f626aad5208fb21e0622bc4b9013791dc105417
-  md5: b66ddd883308a836ed86c247231aab82
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.9 h98fc4e7_1
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2709720
-  timestamp: 1711211314174
-- kind: conda
-  name: gstreamer
-  version: 1.22.9
-  build: h551c6ff_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.22.9-h551c6ff_1.conda
-  sha256: 5e379761c6f429ca2e4296602a7fb13af4d731c89d60bc9f8a6c6b9c4f239861
-  md5: 1c3b67e6251ac77b04d4cc50212fab2c
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.80.0,<3.0a0
-  - libcxx >=16
-  - libglib >=2.80.0,<3.0a0
+  - __osx >=10.13
+  - glib >=2.80.3,<3.0a0
+  - libcxx >=17
+  - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1335313
-  timestamp: 1711211515841
+  size: 1806102
+  timestamp: 1725536657384
 - kind: conda
   name: gstreamer
-  version: 1.22.9
-  build: h98fc4e7_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_1.conda
-  sha256: 13cbc0ee5fa4a61f6f06e223d23d3c179dfbede51faf87cd2a4821efa2c249f2
-  md5: f502076ed4db50d9ee5c907036a5a172
+  version: 1.24.7
+  build: h37d20eb_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
+  sha256: 85a9acd103a2477506c3c92b27dcd4ec5f77bab353fa7a33817f0894bb11a824
+  md5: c672dd04a62139ba21f2ba130b88f235
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.80.0,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - glib >=2.80.3,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
+  - libstdcxx >=13
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1982967
-  timestamp: 1711211168691
+  size: 2027297
+  timestamp: 1725538984316
 - kind: conda
   name: gstreamer
-  version: 1.22.9
-  build: hb4038d2_1
-  build_number: 1
+  version: 1.24.7
+  build: h5006eae_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
-  sha256: 4d42bc24434db62c093748ea3ad0b6ba3872b6810b761363585513ebd79b4f87
-  md5: 70557ab875e72c1f21e8d2351aeb9c54
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
+  sha256: bd3ad109ef3e2e49da8710ff49378b3fa5da916aa2351d932d1b9018b7123512
+  md5: 58e1df95fdab219039e39033302771e8
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.78.4,<3.0a0
-  - libglib >=2.78.4,<3.0a0
+  - glib >=2.80.3,<3.0a0
+  - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1936661
-  timestamp: 1711211717228
+  size: 2022487
+  timestamp: 1725536894511
 - kind: conda
   name: gstreamer
-  version: 1.22.9
-  build: hed71854_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_1.conda
-  sha256: e6b0bf83b41348590c17ccf09e06a4575afe736efd7d2e058cca8255db6dc468
-  md5: 04704bf2cbd0aab04553021026427ec6
+  version: 1.24.7
+  build: hc3f5269_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
+  sha256: 414b1919b746ace641e8cc1eae99ee0bf616a62da2851e248cb04413dcc496b0
+  md5: 51a487eebf20e94bec393d83901ca5eb
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.80.0,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - __osx >=11.0
+  - glib >=2.80.3,<3.0a0
+  - libcxx >=17
+  - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
+  - libintl >=0.22.5,<1.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1986330
-  timestamp: 1711213893994
+  size: 1347352
+  timestamp: 1725536657414
 - kind: conda
   name: gstreamer
-  version: 1.22.9
-  build: hf63bbb8_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.22.9-hf63bbb8_1.conda
-  sha256: dd2c54e38b64d35061d209f02afdd2fca91a5c24b53fce05ee306f2aa727226e
-  md5: 66790d9dd1a29307e379dc3d55a34360
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.80.0,<3.0a0
-  - libcxx >=16
-  - libglib >=2.80.0,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1785014
-  timestamp: 1711211426347
-- kind: conda
-  name: gxx
-  version: 12.3.0
-  build: h95e488c_3
-  build_number: 3
+  version: 1.24.7
+  build: hf3bb09a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h95e488c_3.conda
-  sha256: 12c8d969b1b6acf1bf4f7c7399993dd3d422a713ad6d7ab9343f6b990f8373a0
-  md5: 8c50a4d15a8d4812af563a684d598910
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
+  sha256: 9c059cc7dcb2732da8face18b1c0351da148ef26db0563fed08e818ea0515bb1
+  md5: c78bc4ef0afb3cd2365d9973c71fc876
   depends:
-  - gcc 12.3.0.*
-  - gxx_impl_linux-64 12.3.0.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27244
-  timestamp: 1710260136609
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.80.3,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx >=13
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2023966
+  timestamp: 1725536373253
 - kind: conda
   name: gxx
-  version: 12.3.0
-  build: he80d746_3
-  build_number: 3
+  version: 13.3.0
+  build: h8a56e6e_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-he80d746_3.conda
-  sha256: b26da37112ab50b8a7ae316ccd19451c486e6f4042011fa0292b97baa4140d2a
-  md5: 73d7d6aaf1c41cefe3585ddd89eb4035
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_1.conda
+  sha256: d94714da0135d592d2cd71998a19dc9f65e5a55857c11ec6aa357e5c23fb5a0d
+  md5: 838d6b64b84b1d17c564b146a839e988
   depends:
-  - gcc 12.3.0.*
-  - gxx_impl_linux-aarch64 12.3.0.*
+  - gcc 13.3.0.*
+  - gxx_impl_linux-aarch64 13.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 27304
-  timestamp: 1710260259320
+  size: 53580
+  timestamp: 1724802377970
+- kind: conda
+  name: gxx
+  version: 13.3.0
+  build: h9576a4e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
+  sha256: 5446f5d1d609d996579f706d2020e83ef48e086d943bfeef7ab807ea246888a0
+  md5: 209182ca6b20aeff62f442e843961d81
+  depends:
+  - gcc 13.3.0.*
+  - gxx_impl_linux-64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 53338
+  timestamp: 1724801498389
 - kind: conda
   name: gxx_impl_linux-64
-  version: 12.3.0
-  build: he2b93b0_5
-  build_number: 5
+  version: 13.3.0
+  build: hdbfa832_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
-  sha256: 69371a1e8ad718b033bc1c58743a395e06ad19d08a2ff97e264ed82fd3ccbd9c
-  md5: cddba8fd94e52012abea1caad722b9c2
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
+  sha256: 746dff24bb1efc89ab0ec108838d0711683054e3bbbcb94d042943410a98eca1
+  md5: 806367e23a0a6ad21e51875b34c57d7e
   depends:
-  - gcc_impl_linux-64 12.3.0 he2b93b0_5
-  - libstdcxx-devel_linux-64 12.3.0 h8bca6fd_105
+  - gcc_impl_linux-64 13.3.0 hfea6d02_1
+  - libstdcxx-devel_linux-64 13.3.0 h84ea5a7_101
   - sysroot_linux-64
+  - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 12742481
-  timestamp: 1706820327015
+  size: 13337720
+  timestamp: 1724801455825
 - kind: conda
   name: gxx_impl_linux-aarch64
-  version: 12.3.0
-  build: hcde2664_5
-  build_number: 5
+  version: 13.3.0
+  build: h1211b58_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
-  sha256: 0efcc3ecf96692c08a9158b2b28a70b13e1c0ec5f301c026a302fe47b74f8b3c
-  md5: 88d365e3c078988887fc92e58228a5b4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h1211b58_1.conda
+  sha256: 93eb04cf9ccf5860df113f299febfacad9c66728772d30aaf4bf33995083331a
+  md5: 3721f68549df06c2b0664f8933bbf17f
   depends:
-  - gcc_impl_linux-aarch64 12.3.0 hcde2664_5
-  - libstdcxx-devel_linux-aarch64 12.3.0 h8b5ab12_105
+  - gcc_impl_linux-aarch64 13.3.0 hcdea9b6_1
+  - libstdcxx-devel_linux-aarch64 13.3.0 h0c07274_101
   - sysroot_linux-aarch64
+  - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 11490051
-  timestamp: 1706820597770
+  size: 12732645
+  timestamp: 1724802335796
 - kind: conda
   name: gxx_linux-64
-  version: 12.3.0
-  build: h4a1b8e8_3
-  build_number: 3
+  version: 13.3.0
+  build: h6834431_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h4a1b8e8_3.conda
-  sha256: 5a842fc69c03ac513a2c021f3f21afd9d9ca50b10b95c0dcd236aa77d6d42373
-  md5: 9ec22c7c544f4a4f6d660f0a3b0fd15c
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_5.conda
+  sha256: 4ca452f7abc607d9f0ad45a7fa8c7d8436fca05b9cc6715d1ccd239bed90833b
+  md5: 81ddb2db98fbe3031aa7ebbbf8bb3ffd
   depends:
-  - binutils_linux-64 2.40 hdade7a5_3
-  - gcc_linux-64 12.3.0 h6477408_3
-  - gxx_impl_linux-64 12.3.0.*
+  - binutils_linux-64
+  - gcc_linux-64 13.3.0 hc28eda2_5
+  - gxx_impl_linux-64 13.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 29304
-  timestamp: 1710260169322
+  size: 30284
+  timestamp: 1729281975715
 - kind: conda
   name: gxx_linux-aarch64
-  version: 12.3.0
-  build: h3d1e521_3
-  build_number: 3
+  version: 13.3.0
+  build: h2864abd_5
+  build_number: 5
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_3.conda
-  sha256: 9d2c7649e9341ed218aef701e1db15d8cea4e70d19c4dbf8f9efe06d2c5a0b14
-  md5: f1ac1d0d0b1afcbe3a8ad3a0b33aeaf4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_5.conda
+  sha256: 3079eea2326411009cd8e124d00bab1bf1ca7a244d3d5d8c36d58a9f492bda4c
+  md5: 2d98b991b501e9f303f4feee10f4e794
   depends:
-  - binutils_linux-aarch64 2.40 h95d2017_3
-  - gcc_linux-aarch64 12.3.0 h9622932_3
-  - gxx_impl_linux-aarch64 12.3.0.*
+  - binutils_linux-aarch64
+  - gcc_linux-aarch64 13.3.0 h1cd514b_5
+  - gxx_impl_linux-aarch64 13.3.0.*
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
-  size: 29283
-  timestamp: 1710260291746
+  size: 30319
+  timestamp: 1729281820071
 - kind: conda
   name: harfbuzz
-  version: 8.3.0
-  build: h3d44ed6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
-  sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
-  md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.1,<3.0a0
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 1547473
-  timestamp: 1699925311766
-- kind: conda
-  name: harfbuzz
-  version: 8.3.0
-  build: h7ab893a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.3.0-h7ab893a_0.conda
-  sha256: 5365595303d95810d10662b46f9e857cedc82757cc7b5576bda30e15d66bb3ad
-  md5: b8ef0beb91df83c5e6038c9509b9f730
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=73.2,<74.0a0
-  - libglib >=2.78.1,<3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 1070592
-  timestamp: 1699926990335
-- kind: conda
-  name: harfbuzz
-  version: 8.3.0
-  build: h8f0ba13_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
-  sha256: 55e95aee9e5be7ada5a1cccedf1bb74c1362a7504cb0251fb48bcfa8bbd7cae3
-  md5: 71e7f9ba27feae122733bb9f1bfe594c
-  depends:
-  - __osx >=10.9
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=73.2,<74.0a0
-  - libcxx >=16.0.6
-  - libglib >=2.78.1,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 1295036
-  timestamp: 1699925935335
-- kind: conda
-  name: harfbuzz
-  version: 8.3.0
-  build: hebeb849_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
-  sha256: f6f39bb13d0070565e8975ad5f23005ce894655422a1c50089e6d754c69be084
-  md5: 1c06a74f88f085c2af16809fe4c31b73
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.1,<3.0a0
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 1583124
-  timestamp: 1699927567410
-- kind: conda
-  name: harfbuzz
-  version: 8.3.0
-  build: hf45c392_0
+  version: 9.0.0
+  build: h098a298_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.3.0-hf45c392_0.conda
-  sha256: c6ea14e4f4869bc78b27276c09832af845dfa415585362ed6064e37a1b5fe9c5
-  md5: 41d890485f909e4ecdc608741718c75e
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h098a298_1.conda
+  sha256: dbc7783ea89faaf3a810d0e55979be02031551be8edad00de915807b3b148ff1
+  md5: 8dd3c790d5ce9f3bc94c46e5b218e5f8
   depends:
-  - __osx >=10.9
+  - __osx >=10.13
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - graphite2
-  - icu >=73.2,<74.0a0
-  - libcxx >=16.0.6
-  - libglib >=2.78.1,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 1342172
-  timestamp: 1699925847743
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_h4f84152_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
-  sha256: b814f8f9598cc6e50127533ec256725183ba69db5fd8cf5443223627f19e3e59
-  md5: d471a5c3abc984b662d9bae3bb7fd8a5
-  depends:
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: LicenseRef-HDF5
-  license_family: BSD
-  size: 3892189
-  timestamp: 1701791599022
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_h5bb55e9_100
-  build_number: 100
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h5bb55e9_100.conda
-  sha256: 22331a0ac71a4dd1868f05f8197c36815a41a9f2dcfd01b73ff0d87d9e0ea087
-  md5: 120fefd1da806c4d708ecdfe31263f0c
-  depends:
-  - __osx >=10.9
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: LicenseRef-HDF5
-  license_family: BSD
-  size: 3454453
-  timestamp: 1701791479858
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_h691f4bf_100
-  build_number: 100
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
-  sha256: 158dd2ab901659b47e8f7ee0ec1d9e45a1fedc4871391a44a1c8b9e8ba4c9c6b
-  md5: 8e2ac4ae815a8c9743fe37d70f48f075
-  depends:
-  - __osx >=10.9
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: LicenseRef-HDF5
-  license_family: BSD
-  size: 3720132
-  timestamp: 1701792909005
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_h73e8ff5_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
-  sha256: 89bbb2c878e1b6c6073ef5f1f25eac97ed48393541a4a44a7d182da5ede3dc98
-  md5: 1e91ce0f3a914b0dab762539c0df4ff1
-  depends:
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LicenseRef-HDF5
-  license_family: BSD
-  size: 2045774
-  timestamp: 1701791365837
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_ha486f32_100
-  build_number: 100
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
-  sha256: 6ab7ee800d06f7dcc1fa550c44416a981e213653138eb6da325693e1bd08d918
-  md5: 87cd6b1683c0eea2ba2856700aeee2cf
-  depends:
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: LicenseRef-HDF5
-  license_family: BSD
-  size: 4003056
-  timestamp: 1701796880476
-- kind: conda
-  name: icu
-  version: '73.2'
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  md5: cc47e1facc155f91abd89b11e48e72ff
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 12089150
-  timestamp: 1692900650789
-- kind: conda
-  name: icu
-  version: '73.2'
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
-  sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
-  md5: 0f47d9e3192d9e09ae300da0d28e0f56
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 13422193
-  timestamp: 1692901469029
-- kind: conda
-  name: icu
-  version: '73.2'
-  build: h787c7f5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
-  sha256: aedb9c911ede5596c87e1abd763ed940fab680d71fdb953bce8e4094119d47b3
-  md5: 9d3c29d71f28452a2e843aff8cbe09d2
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 12237094
-  timestamp: 1692900632394
-- kind: conda
-  name: icu
-  version: '73.2'
-  build: hc8870d7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
-  md5: 8521bd47c0e11c5902535bb1a17c565f
-  license: MIT
-  license_family: MIT
-  size: 11997841
-  timestamp: 1692902104771
-- kind: conda
-  name: icu
-  version: '73.2'
-  build: hf5e326d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
-  md5: 5cc301d759ec03f28328428e28f65591
-  license: MIT
-  license_family: MIT
-  size: 11787527
-  timestamp: 1692901622519
-- kind: conda
-  name: imath
-  version: 3.1.11
-  build: h1059232_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.11-h1059232_0.conda
-  sha256: cc6d59bcadde846a81d0c141af6a850f28c397a1c8b8546cee1e1c935b6f8dd6
-  md5: e95ef5164e69abc370842b41438065fa
-  depends:
+  - icu >=75.1,<76.0a0
   - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1372588
+  timestamp: 1721186294497
+- kind: conda
+  name: harfbuzz
+  version: 9.0.0
+  build: h2bedf89_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
+  md5: 254f119aaed2c0be271c1114ae18d09b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1095620
+  timestamp: 1721187287831
+- kind: conda
+  name: harfbuzz
+  version: 9.0.0
+  build: h997cde5_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+  sha256: 5f78f5dcbbfef59b3549ecb6cc2fa9de7b22abda7c8afaf0fa787ceea37a914f
+  md5: 50f6825d3c4a6fca6fefdefa98081554
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1317509
+  timestamp: 1721186764931
+- kind: conda
+  name: harfbuzz
+  version: 9.0.0
+  build: hbf49d6b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
+  sha256: 7496782c3bc0ebbb4de9bc92a3111f42b8a57417fa31ecb87058f250215fabc9
+  md5: ceb458f664cab8550fcd74fff26451db
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1614644
+  timestamp: 1721188789883
+- kind: conda
+  name: harfbuzz
+  version: 9.0.0
+  build: hda332d3_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+  sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
+  md5: 76b32dcf243444aea9c6b804bcfa40b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1603653
+  timestamp: 1721186240105
+- kind: conda
+  name: hdf5
+  version: 1.14.4
+  build: nompi_h13f6c1a_101
+  build_number: 101
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_101.conda
+  sha256: 46a15f93b5d9baf916f65163f535e7be9f50d51bf7619ac42d349c9713c3878c
+  md5: 9516a667178e4336589fc9548cc317ff
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 154276
-  timestamp: 1709194436403
+  size: 4021637
+  timestamp: 1728050555561
 - kind: conda
-  name: imath
-  version: 3.1.11
-  build: h12be248_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
-  sha256: fa7e36df9074ac6d1e67bd655a784b280e83d1cbac24fecdc5c21c716b832809
-  md5: c6849d593fda3d4992a8126d251f50c3
+  name: hdf5
+  version: 1.14.4
+  build: nompi_h2d575fe_101
+  build_number: 101
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_101.conda
+  sha256: fdc091d50eb0a2e5fcc5cab5b605bdaf57471c724aa897aaee67dd5c66d34d53
+  md5: 09967792ea2191a0bdb461f9c889e510
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3954807
+  timestamp: 1728044935147
+- kind: conda
+  name: hdf5
+  version: 1.14.4
+  build: nompi_h57e3b00_101
+  build_number: 101
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h57e3b00_101.conda
+  sha256: 1ce5044901a8150fd82efc1cda1c513b5b4acbe08194d904f96abcc5bfe9211b
+  md5: de2f49fee6cef6f922b3e7497219eb8b
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3745605
+  timestamp: 1728044987255
+- kind: conda
+  name: hdf5
+  version: 1.14.4
+  build: nompi_h99fbd1e_101
+  build_number: 101
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_h99fbd1e_101.conda
+  sha256: 2339506be886b37275039d33e7e4cfa30f3774d6b554f1ec3aea9e1805b10840
+  md5: 719a03d8953ca6cbc5277fbff127e6c6
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3490762
+  timestamp: 1728044046987
+- kind: conda
+  name: hdf5
+  version: 1.14.4
+  build: nompi_hd5d9e70_101
+  build_number: 101
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_101.conda
+  sha256: fa6696af3c73954849ad2b53674f13d7ea6df1d6e790524aff7332f18476b42c
+  md5: 65175ce2be9c8885586039e0fb594f86
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 160297
-  timestamp: 1709194525395
+  size: 2050706
+  timestamp: 1728044187427
 - kind: conda
-  name: imath
-  version: 3.1.11
-  build: h2d185b6_0
+  name: icu
+  version: '75.1'
+  build: h120a0e1_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.11-h2d185b6_0.conda
-  sha256: dfd7540dbfc216a2c1b4c51c6553986e70c7ea7b64453f515d0558c043891b2e
-  md5: 39c1f288d263e971db74f8803e28dabd
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
   depends:
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155338
-  timestamp: 1709194419684
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
 - kind: conda
-  name: imath
-  version: 3.1.11
-  build: hd84c7bf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.11-hd84c7bf_0.conda
-  sha256: d638c7d4b83752864f9c4cbd088c06186086bd38925cc51168fd2ef43f0984ca
-  md5: 3029ebe5cd9a477ee282d80e09e7522a
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 154784
-  timestamp: 1709193935481
-- kind: conda
-  name: imath
-  version: 3.1.11
-  build: hfc55251_0
+  name: icu
+  version: '75.1'
+  build: he02047a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.11-hfc55251_0.conda
-  sha256: b394465d3c6a9c5b17351562a87df2a5ef541d66f1a2d95d80fe28c9ca7638c3
-  md5: 07268e57799c7ad50809cadc297a515e
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- kind: conda
+  name: icu
+  version: '75.1'
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+  sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
+  md5: 8579b6bb8d18be7c0b27fb08adeeeb40
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 14544252
+  timestamp: 1720853966338
+- kind: conda
+  name: icu
+  version: '75.1'
+  build: hf9b3779_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
+  md5: 268203e8b983fddb6412b36f2024e75c
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 12282786
+  timestamp: 1720853454991
+- kind: conda
+  name: icu
+  version: '75.1'
+  build: hfee45f7_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- kind: conda
+  name: imath
+  version: 3.1.12
+  build: h025cafa_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
+  sha256: 8fcf6c3bf91993451412c0003b92044c9fc7980fe3f178ab3260f90ac4099072
+  md5: b7e259bd81b5a7432ca045083959b83a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 162530
-  timestamp: 1709194196768
+  size: 153017
+  timestamp: 1725971790238
+- kind: conda
+  name: imath
+  version: 3.1.12
+  build: h2016aa1_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.12-h2016aa1_0.conda
+  sha256: 5bf9c041b97b1af21808938fcaa64acafe0d853de5478fa08005176664ee4552
+  md5: 326b3d68ab3f43396e7d7e0e9a496f73
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155534
+  timestamp: 1725971674035
+- kind: conda
+  name: imath
+  version: 3.1.12
+  build: h7955e40_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+  sha256: 4d8d07a4d5079d198168b44556fb86d094e6a716e8979b25a9f6c9c610e9fe56
+  md5: 37f5e1ab0db3691929f37dee78335d1b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 159630
+  timestamp: 1725971591485
+- kind: conda
+  name: imath
+  version: 3.1.12
+  build: hbb528cf_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
+  sha256: 184c796615cebaa73246f351144f164ee7b61ea809e4ba3c5d98fa9ca333e058
+  md5: c25af729c8c1c41f96202f8a96652bbe
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 160408
+  timestamp: 1725972042635
+- kind: conda
+  name: imath
+  version: 3.1.12
+  build: hf428078_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
+  md5: ae8535ff689663fe430bec00be24a854
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153368
+  timestamp: 1725971683794
 - kind: conda
   name: intel-openmp
-  version: 2024.0.0
-  build: h57928b3_49841
-  build_number: 49841
+  version: 2024.2.1
+  build: h57928b3_1083
+  build_number: 1083
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
-  sha256: 6ee8eb9080bb3268654e015dd17ad79d0c1ea98b2eee6b928ecd27f01d6b38e8
-  md5: e3255c8cdaf1d52f15816d1970f9c77a
-  license: LicenseRef-ProprietaryIntel
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
-  size: 2325424
-  timestamp: 1706182537883
+  size: 1852356
+  timestamp: 1723739573141
 - kind: conda
   name: ipopt
-  version: 3.14.14
-  build: h04b96a2_1
-  build_number: 1
+  version: 3.14.16
+  build: h122424a_10
+  build_number: 10
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.14-h04b96a2_1.conda
-  sha256: 196622c65a65c28781642befd098a79f3afc485ef25458faa8fa2dc8d8cc7141
-  md5: 8e82b739d2ee8eb3b83e7882c18292f3
+  url: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
+  sha256: b146808eccf916f3186de8926be4ca14bca6d20d6e5fcde4454cae6f1de9d9eb
+  md5: 4ebce336fae43577731ad413e94a6bfa
   depends:
+  - __glibc >=2.17,<3.0.a0
   - ampl-mp >=3.1.0,<3.2.0a0
   - libblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
   - liblapack >=3.9.0,<4.0a0
-  - libspral >=2023.9.7,<2023.9.8.0a0
-  - libstdcxx-ng >=12
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-seq >=5.6.2,<5.6.3.0a0
+  - libspral >=2024.5.8,<2024.5.9.0a0
+  - libstdcxx >=13
+  - mumps-seq >=5.7.3,<5.7.4.0a0
   license: EPL-1.0
-  size: 1020625
-  timestamp: 1705695208814
+  size: 1030827
+  timestamp: 1727440696766
 - kind: conda
   name: ipopt
-  version: 3.14.14
-  build: h09c0c07_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.14-h09c0c07_1.conda
-  sha256: 6d9a8a848a090b2a3f56c872e8ca083650b6200618181ec2fe7db8df4aba9b67
-  md5: 500df5bafb93562771057b7093f96dc8
+  version: 3.14.16
+  build: h202260e_10
+  build_number: 10
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
+  sha256: 69fdeaab6a2528ef37cb8aebfeac7466e79a533f945d83ac56bab0deb642154c
+  md5: b841bdb9ade7994c1a58b00790852046
   depends:
   - ampl-mp >=3.1.0,<3.2.0a0
   - libblas >=3.9.0,<4.0a0
-  - libcxx >=15
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libspral >=2024.5.8,<2024.5.9.0a0
+  - libstdcxx >=13
+  - mumps-seq >=5.7.3,<5.7.4.0a0
+  license: EPL-1.0
+  size: 1028588
+  timestamp: 1727440811283
+- kind: conda
+  name: ipopt
+  version: 3.14.16
+  build: h43feef9_10
+  build_number: 10
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.16-h43feef9_10.conda
+  sha256: 0cc29d2491b0e26a2cb28014af1dc13f4e667e7c8d76a3cfc4315d53a36ca771
+  md5: 8852f30689ef3d8dbdfc869a2838ddfa
+  depends:
+  - __osx >=10.13
+  - ampl-mp >=3.1.0,<3.2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=17
   - libgfortran 5.*
-  - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-seq >=5.6.2,<5.6.3.0a0
+  - mumps-seq >=5.7.3,<5.7.4.0a0
   license: EPL-1.0
-  size: 819742
-  timestamp: 1705695597921
+  size: 823091
+  timestamp: 1727440680726
 - kind: conda
   name: ipopt
-  version: 3.14.14
-  build: h1709daf_1
-  build_number: 1
+  version: 3.14.16
+  build: h920a7db_10
+  build_number: 10
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
+  sha256: cbc2874efb6ef04c81eced387238ad1247174eee5859c68a7dca881eaef65027
+  md5: 1e2c514b61859c1b37e680c20893c283
+  depends:
+  - __osx >=11.0
+  - ampl-mp >=3.1.0,<3.2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - mumps-seq >=5.7.3,<5.7.4.0a0
+  license: EPL-1.0
+  size: 758539
+  timestamp: 1727440718510
+- kind: conda
+  name: ipopt
+  version: 3.14.16
+  build: hfa42872_10
+  build_number: 10
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.14-h1709daf_1.conda
-  sha256: 99889a51a5cc7d672a8173e1fcfb3ae24a1be1b8aa1bf4977551be975ca75f3b
-  md5: 372691bce000bdd78d0aab46bc9bf248
+  url: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
+  sha256: 041ed2b02518d06811391e797cc8a6d071cf9a802b746ebc58265642be3670a0
+  md5: dd8754f62da46096a67bf87a7c6f00b6
   depends:
   - libblas >=3.9.0,<4.0a0
   - libflang >=5.0.0,<6.0.0.a0
   - liblapack >=3.9.0,<4.0a0
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-seq >=5.6.2,<5.6.3.0a0
+  - mumps-seq >=5.7.3,<5.7.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: EPL-1.0
-  size: 906170
-  timestamp: 1705695938763
-- kind: conda
-  name: ipopt
-  version: 3.14.14
-  build: h64a9e3f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.14-h64a9e3f_1.conda
-  sha256: 96e86248a57d993653d839ee7a218f0985a505402a461d4277907c03d6f6f059
-  md5: 30ea142f63fcb2c930d40bd963e9cbdd
-  depends:
-  - ampl-mp >=3.1.0,<3.2.0a0
-  - libblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libspral >=2023.9.7,<2023.9.8.0a0
-  - libstdcxx-ng >=12
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-seq >=5.6.2,<5.6.3.0a0
-  license: EPL-1.0
-  size: 1026626
-  timestamp: 1705695334744
-- kind: conda
-  name: ipopt
-  version: 3.14.14
-  build: h6639f4a_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.14-h6639f4a_1.conda
-  sha256: 28f8ebe16a0787146f81d9164878d89a29f4473aa03c8f600664e26a38a9ed39
-  md5: 7d485b84d4955e999fed77071b7114db
-  depends:
-  - ampl-mp >=3.1.0,<3.2.0a0
-  - libblas >=3.9.0,<4.0a0
-  - libcxx >=15
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-seq >=5.6.2,<5.6.3.0a0
-  license: EPL-1.0
-  size: 757806
-  timestamp: 1705695882554
+  size: 908450
+  timestamp: 1727441201593
 - kind: conda
   name: irrlicht
   version: 1.8.5
-  build: h1344824_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
-  sha256: 9ed28603eb7d0531923b742d75559507630ad96e534533a75a5f089edecdb086
-  md5: 65a53e41b87cffb99035952d370d6791
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcxx >=15.0.7
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1192357
-  timestamp: 1695760649404
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h2a6caf8_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-h2a6caf8_4.conda
-  sha256: edf4c0e81350580f638307f57d22bba93e9d270f6f6bef5a3dbb1c47978885a2
-  md5: 69d9f1f029ccc7b01f9136042dbe4633
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libglu
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1950791
-  timestamp: 1695760376933
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h5bfa9a0_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
-  sha256: d7101e0426f4a42a97adebeab203113f67ff5ab219ed7b9f71168328d338efc7
-  md5: bb0152817299dab5fe6fdd731379bad4
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcxx >=15.0.7
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1361017
-  timestamp: 1695760594533
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h65f4d7e_4
-  build_number: 4
+  build: h20dfb44_5
+  build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
-  sha256: 9c92bda25dcb6da671b8bc76bfdf1a36900a314f923aa4c0aa46fda653cde1e1
-  md5: 25c1d32ba2975b713f3cbab6f99c6776
+  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
+  sha256: aa2de7c7d1e924437438e57b5141a407bfd6a7c69ebedeb4d9f6cd07e683f724
+  md5: 662cf5b69d72c77dc16f6e30df616cc2
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  size: 1141034
-  timestamp: 1695760782225
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h962fdfd_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-h962fdfd_4.conda
-  sha256: 7bc08a000016055d2187d839bdd1418ec97e90e08e299bdcd2d2a3f38f6b47ab
-  md5: 5ff727b81165e5146845a6e53162b044
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libglu
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
   - sdl >=1.2.68,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 1142127
+  timestamp: 1724165302309
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: hc01355b_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-hc01355b_5.conda
+  sha256: 0c8e947236cb988f3c8216bc8d90f8af56a4b02ce68dbd3b9c51393e629e8efa
+  md5: 6dbd611bb92296e1c103d6cd07dddc8a
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   license: Zlib
-  size: 1907558
-  timestamp: 1695760464370
+  size: 1351009
+  timestamp: 1724165176986
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: hc10942e_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-hc10942e_5.conda
+  sha256: ebe591797abc39462aec98f0eb7b037b71d13c3c14f645bcf20d576c2141025c
+  md5: 6806a2ea18a227f4db840b23df88f1d0
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libgl >=1.7.0,<2.0a0
+  - libglu
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  license: Zlib
+  size: 1906014
+  timestamp: 1724165028021
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: hcce6d95_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-hcce6d95_5.conda
+  sha256: 72aa5d6348eeed5b8f6df1c711757c31dab061c9a355a72cc18ea4c77527a475
+  md5: bd78280d5c89a7377e5b79d491aca6cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libgl >=1.7.0,<2.0a0
+  - libglu
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  license: Zlib
+  size: 1947728
+  timestamp: 1724164975931
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: hdfd4c6d_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
+  sha256: f13abda30c917f95b012a4552f84f505ce662ddcff0a563e39f0e60b9bc131ea
+  md5: 2011bfec6849090eef9ca0e9b75abc66
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1202474
+  timestamp: 1724165134357
 - kind: conda
   name: jasper
-  version: 4.2.3
-  build: h28f2b1a_0
+  version: 4.2.4
+  build: h536e39c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+  sha256: 0a5ca92ea0261f435c27a3c3c5c5bc5e8b4b1af1343b21ef0cbc7c33b62f5239
+  md5: 9518ab7016cf4564778aef08b6bd8792
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 675951
+  timestamp: 1714298705230
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: h6c4e4ef_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+  sha256: 9c874070f201b64d7ca02b59f1348354ae1c834e969cb83259133bb0406ee7fa
+  md5: 9019e1298c84b0185a60c62741d720dd
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 583310
+  timestamp: 1714298773123
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: ha25e7e8_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+  sha256: 01cf16b5df4f685ea5952498d2d3cc0bd9ef54460adfed28a43b6fe05e4743e8
+  md5: f888b2805a130afa6f6657acc5afaa1a
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 707709
+  timestamp: 1714298735485
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: hb10263b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
+  sha256: da2c2fa393b89596cf0f81c8e73db2e9b589ae961058317f6fcb4867e05055dd
+  md5: b7a6171ecee244e2b2a19177ec3c34a9
+  depends:
+  - __osx >=10.9
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 571569
+  timestamp: 1714298729445
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: hcb1a123_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.3-h28f2b1a_0.conda
-  sha256: b9a72b3672301f9289ecf13bd47db6ea9bd3b7e0769401ebbbd4ef3ec80b506d
-  md5: 2ff43a688dc2dbb333b6fc2e1dadf3eb
+  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+  sha256: ecddfba94b78849dbde3c73fffb7877e9f1e7a8c1a71786135538af0c524b49b
+  md5: 94e32e7c907c6c80c0d0db4c8b163baf
   depends:
   - freeglut >=3.2.2,<4.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
@@ -4886,100 +4952,40 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: JasPer-2.0
-  size: 441882
-  timestamp: 1711831477593
-- kind: conda
-  name: jasper
-  version: 4.2.3
-  build: h381c573_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.3-h381c573_0.conda
-  sha256: 847f06136bc6bf3d2cc888b081eb09b9bbea179c1141a94fc15fce11fbb9c435
-  md5: 88ff28462871d8263565902caed3dda4
-  depends:
-  - freeglut >=3.2.2,<4.0a0
-  - libgcc-ng >=12
-  - libglu >=9.0.0,<10.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  size: 709922
-  timestamp: 1711831039048
-- kind: conda
-  name: jasper
-  version: 4.2.3
-  build: h6ff19ee_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.3-h6ff19ee_0.conda
-  sha256: 1ec4bc54e277af13b6016d69c8f3fe769a56d0642f3e60783aaf03536c0220af
-  md5: fe830a9cdfb229efde037ce4c8b5d677
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  size: 571791
-  timestamp: 1711831194534
-- kind: conda
-  name: jasper
-  version: 4.2.3
-  build: h7c0e182_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.3-h7c0e182_0.conda
-  sha256: 674855f8ac05e4155fbd921469aaae46ed5e4ee7ab50beb7f40ec898f79c8926
-  md5: 74f2870f01bfa190827f0e74257fcda7
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  size: 584055
-  timestamp: 1711831130577
-- kind: conda
-  name: jasper
-  version: 4.2.3
-  build: he6dfbbe_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.3-he6dfbbe_0.conda
-  sha256: 5cc5e2ae5127d655747a377e267ff40856c262a00f52cc6840238cfdb52368c4
-  md5: 05c1609de571f7a9a40e6d7d4116c21a
-  depends:
-  - freeglut >=3.2.2,<4.0a0
-  - libgcc-ng >=12
-  - libglu >=9.0.0,<10.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  size: 675096
-  timestamp: 1711830978335
+  size: 442367
+  timestamp: 1714299052957
 - kind: conda
   name: kernel-headers_linux-64
-  version: 2.6.32
-  build: he073ed8_17
-  build_number: 17
+  version: 3.10.0
+  build: he073ed8_18
+  build_number: 18
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_17.conda
-  sha256: fb39d64b48f3d9d1acc3df208911a41f25b6a00bd54935d5973b4739a9edd5b6
-  md5: d731b543793afc0433c4fd593e693fce
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
+  sha256: a922841ad80bd7b222502e65c07ecb67e4176c4fa5b03678a005f39fcc98be4b
+  md5: ad8527bf134a90e1c9ed35fa0b64318c
   constrains:
-  - sysroot_linux-64 ==2.12
+  - sysroot_linux-64 ==2.17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 710627
-  timestamp: 1708000830116
+  size: 943486
+  timestamp: 1729794504440
 - kind: conda
   name: kernel-headers_linux-aarch64
   version: 4.18.0
-  build: h5b4a56d_14
-  build_number: 14
+  build: h05a177a_18
+  build_number: 18
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
-  sha256: c44b178b38de4126d50a71501ac9e1c49119bb7aba9d09ab861ba12bc8d4e21c
-  md5: 9b0446ad203105e5bbdda273a78d1d0f
-  depends:
-  - _sysroot_linux-aarch64_curr_repodata_hack 4.*
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
+  sha256: 99731884b26d5801c931f6ed4e1d40f0d1b2efc60ab2d1d49e9b3a6508a390df
+  md5: 40ebaa9844bc99af99fc1beaed90b379
   constrains:
   - sysroot_linux-aarch64 ==2.17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 1114567
-  timestamp: 1708000894708
+  size: 1113306
+  timestamp: 1729794501866
 - kind: conda
   name: keyutils
   version: 1.6.1
@@ -5008,109 +5014,111 @@ packages:
   timestamp: 1646166857935
 - kind: conda
   name: khronos-opencl-icd-loader
-  version: 2023.04.17
-  build: h64bf75a_0
+  version: 2024.05.08
+  build: hc70643c_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
-  sha256: aca20cb000427881e0b1eb5301568278650ca9f7b069fec0c7904cdf94b995e6
-  md5: 8c51fee1005a058dc96b1da5eba9b308
+  url: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
+  sha256: 701357f02926bef5cb6d060a5471d50dc6528500fd045805ea785398fbb6d6d2
+  md5: 22b22ac3be757e10705caa3b5f321e0d
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
+  - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 86302
-  timestamp: 1681919883423
+  size: 87736
+  timestamp: 1727732609299
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: h659d440_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  md5: cd95826dbd331ed1be26bdf401432844
-  depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.1.2,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1371181
-  timestamp: 1692097755782
-- kind: conda
-  name: krb5
-  version: 1.21.2
-  build: h92f50d5_0
+  version: 1.21.3
+  build: h237132a_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
-  sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
-  md5: 92f1cff174a538e0722bf2efb16fc0b2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
   depends:
-  - libcxx >=15.0.7
+  - __osx >=11.0
+  - libcxx >=16
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1195575
-  timestamp: 1692098070699
+  size: 1155530
+  timestamp: 1719463474401
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: hb884880_0
+  version: 1.21.3
+  build: h37d8d59_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
-  sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
-  md5: 80505a68783f01dc8d7308c075261b2f
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
   depends:
-  - libcxx >=15.0.7
+  - __osx >=10.13
+  - libcxx >=16
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1183568
-  timestamp: 1692098004387
+  size: 1185323
+  timestamp: 1719463492984
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: hc419048_0
+  version: 1.21.3
+  build: h50a48e9_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
-  sha256: c3f24ead49fb7d7c29fae491bec3f090f63d77a46954eadbc4463f137e2b42cd
-  md5: 55b51af37bf6fdcfe06f140e62e8c8db
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
+  md5: 29c10432a2ca1472b53f299ffb2ffa37
   depends:
   - keyutils >=1.6.1,<2.0a0
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1473397
-  timestamp: 1692097651347
+  size: 1474620
+  timestamp: 1719463205834
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: heb0366b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
-  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  version: 1.21.3
+  build: h659f571_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
-  - openssl >=3.1.2,<4.0a0
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- kind: conda
+  name: krb5
+  version: 1.21.3
+  build: hdf4eb48_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 710894
-  timestamp: 1692098129546
+  size: 712034
+  timestamp: 1719463874284
 - kind: conda
   name: lame
   version: '3.100'
@@ -5169,112 +5177,122 @@ packages:
   timestamp: 1664996421531
 - kind: conda
   name: ld64
-  version: '711'
-  build: h634c8be_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-711-h634c8be_0.conda
-  sha256: bf1fa905f08aa2044d5ca9a387c4d626c1b92a81773665268e87cf03a4db1159
-  md5: 5fb1c87739bf8f52d36cb001248e29b6
+  version: '951.9'
+  build: h0a3eb4e_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-h0a3eb4e_1.conda
+  sha256: d6ce3be8687f7fb607173112901e72262a4608dc351bfcb27012c068a5f25fa6
+  md5: 8b8e1a4bd8384bf4b884c9e41636038f
   depends:
-  - ld64_osx-arm64 711 ha4bd21c_0
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - ld64_osx-64 951.9 h38c89e5_1
+  - libllvm17 >=17.0.6,<17.1.0a0
   constrains:
-  - cctools 986.*
-  - cctools_osx-arm64 986.*
+  - cctools_osx-64 1010.6.*
+  - cctools 1010.6.*
   license: APSL-2.0
   license_family: Other
-  size: 18884
-  timestamp: 1710466784602
+  size: 18841
+  timestamp: 1726771674999
 - kind: conda
   name: ld64
-  version: '711'
-  build: ha02d983_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-711-ha02d983_0.conda
-  sha256: 189f5a0f9f923ee7f165fd9f18633ffa5680c24118d731c0a9956ac21dd42720
-  md5: 3ae4930ec076735cce481e906f5192e0
+  version: '951.9'
+  build: h39a299f_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_1.conda
+  sha256: 7dc2adcb40f2bc61b7445980c882a690d1bdef5de206970da2779c2bec5fe876
+  md5: b2f41d20ec157f81280e89bcb4f7164a
   depends:
-  - ld64_osx-64 711 ha20a434_0
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - ld64_osx-arm64 951.9 hc81425b_1
+  - libllvm17 >=17.0.6,<17.1.0a0
   constrains:
-  - cctools 986.*
-  - cctools_osx-64 986.*
+  - cctools_osx-arm64 1010.6.*
+  - cctools 1010.6.*
   license: APSL-2.0
   license_family: Other
-  size: 18819
-  timestamp: 1710466446391
+  size: 18942
+  timestamp: 1726771707244
 - kind: conda
   name: ld64_osx-64
-  version: '711'
-  build: ha20a434_0
+  version: '951.9'
+  build: h38c89e5_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-711-ha20a434_0.conda
-  sha256: 8c4cdd119ff4d8c83f6ae044c76560be302e4986ec1d5f278943ed9319f1171c
-  md5: a8b41eb97c8a9d618243a79ba78fdc3c
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h38c89e5_1.conda
+  sha256: 8370978550dd96479d8ba635a59a97231ccf602d3a189cd2a4cb234947cf61f2
+  md5: 423183fc4729ed4b8e167a980aad83ce
   depends:
+  - __osx >=10.13
   - libcxx
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
   - sigtool
-  - tapi >=1100.0.11,<1101.0a0
+  - tapi >=1300.6.5,<1301.0a0
   constrains:
-  - clang >=16.0.6,<17.0a0
-  - cctools 986.*
-  - ld 711.*
-  - cctools_osx-64 986.*
+  - ld 951.9.*
+  - cctools_osx-64 1010.6.*
+  - cctools 1010.6.*
+  - clang >=17.0.6,<18.0a0
   license: APSL-2.0
   license_family: Other
-  size: 1075550
-  timestamp: 1710466354788
+  size: 1088909
+  timestamp: 1726771576050
 - kind: conda
   name: ld64_osx-arm64
-  version: '711'
-  build: ha4bd21c_0
+  version: '951.9'
+  build: hc81425b_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-711-ha4bd21c_0.conda
-  sha256: f27b661fa4cac5b351ed4ee0ec8c8baf27c2f982309a453968418438c8197450
-  md5: 38abda2ba1128fdde7b7108cc36a9d99
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-hc81425b_1.conda
+  sha256: 37b083cbee78393c511f6ddb21a6ce484ebc037bc3f85c2c293fbc0f418616f1
+  md5: 99473e66ff9960be2995dd1b5fe04ace
   depends:
+  - __osx >=11.0
   - libcxx
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
   - sigtool
-  - tapi >=1100.0.11,<1101.0a0
+  - tapi >=1300.6.5,<1301.0a0
   constrains:
-  - ld 711.*
-  - clang >=16.0.6,<17.0a0
-  - cctools 986.*
-  - cctools_osx-arm64 986.*
+  - cctools_osx-arm64 1010.6.*
+  - cctools 1010.6.*
+  - clang >=17.0.6,<18.0a0
+  - ld 951.9.*
   license: APSL-2.0
   license_family: Other
-  size: 1066358
-  timestamp: 1710466668466
+  size: 1013046
+  timestamp: 1726771628233
 - kind: conda
   name: ld_impl_linux-64
-  version: '2.40'
-  build: h41732ed_0
+  version: '2.43'
+  build: h712a8e2_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  md5: 7aca3059a1729aa76c597603f10b0dd3
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
   constrains:
-  - binutils_impl_linux-64 2.40
+  - binutils_impl_linux-64 2.43
   license: GPL-3.0-only
   license_family: GPL
-  size: 704696
-  timestamp: 1674833944779
+  size: 669211
+  timestamp: 1729655358674
 - kind: conda
   name: ld_impl_linux-aarch64
-  version: '2.40'
-  build: h2d8c526_0
+  version: '2.43'
+  build: h80caac9_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
-  sha256: 1ba06e8645094b340b4aee23603a6abb1b0383788180e65f3de34e655c5f577c
-  md5: 16246d69e945d0b1969a6099e7c5d457
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
+  sha256: 80ec7e8f006196808fac5bd4b3773a652847f97bbf08044cd87731424ac64f8b
+  md5: fcbde5ea19d55468953bf588770c0501
   constrains:
-  - binutils_impl_linux-aarch64 2.40
+  - binutils_impl_linux-aarch64 2.43
   license: GPL-3.0-only
   license_family: GPL
-  size: 738776
-  timestamp: 1674833843183
+  size: 698245
+  timestamp: 1729655345825
 - kind: conda
   name: lerc
   version: 4.0.0
@@ -5350,99 +5368,101 @@ packages:
   timestamp: 1657977526749
 - kind: conda
   name: libabseil
-  version: '20240116.1'
-  build: cxx17_h2f0025b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240116.1-cxx17_h2f0025b_2.conda
-  sha256: bf8d5c1ee76960840d6a0e8eac4fd4111712a4745fffb1e6f9466feb3f11c1c6
-  md5: 85dff948e5ec41a2eba9eb8fb001d01e
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  constrains:
-  - abseil-cpp =20240116.1
-  - libabseil-static =20240116.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1286200
-  timestamp: 1709159884574
-- kind: conda
-  name: libabseil
-  version: '20240116.1'
-  build: cxx17_h59595ed_2
-  build_number: 2
+  version: '20240722.0'
+  build: cxx17_h5888daf_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
-  sha256: 9951421311285dd4335ad3aceffb223a4d3bc90fb804245508cd27aceb184a29
-  md5: 75648bc5dd3b8eab22406876c24d81ec
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
+  md5: e1f604644fe8d78e22660e2fec6756bc
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   constrains:
-  - libabseil-static =20240116.1=cxx17*
-  - abseil-cpp =20240116.1
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
   license: Apache-2.0
   license_family: Apache
-  size: 1266503
-  timestamp: 1709159756788
+  size: 1310521
+  timestamp: 1727295454064
 - kind: conda
   name: libabseil
-  version: '20240116.1'
-  build: cxx17_h63175ca_2
-  build_number: 2
+  version: '20240722.0'
+  build: cxx17_h5ad3122_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
+  sha256: 590e47dce38031a8893e70491f3b71e214de7781cab53b6f017aa6f6841cb076
+  md5: 6fe6b3694c4792a8e26755d3b06f0b80
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1328502
+  timestamp: 1727295490806
+- kind: conda
+  name: libabseil
+  version: '20240722.0'
+  build: cxx17_hac325c4_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+  sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
+  md5: 40373920232a6ac0404eee9cf39a9f09
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1170354
+  timestamp: 1727295597292
+- kind: conda
+  name: libabseil
+  version: '20240722.0'
+  build: cxx17_he0c23c2_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
-  sha256: 565071112e6339051b037bb9c5dae3f4bbc3b45c6f7b8ee598d0ec9056346c93
-  md5: bda6bc65300c4188933d8c68abc97923
+  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
+  md5: 3f59a73b07a05530b252ecb07dd882b9
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - libabseil-static =20240116.1=cxx17*
-  - abseil-cpp =20240116.1
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
   license: Apache-2.0
   license_family: Apache
-  size: 1737645
-  timestamp: 1709160246325
+  size: 1777570
+  timestamp: 1727296115119
 - kind: conda
   name: libabseil
-  version: '20240116.1'
-  build: cxx17_hc1bcbd7_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
-  sha256: 30c0f569949a2fa0c5fd9aae3416e3f6623b9dd6fccdaa8d3437f143b67cca2a
-  md5: 819934a15bc13a0d30778bf18446ada6
-  depends:
-  - libcxx >=16
-  constrains:
-  - libabseil-static =20240116.1=cxx17*
-  - __osx >=10.13
-  - abseil-cpp =20240116.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1133225
-  timestamp: 1709160179404
-- kind: conda
-  name: libabseil
-  version: '20240116.1'
-  build: cxx17_hebf3989_2
-  build_number: 2
+  version: '20240722.0'
+  build: cxx17_hf9b8971_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.1-cxx17_hebf3989_2.conda
-  sha256: 3e87e8da8e40c71f6107386f6e87aeadc8c7b42e2736f6ac894abe50c763d642
-  md5: 0b85aac2fab429166f76940791de071a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
   depends:
-  - libcxx >=16
+  - __osx >=11.0
+  - libcxx >=17
   constrains:
-  - abseil-cpp =20240116.1
-  - libabseil-static =20240116.1=cxx17*
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
   license: Apache-2.0
   license_family: Apache
-  size: 1144666
-  timestamp: 1709160261245
+  size: 1179072
+  timestamp: 1727295571173
 - kind: conda
   name: libaec
   version: 1.1.3
@@ -5518,305 +5538,410 @@ packages:
   size: 28451
   timestamp: 1711021498493
 - kind: conda
-  name: libass
-  version: 0.17.1
-  build: h36b5d3b_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
-  sha256: 49e6709371fae03e2e1ee54914e8825511a1444b8a4e649cff7ffe565a20af35
-  md5: 9dd28617627c9ae4a0783402ab53e09f
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=8.1.1,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: ISC
-  license_family: OTHER
-  size: 133027
-  timestamp: 1693027070371
-- kind: conda
-  name: libass
-  version: 0.17.1
-  build: h80904bb_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
-  sha256: f97c70aa61ecc1b43907cf0322215a58f19e0723ee67b4ebd02146da24f03976
-  md5: 9ccad0aebe916aa3715fda9eefe92584
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=8.1.1,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  license: ISC
-  license_family: OTHER
-  size: 125235
-  timestamp: 1693027259439
-- kind: conda
-  name: libass
-  version: 0.17.1
-  build: h8fe9dca_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
-  sha256: 1bc3e44239a11613627488b7a9b6c021ec6b52c5925abd666832db0cb2a59f05
-  md5: c306fd9cc90c0585171167d09135a827
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=8.1.1,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: ISC
-  license_family: OTHER
-  size: 126896
-  timestamp: 1693027051367
-- kind: conda
-  name: libass
-  version: 0.17.1
-  build: hf7da4fe_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
-  sha256: 31b17bebadd114c6c3e4a647245888fd83ec93533b6ee8f6bfca0bbbc3a95c35
-  md5: 53fff6fc379154382f5121325c5fe2f5
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=8.1.1,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  license: ISC
-  license_family: OTHER
-  size: 110763
-  timestamp: 1693027364342
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 21_linux64_openblas
-  build_number: 21
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
-  sha256: ebd5c91f029f779fb88a1fcbd1e499559a9c258e3674ff58a2fbb4e375ae56d9
-  md5: 0ac9f44fc096772b0aa092119b00c3ca
-  depends:
-  - libopenblas >=0.3.26,<0.3.27.0a0
-  - libopenblas >=0.3.26,<1.0a0
-  constrains:
-  - liblapacke 3.9.0 21_linux64_openblas
-  - blas * openblas
-  - libcblas 3.9.0 21_linux64_openblas
-  - liblapack 3.9.0 21_linux64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14691
-  timestamp: 1705979549006
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 21_linuxaarch64_openblas
-  build_number: 21
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
-  sha256: 5d1dcfc2ef54ce415ffabc8e2d94d10f8a24e10096193da24b0b62dbfe35bf32
-  md5: 7358230781e5d6e76e6adacf5201bcdf
-  depends:
-  - libopenblas >=0.3.26,<0.3.27.0a0
-  - libopenblas >=0.3.26,<1.0a0
-  constrains:
-  - liblapacke 3.9.0 21_linuxaarch64_openblas
-  - liblapack 3.9.0 21_linuxaarch64_openblas
-  - blas * openblas
-  - libcblas 3.9.0 21_linuxaarch64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14650
-  timestamp: 1705979384501
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 21_osx64_openblas
-  build_number: 21
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
-  sha256: 5381eab20f4793996cf22e58461ea8a3a4dff1442bb45663b5920f2d26288688
-  md5: 23286066c595986aa0df6452a8416c08
-  depends:
-  - libopenblas >=0.3.26,<0.3.27.0a0
-  - libopenblas >=0.3.26,<1.0a0
-  constrains:
-  - libcblas 3.9.0 21_osx64_openblas
-  - liblapacke 3.9.0 21_osx64_openblas
-  - blas * openblas
-  - liblapack 3.9.0 21_osx64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14822
-  timestamp: 1705979699547
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 21_osxarm64_openblas
-  build_number: 21
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-21_osxarm64_openblas.conda
-  sha256: 9a553af92af9f241457f4d14eabb872bc341cd0ddea1da6e7939e9c6a7ee1a25
-  md5: b3804f4af39eca9d77360b12811e6d1d
-  depends:
-  - libopenblas >=0.3.26,<0.3.27.0a0
-  - libopenblas >=0.3.26,<1.0a0
-  constrains:
-  - libcblas 3.9.0 21_osxarm64_openblas
-  - liblapack 3.9.0 21_osxarm64_openblas
-  - blas * openblas
-  - liblapacke 3.9.0 21_osxarm64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14915
-  timestamp: 1705980172730
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 21_win64_mkl
-  build_number: 21
+  name: libasprintf
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
-  sha256: ad47053cee17802df875203aba191b04d97a50d820dbf75a114a50972c517334
-  md5: ebba3846d11201fe54277e4965ba5250
-  depends:
-  - mkl 2024.0.0 h66d3029_49657
-  constrains:
-  - liblapack 3.9.0 21_win64_mkl
-  - blas * mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapacke 3.9.0 21_win64_mkl
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5017135
-  timestamp: 1705980415163
+  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
+  md5: 9f661052be1d477dcf61ee3cd77ce5ee
+  license: LGPL-2.1-or-later
+  size: 49776
+  timestamp: 1723629333404
 - kind: conda
-  name: libboost
-  version: 1.84.0
-  build: h1fed05a_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-h1fed05a_2.conda
-  sha256: e2004c18d963094168c1da3f13b94ed61ba85135d5c737d0ac0df2fce7dc14cb
-  md5: 1234fbf96351f64a91fcc5ac1928fd7a
+  name: libasprintf
+  version: 0.22.5
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+  sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
+  md5: 472b673c083175195965a48f2f4808f8
   depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.2,<74.0a0
+  - __osx >=11.0
+  - libcxx >=16
+  license: LGPL-2.1-or-later
+  size: 40657
+  timestamp: 1723626937704
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: h87f4aca_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+  sha256: b438814a7190a541950da68d3cde8ecbcc55629ce677eb65afbb01cfa1e4e651
+  md5: 332ce64c2dec75dc0849e7ffcdf7a3a4
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 2993478
-  timestamp: 1711404468443
+  license: LGPL-2.1-or-later
+  size: 42627
+  timestamp: 1723626204541
 - kind: conda
-  name: libboost
-  version: 1.84.0
-  build: h6ebd1c4_2
-  build_number: 2
+  name: libasprintf
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-h6ebd1c4_2.conda
-  sha256: 7027fa98a1c3323729a61d9a9b1d6940d0c48041a208bcfbd9561b414a9fe7d2
-  md5: 1305a412e52c835924d29035c7bcac5d
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
+  sha256: 9c6f3e2558e098dbbc63c9884b4af368ea6cc4185ea027563ac4f5ee8571b143
+  md5: 55363e1d53635b3497cdf753ab0690c1
   depends:
   - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.2,<74.0a0
   - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 2086979
-  timestamp: 1711406164959
+  license: LGPL-2.1-or-later
+  size: 40442
+  timestamp: 1723626787726
 - kind: conda
-  name: libboost
-  version: 1.84.0
-  build: h8013b2b_2
-  build_number: 2
+  name: libasprintf
+  version: 0.22.5
+  build: he8f35ee_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-h8013b2b_2.conda
-  sha256: f38191766b87bbf4099851d40ecc17c5d6cf4f898b76a8d8648a5caaf04bf2da
-  md5: 2de948e2fa2aea5f2b23cd02edcba24a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+  sha256: 2da5c735811cbf38c7f7844ab457ff8b25046bbf5fe5ebd5dc1c2fafdf4fbe1c
+  md5: 4fab9799da9571266d05ca5503330655
   depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.2,<74.0a0
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  license: LGPL-2.1-or-later
+  size: 42817
+  timestamp: 1723626012203
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h87f4aca_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
+  sha256: c9eda86140a5a023b72a8997f82629f4b071df17d57d00ba75a66b65a0525a5e
+  md5: dbaa9d8c0030bda3e3d22d325ea48191
+  depends:
+  - libasprintf 0.22.5 h87f4aca_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34359
+  timestamp: 1723626223953
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: he8f35ee_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+  sha256: ccc7967e298ddf3124c8ad9741c7180dc6f778ae4135ec87978214f7b3c64dc2
+  md5: 1091193789bb830127ed067a9e01ac57
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libasprintf 0.22.5 he8f35ee_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34172
+  timestamp: 1723626026096
+- kind: conda
+  name: libass
+  version: 0.17.3
+  build: h1dc1e6a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+  sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
+  md5: 2a66267ba586dadd110cc991063cfff7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: ISC
+  license_family: OTHER
+  size: 133110
+  timestamp: 1719985879751
+- kind: conda
+  name: libass
+  version: 0.17.3
+  build: h5386a9e_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.3-h5386a9e_0.conda
+  sha256: 2a19c0230f0d6d707a2f0d3fdfe50fb41fbf05e88fb4a79e8e2b5a29f66c4c55
+  md5: b6b8a0a32d77060c4431933a0ba11d3b
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: ISC
+  license_family: OTHER
+  size: 133998
+  timestamp: 1719986071273
+- kind: conda
+  name: libass
+  version: 0.17.3
+  build: hcc173ff_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
+  sha256: 93d84d22f9fa360c175ce6b0bdd4ec33c0f6399eb6e6a17fcbf8b34375343528
+  md5: 7a3fcba797d23512f55ef23e68ae4ec9
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: ISC
+  license_family: OTHER
+  size: 145939
+  timestamp: 1719986023948
+- kind: conda
+  name: libass
+  version: 0.17.3
+  build: hf20b609_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
+  sha256: 2c03d080b48e65e4c488b4824b817fbdce5b79e18f49fc4e823819268b74bb7d
+  md5: 50f6b3ead2c75c7c4009a8ed477d8142
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: ISC
+  license_family: OTHER
+  size: 116755
+  timestamp: 1719986027249
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 25_linux64_openblas
+  build_number: 25
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
   constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  size: 2790076
-  timestamp: 1711404148144
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 25_linuxaarch64_openblas
+  build_number: 25
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
+  sha256: 5c08f78312874bb61307f5ea737377df2d0f6e7f7833ded21ca58d8820c794ca
+  md5: f9b8a4a955ed2d0b68b1f453abcc1c9e
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_linuxaarch64_openblas
+  - liblapack 3.9.0 25_linuxaarch64_openblas
+  - libcblas 3.9.0 25_linuxaarch64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15808
+  timestamp: 1729643002627
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 25_osx64_openblas
+  build_number: 25
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 25_osxarm64_openblas
+  build_number: 25
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 25_win64_mkl
+  build_number: 25
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
 - kind: conda
   name: libboost
-  version: 1.84.0
-  build: h8e0f962_2
+  version: 1.86.0
+  build: h29978a0_2
   build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-h8e0f962_2.conda
-  sha256: 6df34b05b01cd4cb7ed5303a3bc4717b22feb3c2cb90f8199b5b39433e6e0053
-  md5: 1213805efc29946aaf35820220ea3b87
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
+  sha256: d9e080b69dc963cab704d33439a7ed6d76b6c9eb644b63163eda2a32e3a1a799
+  md5: 3f5b15eed5e82e7ea8358a161e974ced
   depends:
+  - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.2,<74.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - boost-cpp =1.84.0
+  - boost-cpp <0.0a0
   license: BSL-1.0
-  size: 1935331
-  timestamp: 1711406196397
+  size: 2004506
+  timestamp: 1725334277168
 - kind: conda
   name: libboost
-  version: 1.84.0
-  build: hcc118f5_2
+  version: 1.86.0
+  build: h444863b_2
   build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-hcc118f5_2.conda
-  sha256: 007b10ec28cca446913b103d8de869cdc101ce9b764f2b937a0c07d49096c7aa
-  md5: 567404551f99afdaf8322c2ae36d7cae
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
+  sha256: a444cc7877f061b7f7c6195c806db183806f1f3a3b6ae26b1c9a89c89a049632
+  md5: 3208cfab6cdb23e6b49805a3771361f2
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - boost-cpp =1.84.0
+  - boost-cpp <0.0a0
   license: BSL-1.0
-  size: 2414055
-  timestamp: 1711405735639
+  size: 2384613
+  timestamp: 1725335041520
+- kind: conda
+  name: libboost
+  version: 1.86.0
+  build: hb8260a3_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
+  sha256: d2b5959c9d73486fba422b1f4f844447df110924860df5583847b7ca62e98a6e
+  md5: 5e0ef327c03bb0092046cc9e964b3ceb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 3075722
+  timestamp: 1725333797199
+- kind: conda
+  name: libboost
+  version: 1.86.0
+  build: hbe88bda_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.86.0-hbe88bda_2.conda
+  sha256: 92184cfa6b59e3176d9dcdd0662f55d72850bd429771e2ec19e1bd8b4af17cb4
+  md5: 639e62feb43b9d312657ca595410fdfb
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 2138336
+  timestamp: 1725333992879
+- kind: conda
+  name: libboost
+  version: 1.86.0
+  build: hcc9b45e_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
+  sha256: 4b8fc3d46b64ba4e690a3d6eb9a1a7c38ac2e6c20f54c2621d796f1749c7015b
+  md5: 9098a06de7a66110540ca2974f69a6b4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 3105189
+  timestamp: 1725333795866
 - kind: conda
   name: libcap
   version: '2.69'
@@ -5850,315 +5975,255 @@ packages:
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 21_linux64_openblas
-  build_number: 21
+  build: 25_linux64_openblas
+  build_number: 25
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
-  sha256: 467bbfbfe1a1aeb8b1f9f6485eedd8ed1b6318941bf3702da72336ccf4dc25a6
-  md5: 4a3816d06451c4946e2db26b86472cb6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
   depends:
-  - libblas 3.9.0 21_linux64_openblas
+  - libblas 3.9.0 25_linux64_openblas
   constrains:
-  - liblapacke 3.9.0 21_linux64_openblas
+  - liblapack 3.9.0 25_linux64_openblas
   - blas * openblas
-  - liblapack 3.9.0 21_linux64_openblas
+  - liblapacke 3.9.0 25_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14614
-  timestamp: 1705979564122
+  size: 15613
+  timestamp: 1729642905619
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 21_linuxaarch64_openblas
-  build_number: 21
+  build: 25_linuxaarch64_openblas
+  build_number: 25
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-21_linuxaarch64_openblas.conda
-  sha256: 86224669232944141f46b41d0ba18192c7f5af9cc3133fa89694f42701fe89fd
-  md5: 7eb9aa7a90f067f8dbfede586cdc55cd
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
+  sha256: fde797e5528040fed0e9228dd75331be0cf5cbb0bc63641f53c3cca9eb86ec16
+  md5: db6af51123c67814572a8c25542cb368
   depends:
-  - libblas 3.9.0 21_linuxaarch64_openblas
+  - libblas 3.9.0 25_linuxaarch64_openblas
   constrains:
-  - liblapacke 3.9.0 21_linuxaarch64_openblas
-  - liblapack 3.9.0 21_linuxaarch64_openblas
   - blas * openblas
+  - liblapacke 3.9.0 25_linuxaarch64_openblas
+  - liblapack 3.9.0 25_linuxaarch64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14575
-  timestamp: 1705979392590
+  size: 15700
+  timestamp: 1729643006729
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 21_osx64_openblas
-  build_number: 21
+  build: 25_osx64_openblas
+  build_number: 25
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
-  sha256: e2b1455612d4cfb3ac3170f0c538516ebd0b113780ac6603338245354e1b2f02
-  md5: 7a1b54774bad723e8ba01ca48eb301b5
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
   depends:
-  - libblas 3.9.0 21_osx64_openblas
+  - libblas 3.9.0 25_osx64_openblas
   constrains:
-  - liblapacke 3.9.0 21_osx64_openblas
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
   - blas * openblas
-  - liblapack 3.9.0 21_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14715
-  timestamp: 1705979715508
+  size: 15842
+  timestamp: 1729643166929
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 21_osxarm64_openblas
-  build_number: 21
+  build: 25_osxarm64_openblas
+  build_number: 25
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-21_osxarm64_openblas.conda
-  sha256: 4510e3e4824693c3f80fc54e72d81dd89acaa6e6d68cd948af0870a640ea7eeb
-  md5: 48e9d42c65ce664d8fccef2ac6af853c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
   depends:
-  - libblas 3.9.0 21_osxarm64_openblas
+  - libblas 3.9.0 25_osxarm64_openblas
   constrains:
-  - liblapack 3.9.0 21_osxarm64_openblas
   - blas * openblas
-  - liblapacke 3.9.0 21_osxarm64_openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14800
-  timestamp: 1705980195551
+  size: 15837
+  timestamp: 1729643270793
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 21_win64_mkl
-  build_number: 21
+  build: 25_win64_mkl
+  build_number: 25
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
-  sha256: 886505d0a4a5b508b2255991395aadecdad140719ba0d413411fec86491a9283
-  md5: 38e5ec23bc2b62f9dd971143aa9dddb7
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
   depends:
-  - libblas 3.9.0 21_win64_mkl
+  - libblas 3.9.0 25_win64_mkl
   constrains:
-  - liblapack 3.9.0 21_win64_mkl
   - blas * mkl
-  - liblapacke 3.9.0 21_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 5017024
-  timestamp: 1705980469944
+  size: 3732258
+  timestamp: 1729643561581
 - kind: conda
-  name: libclang-cpp15
-  version: 15.0.7
-  build: default_h127d8a8_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
-  sha256: 9b0238e705a33da74ca82efd03974f499550f7dada1340cc9cb7c35a92411ed8
-  md5: d0a9633b53cdc319b8a1a532ae7822b8
-  depends:
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 17206402
-  timestamp: 1711063711931
-- kind: conda
-  name: libclang-cpp15
-  version: 15.0.7
-  build: default_h7151d67_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp15-15.0.7-default_h7151d67_5.conda
-  sha256: 0389c856f8524615e29980ed15ad39cdca6bbd01de35ddf5f6550392db943838
-  md5: ec9151310badcf29fa53ae554273e269
-  depends:
-  - libcxx >=16.0.6
-  - libllvm15 >=15.0.7,<15.1.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 12345888
-  timestamp: 1711067079759
-- kind: conda
-  name: libclang-cpp15
-  version: 15.0.7
-  build: default_hb368394_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp15-15.0.7-default_hb368394_5.conda
-  sha256: d36b69c8cbc145ec8a7d2d5b0e73af406d9b23819938bd7d52da2441c51960e6
-  md5: b194b775281eb749e2fa6ca40ea993ca
-  depends:
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 16890274
-  timestamp: 1711066480427
-- kind: conda
-  name: libclang-cpp15
-  version: 15.0.7
-  build: default_he012953_5
-  build_number: 5
+  name: libclang-cpp17
+  version: 17.0.6
+  build: default_h146c034_7
+  build_number: 7
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_he012953_5.conda
-  sha256: 2e56e0acc3afad2708bc410e499d23db517cd66dcfaba150d7d28cf5a35911a8
-  md5: a3035345155ca0a31eb1588bbbb2cff0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
+  sha256: 2e338629ae19faae0d1a85543b8c84441ead61957cf69a65c0031d5b18ebac08
+  md5: bc6797a6a66ec6f919cc8d4d9285b11c
   depends:
-  - libcxx >=16.0.6
-  - libllvm15 >=15.0.7,<15.1.0a0
+  - __osx >=11.0
+  - libcxx >=17.0.6
+  - libllvm17 >=17.0.6,<17.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 11404805
-  timestamp: 1711086898132
+  size: 12408943
+  timestamp: 1725505311206
 - kind: conda
-  name: libclang-cpp16
-  version: 16.0.6
-  build: default_h7151d67_6
-  build_number: 6
+  name: libclang-cpp17
+  version: 17.0.6
+  build: default_hb173f14_7
+  build_number: 7
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_6.conda
-  sha256: 8d77bf8bb12e4dff0bdc0d6dbc9ec674a46470c4e51a1fc8ffec16ed7da3365f
-  md5: 7eaad118ab797d1427f8745c861d1925
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp17-17.0.6-default_hb173f14_7.conda
+  sha256: 59759d25952ac0fd0b07b56af9ab615e379ca4499c9d5277b0bd19a20afb33c9
+  md5: 9fb4dfe8b2c3ba1b68b79fcd9a71cb76
   depends:
-  - libcxx >=16.0.6
-  - libllvm16 >=16.0.6,<16.1.0a0
+  - __osx >=10.13
+  - libcxx >=17.0.6
+  - libllvm17 >=17.0.6,<17.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 12714864
-  timestamp: 1711067666274
+  size: 13187621
+  timestamp: 1725505540477
 - kind: conda
-  name: libclang-cpp16
-  version: 16.0.6
-  build: default_he012953_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_6.conda
-  sha256: 83ebaab5779a592de1b349d29a0f633ec0d7ed2722746c616f89ecf43c7a6675
-  md5: 4562ed88b0429ac497603df91cdd4f5c
-  depends:
-  - libcxx >=16.0.6
-  - libllvm16 >=16.0.6,<16.1.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11762505
-  timestamp: 1711066876125
-- kind: conda
-  name: libclang-cpp18.1
-  version: 18.1.2
-  build: default_h127d8a8_1
+  name: libclang-cpp19.1
+  version: 19.1.2
+  build: default_hb5137d0_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.2-default_h127d8a8_1.conda
-  sha256: f1aeeae04a316a7425d7ff71895b828a7fc26f58d2509fd266dd4683aac9ffa2
-  md5: dc9fe55eef7cc9f1cce884b21c402a93
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.2-default_hb5137d0_1.conda
+  sha256: 2638abec6f79942a9176b30b2ea70bd47967e873d3d120822cbab38ab4895c14
+  md5: 7e574c7499bc41f92537634a23fed79a
   depends:
-  - libgcc-ng >=12
-  - libllvm18 >=18.1.2,<18.2.0a0
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 19272925
-  timestamp: 1711067597580
+  size: 20533631
+  timestamp: 1729290507675
 - kind: conda
-  name: libclang-cpp18.1
-  version: 18.1.2
-  build: default_hb368394_1
+  name: libclang-cpp19.1
+  version: 19.1.2
+  build: default_he324ac1_1
   build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp18.1-18.1.2-default_hb368394_1.conda
-  sha256: cb273824d5c12b93db9e02456b04f79b89a753d65c498415055fe2e8c177a45a
-  md5: 8284e1ce0281f36d09d9d4dbcba69a00
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.2-default_he324ac1_1.conda
+  sha256: dab99fbd0fa84508e47871c764dfcb5f75ce4fc5c4827258a304763bed33e782
+  md5: 6d4b791f9aa0523de4a8f46cd8b2e3ea
   depends:
-  - libgcc-ng >=12
-  - libllvm18 >=18.1.2,<18.2.0a0
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 18874723
-  timestamp: 1711070404535
+  size: 20098468
+  timestamp: 1729292090129
 - kind: conda
   name: libclang13
-  version: 18.1.2
-  build: default_h0edc4dd_1
+  version: 19.1.2
+  build: default_h0c68bdf_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-18.1.2-default_h0edc4dd_1.conda
-  sha256: 8ecb10d57976991830f523c4dc48c9de2fd2f246dd961633ca78db2d9bd80fae
-  md5: 8e26ef06568f888286a077c759972c48
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-19.1.2-default_h0c68bdf_1.conda
+  sha256: 069401db5b26480f380a472efc5991ebdc8a6e55ba0b71cfbb1347a7e68215f3
+  md5: 2243d33c31db0d6e6fc00e07959e3f38
   depends:
-  - libcxx >=16.0.6
-  - libllvm18 >=18.1.2,<18.2.0a0
+  - __osx >=10.13
+  - libcxx >=19.1.2
+  - libllvm19 >=19.1.2,<19.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 8053259
-  timestamp: 1711070248968
+  size: 8605209
+  timestamp: 1729287659101
 - kind: conda
   name: libclang13
-  version: 18.1.2
-  build: default_h5d6823c_1
+  version: 19.1.2
+  build: default_h4390ef5_1
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.2-default_h5d6823c_1.conda
-  sha256: fd1bb5fb2cd65526e1c67ea20efbbe8c1b1bf8ff61465af591d7b25f0c037b06
-  md5: 7aa3c2bbedb583b81e1efc997cb22073
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.2-default_h4390ef5_1.conda
+  sha256: 68751a926366aedc38943d8250f45339f7aca37cd82826e826647a90322dcfcb
+  md5: 0aed30adc7dd7e5929596bde6659785d
   depends:
-  - libgcc-ng >=12
-  - libllvm18 >=18.1.2,<18.2.0a0
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 11070109
-  timestamp: 1711067889145
+  size: 11604370
+  timestamp: 1729292368607
 - kind: conda
   name: libclang13
-  version: 18.1.2
-  build: default_h83d0a53_1
+  version: 19.1.2
+  build: default_h5f28f6d_1
   build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-18.1.2-default_h83d0a53_1.conda
-  sha256: 367ca773609a69b5dfb4f13ffac9b579490eb51ce6f8083c8d9f6b718f146ff5
-  md5: 8fbed37344ef3939d791dc0243c6768a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.2-default_h5f28f6d_1.conda
+  sha256: 550b742557e2c18cc05fddce485a88a015d76bb278d704275bf614ed283709bc
+  md5: 6f9992d748b402ffeefd0ab66ff24dde
   depends:
-  - libcxx >=16.0.6
-  - libllvm18 >=18.1.2,<18.2.0a0
+  - __osx >=11.0
+  - libcxx >=19.1.2
+  - libllvm19 >=19.1.2,<19.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 7520538
-  timestamp: 1711068419314
+  size: 8060643
+  timestamp: 1729287131146
 - kind: conda
   name: libclang13
-  version: 18.1.2
-  build: default_hf64faad_1
+  version: 19.1.2
+  build: default_h9c6a7e4_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.2-default_h9c6a7e4_1.conda
+  sha256: 8a38fb764bf65cc18f03006db6aeb345d390102182db2e46fd3f452a1b2dcfcc
+  md5: cb5c5ff12b37aded00d9aaa7b9a86a78
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11819644
+  timestamp: 1729290739883
+- kind: conda
+  name: libclang13
+  version: 19.1.2
+  build: default_ha5278ca_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.2-default_hf64faad_1.conda
-  sha256: 847dc28280d6564a02ef971a232f30c84fcb5d366a54e59de35fae33e096c8cc
-  md5: ece5a1b226db1000b2c479694c1ae265
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.2-default_ha5278ca_1.conda
+  sha256: 4349ba29e57a7487e3abe243037dc53185a523afe4d7a889c227e05ab3dfd5b9
+  md5: c38f43ef7461c7fac0d5010153ae8d42
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 25310297
-  timestamp: 1711069468740
-- kind: conda
-  name: libclang13
-  version: 18.1.2
-  build: default_hf9b4efe_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-18.1.2-default_hf9b4efe_1.conda
-  sha256: 6b1ae59e97f4a2405e289aa4ac47452f1bfedbbf365dfb0cd7d59a43bbaae054
-  md5: 1b48ba729613c747f500969dedde412c
-  depends:
-  - libgcc-ng >=12
-  - libllvm18 >=18.1.2,<18.2.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 10872620
-  timestamp: 1711070744924
+  size: 26750034
+  timestamp: 1729293730509
 - kind: conda
   name: libcups
   version: 2.3.3
@@ -6172,7 +6237,7 @@ packages:
   - krb5 >=1.21.1,<1.22.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: Apache-2.0
   license_family: Apache
   size: 4551247
@@ -6190,230 +6255,273 @@ packages:
   - krb5 >=1.21.1,<1.22.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: Apache-2.0
   license_family: Apache
   size: 4519402
   timestamp: 1689195353551
 - kind: conda
   name: libcurl
-  version: 8.7.1
-  build: h2d989ff_0
+  version: 8.10.1
+  build: h13a7ad3_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
-  sha256: 973ac9368efca712a8fd19fe68524d7d9a3087fd88ad6b7fcdf60c3d2e19a498
-  md5: 34b9171710f0d9bf093d55bdc36ff355
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
   - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 358080
-  timestamp: 1711548548174
+  size: 379948
+  timestamp: 1726660033582
 - kind: conda
   name: libcurl
-  version: 8.7.1
-  build: h4e8248e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.7.1-h4e8248e_0.conda
-  sha256: 2e2c716875ee48947e4e7a56823c810b5a3d98013ae44d0b55cdfd337f77d693
-  md5: 4e38af63e8603414534bbebdd9885021
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 409751
-  timestamp: 1711548134067
-- kind: conda
-  name: libcurl
-  version: 8.7.1
-  build: h726d00d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
-  sha256: 06cb1bd3bbaf905213777d6ade190ac4c7fb7a20dfe0cf901c977dbbc6cec265
-  md5: fa58e5eaa12006bc3289a71357bef167
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 378176
-  timestamp: 1711548390530
-- kind: conda
-  name: libcurl
-  version: 8.7.1
-  build: hca28451_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
-  sha256: 82a75e9a5d9ee5b2f487d850ec5d4edc18a56eb9527608a95a916c40baae3843
-  md5: 755c7f876815003337d2c61ff5d047e5
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 398293
-  timestamp: 1711548114077
-- kind: conda
-  name: libcurl
-  version: 8.7.1
-  build: hd5e4a3a_0
+  version: 8.10.1
+  build: h1ee3ff0_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
-  sha256: 8dd272362e2aeb1d4f49333ff57e07eb4da2bbabce20110a2416df9152ba03e0
-  md5: 3396aff340d0903e8814c2852d631e4e
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
+  - krb5 >=1.21.3,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: curl
   license_family: MIT
-  size: 331262
-  timestamp: 1711548608132
+  size: 342388
+  timestamp: 1726660508261
 - kind: conda
-  name: libcxx
-  version: 16.0.6
-  build: h4653b0c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
-  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
-  md5: 9d7d724faf0413bf1dbc5a85935700c8
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 1160232
-  timestamp: 1686896993785
-- kind: conda
-  name: libcxx
-  version: 16.0.6
-  build: hd57cbcb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
-  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
-  md5: 7d6972792161077908b62971802f289a
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 1142172
-  timestamp: 1686896907750
-- kind: conda
-  name: libdeflate
-  version: '1.20'
-  build: h31becfc_0
+  name: libcurl
+  version: 8.10.1
+  build: h3ec0cbf_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.20-h31becfc_0.conda
-  sha256: 01efbc296d47de9861100d9a9ad2c7f682adc71a0e9b9b040a35b454d1ccd3bd
-  md5: 018592a3d691662f451f89d0de474a20
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
+  sha256: 7c4983001c727f713b4448280ed4803d301087c184cd2819ba0b788ca62b73d1
+  md5: f43539295c4e0cd15202d41bc72b8a26
   depends:
-  - libgcc-ng >=12
-  license: MIT
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
   license_family: MIT
-  size: 69943
-  timestamp: 1711196586503
+  size: 439171
+  timestamp: 1726659843118
 - kind: conda
-  name: libdeflate
-  version: '1.20'
-  build: h49d49c5_0
+  name: libcurl
+  version: 8.10.1
+  build: h58e7537_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
-  sha256: 8c2087952db55c4118dd2e29381176a54606da47033fd61ebb1b0f4391fcd28d
-  md5: d46104f6a896a0bc6a1d37b88b2edf5c
-  license: MIT
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
   license_family: MIT
-  size: 70364
-  timestamp: 1711196727346
+  size: 402588
+  timestamp: 1726660264675
 - kind: conda
-  name: libdeflate
-  version: '1.20'
-  build: h93a5062_0
+  name: libcurl
+  version: 8.10.1
+  build: hbbe4b11_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- kind: conda
+  name: libcxx
+  version: 19.1.2
+  build: ha82da77_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
-  sha256: 6d16cccb141b6bb05c38107b335089046664ea1d6611601d3f6e7e4227a99925
-  md5: 97efeaeba2a9a82bdf46fc6d025e3a57
-  license: MIT
-  license_family: MIT
-  size: 54481
-  timestamp: 1711196723486
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.2-ha82da77_0.conda
+  sha256: 9c714110264f4fe824d40e11ad39b0eda65251f87826c81f4d67ccf8a3348d29
+  md5: ba89ad7c5477e6a9d020020fcdadd37d
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 521199
+  timestamp: 1729038190391
+- kind: conda
+  name: libcxx
+  version: 19.1.2
+  build: hf95d169_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.2-hf95d169_0.conda
+  sha256: 04593566411ce8dc6400777c772c10a153ebf1082b104ee52a98562a24a50880
+  md5: 8bdfb741a2cdbd0a4e7b7dc30fbc0d6c
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 526600
+  timestamp: 1729038055775
+- kind: conda
+  name: libcxx-devel
+  version: 17.0.6
+  build: h86353a2_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
+  sha256: 914cc589f356dfc64ddc4f0dc305fce401356b688730b62e24b4f52358595a58
+  md5: 555639d6c7a4c6838cec6e50453fea43
+  depends:
+  - libcxx >=17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 820887
+  timestamp: 1725403726157
+- kind: conda
+  name: libcxx-devel
+  version: 17.0.6
+  build: h8f8a49f_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-17.0.6-h8f8a49f_6.conda
+  sha256: 3b23efafbf36b8d30bbd2f421e189ef4eb805ac29e65249c174391c23afd665b
+  md5: faa013d493ffd2d5f2d2fc6df5f98f2e
+  depends:
+  - libcxx >=17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 822480
+  timestamp: 1725403649896
 - kind: conda
   name: libdeflate
-  version: '1.20'
-  build: hcfcfb64_0
+  version: '1.22'
+  build: h00291cd_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- kind: conda
+  name: libdeflate
+  version: '1.22'
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
-  sha256: 6628a5b76ad70c1a0909563c637ddc446ee824739ba7c348d4da2f0aa6ac9527
-  md5: b12b5bde5eb201a1df75e49320cc938a
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 155358
-  timestamp: 1711197066985
+  size: 155506
+  timestamp: 1728177485361
 - kind: conda
   name: libdeflate
-  version: '1.20'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
-  sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
-  md5: 8e88f9389f1165d7c0936fe40d9a9a79
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 71500
-  timestamp: 1711196523408
-- kind: conda
-  name: libdrm
-  version: 2.4.120
-  build: h31becfc_0
+  version: '1.22'
+  build: h86ecc28_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.120-h31becfc_0.conda
-  sha256: 9660f299fac49b5fa69f3b2e0a610dc5c4adb22f5135c3d5db555b7b031aabca
-  md5: 21a381c9fc281507bb7d3855c85df0d3
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
+  sha256: 986207f130703897300ddc3637c52e86a5b21c735fe384bf48554d9a6d91c56d
+  md5: ff6a44e8b1707d02be2fe9a36ea88d4a
   depends:
-  - libgcc-ng >=12
-  - libpciaccess >=0.18,<0.19.0a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 272881
-  timestamp: 1708374299125
+  size: 69601
+  timestamp: 1728177137503
+- kind: conda
+  name: libdeflate
+  version: '1.22'
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- kind: conda
+  name: libdeflate
+  version: '1.22'
+  build: hd74edd7_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
 - kind: conda
   name: libdrm
-  version: 2.4.120
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
-  sha256: 8622f52e517418ae7234081fac14a3caa8aec5d1ee5f881ca1f3b194d81c3150
-  md5: 7c3071bdf1d28b331a06bda6e85ab607
+  version: 2.4.123
+  build: h86ecc28_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
+  sha256: 9a5dc3585a6468b266fc80e21fd2b6f3d8236818ee3fa853b6972ab0a44d7804
+  md5: 4e3c67f6999ea7ccac41611f930d19d4
   depends:
-  - libgcc-ng >=12
+  - libgcc-ng >=13
   - libpciaccess >=0.18,<0.19.0a0
   license: MIT
   license_family: MIT
-  size: 303067
-  timestamp: 1708374304366
+  size: 273843
+  timestamp: 1724719291504
+- kind: conda
+  name: libdrm
+  version: 2.4.123
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+  sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
+  md5: ee605e794bdc14e2b7f84c4faa0d8c2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  size: 303108
+  timestamp: 1724719521496
 - kind: conda
   name: libedit
   version: 3.1.20191231
@@ -6476,6 +6584,35 @@ packages:
   license_family: BSD
   size: 134104
   timestamp: 1597617110769
+- kind: conda
+  name: libegl
+  version: 1.7.0
+  build: ha4b6fd6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
+  sha256: e64388e983cf14354b70fe908ca3943f2481ea63df8a4de5e4d418dc2addd38e
+  md5: 38a5cd3be5fb620b48069e27285f1a44
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_1
+  license: LicenseRef-libglvnd
+  size: 44620
+  timestamp: 1727968589748
+- kind: conda
+  name: libegl
+  version: 1.7.0
+  build: hd24410f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_1.conda
+  sha256: 52cc18200fefa4a65852421c6fd1ccff57e598d2c331574b9093258a4ee774a2
+  md5: f82d2736a04324c05bdce1c39a57fee6
+  depends:
+  - libglvnd 1.7.0 hd24410f_1
+  license: LicenseRef-libglvnd
+  size: 53358
+  timestamp: 1727968557699
 - kind: conda
   name: libev
   version: '4.33'
@@ -6566,78 +6703,87 @@ packages:
   timestamp: 1685725977222
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
-  sha256: 07453df3232a649f39fb4d1e68cfe1c78c3457764f85225f6f3ccd1bdd9818a4
-  md5: 1b9f46b804a2c3c5d7fd6a80b77c35f9
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 72544
-  timestamp: 1710362309065
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: h59595ed_0
+  version: 2.6.3
+  build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
-  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
-  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+  sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
+  md5: 59f4c43bb1b5ef1c71946ff2cbf59524
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 73730
-  timestamp: 1710362120304
+  size: 73616
+  timestamp: 1725568742634
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
-  sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
-  md5: bc592d03f62779511d392c175dcece64
+  version: 2.6.3
+  build: h5ad3122_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
+  sha256: 02341c9c35128055fd404dfe675832b80f2bf9dbb99539457652c11c06e52757
+  md5: 1d2b842bb76e268625e8ee8d0a9fe8c3
+  depends:
+  - libgcc >=13
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 139224
-  timestamp: 1710362609641
+  size: 72342
+  timestamp: 1725568840022
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: h73e2aa4_0
+  version: 2.6.3
+  build: hac325c4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
-  sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
-  md5: 3d1d51c8f716d97c864d12f7af329526
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
+  sha256: dd22dffad6731c352f4c14603868c9cce4d3b50ff5ff1e50f416a82dcb491947
+  md5: c1db99b0a94a2f23bd6ce39e2d314e07
+  depends:
+  - __osx >=10.13
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 69246
-  timestamp: 1710362566073
+  size: 70517
+  timestamp: 1725568864316
 - kind: conda
   name: libexpat
-  version: 2.6.2
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
-  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
-  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+  version: 2.6.3
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
+  sha256: 9543965d155b8da96fc67dd81705fe5c2571c7c00becc8de5534c850393d4e3c
+  md5: 21415fbf4d0de6767a621160b43e5dea
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   constrains:
-  - expat 2.6.2.*
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 63655
-  timestamp: 1710362424980
+  size: 138992
+  timestamp: 1725569106114
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
+  sha256: 5cbe5a199fba14ade55457a468ce663aac0b54832c39aa54470b3889b4c75c4a
+  md5: 5f22f07c2ab2dea8c66fe9585a062c96
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 63895
+  timestamp: 1725568783033
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -6766,98 +6912,250 @@ packages:
   size: 531143
   timestamp: 1527899216421
 - kind: conda
-  name: libgcc-devel_linux-64
-  version: 12.3.0
-  build: h8bca6fd_105
-  build_number: 105
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
-  sha256: ed2dfc6d959dc27e7668439e1ad31b127b43e99f9a7e77a2d34b958fa797316b
-  md5: e12ce6b051085b8f27e239f5e5f5bce5
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 2568967
-  timestamp: 1706819720613
-- kind: conda
-  name: libgcc-devel_linux-aarch64
-  version: 12.3.0
-  build: h8b5ab12_105
-  build_number: 105
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
-  sha256: 1ff691733d28774c8f56e0159fe0fffc56b1cf4de64630501f6c3b8438aa893f
-  md5: cb2ce837146463f83f24f52face3ca9d
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 285097
-  timestamp: 1706819953671
-- kind: conda
-  name: libgcc-ng
-  version: 13.2.0
-  build: h807b86a_5
-  build_number: 5
+  name: libgcc
+  version: 14.2.0
+  build: h77fa898_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
-  sha256: d32f78bfaac282cfe5205f46d558704ad737b8dbf71f9227788a5ca80facaba4
-  md5: d4ff227c46917d3b4565302a2bbb276b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
   depends:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 13.2.0 h807b86a_5
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 770506
-  timestamp: 1706819192021
+  size: 848745
+  timestamp: 1729027721139
 - kind: conda
-  name: libgcc-ng
-  version: 13.2.0
-  build: hf8544c7_5
-  build_number: 5
+  name: libgcc
+  version: 14.2.0
+  build: he277a41_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
-  sha256: 869e44e1cf329198f5bea56c146207ed639b24b6281187159435b9499ecb3959
-  md5: dee934e640275d9e74e7bbd455f25162
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
+  sha256: 5d56757ccad208c79214395b00d006d8d18929a4ba49c47bd9460789a7620943
+  md5: 511b511c5445e324066c3377481bcab8
   depends:
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 13.2.0 hf8544c7_5
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 he277a41_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 456795
-  timestamp: 1706820691781
+  size: 535243
+  timestamp: 1729089435134
 - kind: conda
-  name: libgcrypt
-  version: 1.10.3
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
-  sha256: 226d94d89715cbb6aae4889e9fb5045add07739afce24a2a70b95d6cbdbd7966
-  md5: 53f21c62feaeba1633038bccc6dae679
+  name: libgcc-devel_linux-64
+  version: 13.3.0
+  build: h84ea5a7_101
+  build_number: 101
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+  sha256: 027cfb011328a108bc44f512a2dec6d954db85709e0b79b748c3392f85de0c64
+  md5: 0ce69d40c142915ac9734bc6134e514a
   depends:
-  - libgcc-ng >=12
-  - libgpg-error >=1.47,<2.0a0
-  license: LGPL-2.1-or-later AND GPL-2.0-or-later
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 619842
-  timestamp: 1701383495049
+  size: 2598313
+  timestamp: 1724801050802
 - kind: conda
-  name: libgcrypt
-  version: 1.10.3
-  build: hd590300_0
+  name: libgcc-devel_linux-aarch64
+  version: 13.3.0
+  build: h0c07274_101
+  build_number: 101
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+  sha256: 2e4b691f811c1bddc72984e09d605c8b45532ec32307c3be007a84fac698bee2
+  md5: 4729642346d35283ed198d32ecc41206
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2063611
+  timestamp: 1724801861173
+- kind: conda
+  name: libgcc-ng
+  version: 14.2.0
+  build: h69a702a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
-  sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
-  md5: 32d16ad533c59bb0a3c5ffaf16110829
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- kind: conda
+  name: libgcc-ng
+  version: 14.2.0
+  build: he9431aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
+  sha256: 9b5cf168a6c7361cae869cb74b716766ee7c6d6b3f6172b32ba9bf91135efdc4
+  md5: 0694c249c61469f2c0f7e2990782af21
+  depends:
+  - libgcc 14.2.0 he277a41_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54104
+  timestamp: 1729089444587
+- kind: conda
+  name: libgcrypt
+  version: 1.11.0
+  build: h4ab18f5_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+  sha256: 9e97e4a753d2ee238cfc7375f0882830f0d8c1667431bc9d070a0f6718355570
+  md5: 14858a47d4cc995892e79f2b340682d7
   depends:
   - libgcc-ng >=12
-  - libgpg-error >=1.47,<2.0a0
+  - libgpg-error >=1.50,<2.0a0
   license: LGPL-2.1-or-later AND GPL-2.0-or-later
   license_family: GPL
-  size: 634887
-  timestamp: 1701383493365
+  size: 684307
+  timestamp: 1721392291497
+- kind: conda
+  name: libgcrypt
+  version: 1.11.0
+  build: h68df207_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
+  sha256: c0b09d4135a3d613c0ca6d52b5efa0c043bc497bcfe1c80d9b8385c40990f298
+  md5: 75b5ba9d835a79c15a27cb7af804762f
+  depends:
+  - libgcc-ng >=12
+  - libgpg-error >=1.50,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-2.0-or-later
+  license_family: GPL
+  size: 736802
+  timestamp: 1721392376840
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h0a1ffab_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+  sha256: f816747b63432def4bfe2bfa517057149b2b94a48101fe13e7fcc2c223ec2042
+  md5: 263a0b8af4b3fcdb35acc4038bb5bff5
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 199824
+  timestamp: 1723626215655
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
+  md5: e46c142e2d2d9ccef31ad3d176b10fab
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 171120
+  timestamp: 1723629671164
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
+  sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
+  md5: c8cd7295cfb7bda5cbabea4fef904349
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8414b35_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 159800
+  timestamp: 1723627007035
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
+  sha256: 8f7631d03a093272a5a8423181ac2c66514503e082e5494a2e942737af8a34ad
+  md5: ba6eeccaee150e24a544be8ae71aeca1
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 hdfe23c8_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 172305
+  timestamp: 1723626852373
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
+  md5: efab66b82ec976930b96d62a976de8e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 170646
+  timestamp: 1723626019265
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: h0a1ffab_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
+  sha256: 677df7af241b36c6b06dff52528c2a8e4f42f8cf40d962e693caa707b563c86c
+  md5: 5c1498c4da030824d57072f05220aad8
+  depends:
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h0a1ffab_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 36989
+  timestamp: 1723626232155
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+  sha256: 0a66cdd46d1cd5201061252535cd91905b3222328a9294c1a5bcd32e85531545
+  md5: 9aba7960731e6b4547b3a52f812ed801
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 he02047a_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 36790
+  timestamp: 1723626032786
 - kind: conda
   name: libgfortran
   version: 5.0.0
@@ -6889,35 +7187,69 @@ packages:
   size: 110233
   timestamp: 1707330749033
 - kind: conda
-  name: libgfortran-ng
-  version: 13.2.0
-  build: h69a702a_5
-  build_number: 5
+  name: libgfortran
+  version: 14.2.0
+  build: h69a702a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
-  sha256: 238c16c84124d58307376715839aa152bd4a1bf5a043052938ad6c3137d30245
-  md5: e73e9cfd1191783392131e6238bdb3e9
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
   depends:
-  - libgfortran5 13.2.0 ha4646dd_5
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23829
-  timestamp: 1706819413770
+  size: 53997
+  timestamp: 1729027752995
+- kind: conda
+  name: libgfortran
+  version: 14.2.0
+  build: he9431aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+  sha256: cb66e411fa32a5c6040f4e5e2a63c00897aae4c3133a9c004c2e929ccf19575b
+  md5: 0294b92d2f47a240bebb1e3336b495f1
+  depends:
+  - libgfortran5 14.2.0 hb6113d0_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729089471124
 - kind: conda
   name: libgfortran-ng
-  version: 13.2.0
-  build: he9431aa_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
-  sha256: a7e5d1ac34118a4fad8286050af0146226d2fb2bd63e7a1066dc4dae7ba42daa
-  md5: fab7c6a8c84492e18cbe578820e97a56
+  version: 14.2.0
+  build: h69a702a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+  sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
+  md5: 0a7f4cd238267c88e5d69f7826a407eb
   depends:
-  - libgfortran5 13.2.0 h582850c_5
+  - libgfortran 14.2.0 h69a702a_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23994
-  timestamp: 1706820985230
+  size: 54106
+  timestamp: 1729027945817
+- kind: conda
+  name: libgfortran-ng
+  version: 14.2.0
+  build: he9431aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+  sha256: cdd5bae1e33d6bdafe837c2e6ea594faf5bb7f880272ac1984468c7967adff41
+  md5: 5e90005d310d69708ba0aa7f4fed1de6
+  depends:
+  - libgfortran 14.2.0 he9431aa_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54111
+  timestamp: 1729089714658
 - kind: conda
   name: libgfortran5
   version: 13.2.0
@@ -6938,40 +7270,6 @@ packages:
 - kind: conda
   name: libgfortran5
   version: 13.2.0
-  build: h582850c_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
-  sha256: f778346e85eb19bca36d1a5c8cddf8e089dcd6799b8f3e1b3f2d5a3157920827
-  md5: 547486aac825d236de3beecb927b389c
-  depends:
-  - libgcc-ng >=13.2.0
-  constrains:
-  - libgfortran-ng 13.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1082835
-  timestamp: 1706820715400
-- kind: conda
-  name: libgfortran5
-  version: 13.2.0
-  build: ha4646dd_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
-  sha256: ba8d94e8493222ce155bb264d9de4200e41498a458e866fedf444de809bde8b6
-  md5: 7a6bd7a12a4bd359e2afe6c0fa1acace
-  depends:
-  - libgcc-ng >=13.2.0
-  constrains:
-  - libgfortran-ng 13.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1442769
-  timestamp: 1706819209473
-- kind: conda
-  name: libgfortran5
-  version: 13.2.0
   build: hf226fd6_3
   build_number: 3
   subdir: osx-arm64
@@ -6987,323 +7285,448 @@ packages:
   size: 997381
   timestamp: 1707330687590
 - kind: conda
-  name: libglib
-  version: 2.80.0
-  build: h39d0aa6_1
+  name: libgfortran5
+  version: 14.2.0
+  build: hb6113d0_1
   build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
+  sha256: a87ff46d19916403cbf68cf1d785bf56b4d1ab7b2552468d2ea775d70782493f
+  md5: fc068e11b10e18f184e027782baa12b6
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1102158
+  timestamp: 1729089452640
+- kind: conda
+  name: libgfortran5
+  version: 14.2.0
+  build: hd5240d6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- kind: conda
+  name: libgl
+  version: 1.7.0
+  build: ha4b6fd6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
+  sha256: 2de573a2231d0ffa13242e274d33b7bae88fb0a178392fd4a03cf803a47e4051
+  md5: 204892bce2e44252b5cf272712f10bdd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_1
+  - libglx 1.7.0 ha4b6fd6_1
+  license: LicenseRef-libglvnd
+  size: 134476
+  timestamp: 1727968620103
+- kind: conda
+  name: libgl
+  version: 1.7.0
+  build: hd24410f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
+  sha256: 26e3570dcd72d95c4c5d007776fd0169028575140adef029a5b23729c4f164d6
+  md5: 06cf88e73c69957c56318c6a1ccc5306
+  depends:
+  - libglvnd 1.7.0 hd24410f_1
+  - libglx 1.7.0 hd24410f_1
+  license: LicenseRef-libglvnd
+  size: 146874
+  timestamp: 1727968574647
+- kind: conda
+  name: libglib
+  version: 2.82.2
+  build: h07bd6cf_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
+  sha256: 101fb31c509d6a69ac5d612b51d4088ddbc675fca18cf0c3589cfee26cd01ca0
+  md5: 890783f64502fa6bfcdc723cfbf581b4
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3635416
+  timestamp: 1729191799117
+- kind: conda
+  name: libglib
+  version: 2.82.2
+  build: h2ff4ddf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+  sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
+  md5: 13e8e54035ddd2b91875ba399f0f7c04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3931898
+  timestamp: 1729191404130
+- kind: conda
+  name: libglib
+  version: 2.82.2
+  build: h7025463_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_1.conda
-  sha256: 326fb2d1c8789660cec01eda3eec2fa15dd816d291126df13f1c34d80ffda6aa
-  md5: 6160439f169ec670951460024751b2ae
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+  sha256: 7dfbf492b736f8d379f8c3b32a823f0bf2167ff69963e4c940339b146a04c54a
+  md5: 3e379c1b908a7101ecbc503def24613f
   depends:
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - glib 2.80.0 *_1
+  - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
-  size: 2805065
-  timestamp: 1710939443433
+  size: 3810166
+  timestamp: 1729192227078
 - kind: conda
   name: libglib
-  version: 2.80.0
-  build: h81c1438_1
-  build_number: 1
+  version: 2.82.2
+  build: hb6ef654_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_1.conda
-  sha256: 5bc911f8c29878252f14dfc08fcf72cf550038a7102f9c03612fee9f7ccf6234
-  md5: e1c7ad2617b7ebe7589e87024d90ddda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-hb6ef654_0.conda
+  sha256: d782be2d8d6784f0b8584ca3cfa93357cddc71b0975560a2bcabd174dac60fff
+  md5: 2e0511f82f1481210f148e1205fe2482
   depends:
-  - gettext >=0.21.1,<1.0a0
+  - __osx >=10.13
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
   constrains:
-  - glib 2.80.0 *_1
+  - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
-  size: 2641391
-  timestamp: 1710939600553
+  size: 3692367
+  timestamp: 1729191628049
 - kind: conda
   name: libglib
-  version: 2.80.0
-  build: h9d8fbc1_1
-  build_number: 1
+  version: 2.82.2
+  build: hc486b8e_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.0-h9d8fbc1_1.conda
-  sha256: 6f472f2bb3d4beda02668ec5d13ad29ab742dab6426f8204febb069d3ffa2a61
-  md5: 6dcce63f13ac16ab5ff26e00b2b92a12
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
+  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
+  md5: 47f6d85fe47b865e56c539f2ba5f4dad
   depends:
   - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
+  - libgcc >=13
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
   constrains:
-  - glib 2.80.0 *_1
+  - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
-  size: 2995380
-  timestamp: 1710938796473
-- kind: conda
-  name: libglib
-  version: 2.80.0
-  build: hf2295e7_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_1.conda
-  sha256: 636d984568a1e5d915098a5020712f82bb3988635015765c3caf70f1a91340c5
-  md5: 0725f6081030c29b109088639824ff90
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  constrains:
-  - glib 2.80.0 *_1
-  license: LGPL-2.1-or-later
-  size: 2888982
-  timestamp: 1710939100254
-- kind: conda
-  name: libglib
-  version: 2.80.0
-  build: hfc324ee_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.0-hfc324ee_1.conda
-  sha256: b7411c3b19681fea1a33c093364cb2d8a021a408133399b23c947231aac157d9
-  md5: 3d8a5773a6ba1be1db8dc23ea9f44a0a
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libffi >=3.4,<4.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  constrains:
-  - glib 2.80.0 *_1
-  license: LGPL-2.1-or-later
-  size: 2630397
-  timestamp: 1710939388253
+  size: 4020802
+  timestamp: 1729191545578
 - kind: conda
   name: libglu
   version: 9.0.0
-  build: hac7e632_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
-  sha256: 8368435c41105dc3e1c02896a02ecaa21b77d0b0d67fc8b06a16ba885c86f917
-  md5: 50c389a09b6b7babaef531eb7cb5e0ca
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  license: SGI-2
-  size: 331249
-  timestamp: 1694431884320
-- kind: conda
-  name: libglu
-  version: 9.0.0
-  build: hf4b6fbe_1003
-  build_number: 1003
+  build: h5eeb66e_1004
+  build_number: 1004
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
-  sha256: fdb8b42c6e2ad5c70d7f05c4f4d87d20fa38468146e61ddf66cc42fdc5e99ef7
-  md5: 815755517215132a05c485e748449a38
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
+  sha256: d4b60ab4337f7513c2c40419b04f3f8d71dc12bdf7e5baf0517d936296f11d78
+  md5: 0554e8a9ccab69bc8033d0bebed1b933
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-xextproto >=7.3.0,<8.0a0
   license: SGI-2
-  size: 317590
-  timestamp: 1694431968293
+  size: 317747
+  timestamp: 1718880641384
+- kind: conda
+  name: libglu
+  version: 9.0.0
+  build: ha6d2627_1004
+  build_number: 1004
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
+  sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
+  md5: df069bea331c8486ac21814969301c1f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  license: SGI-2
+  size: 325824
+  timestamp: 1718880563533
+- kind: conda
+  name: libglvnd
+  version: 1.7.0
+  build: ha4b6fd6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
+  sha256: 67942c2b6e4ddb705640b5db962e678f17d8305df5c1633e939cef1158a95058
+  md5: 1ece2ccb1dc8c68639712b05e0fae070
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  size: 132216
+  timestamp: 1727968577428
+- kind: conda
+  name: libglvnd
+  version: 1.7.0
+  build: hd24410f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
+  sha256: 281d2be6dbad9a7267ef2581bbaefb95f26be8d62c119e1a4efbc3c405d381b7
+  md5: 32763e24bc6e5ed4de4a4a1598448d5b
+  license: LicenseRef-libglvnd
+  size: 142605
+  timestamp: 1727968549960
+- kind: conda
+  name: libglx
+  version: 1.7.0
+  build: ha4b6fd6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
+  sha256: facc239145719034f7b8815d9630032e701d26534dae28303cdbae8b19590a82
+  md5: 80a57756c545ad11f9847835aa21e6b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_1
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 77902
+  timestamp: 1727968607539
+- kind: conda
+  name: libglx
+  version: 1.7.0
+  build: hd24410f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
+  sha256: 822e2178395d18dc71d25dee255852b9eac0f6943bafa5be44cc2a12cf00e7e5
+  md5: b4e4c7703e944564b512dabbcc1130d0
+  depends:
+  - libglvnd 1.7.0 hd24410f_1
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 77728
+  timestamp: 1727968567627
 - kind: conda
   name: libgomp
-  version: 13.2.0
-  build: h807b86a_5
-  build_number: 5
+  version: 14.2.0
+  build: h77fa898_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
-  sha256: 0d3d4b1b0134283ea02d58e8eb5accf3655464cf7159abf098cc694002f8d34e
-  md5: d211c42b9ce49aee3734fdc828731689
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
   depends:
   - _libgcc_mutex 0.1 conda_forge
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 419751
-  timestamp: 1706819107383
+  size: 460992
+  timestamp: 1729027639220
 - kind: conda
   name: libgomp
-  version: 13.2.0
-  build: hf8544c7_5
-  build_number: 5
+  version: 14.2.0
+  build: he277a41_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
-  sha256: a98d4f242a351feb7983a28e7d6a0ca51da764c6233ea3dfc776975a3aba8a01
-  md5: 379be2f115ffb73860e4e260dd2170b7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
+  sha256: 5aa53874a5e57a00f2e0c2e2910684eb674429cd5fcb803619b226a73e89aedf
+  md5: 376f0e73abbda6d23c0cb749adc195ef
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 423091
-  timestamp: 1706820564165
+  size: 463521
+  timestamp: 1729089357313
 - kind: conda
   name: libgpg-error
-  version: '1.48'
-  build: h5ce24db_0
+  version: '1.50'
+  build: h4f305b6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+  sha256: c60969d5c315f33fee90a1f2dd5d169e2834ace5a55f5a6f822aa7485a3a84cc
+  md5: 0d7ff1a8e69565ca3add6925e18e708f
+  depends:
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc-ng >=12
+  - libgettextpo >=0.22.5,<1.0a0
+  - libstdcxx-ng >=12
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 273774
+  timestamp: 1719390736440
+- kind: conda
+  name: libgpg-error
+  version: '1.50'
+  build: hb13efb6_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.48-h5ce24db_0.conda
-  sha256: c559389a67d3102410671b5ad8d9457e671dcb719aaedf151c2a9e8c13443ccd
-  md5: b4139dba81278589ea67408962cf8cdf
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
+  sha256: 03742eddce9f264edfcf6a02a3c7bfef2b1d27e7d0c32b1598ebbcadab84cc65
+  md5: 7c2cdd2e6915976622cfc519b76a3d56
   depends:
-  - gettext >=0.21.1,<1.0a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
   - libgcc-ng >=12
+  - libgettextpo >=0.22.5,<1.0a0
   - libstdcxx-ng >=12
   license: GPL-2.0-only
   license_family: GPL
-  size: 278143
-  timestamp: 1708702398068
-- kind: conda
-  name: libgpg-error
-  version: '1.48'
-  build: h71f35ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.48-h71f35ed_0.conda
-  sha256: c448c6d86d27e10b9e844172000540e9cbfe9c28f968db87f949ba05add9bd50
-  md5: 4d18d86916705d352d5f4adfb7f0edd3
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-only
-  license_family: GPL
-  size: 266447
-  timestamp: 1708702470365
+  size: 283819
+  timestamp: 1719390791757
 - kind: conda
   name: libhwloc
-  version: 2.9.3
-  build: default_h24e0189_1009
-  build_number: 1009
+  version: 2.11.1
+  build: default_h3030c0e_1000
+  build_number: 1000
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.1-default_h3030c0e_1000.conda
+  sha256: 0e07bd9b8aedc12975d16c2d0b14879ce913859a3eefe95ce54b466c852c9e97
+  md5: 5e9bea190b04e32a062fa34cda4223fa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2431447
+  timestamp: 1720460748563
+- kind: conda
+  name: libhwloc
+  version: 2.11.1
+  build: default_h456cccd_1000
+  build_number: 1000
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
-  sha256: a9fc54b481d0477cdf5700d702d44fc04fe00ffe63fc253aa0c6d2944abe8f3f
-  md5: 22fcbfd2a4cdf941b074a00b773b43dd
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.11.1-default_h456cccd_1000.conda
+  sha256: 0b5294c8e8fc5f9faab7e54786c5f3c4395ee64b5577a1f2ae687a960e089624
+  md5: a14989f6bbea46e6ec4521a403f63ff2
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libxml2 >=2.11.5,<3.0.0a0
+  - __osx >=10.13
+  - libcxx >=16
+  - libxml2 >=2.12.7,<3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2555838
-  timestamp: 1699473547291
+  size: 2350774
+  timestamp: 1720460664713
 - kind: conda
   name: libhwloc
-  version: 2.9.3
-  build: default_h4394839_1009
-  build_number: 1009
+  version: 2.11.1
+  build: default_h7685b71_1000
+  build_number: 1000
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
-  sha256: b9a0574f8919f3943a4f5c81d2d40da94913afcbe02098685abce001a526141c
-  md5: 8c30d3b6ed7c46fce04cc623d83b6c22
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.1-default_h7685b71_1000.conda
+  sha256: ffe883123f06a7398fdb5039a52f03e3e0ee2a55ed64133580446cda62d11d16
+  md5: 4c4f204c15fdc91ee75cd0449a08b87a
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libxml2 >=2.11.5,<3.0.0a0
+  - __osx >=11.0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2530597
-  timestamp: 1699473469798
+  size: 2325644
+  timestamp: 1720460737568
 - kind: conda
   name: libhwloc
-  version: 2.9.3
-  build: default_h554bfaf_1009
-  build_number: 1009
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
-  sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
-  md5: f36ddc11ca46958197a45effdd286e45
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.11.5,<3.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2615665
-  timestamp: 1694532603730
-- kind: conda
-  name: libhwloc
-  version: 2.9.3
-  build: default_haede6df_1009
-  build_number: 1009
+  version: 2.11.1
+  build: default_h8125262_1000
+  build_number: 1000
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
-  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+  sha256: 92728e292640186759d6dddae3334a1bc0b139740b736ffaeccb825fb8c07a2e
+  md5: 933bad6e4658157f1aec9b171374fde2
   depends:
-  - libxml2 >=2.11.5,<3.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
   - pthreads-win32
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 2578462
-  timestamp: 1694533393675
+  size: 2379689
+  timestamp: 1720461835526
 - kind: conda
   name: libhwloc
-  version: 2.9.3
-  build: default_hda148da_1009
-  build_number: 1009
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
-  sha256: 7eaf20be9a5a21bcc8ca3d6a9cddffb78f70ba9314e9149ac9add1b28dce5973
-  md5: 28766712d1b5eeb1d20b3e45facf3a72
+  version: 2.11.1
+  build: default_hecaa2ac_1000
+  build_number: 1000
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
+  sha256: 8473a300e10b79557ce0ac81602506b47146aff3df4cc3568147a7dd07f480a2
+  md5: f54aeebefb5c5ff84eca4fb05ca8aa3a
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.11.5,<3.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2625499
-  timestamp: 1694532579760
+  size: 2417964
+  timestamp: 1720460562447
 - kind: conda
   name: libi2c
-  version: '4.3'
-  build: hcb278e6_2
-  build_number: 2
+  version: '4.4'
+  build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.3-hcb278e6_2.conda
-  sha256: 2b68ba469f267e7fc61fd41c22e9db16fd2bacf9039351a5f3a2572213d3184e
-  md5: 49280d75f186fd9121d19b9e2fe79def
+  url: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
+  sha256: c6edef9b97719961a68aa631e4b0ed4dcd34254646e10b37555562c119ddefc5
+  md5: 36c48b1a98b62f477ddb1185eecddbc5
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   license: LGPL-2.1-or-later
-  size: 18647
-  timestamp: 1681566579190
+  size: 18846
+  timestamp: 1728589119656
 - kind: conda
   name: libi2c
-  version: '4.3'
-  build: hd600fc2_2
-  build_number: 2
+  version: '4.4'
+  build: h5ad3122_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.3-hd600fc2_2.conda
-  sha256: 3355e3534d91067c6333d6379df13f9ff9635e661c541c65e12ed1b90cb3f239
-  md5: fa802d6ae1d5f9b37b86f4c2999caf8c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.4-h5ad3122_0.conda
+  sha256: 859343e7bfaf073235742905b529bc08fb2c1d47989117dc2cad208e747ba38e
+  md5: a2cc659fbbcf1d4ca9aa6ae3d0d6651b
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libstdcxx >=13
   license: LGPL-2.1-or-later
-  size: 19075
-  timestamp: 1681566640303
+  size: 19131
+  timestamp: 1728589137907
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -7373,63 +7796,96 @@ packages:
   size: 666538
   timestamp: 1702682713201
 - kind: conda
-  name: libidn2
-  version: 2.3.7
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
-  sha256: 54430e45dffa8cbe3cbf12a3f4376947e7e2d50c67db90a90e91c3350510823e
-  md5: a985867eae03167666bba45c2a297da1
+  name: libintl
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libunistring >=0,<1.0a0
-  license: LGPLv2
-  size: 133237
-  timestamp: 1706368325339
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 95568
+  timestamp: 1723629479451
 - kind: conda
-  name: libidn2
-  version: 2.3.7
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
-  sha256: 0227930e1cf1d326cfe04a17392587840cf180a91c15fbc38da8ebd297cc4146
-  md5: 7b87508d7df33b9b0e68cea0fcfef12a
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libunistring >=0,<1.0a0
-  license: LGPLv2
-  size: 138303
-  timestamp: 1706370220301
-- kind: conda
-  name: libidn2
-  version: 2.3.7
-  build: h93a5062_0
+  name: libintl
+  version: 0.22.5
+  build: h8414b35_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
-  sha256: ae6be1c42fa18cb76fb1d17093f5b467b7a9bcf402da91081a9126c8843c004d
-  md5: 6e4a21ef7a8e4c0cc65381854848e232
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+  sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
+  md5: 3b98ec32e91b3b59ad53dbb9c96dd334
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libunistring >=0,<1.0a0
-  license: LGPLv2
-  size: 134491
-  timestamp: 1706368362998
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 81171
+  timestamp: 1723626968270
 - kind: conda
-  name: libidn2
-  version: 2.3.7
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
-  sha256: 253f9be445c58bf07b39d8f67ac08bccc5010c75a8c2070cddfb6c20e1ca4f4f
-  md5: 2b7b0d827c6447cc1d85dc06d5b5de46
+  name: libintl
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+  sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
+  md5: 52d4d643ed26c07599736326c46bf12f
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libunistring >=0,<1.0a0
-  license: LGPLv2
-  size: 126515
-  timestamp: 1706368269716
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 88086
+  timestamp: 1723626826235
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
+  sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
+  md5: 7537784e9e35399234d4007f45cdb744
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  license: LGPL-2.1-or-later
+  size: 40746
+  timestamp: 1723629745649
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
+  sha256: c9d1d4fdfb5775828e54bc9fb443b1a6de9319a04b81d1bac52c26114a763154
+  md5: 271646de11b018c66e81eb4c4717b291
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8414b35_3
+  license: LGPL-2.1-or-later
+  size: 38584
+  timestamp: 1723627022409
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-hdfe23c8_3.conda
+  sha256: 4913a20244520d6fae14452910613b652752982193a401482b7d699ee70bb13a
+  md5: aeb045f400ec2b068c6c142b16f87c7e
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 hdfe23c8_3
+  license: LGPL-2.1-or-later
+  size: 38249
+  timestamp: 1723626863306
 - kind: conda
   name: libjpeg-turbo
   version: 3.0.0
@@ -7511,455 +7967,384 @@ packages:
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 21_linux64_openblas
-  build_number: 21
+  build: 25_linux64_openblas
+  build_number: 25
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
-  sha256: 64b5c35dce00dd6f9f53178b2fe87116282e00967970bd6551a5a42923806ded
-  md5: 1a42f305615c3867684e049e85927531
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
   depends:
-  - libblas 3.9.0 21_linux64_openblas
+  - libblas 3.9.0 25_linux64_openblas
   constrains:
-  - liblapacke 3.9.0 21_linux64_openblas
-  - libcblas 3.9.0 21_linux64_openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14599
-  timestamp: 1705979579648
+  size: 15608
+  timestamp: 1729642910812
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 21_linuxaarch64_openblas
-  build_number: 21
+  build: 25_linuxaarch64_openblas
+  build_number: 25
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-21_linuxaarch64_openblas.conda
-  sha256: 87c110c6a1171c62d6a8802098c4186dcc8eca0ee2d0376a843e0cd025096e4a
-  md5: ab08b651e3630c20d3032e59859f34f7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
+  sha256: 2b399e65e0338bf249657b98333e910cd7086ea1332d4d6f303735883ca49318
+  md5: 0eb74e81de46454960bde9e44e7ee378
   depends:
-  - libblas 3.9.0 21_linuxaarch64_openblas
+  - libblas 3.9.0 25_linuxaarch64_openblas
   constrains:
-  - liblapacke 3.9.0 21_linuxaarch64_openblas
   - blas * openblas
-  - libcblas 3.9.0 21_linuxaarch64_openblas
+  - liblapacke 3.9.0 25_linuxaarch64_openblas
+  - libcblas 3.9.0 25_linuxaarch64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14583
-  timestamp: 1705979400733
+  size: 15711
+  timestamp: 1729643010817
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 21_osx64_openblas
-  build_number: 21
+  build: 25_osx64_openblas
+  build_number: 25
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
-  sha256: 5d0ef4743e8684ad436e31bd3c378d48642815a20c260d358668ba29cd80987a
-  md5: cf0e4d82cfca6cd9d6c9ed3df45907c9
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
   depends:
-  - libblas 3.9.0 21_osx64_openblas
+  - libblas 3.9.0 25_osx64_openblas
   constrains:
-  - libcblas 3.9.0 21_osx64_openblas
-  - liblapacke 3.9.0 21_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
   - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14738
-  timestamp: 1705979734819
+  size: 15852
+  timestamp: 1729643174413
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 21_osxarm64_openblas
-  build_number: 21
+  build: 25_osxarm64_openblas
+  build_number: 25
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-21_osxarm64_openblas.conda
-  sha256: a917e99f26d205df1ec22d7a9fff0d2f2f3c7ba06ea2be886dc220a8340d5917
-  md5: a4510e3913ef552d69ab2080a0048523
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
   depends:
-  - libblas 3.9.0 21_osxarm64_openblas
+  - libblas 3.9.0 25_osxarm64_openblas
   constrains:
-  - libcblas 3.9.0 21_osxarm64_openblas
   - blas * openblas
-  - liblapacke 3.9.0 21_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14829
-  timestamp: 1705980215575
+  size: 15823
+  timestamp: 1729643275943
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 21_win64_mkl
-  build_number: 21
+  build: 25_win64_mkl
+  build_number: 25
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
-  sha256: 3fa7c08dd4edf59cb0907d2e5b74e6be890e0671f845e1bae892d212d118a7e9
-  md5: c4740f091cb75987390087934354a621
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
   depends:
-  - libblas 3.9.0 21_win64_mkl
+  - libblas 3.9.0 25_win64_mkl
   constrains:
   - blas * mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapacke 3.9.0 21_win64_mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 5017043
-  timestamp: 1705980523462
+  size: 3736560
+  timestamp: 1729643588182
 - kind: conda
   name: liblapacke
   version: 3.9.0
-  build: 21_linux64_openblas
-  build_number: 21
+  build: 25_linux64_openblas
+  build_number: 25
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_openblas.conda
-  sha256: 7e6281a788aa3e9a74eac95cce075634afb25a2cea0416a8b7c77e95de524044
-  md5: 854c3c762b25ccfbaa1aa24ee34288e3
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_openblas.conda
+  sha256: f8bc6fe22126ca0bf204c27f829d1e0006069cc98776a33122bf8d0548940b3c
+  md5: 8f5ead31b3a168aedd488b8a87736c41
   depends:
-  - libblas 3.9.0 21_linux64_openblas
-  - libcblas 3.9.0 21_linux64_openblas
-  - liblapack 3.9.0 21_linux64_openblas
+  - libblas 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - liblapack 3.9.0 25_linux64_openblas
   constrains:
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14608
-  timestamp: 1705979594896
+  size: 15609
+  timestamp: 1729642916038
 - kind: conda
   name: liblapacke
   version: 3.9.0
-  build: 21_linuxaarch64_openblas
-  build_number: 21
+  build: 25_linuxaarch64_openblas
+  build_number: 25
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-21_linuxaarch64_openblas.conda
-  sha256: f3f7bf84968016797ff9831cf435edf9fd4271b52e8d3524e597789e6d2b2647
-  md5: be00a60ef5d88de133a28cb1fb6e0b31
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-25_linuxaarch64_openblas.conda
+  sha256: f0a591a2ac7e1259971124ddd466ce39da646699decda1a8ab45a2fabd257665
+  md5: 1e68063075954830f707b41dab6c7fd8
   depends:
-  - libblas 3.9.0 21_linuxaarch64_openblas
-  - libcblas 3.9.0 21_linuxaarch64_openblas
-  - liblapack 3.9.0 21_linuxaarch64_openblas
+  - libblas 3.9.0 25_linuxaarch64_openblas
+  - libcblas 3.9.0 25_linuxaarch64_openblas
+  - liblapack 3.9.0 25_linuxaarch64_openblas
   constrains:
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14570
-  timestamp: 1705979408964
+  size: 15712
+  timestamp: 1729643014949
 - kind: conda
   name: liblapacke
   version: 3.9.0
-  build: 21_osx64_openblas
-  build_number: 21
+  build: 25_osx64_openblas
+  build_number: 25
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-21_osx64_openblas.conda
-  sha256: 8c1bd2654e70a642dcbea652a3a0b44995bbcbd37eebb39d5ade3b30da543d42
-  md5: 563b6afae21aed1e0df12cad7a0db2cf
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-25_osx64_openblas.conda
+  sha256: 14e1ec71bd47d63ec32b95801b04d850f12fb8ece3b03483fd36f898336d987b
+  md5: ddd746770d7811274ba38e0a832e3a50
   depends:
-  - libblas 3.9.0 21_osx64_openblas
-  - libcblas 3.9.0 21_osx64_openblas
-  - liblapack 3.9.0 21_osx64_openblas
+  - libblas 3.9.0 25_osx64_openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  - liblapack 3.9.0 25_osx64_openblas
   constrains:
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14721
-  timestamp: 1705979752564
+  size: 15846
+  timestamp: 1729643185849
 - kind: conda
   name: liblapacke
   version: 3.9.0
-  build: 21_osxarm64_openblas
-  build_number: 21
+  build: 25_osxarm64_openblas
+  build_number: 25
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-21_osxarm64_openblas.conda
-  sha256: 5d75b998be9644ad8fcf8bc3acab2751911c4d8026a00ee006d0c00adde7882d
-  md5: 203ceef3c48a49ba914a12518bac7882
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-25_osxarm64_openblas.conda
+  sha256: 3db3a803a9295784c1fae97c1397b44f5c1c58472b7b06834d8387ed986778f9
+  md5: fe649c1f453f9952a9048b80dc25f92f
   depends:
-  - libblas 3.9.0 21_osxarm64_openblas
-  - libcblas 3.9.0 21_osxarm64_openblas
-  - liblapack 3.9.0 21_osxarm64_openblas
+  - libblas 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
   constrains:
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14827
-  timestamp: 1705980239523
+  size: 15836
+  timestamp: 1729643281243
 - kind: conda
   name: liblapacke
   version: 3.9.0
-  build: 21_win64_mkl
-  build_number: 21
+  build: 25_win64_mkl
+  build_number: 25
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_mkl.conda
-  sha256: 965820dbb7f0da76487b4682e045343543b78d63568007f1d66fa555d0011f0e
-  md5: a4844669ed07bb5b7f182e9ca4de2a70
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
+  sha256: a7a6d417bf963659bdfa6ef6f5604696fb0717f7bed7f594ceb1ceedf7d93d16
+  md5: d59fc46f1e1c2f3cf38a08a0a76ffee5
   depends:
-  - libblas 3.9.0 21_win64_mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapack 3.9.0 21_win64_mkl
+  - libblas 3.9.0 25_win64_mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
   constrains:
   - blas * mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 5040017
-  timestamp: 1705980578057
+  size: 3736581
+  timestamp: 1729643615092
 - kind: conda
-  name: libllvm15
-  version: 15.0.7
-  build: h2621b3d_4
-  build_number: 4
+  name: libllvm17
+  version: 17.0.6
+  build: h5090b49_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
-  sha256: 63e22ccd4c1b80dfc7da169c65c62a878a46ef0e5771c3b0c091071e718ae1b1
-  md5: 8d7f7a7286d99a2671df2619cb3bfb2c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
+  sha256: 5829e490e395d85442fb6c7edb0ec18d1a5bb1bc529919a89337d34235205064
+  md5: 443b26505722696a9535732bc2a07576
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 24612870
+  timestamp: 1718320971519
+- kind: conda
+  name: libllvm17
+  version: 17.0.6
+  build: hbedff68_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
+  sha256: 605460ecc4ccc04163d0b06c99693864e5bcba7a9f014a5263c9856195282265
+  md5: fcd38f0553a99fa279fb66a5bfc2fb28
   depends:
   - libcxx >=16
   - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 22049607
-  timestamp: 1701372072765
-- kind: conda
-  name: libllvm15
-  version: 15.0.7
-  build: hb3ce162_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
-  sha256: e71584c0f910140630580fdd0a013029a52fd31e435192aea2aa8d29005262d1
-  md5: 8a35df3cbc0c8b12cc8af9473ae75eef
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 33321457
-  timestamp: 1701375836233
+  size: 26306756
+  timestamp: 1701378823527
 - kind: conda
-  name: libllvm15
-  version: 15.0.7
-  build: hb4f23b0_4
-  build_number: 4
+  name: libllvm19
+  version: 19.1.2
+  build: h1e63acb_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm19-19.1.2-h1e63acb_0.conda
+  sha256: 31035f7aa439ca93645fb995a9b548f82f363068271cb4755fc5a3757d3af496
+  md5: f71d5443e58de8b821ba9fce74447b23
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 28702727
+  timestamp: 1729023904579
+- kind: conda
+  name: libllvm19
+  version: 19.1.2
+  build: h2edbd07_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
-  sha256: 12da3344f2ef37dcb80b4e2d106cf36ebc267c3be6211a8306dd1dbf07399d61
-  md5: 8d7aa8eae04dc19426a417528d7041eb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.2-h2edbd07_0.conda
+  sha256: 4d3d0e704068fb6baa5d4be494122c6e894501797838aa821d26b7952b01027d
+  md5: e0c251e0b6815995e2f19532ab604f9b
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 32882415
-  timestamp: 1701366839578
+  size: 39382849
+  timestamp: 1729030002029
 - kind: conda
-  name: libllvm15
-  version: 15.0.7
-  build: hbedff68_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
-  sha256: a0598cc166e92c6c63e58a7eaa184fa0b8b467693b965dbe19f1c9ff37e134c3
-  md5: bdc80cf2aa69d6eb8dd101dfd804db07
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 23755109
-  timestamp: 1701376376564
-- kind: conda
-  name: libllvm16
-  version: 16.0.6
-  build: haab561b_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
-  sha256: f240f3776b02c39a32ce7397d6f2de072510321c835f4def452fc62e5c3babc0
-  md5: 9900d62ede9ce25b569beeeab1da094e
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 23347663
-  timestamp: 1701374993634
-- kind: conda
-  name: libllvm16
-  version: 16.0.6
-  build: hbedff68_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
-  sha256: ad848dc0bb02b1dbe54324ee5700b050a2e5f63c095f5229b2de58249a3e268e
-  md5: 8fd56c0adc07a37f93bd44aa61a97c90
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 25196932
-  timestamp: 1701379796962
-- kind: conda
-  name: libllvm18
-  version: 18.1.2
-  build: h2448989_0
+  name: libllvm19
+  version: 19.1.2
+  build: ha7bfdaf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.2-h2448989_0.conda
-  sha256: 231b3edb7650786fd9fc6ac8d7ecf38d663a0ae63eeb1f19c4c1c17d2eb98d51
-  md5: fae7780457e00a07d068417d9dbdb24b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.2-ha7bfdaf_0.conda
+  sha256: 8c0eb8f753ef2a449acd846bc5853f7f11d319819bb5bbdf721c8ac0d8db875a
+  md5: 128e74a4f8f4fef4dc5130a8bbccc15d
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 38407510
-  timestamp: 1710943474854
+  size: 40136241
+  timestamp: 1729031844469
 - kind: conda
-  name: libllvm18
-  version: 18.1.2
-  build: h30cc82d_0
+  name: libllvm19
+  version: 19.1.2
+  build: haf57ff0_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.2-h30cc82d_0.conda
-  sha256: 0d94c605bae6d743713dd902e2f56f52f65cbd3456b90c5d7c464321607e2b5b
-  md5: 6e8e9ff62e7886035618ac93fad76f9e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.2-haf57ff0_0.conda
+  sha256: 049b7dcb3bc43a1e496987b0d45ce9b9f894a88385744d5779027062e2cea6ae
+  md5: 6038eda47f011c0f808d34accd8dacb6
   depends:
-  - libcxx >=16
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - __osx >=11.0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 25780908
-  timestamp: 1710946768066
-- kind: conda
-  name: libllvm18
-  version: 18.1.2
-  build: hbcf5fad_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm18-18.1.2-hbcf5fad_0.conda
-  sha256: 524cfa625bac98ef647333ea0a4851eea7b0bd190df78053c43de96fd09c423c
-  md5: 30296989a5953e7fdc2dc6a87ced95a8
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 27602478
-  timestamp: 1710945854082
-- kind: conda
-  name: libllvm18
-  version: 18.1.2
-  build: hbfe100b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm18-18.1.2-hbfe100b_0.conda
-  sha256: 64dced2c04792000307e7ba9a2d97f94c259e3685c857eec85a1fda718d2db8e
-  md5: 1afc79b63d5265bf0a28fad8387dd6ac
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 37754455
-  timestamp: 1710943715667
+  size: 26882925
+  timestamp: 1729025168222
 - kind: conda
   name: libnghttp2
-  version: 1.58.0
-  build: h47da74e_1
-  build_number: 1
+  version: 1.64.0
+  build: h161d5f1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
-  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
-  md5: 700ac6ea6d53d5510591c4344d5c989a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
   depends:
-  - c-ares >=1.23.0,<2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
   license: MIT
   license_family: MIT
-  size: 631936
-  timestamp: 1702130036271
+  size: 647599
+  timestamp: 1729571887612
 - kind: conda
   name: libnghttp2
-  version: 1.58.0
-  build: h64cf6d3_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-  sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
-  md5: faecc55c2a8155d9ff1c0ff9a0fef64f
-  depends:
-  - __osx >=10.9
-  - c-ares >=1.23.0,<2.0a0
-  - libcxx >=16.0.6
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 599736
-  timestamp: 1702130398536
-- kind: conda
-  name: libnghttp2
-  version: 1.58.0
-  build: ha4dd798_1
-  build_number: 1
+  version: 1.64.0
+  build: h6d7220d_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
-  sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
-  md5: 1813e066bfcef82de579a0be8a766df4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
   depends:
-  - __osx >=10.9
-  - c-ares >=1.23.0,<2.0a0
-  - libcxx >=16.0.6
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
   license: MIT
   license_family: MIT
-  size: 565451
-  timestamp: 1702130473930
+  size: 566719
+  timestamp: 1729572385640
 - kind: conda
   name: libnghttp2
-  version: 1.58.0
-  build: hb0e430d_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
-  sha256: ecc11e4f92f9d5830a90d42b4db55c66c4ad531e00dcf30d55171d934a568cb5
-  md5: 8f724cdddffa79152de61f5564a3526b
+  version: 1.64.0
+  build: hc7306c3_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
   depends:
-  - c-ares >=1.23.0,<2.0a0
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
   license: MIT
   license_family: MIT
-  size: 677508
-  timestamp: 1702130071743
+  size: 606663
+  timestamp: 1729572019083
+- kind: conda
+  name: libnghttp2
+  version: 1.64.0
+  build: hc8609a4_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
+  sha256: c093c6d370aadbf0409c20b6c54c488ee2f6fea976181919fcc63e87ee232673
+  md5: f52c614fa214a8bedece9421c771670d
+  depends:
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 714610
+  timestamp: 1729571912479
 - kind: conda
   name: libnsl
   version: 2.0.1
@@ -7990,1306 +8375,1399 @@ packages:
   timestamp: 1697359010159
 - kind: conda
   name: libogg
-  version: 1.3.4
-  build: h27ca646_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.4-h27ca646_1.tar.bz2
-  sha256: 916bbd5b7da6c922d6a16dd7d396b8a4e862edaca045671692e35add58aace64
-  md5: fb211883ad5716e398b974a9cde9d78e
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 207390
-  timestamp: 1610382137160
-- kind: conda
-  name: libogg
-  version: 1.3.4
-  build: h3557bc0_1
-  build_number: 1
+  version: 1.3.5
+  build: h0b9eccb_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.4-h3557bc0_1.tar.bz2
-  sha256: cc9ef00410ac723e3abb667afd65c049ea50eb91fd2ff06a33f51083f91da792
-  md5: a8b4ce49dbd48176e82c11ecf01ae588
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
+  sha256: e65acc318b7535fb8f2b5e994fe6eac3ae0be3bdb2acbe6037841d033c51f290
+  md5: 15cb67b1b9dd0d4b37c81daba785e6ad
   depends:
-  - libgcc-ng >=9.3.0
+  - libgcc-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 213591
-  timestamp: 1610381911963
+  size: 208233
+  timestamp: 1719301637185
 - kind: conda
   name: libogg
-  version: 1.3.4
-  build: h35c211d_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.4-h35c211d_1.tar.bz2
-  sha256: e3cec0c66d352d822b7a90db8edbc62f237fca079b6044e5b27f6ca529f7d9d9
-  md5: a7ab4b53ef18c598ffaa597230bc3ba1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 207262
-  timestamp: 1610382038748
-- kind: conda
-  name: libogg
-  version: 1.3.4
-  build: h7f98852_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
-  sha256: b88afeb30620b11bed54dac4295aa57252321446ba4e6babd7dce4b9ffde9b25
-  md5: 6e8cc2173440d77708196c5b93771680
-  depends:
-  - libgcc-ng >=9.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 210550
-  timestamp: 1610382007814
-- kind: conda
-  name: libogg
-  version: 1.3.4
-  build: h8ffe710_1
-  build_number: 1
+  version: 1.3.5
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
-  sha256: ef20f04ad2121a07e074b34bfc211587df18180e680963f5c02c54d1951b9ee6
-  md5: 04286d905a0dcb7f7d4a12bdfe02516d
+  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+  sha256: fcffdf32c620569738b85c98ddd25e1c84c8add80cd732743d90d469b7b532bb
+  md5: 44a4d173e62c5ed6d715f18ae7c46b7a
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 35187
-  timestamp: 1610382533961
+  size: 35459
+  timestamp: 1719302192495
 - kind: conda
-  name: libopenblas
-  version: 0.3.26
-  build: openmp_h6c19121_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.26-openmp_h6c19121_0.conda
-  sha256: 2a59b92c412fd0f59a8079dfa21c561ae17e72e72e47d4d7aee474bf6fd642e1
-  md5: 000970261d954431ccca3cce68d873d8
-  depends:
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=16.0.6
-  constrains:
-  - openblas >=0.3.26,<0.3.27.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2917606
-  timestamp: 1704950245195
-- kind: conda
-  name: libopenblas
-  version: 0.3.26
-  build: openmp_hfef2a42_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
-  sha256: 4a5994cc608708eca19b90b642a144bb073e4a1cd27b824281dfcae67917204e
-  md5: 9df60162aea811087267b515f359536c
-  depends:
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=16.0.6
-  constrains:
-  - openblas >=0.3.26,<0.3.27.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6044576
-  timestamp: 1704951566923
-- kind: conda
-  name: libopenblas
-  version: 0.3.26
-  build: pthreads_h413a1c8_0
+  name: libogg
+  version: 1.3.5
+  build: h4ab18f5_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
-  sha256: b626954b5a1113dafec8df89fa8bf18ce9b4701464d9f084ddd7fc9fac404bbd
-  md5: 760ae35415f5ba8b15d09df5afe8b23a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+  sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
+  md5: 601bfb4b3c6f0b844443bb81a56651e0
   depends:
   - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  constrains:
-  - openblas >=0.3.26,<0.3.27.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5578031
-  timestamp: 1704950143521
+  size: 205914
+  timestamp: 1719301575771
 - kind: conda
-  name: libopenblas
-  version: 0.3.26
-  build: pthreads_h5a5ec62_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.26-pthreads_h5a5ec62_0.conda
-  sha256: b72719014a86f69162398fc32af0f23e6e1746ec795f7c5d38ad5998a78eb6f8
-  md5: 2ea496754b596063335b3aeaa2b982ac
-  depends:
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  constrains:
-  - openblas >=0.3.26,<0.3.27.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4306237
-  timestamp: 1704951018697
-- kind: conda
-  name: libopencv
-  version: 4.9.0
-  build: headless_py312h52052b3_12
-  build_number: 12
+  name: libogg
+  version: 1.3.5
+  build: h99b78c6_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-headless_py312h52052b3_12.conda
-  sha256: 6c425f711622d475a58c291be3424397fa9d879ea8a640efacbe8ad3003b814f
-  md5: 8675e25690a7f5d2c81e1bf4788bbde4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
+  sha256: 685f73b7241978007dfe0cecb9cae46c6a26d87d192b6f85a09eb65023c0b99e
+  md5: 57b668b9b78dea2c08e44bb2385d57c0
   depends:
-  - ffmpeg >=6.1.1,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.2,<5.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
-  - libglib >=2.80.0,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - openexr >=3.2.2,<3.3.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  license: Apache-2.0
-  license_family: Apache
-  size: 16820850
-  timestamp: 1711065529023
+  - __osx >=11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205451
+  timestamp: 1719301708541
 - kind: conda
-  name: libopencv
-  version: 4.9.0
-  build: headless_py39h1cbcdfd_12
-  build_number: 12
+  name: libogg
+  version: 1.3.5
+  build: hfdf4475_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-headless_py39h1cbcdfd_12.conda
-  sha256: 51956f3e06a7ceb1abceaa5fdd97ca13434e0e3d0afe8c75b358707fa818355e
-  md5: ffc389f68f36373c0f01be5834504ad1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-hfdf4475_0.conda
+  sha256: bebf5797e2a278fd2094f2b0c29ccdfc51d400f4736701108a7e544a49705c64
+  md5: 7497372c91a31d3e8d64ce3f1a9632e8
   depends:
   - __osx >=10.13
-  - ffmpeg >=6.1.1,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203604
+  timestamp: 1719301669662
+- kind: conda
+  name: libopenblas
+  version: 0.3.28
+  build: openmp_h1a8b088_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-openmp_h1a8b088_0.conda
+  sha256: 83034982f733c5762e54cb046c1fbd44bc885466c58e3d251964e5ca5e3d6786
+  md5: eba54dbc44fbbd54751b5810b1126f4c
+  depends:
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=14
+  - libgfortran-ng
+  - libgfortran5 >=14.1.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  track_features:
+  - openblas_threading_openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4801515
+  timestamp: 1723932156159
+- kind: conda
+  name: libopenblas
+  version: 0.3.28
+  build: openmp_h517c56d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_h517c56d_0.conda
+  sha256: 43d69d072f1a3774994d31f9d3241cfa0f1c5560b536989020d7cde30fbef956
+  md5: 9306fd5b6b39b2b7e13c1d50c3fee354
+  depends:
+  - __osx >=11.0
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2934061
+  timestamp: 1723931625423
+- kind: conda
+  name: libopenblas
+  version: 0.3.28
+  build: openmp_h8869122_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_h8869122_0.conda
+  sha256: f86ff61991104bfa4fc7725c6d45c29516e7eb504a6d73ee23c50cd208900906
+  md5: 6bf3c78f6d014543765570c8e1c65642
+  depends:
+  - __osx >=10.13
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6052706
+  timestamp: 1723932292682
+- kind: conda
+  name: libopenblas
+  version: 0.3.28
+  build: openmp_hd680484_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_0.conda
+  sha256: 4412f2d82f343954f5d5ce0f479069d21770b488b8b49583f7b24f186a1e3e8f
+  md5: f9d66b83195eb11c4a4a4413b30c13ff
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=14
+  - libgfortran-ng
+  - libgfortran5 >=14.1.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  track_features:
+  - openblas_threading_openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5582186
+  timestamp: 1723932272354
+- kind: conda
+  name: libopencv
+  version: 4.10.0
+  build: headless_py310hedf1e49_8
+  build_number: 8
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.10.0-headless_py310hedf1e49_8.conda
+  sha256: 9e393d7a436613a94debfb17dd9e2fd530e189c750fdda570b5c2fcdd6489ca7
+  md5: 387c2ab3a4cc701f153b73dd93e79f14
+  depends:
+  - __osx >=10.13
+  - ffmpeg >=6.1.2,<7.0a0
   - freetype >=2.12.1,<3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.2,<5.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
-  - libglib >=2.80.0,<3.0a0
+  - libcxx >=17
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
   - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.22.4,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
   - openexr >=3.2.2,<3.3.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 27163393
-  timestamp: 1711060417560
+  size: 27549718
+  timestamp: 1728021103563
 - kind: conda
   name: libopencv
-  version: 4.9.0
-  build: qt6_py312h0bce51b_612
-  build_number: 612
+  version: 4.10.0
+  build: headless_py312h127a95d_8
+  build_number: 8
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-qt6_py312h0bce51b_612.conda
-  sha256: 700dc2c75e144dd09f38417249943e865fa52bafb1ade0a8f6ade0aa00dc4760
-  md5: fcb81a050bf70ddd54805ecd6416f6e4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312h127a95d_8.conda
+  sha256: f3cc44ab8ac58c07e90ee9e66fe5b7bec47baf633e5fd6534a0919f102bea3ab
+  md5: 71b194cbbd7c8d9599f31256355d3bc4
   depends:
   - _openmp_mutex >=4.5
-  - ffmpeg >=6.1.1,<7.0a0
+  - ffmpeg >=6.1.2,<7.0a0
   - freetype >=2.12.1,<3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.2,<5.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
   - openexr >=3.2.2,<3.3.0a0
   - python >=3.12,<3.13.0a0 *_cpython
-  - qt6-main >=6.6.2,<6.7.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 20008076
-  timestamp: 1711059152885
+  size: 19960312
+  timestamp: 1728020811394
 - kind: conda
   name: libopencv
-  version: 4.9.0
-  build: qt6_py312hd35d245_612
-  build_number: 612
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-qt6_py312hd35d245_612.conda
-  sha256: 632c454d0bc1bfc1bfbb93a5954a62a11053d7cf9b30d410af6740e3346ced1e
-  md5: 46fc3c0e3229c67a870288d81a5633cf
+  version: 4.10.0
+  build: headless_py312he31edb6_8
+  build_number: 8
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312he31edb6_8.conda
+  sha256: 27683f7401cd176d7e368e297e6565ef733180b39c2f52f5d96eb665708c2b8d
+  md5: 05f0570253fe4ac7f40d5f46b258214e
   depends:
-  - ffmpeg >=6.1.1,<7.0a0
+  - __osx >=11.0
+  - ffmpeg >=6.1.2,<7.0a0
   - freetype >=2.12.1,<3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.2,<5.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libglib >=2.80.0,<3.0a0
+  - libcxx >=17
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
   - openexr >=3.2.2,<3.3.0a0
-  - qt6-main >=6.6.2,<6.7.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  size: 21886575
+  timestamp: 1728020459453
+- kind: conda
+  name: libopencv
+  version: 4.10.0
+  build: qt6_py311h5a8f696_608
+  build_number: 608
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py311h5a8f696_608.conda
+  sha256: 0477cf06cd31ac79d08d1eb4e0c20fd321d372025a22dd7b727886065049091e
+  md5: 220a89c1f668b15090d52506aa941956
+  depends:
+  - ffmpeg >=6.1.2,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.2.2,<3.3.0a0
+  - qt6-main >=6.7.3,<6.8.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
-  size: 32933191
-  timestamp: 1711063801744
+  size: 32987550
+  timestamp: 1728023066233
 - kind: conda
   name: libopencv
-  version: 4.9.0
-  build: qt6_py39h8add8c0_612
-  build_number: 612
+  version: 4.10.0
+  build: qt6_py39h5cac152_610
+  build_number: 610
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-qt6_py39h8add8c0_612.conda
-  sha256: bd8b339c5c74714a26bc558d29452a463c388054b1b4935630e5176dd6744171
-  md5: 1d865fbc913b6c1d69038882e4b59940
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py39h5cac152_610.conda
+  sha256: 966c9c441f8a0005ebbe26d66cefccd08556faf4eaf6df2ee308c08ef0f50d91
+  md5: 45d7118cbbbb6f4733a9b23d91989a3d
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
-  - ffmpeg >=6.1.1,<7.0a0
+  - ffmpeg >=7.1.0,<8.0a0
   - freetype >=2.12.1,<3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.2,<5.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.82.2,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.22.4,<2.0a0
-  - openexr >=3.2.2,<3.3.0a0
-  - qt6-main >=6.6.2,<6.7.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-npu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.3.1,<3.4.0a0
+  - qt6-main >=6.7.3,<6.8.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 30232129
-  timestamp: 1711058937296
+  size: 30891589
+  timestamp: 1729610949785
 - kind: conda
   name: libopenvino
-  version: 2024.0.0
-  build: h113ac47_4
-  build_number: 4
+  version: 2024.4.0
+  build: h49f535f_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-h49f535f_1.conda
+  sha256: 5e0c931478ed4113c9edb4ef0898c7f10f41b1af6bb580ae837b102fda887ca2
+  md5: 128013add92b7e579af3de6759bb8b46
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 3951327
+  timestamp: 1727734428093
+- kind: conda
+  name: libopenvino
+  version: 2024.4.0
+  build: h7bc525e_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.0.0-h113ac47_4.conda
-  sha256: 18359d9a5d343a89fd9fb8d0dc7890b290c52fbfc51fc2fdc7e639246ddccc60
-  md5: 9d8a53bb2dbc55cee97d7c5093164e5b
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.4.0-h7bc525e_1.conda
+  sha256: eb560161fd7a355c28988c8ca3a826f89aef41917617df427b56eb1922e22c95
+  md5: 41f83efe50e2140fe79e74f835e1d744
   depends:
-  - libcxx >=16
+  - __osx >=10.15
+  - libcxx >=17
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 3978821
-  timestamp: 1711026119791
+  - tbb >=2021.13.0
+  size: 4231912
+  timestamp: 1727735006500
 - kind: conda
   name: libopenvino
-  version: 2024.0.0
-  build: h2e90f83_4
-  build_number: 4
+  version: 2024.4.0
+  build: hac27bb2_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.0.0-h2e90f83_4.conda
-  sha256: 901d6a974cf86c96f5ec29e7ef0e3a3bcf128ad9f48ee65d244d796512c2c8f5
-  md5: 126a2a61d276c4268f71adeef25bfc33
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
+  sha256: 1f804b6238951d59b3a431c2e01bd831d44e015ea6835809775bb60b6978e3b3
+  md5: ba5ac0bb9ec5aec38dec37c230b12d64
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 5111555
-  timestamp: 1711027178467
+  - tbb >=2021.13.0
+  size: 5362131
+  timestamp: 1729594675874
 - kind: conda
   name: libopenvino
-  version: 2024.0.0
-  build: h3e0449b_4
-  build_number: 4
+  version: 2024.4.0
+  build: hd7d4d4f_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.0.0-h3e0449b_4.conda
-  sha256: f0b6a9a5ba4c9f1792c20d91789dbc3ae50ba81a45d10470c2965aefc6bd227f
-  md5: d99b3eaf761f16a28397eb539b890547
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_1.conda
+  sha256: 781349dd5c10ef37bf7a0d7afb6d83c2c217bf798f4d79cc47ff339227cd7bf5
+  md5: f4812fe0c0e4934ae2ec41b5371823ff
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 4591172
-  timestamp: 1711021267498
+  - tbb >=2021.13.0
+  size: 4907367
+  timestamp: 1727736165150
 - kind: conda
   name: libopenvino
-  version: 2024.0.0
-  build: hc2557fa_4
-  build_number: 4
+  version: 2024.4.0
+  build: hfe1841e_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.0.0-hc2557fa_4.conda
-  sha256: d82e141f2e821d5f15995dff5873cd1c9ce0b3c892751442f840ec14518d766a
-  md5: 6471a7c178d58242f856b9ae89ea4a92
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_1.conda
+  sha256: 9849d119e37f6c424ab04a8692d7cd37524d82eba8a0a2920a074bf3dbc1b44b
+  md5: 8112a7a31fa5fa7adcd9f213db4545c2
   depends:
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 3116652
-  timestamp: 1711027954881
-- kind: conda
-  name: libopenvino
-  version: 2024.0.0
-  build: he6dadac_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.0.0-he6dadac_4.conda
-  sha256: fc4c9e19a5314c6a50205f226062e0bcc6899749371fd6bf6399eafdff4b4adc
-  md5: 48783d76d1cff4a85dada8fc8de4106b
-  depends:
-  - libcxx >=16
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 3667126
-  timestamp: 1711025235569
+  size: 3323185
+  timestamp: 1727742797259
 - kind: conda
   name: libopenvino-arm-cpu-plugin
-  version: 2024.0.0
-  build: h3e0449b_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.0.0-h3e0449b_4.conda
-  sha256: 5090bf7282e29f5f7322d4e6b4d838357da558ed6696b0e4558f56fbc96758b6
-  md5: 7af51baa5c9f8de6d8937ad1ad63054c
+  version: 2024.4.0
+  build: h49f535f_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-h49f535f_1.conda
+  sha256: 525dd6549178c4cb462a4c6d9941e2656092303875f20e756bc308d6666aa272
+  md5: e4fea763df742e2f2258fac928fcd735
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 6193823
-  timestamp: 1711021298834
+  - tbb >=2021.13.0
+  size: 7441642
+  timestamp: 1727734456011
 - kind: conda
   name: libopenvino-arm-cpu-plugin
-  version: 2024.0.0
-  build: he6dadac_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.0.0-he6dadac_4.conda
-  sha256: 129eea1691443392ffe6887ae8b704774164a21d7a40b6677f1ce099865c9c08
-  md5: 15808ae7cc119a909c2ef41e58a72c20
+  version: 2024.4.0
+  build: hd7d4d4f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_1.conda
+  sha256: 8891f029fdb29bcd0da1dc2f60742700f94b6641df7726dae3188ee4fd95ca44
+  md5: 3505d23e00013066cc80b544abcaf526
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 5910778
-  timestamp: 1711025307421
+  - tbb >=2021.13.0
+  size: 8396025
+  timestamp: 1727736188890
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2024.0.0
-  build: h002f227_4
-  build_number: 4
+  version: 2024.4.0
+  build: h04f32e0_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.0.0-h002f227_4.conda
-  sha256: 445181150f4c89dc9b9d652ed7dbf80a63bea91ee0ae1565ca73542278355bef
-  md5: 1e220626bc704d43cb690b6479866bae
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_1.conda
+  sha256: 78cb1c9dcab0a925a422a5a38d7a3e2127c91189b554eba5552d96db77e2d558
+  md5: 8bcf361232b712f26183ec1344b4b1c2
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
-  - tbb >=2021.11.0
+  - libopenvino 2024.4.0 hfe1841e_1
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 98587
-  timestamp: 1711028047720
+  size: 99710
+  timestamp: 1727742845056
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2024.0.0
-  build: h9adb129_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.0.0-h9adb129_4.conda
-  sha256: 735797a48790d2317ca18d081ae3fa96cede63bd7c1d749d95aabebd946e4b1b
-  md5: bc0a89ad1ab1fdc0ac29434109086c86
-  depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  - tbb >=2021.11.0
-  size: 103483
-  timestamp: 1711026194169
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.0.0
-  build: hc9f00d9_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.0.0-hc9f00d9_4.conda
-  sha256: c3cf9f7543eef2c3924b23b80f40bae51348d37e876959a6217c6543aa3db965
-  md5: 83a4a7cf4b07bd8cd9def70bbbc1f6b8
-  depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  - tbb >=2021.11.0
-  size: 101644
-  timestamp: 1711025395864
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.0.0
-  build: hd429f41_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.0.0-hd429f41_4.conda
-  sha256: 364c62a3ccc819e3b0647b94933ca83b5d59c8dd35e9d16dca8478557fcc1faf
-  md5: 891f5b643aa3842cf82493c884d7d2dd
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
-  - tbb >=2021.11.0
-  size: 104627
-  timestamp: 1711021334086
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.0.0
-  build: hd5fc58b_4
-  build_number: 4
+  version: 2024.4.0
+  build: h4d9b6c2_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.0.0-hd5fc58b_4.conda
-  sha256: 7997f2e1e24d79dbecbc7a275a0aef495cdb25018b19ab982b23147cfe80f659
-  md5: de9c380fea8634540db5fc8422888df1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
+  sha256: dc596ff555b7ae19a7cd62af8965445575e1441dd486b8aec6a647f9ecbada3a
+  md5: 1d05a25da36ba5f98291d7237fc6b8ce
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
-  - tbb >=2021.11.0
-  size: 110186
-  timestamp: 1711027220662
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 111701
+  timestamp: 1729594696807
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2024.4.0
+  build: h8a2fcec_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-h8a2fcec_1.conda
+  sha256: e063af46407bce327fa2a5c346a15129268c0fb9968f23909b7661074138a204
+  md5: 69a92fdcb51c3f60c6b740e33aea1f2a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - tbb >=2021.13.0
+  size: 104178
+  timestamp: 1727734500385
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2024.4.0
+  build: h904f6e8_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.4.0-h904f6e8_1.conda
+  sha256: 17b5dd31e9dd0e4029547d7b8e59be64eda5cc4bd49f472a60ba02225ed76089
+  md5: 040d99f3abf2f1954dc82f10943c3ad2
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - tbb >=2021.13.0
+  size: 105675
+  timestamp: 1727735029695
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2024.4.0
+  build: hf15766e_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_1.conda
+  sha256: d8533e8f9fdcf6fb6ea44aba5007c8bb62b0da0ea28bc6b4b75bbcb3de4df8e5
+  md5: c8168b9954a8e347d8a870a0bdba6cc2
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 107990
+  timestamp: 1727736222949
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2024.0.0
-  build: h002f227_4
-  build_number: 4
+  version: 2024.4.0
+  build: h04f32e0_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.0.0-h002f227_4.conda
-  sha256: cda1e01e446eebb2d41833890dab03d1ea3c4c13bfbe4110a92f0bcc275941bf
-  md5: 540e607b26c81910275f5b2c25bcc6ff
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_1.conda
+  sha256: d874d48f60257e53b58d403a338159be0faaffac93f7d39e97c111c711554deb
+  md5: 9caed540cf3f82423b36fdd49ade48ea
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
-  - tbb >=2021.11.0
+  - libopenvino 2024.4.0 hfe1841e_1
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 186806
-  timestamp: 1711028111911
+  size: 194349
+  timestamp: 1727742884368
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2024.0.0
-  build: h9adb129_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.0.0-h9adb129_4.conda
-  sha256: d417139fa5501b8765085443e811e91c90c4a45350378f34dc0fa2121edc4f3b
-  md5: 99efdc8defbec695d3b5c02359dc2c92
+  version: 2024.4.0
+  build: h4d9b6c2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
+  sha256: 27b732f1ba3ae7dc8263f59e69447eebabcc76de86e2ec4c9722842a1d2f4aa8
+  md5: 838b2db868f9ab69a7bad9c065a3362d
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  - tbb >=2021.11.0
-  size: 204632
-  timestamp: 1711026258627
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 237694
+  timestamp: 1729594707449
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2024.0.0
-  build: hc9f00d9_4
-  build_number: 4
+  version: 2024.4.0
+  build: h8a2fcec_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.0.0-hc9f00d9_4.conda
-  sha256: 7a2cd693494c5a5cd5bd09727db88fe9e78a9fad8047269bf07be4ec61f40ace
-  md5: c05237e0d9572b6bacc316d32f4e746d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-h8a2fcec_1.conda
+  sha256: 3fa11fc10209a97dc06064a27a5ef4ca6ec619ccc6c26b3fc9c2618c2d338d1f
+  md5: e8a4b17000d53f2535ac2aa9d83d5ba4
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  - tbb >=2021.11.0
-  size: 198650
-  timestamp: 1711025449439
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - tbb >=2021.13.0
+  size: 211529
+  timestamp: 1727734517574
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2024.0.0
-  build: hd429f41_4
-  build_number: 4
+  version: 2024.4.0
+  build: h904f6e8_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.4.0-h904f6e8_1.conda
+  sha256: ccdaf62023d0625a03eba83396379e3a4683075d0ff33ed375d857642ab1d9cc
+  md5: 3e58791c03a55e0f2cd7f937078b2336
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - tbb >=2021.13.0
+  size: 217416
+  timestamp: 1727735046115
+- kind: conda
+  name: libopenvino-auto-plugin
+  version: 2024.4.0
+  build: hf15766e_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.0.0-hd429f41_4.conda
-  sha256: 250ac7d2eedbdb13ecf18d303aa4bbae9f5c1b440a9b6dda929446b2a8cc8ac0
-  md5: 94131818c623c83ece60c2fca1c68a0b
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_1.conda
+  sha256: d9c2b766b1d491efdad4987d74287cea0945bb279c0666b2aba1091c7a9cb1b4
+  md5: 4a85f812507f352c3dd162255ca92054
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
-  - tbb >=2021.11.0
-  size: 211325
-  timestamp: 1711021356485
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.0.0
-  build: hd5fc58b_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.0.0-hd5fc58b_4.conda
-  sha256: 1ec1dc0cf9aa4e1879145f0d8645d6132d19e7f8ea0a678b500ee96a110527e7
-  md5: de1cbf145ecdc1d29af18e14eb267bca
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
-  - tbb >=2021.11.0
-  size: 229461
-  timestamp: 1711027252355
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 224280
+  timestamp: 1727736262029
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2024.0.0
-  build: h3ecfda7_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.0.0-h3ecfda7_4.conda
-  sha256: 6b530d036bf3a608c6cae2de4ab8f7e9471b53603c63b10d0a04c211e3325b1f
-  md5: 016b763e4776b4c2c536420a7e6a2349
+  version: 2024.4.0
+  build: h364e3e2_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.4.0-h364e3e2_1.conda
+  sha256: 18d02087eb6bc2020438197e4c4d769e8da0275e70c029dcae211dc28bb16527
+  md5: d88d2184086ea72c6d82a914b3206c33
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
   - pugixml >=1.14,<1.15.0a0
-  size: 180199
-  timestamp: 1711027285756
+  size: 181128
+  timestamp: 1727735062714
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2024.0.0
-  build: h7e3b17c_4
-  build_number: 4
+  version: 2024.4.0
+  build: h372dad0_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.0.0-h7e3b17c_4.conda
-  sha256: 0ecd1693764ce97d01512c614e030ca745bb9e9dd09977e36fd943cb76b316ed
-  md5: 71df158a1f05a9ba4d27938a767ee899
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_1.conda
+  sha256: 4255d0ae5ee122a47e0a77418f951d57f35c6b363a173c4583c907637ac9699e
+  md5: 3dc40fff10eab0d7a8f719756a7e30f7
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
+  - libopenvino 2024.4.0 hfe1841e_1
   - pugixml >=1.14,<1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 150628
-  timestamp: 1711028175536
+  size: 159985
+  timestamp: 1727742935549
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2024.0.0
-  build: hc6dd956_4
-  build_number: 4
+  version: 2024.4.0
+  build: h3f63f65_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
+  sha256: 0c7cd10c9e3d99d6f23e4d7b48cd8e72aeb4a1c7acb801b6ca9add0f87f238d3
+  md5: 00a6127960a3f41d4bfcabd35d5fbeec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  size: 197567
+  timestamp: 1729594718187
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2024.4.0
+  build: h6ef32b0_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.0.0-hc6dd956_4.conda
-  sha256: b8d9d4a8c1cf43408d713883381f1f0c98af0b4bf6383c98b6b6b85c13b9fe4a
-  md5: d7f48666882d053dcdb9da3c39422936
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_1.conda
+  sha256: 6ba3e169093cc4937baa1366552f8bdd1133bb4851ea6eda2c20897ffe76bc25
+  md5: 3bb4e66afee69752d0254f399454a015
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  size: 168072
-  timestamp: 1711021380636
+  size: 184604
+  timestamp: 1727736275255
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2024.0.0
-  build: hf483cef_4
-  build_number: 4
+  version: 2024.4.0
+  build: h868cbb4_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.0.0-hf483cef_4.conda
-  sha256: 1e670b5ed9c7f81c9512ad08912e0a8ff15316b7ce95da75e4e8e58796a1de06
-  md5: 18b7390ccce7e83d0d36a1131ea6cb84
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h868cbb4_1.conda
+  sha256: c31517fc4ff50d95cf3c8888307019e6424d685e2d9da9843ab83295c3b4de6a
+  md5: 78c2f1ec1ec18e20b19e20fe8a30db8e
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
   - pugixml >=1.14,<1.15.0a0
-  size: 159686
-  timestamp: 1711025501657
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.0.0
-  build: hfe2fe54_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.0.0-hfe2fe54_4.conda
-  sha256: 37bc25f92b6803d7d4a1e5424c780a75ad1eda4974ca6dbcc4cbb573e240a377
-  md5: cece1c44db441905aa3caaa79b1c8a86
-  depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  - pugixml >=1.14,<1.15.0a0
-  size: 167431
-  timestamp: 1711026321577
+  size: 173970
+  timestamp: 1727734536231
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2024.0.0
-  build: h113ac47_4
-  build_number: 4
+  version: 2024.4.0
+  build: h7bc525e_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.0.0-h113ac47_4.conda
-  sha256: eb5985f740ee97b8a30efd7ff6a48c36e3eb33678bf7a3f6fb53d5fc4bcc9cc7
-  md5: 0714af035978be750d5e1f9adc8ee4cb
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.4.0-h7bc525e_1.conda
+  sha256: 6e949602df71436eeeb251d3341068e0de28dd3acf4aa6ea0956d1ab2a785bda
+  md5: bf19aff20ed3c8146703f0d225628a25
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 9930944
-  timestamp: 1711026387156
+  - tbb >=2021.13.0
+  size: 11144640
+  timestamp: 1727735085846
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2024.0.0
-  build: h2e90f83_4
-  build_number: 4
+  version: 2024.4.0
+  build: hac27bb2_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.0.0-h2e90f83_4.conda
-  sha256: 2daa2f6fc584674adee84b036a9a267a6bcae731c912326efda155f2328586d8
-  md5: d866cc8dc37f101505e65a4372794631
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
+  sha256: 5642443645408f030e9dfbe20dbe2c2ab6d852daf02c9a36eac123b44bf2980f
+  md5: 6cfc840bc39c17d92fb25e5a35789e5b
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 10618695
-  timestamp: 1711027317641
+  - tbb >=2021.13.0
+  size: 12101994
+  timestamp: 1729594729554
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2024.0.0
-  build: hc2557fa_4
-  build_number: 4
+  version: 2024.4.0
+  build: hfe1841e_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.0.0-hc2557fa_4.conda
-  sha256: 264eb4dee7695a60d37b6eecbab4967db3c76a62f1b910c4d0ada4c076bbef3f
-  md5: 99906c0b41251d08acedd963214f080c
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_1.conda
+  sha256: 0e25e7c5fc374c49b795ce4546e49a6b181b36029a2fbfa43ea289e268022685
+  md5: fb644753d714acace1f62f180252aaf2
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
+  - libopenvino 2024.4.0 hfe1841e_1
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 7223389
-  timestamp: 1711028247831
+  size: 8038586
+  timestamp: 1727742976578
 - kind: conda
   name: libopenvino-intel-gpu-plugin
-  version: 2024.0.0
-  build: h2e90f83_4
-  build_number: 4
+  version: 2024.4.0
+  build: hac27bb2_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.0.0-h2e90f83_4.conda
-  sha256: 15f0ad9ea10829d8964253b08667af015dfa4befa0afd2e6f3a44110f6efcb96
-  md5: 6ebefdc74cb700ec82cd6702125cc422
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
+  sha256: 508d0e36febebfb66628d8cb0312b4133c212eac1e8d891fc8977e0d85b23741
+  md5: 9e9814b40d8fdfd8485451e3fa2f1719
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
   - ocl-icd >=2.3.2,<3.0a0
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
-  size: 8353160
-  timestamp: 1711027380449
+  - tbb >=2021.13.0
+  size: 8885078
+  timestamp: 1729594772427
 - kind: conda
   name: libopenvino-intel-gpu-plugin
-  version: 2024.0.0
-  build: hc2557fa_4
-  build_number: 4
+  version: 2024.4.0
+  build: hfe1841e_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.0.0-hc2557fa_4.conda
-  sha256: 9db806c981d14942dd2f2a46f7d58003a267d28fe9b2afb14fcc3c144daec922
-  md5: 47f49ccca5334fc44dddaf9a8ad1dd84
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_1.conda
+  sha256: 807d69917f8924519423e3f6b64f32345551c5f1a08c0dead4ddcf71bdbd1b36
+  md5: 3425d54332ca5792678c189e7eb2cc4a
   depends:
   - khronos-opencl-icd-loader >=2023.4.17
-  - libopenvino 2024.0.0 hc2557fa_4
+  - libopenvino 2024.4.0 hfe1841e_1
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.11.0
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 7151374
-  timestamp: 1711028339128
+  size: 7182614
+  timestamp: 1727743041822
+- kind: conda
+  name: libopenvino-intel-npu-plugin
+  version: 2024.4.0
+  build: hac27bb2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
+  sha256: a07bdb55c3214cd5b27736ee6d06abe55782ddf1cfaeb9fffee96179bf12390b
+  md5: 724719ce97feb6f310f88ae8dbb40afd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 799335
+  timestamp: 1729594804720
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.0.0
-  build: h3ecfda7_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.0.0-h3ecfda7_4.conda
-  sha256: 09c91b8701764154b41a2c82d0412939e5625c712edfe965496930cdad6c822e
-  md5: 6397395a4677d59bbd32c4f05bb8fa63
+  version: 2024.4.0
+  build: h364e3e2_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.4.0-h364e3e2_1.conda
+  sha256: f2ff5a5da8f2adf6bcfca080d920066f24a7d10a0c237ae1343722056d31b204
+  md5: 65d5c0d7deb8d568d363fc90bba668d9
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
   - pugixml >=1.14,<1.15.0a0
-  size: 201195
-  timestamp: 1711027432846
+  size: 182957
+  timestamp: 1727735135816
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.0.0
-  build: h7e3b17c_4
-  build_number: 4
+  version: 2024.4.0
+  build: h372dad0_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.0.0-h7e3b17c_4.conda
-  sha256: 77bc36d1501bc6c1b0b6fcd8589f7cfbc7e1ebe14dc1a0d4b25b208d9fe9ba1a
-  md5: 9a45a5589d14166671ae5463f9cf48cc
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_1.conda
+  sha256: dd777e23535b70e4071baa44258648c95baf6d79f43e9bc8cd27faa810df0f68
+  md5: a597057c32cd79d96403bd4a5ac6d38c
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
+  - libopenvino 2024.4.0 hfe1841e_1
   - pugixml >=1.14,<1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 157968
-  timestamp: 1711028420821
+  size: 158232
+  timestamp: 1727743098747
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.0.0
-  build: hc6dd956_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.0.0-hc6dd956_4.conda
-  sha256: 57a97848d64d2f95b0f5ed1209da9f55965af4cbe1011700cd7e22a97addef6e
-  md5: 44041135feefb1a23b74484d4e28b7ad
+  version: 2024.4.0
+  build: h3f63f65_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
+  sha256: 6038aefea84aeb9534aaf6963d2b266eb757fa36c1a7a9f5e29d6d813bd85a2c
+  md5: 8908f31eab30f65636eb61ab9cb1f3ad
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  size: 186649
-  timestamp: 1711021402947
+  size: 204163
+  timestamp: 1729594816408
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.0.0
-  build: hf483cef_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.0.0-hf483cef_4.conda
-  sha256: 90c6b63568d705aecd213f2de63cc0b8b0afafd30e61f72e76ab4302fd4cb863
-  md5: 77654f9ad0a6c38fb90d069ac7792d98
+  version: 2024.4.0
+  build: h6ef32b0_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_1.conda
+  sha256: 30f4825789b3a82d51bf80eeb2baeba8f2c15eb1c58296a61b5d0dfde10ad191
+  md5: 5f8c79d05bec97d469a3174c8328f61a
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
   - pugixml >=1.14,<1.15.0a0
-  size: 170057
-  timestamp: 1711025552719
+  size: 192039
+  timestamp: 1727736288484
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2024.0.0
-  build: hfe2fe54_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.0.0-hfe2fe54_4.conda
-  sha256: 64b45b4df151b80988d13f72cec3145ab3773f255e089d21cdb6a7ab7b2dc852
-  md5: c3f40e2622af41f0e597733266a0ec09
+  version: 2024.4.0
+  build: h868cbb4_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h868cbb4_1.conda
+  sha256: 8d21c0ca0b76258cee94473cd914b9bf057218bd6e36bd8d8e78abf0530b8a5b
+  md5: c203b54e1edf2a5ea2c76d297e097159
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
   - pugixml >=1.14,<1.15.0a0
-  size: 178232
-  timestamp: 1711026493930
+  size: 173568
+  timestamp: 1727734556587
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2024.0.0
-  build: h1a3ed6a_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.0.0-h1a3ed6a_4.conda
-  sha256: 16da5c3b4526a340145e074b32253221059f60389bc6c048cec8dc2767ad357e
-  md5: 543a343c411d307d3076e021f4eec355
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  size: 1264777
-  timestamp: 1711026558792
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.0.0
-  build: h298fcef_4
-  build_number: 4
+  version: 2024.4.0
+  build: h56b1c3c_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.0.0-h298fcef_4.conda
-  sha256: 4b8a7777d10b327fce52d8bab324d94ff12d5c3a008a40ddcd86699f5cebfa7c
-  md5: d3d7b3d5d7b9e59fdcf68bbbdbb571cc
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-h56b1c3c_1.conda
+  sha256: f189bcd7aa68b2e61dbb334757f14133c5d1da6cb07679c226ebe0fa83892ce3
+  md5: 031735d911b8f46c7ba3cacb0565c860
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  size: 1198233
-  timestamp: 1711025605707
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 1228021
+  timestamp: 1727734590200
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2024.0.0
-  build: h55b4db4_4
-  build_number: 4
+  version: 2024.4.0
+  build: h5707d70_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.0.0-h55b4db4_4.conda
-  sha256: d5fb8ea4a2eb7d27cb29171f9c84bf63ca9f6473852c8b2b9d8a87e0901ba297
-  md5: 5b603ddb74d306d4e9a1871a46e232c4
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-h5707d70_1.conda
+  sha256: 39b66fbf88884fe093a2b1c87b432851afbf15e57ef9b18800634619aceb559b
+  md5: 52d26dbc42460ba541e234626fea1011
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libopenvino 2024.4.0 hfe1841e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 987441
-  timestamp: 1711028489373
+  size: 991756
+  timestamp: 1727743145820
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2024.0.0
-  build: h757c851_4
-  build_number: 4
+  version: 2024.4.0
+  build: h5c8f2c3_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.0.0-h757c851_4.conda
-  sha256: c29f5bead57bfb14cca7bd89e20f13eb18ec9a4624dcff1d56834454deb3be9c
-  md5: 24c9cf1dd8f6d6189102a136a731758c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
+  sha256: b68c2ee5fd08c0974ad9395ea0de809b306c261485114cbcbbc0f55c1e0285b3
+  md5: e098caa87868e8dcc7ed5d011981207d
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  size: 1586430
-  timestamp: 1711027467156
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  size: 1559399
+  timestamp: 1729594827815
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2024.0.0
-  build: h81208d3_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.0.0-h81208d3_4.conda
-  sha256: 766e78e6400a2be23cb23c33428873df87943f33b2afddf22124fe706b20c867
-  md5: bd078064c35012e2c28e58d2d39069f8
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  size: 1403136
-  timestamp: 1711021425932
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.0.0
-  build: h1a3ed6a_4
-  build_number: 4
+  version: 2024.4.0
+  build: h9381666_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.0.0-h1a3ed6a_4.conda
-  sha256: 37de5299f8f9c790f073bf7b5dd2d1c21ee148302fc8087a31291e72f49c0c52
-  md5: f52039a0882dad166cbc55e1d41c05a4
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.4.0-h9381666_1.conda
+  sha256: 7fab7fadd14918bbc41375422279b6d9d63459e22e8e3f689cc8cbf612cc7c64
+  md5: ef81e0bd029cd0ed174bf967589f6628
   depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  size: 426912
-  timestamp: 1711026626668
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 1281366
+  timestamp: 1727735162793
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2024.4.0
+  build: he59a552_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-he59a552_1.conda
+  sha256: 0c86cce07d20a3b2d0db14b349096ad197b42113eb854c64242b748b3cae5d84
+  md5: 8ce3f67a3d4b070b6493c88b0afe400f
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  size: 1404754
+  timestamp: 1727736302649
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2024.0.0
-  build: h298fcef_4
-  build_number: 4
+  version: 2024.4.0
+  build: h56b1c3c_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.0.0-h298fcef_4.conda
-  sha256: 8e9336faddf8191486b127986344d0b7500182c584f7cd8f806768bd79f8c606
-  md5: 08c0bba5af5c86b7e20eac7f9567756f
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-h56b1c3c_1.conda
+  sha256: 802622fc93ece7ddae63461fe1212677d606e2f273217c8bdcce30eb734f241f
+  md5: 2774e2b992650f812668f1417d254e9d
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  size: 415162
-  timestamp: 1711025663174
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 419159
+  timestamp: 1727734612023
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2024.0.0
-  build: h55b4db4_4
-  build_number: 4
+  version: 2024.4.0
+  build: h5707d70_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.0.0-h55b4db4_4.conda
-  sha256: 91fed61727c82d22b058d0378665f3baeb11133a50a237501f80e07fc5136059
-  md5: 4d52bd422679701b6640ae3d2cf28c07
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-h5707d70_1.conda
+  sha256: 3bfdfaca70c91af517fe7ee5897164611676e91d68b639717b7da3b6db037b85
+  md5: 27b80a14e7f69e8facc6d021692b9543
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libopenvino 2024.4.0 hfe1841e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 417982
-  timestamp: 1711028557850
+  size: 419305
+  timestamp: 1727743190562
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2024.0.0
-  build: h757c851_4
-  build_number: 4
+  version: 2024.4.0
+  build: h5c8f2c3_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.0.0-h757c851_4.conda
-  sha256: cc16cf9103d57d14a4f65b0148ae6197ced75063bebb07533744a1f0675ef294
-  md5: 259bd0c788f447fe78aab69895365528
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
+  sha256: fa57b201fb92af0adc2118de8e92648959b98c0dc1a60b278ba2b79c5601eea6
+  md5: 59bb8c3502cb9d35f1fb26691730288c
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  size: 695625
-  timestamp: 1711027501848
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  size: 653105
+  timestamp: 1729594841297
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2024.0.0
-  build: h81208d3_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.0.0-h81208d3_4.conda
-  sha256: c7dd82dab0bf4661973e5ee61655b4ecf606e9a02c0a737e3f84115bba54d8d2
-  md5: f93fa34d7545a46a08836d97c1eb3145
+  version: 2024.4.0
+  build: h9381666_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.4.0-h9381666_1.conda
+  sha256: 02a79422eb03e329dc2daa60242a299ba0b5ad6c7d2fbe16690ae9b6b0d09d11
+  md5: 733d3c5fe554e675fe279308f28dbd0c
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  size: 630686
-  timestamp: 1711021452310
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 427045
+  timestamp: 1727735182582
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2024.4.0
+  build: he59a552_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-he59a552_1.conda
+  sha256: e38bd130841f9ac7ff73befcb1f241a17efd0568678a994c2e3f64b11009da79
+  md5: 03a42996356af6a472c6b29bfaab8275
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  size: 605738
+  timestamp: 1727736320540
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2024.0.0
-  build: h2f0025b_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.0.0-h2f0025b_4.conda
-  sha256: 7678b94bd34b41782d620b6ecbc9c1a2cc56d4904105088af6a6820c855cab09
-  md5: c37b2c39a1324b009be45794a5f44f10
+  version: 2024.4.0
+  build: h4398f7a_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.4.0-h4398f7a_1.conda
+  sha256: e04195e7ce2fb0709b3fc22d53f2560046ad7ac956c334ed3af1a30363afde5a
+  md5: 8834ede936d55c678b2e4fe07c2a8575
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
-  size: 959260
-  timestamp: 1711021475330
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  size: 788511
+  timestamp: 1727735199787
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2024.0.0
-  build: h59595ed_4
-  build_number: 4
+  version: 2024.4.0
+  build: h5888daf_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.0.0-h59595ed_4.conda
-  sha256: 2f032e4cec7d24f80ea932c99b0fea896fbf1e4a202453b71b50bc6980d0cfae
-  md5: ec121a4195acadad086f84719cc91430
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
+  sha256: a029b3ebff1e8d1d2736a548a616c20066ed6508f238782afbf3a77a4f57c6cd
+  md5: e0b88fd64dc95f715ef52e607a9af89b
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
-  size: 1062658
-  timestamp: 1711027534033
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
+  size: 1075090
+  timestamp: 1729594854413
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2024.0.0
-  build: h63175ca_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.0.0-h63175ca_4.conda
-  sha256: 0167c1620028884f0a6a6f37d7841981117bb795a8babe8f53eb416293a16424
-  md5: a0f1a943347cebd2ce7db39faa1d8ddf
+  version: 2024.4.0
+  build: h5ad3122_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_1.conda
+  sha256: 19458d2980e8f69af5528ebbc6e1c8a70ba940b54122ccd4e4b75669f8c183fe
+  md5: 19f5a7e35f6208f892455941e0aa29a0
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
+  size: 996782
+  timestamp: 1727736334613
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2024.4.0
+  build: he0c23c2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_1.conda
+  sha256: 38e25f599eb022e3c655541ecd33547f7111058b520373a785fd16463caeabd9
+  md5: 1607477ea0676f98505df042a9ec6672
+  depends:
+  - libopenvino 2024.4.0 hfe1841e_1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 647043
-  timestamp: 1711028623161
+  size: 677864
+  timestamp: 1727743230045
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2024.0.0
-  build: hd427752_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.0.0-hd427752_4.conda
-  sha256: a78255491cc455d1b8ac8436996e8112d59f49e6994013a3184f93cf55c6cd0d
-  md5: 7489363c2aa4d7a29c2b6f2c505099a4
-  depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  size: 760887
-  timestamp: 1711026691193
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.0.0
-  build: hebf3989_4
-  build_number: 4
+  version: 2024.4.0
+  build: hf9b8971_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.0.0-hebf3989_4.conda
-  sha256: 2bf917984a213800cca75e3c2d5ebeb23a1704b85be4bc17b07f336f4ec77ba7
-  md5: 19fa1a81ca49a5f3cb357fe6c3a57b40
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-hf9b8971_1.conda
+  sha256: c4dee1ecc31696bf5ac52e8af88305a814ca6068ec128517af6c6979c9dbc732
+  md5: 2820ed3662ff9ac7ac61a717049d08c2
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  size: 730406
-  timestamp: 1711025718854
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  size: 767608
+  timestamp: 1727734631665
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2024.0.0
-  build: h356fca3_4
-  build_number: 4
+  version: 2024.4.0
+  build: h0b17760_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.0.0-h356fca3_4.conda
-  sha256: eb63037c898e133130bb52d243301cfbfa91301f02dd932d91475e16b64b174d
-  md5: cb5593445e5ac05a3c7682c88e80de17
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h0b17760_1.conda
+  sha256: b7330f292ab20b3175c2daaa5adb3d0ece25c529523a013492899296e4872338
+  md5: 90c4254246b927db47137bd7bd5ffeda
   depends:
+  - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - snappy >=1.1.10,<2.0a0
-  size: 881831
-  timestamp: 1711025780162
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  size: 932670
+  timestamp: 1727734671391
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2024.0.0
-  build: h5177828_4
-  build_number: 4
+  version: 2024.4.0
+  build: h6481b9d_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
+  sha256: fdc4871a05bbb61cfe6db1e60018d74cbd6d65d82f03b9be515c3ad41bb7ca04
+  md5: 12bf831b85f17368bc71a26ac93a8493
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - snappy >=1.2.1,<1.3.0a0
+  size: 1282840
+  timestamp: 1729594867098
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2024.4.0
+  build: h7d3acce_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.0.0-h5177828_4.conda
-  sha256: 48979c422bd2df5eb374c4cc3c28c69fdc200791b35fd91689c5b9c3e11ee3e0
-  md5: 43a29ea76c5072b69f75495141623112
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-h7d3acce_1.conda
+  sha256: 5d72bff273fb65e4ac21b7970eaab49c539d3603a81d706aa806f8535bda9301
+  md5: c606736dd480b09d24251123f8108f3c
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - snappy >=1.1.10,<2.0a0
-  size: 1174002
-  timestamp: 1711021499528
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  - snappy >=1.2.1,<1.3.0a0
+  size: 1192551
+  timestamp: 1727736349937
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2024.0.0
-  build: h7d3639a_4
-  build_number: 4
+  version: 2024.4.0
+  build: hd55e6c5_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.0.0-h7d3639a_4.conda
-  sha256: 077a86295e5b30c8c9f9a140486f6d3b2eff32a9ff7e1c462a28f4e95bd60c66
-  md5: 426d2097dd8f8c129351ab6d0158dde6
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.4.0-hd55e6c5_1.conda
+  sha256: 57a21aeaeaf0a8b811f545ad8eb3c6e1dd74848e5a67ce8d84a82b21834c63ce
+  md5: 7c270faed41a76fc45b4a1641154b51f
   depends:
-  - __osx >=10.13
+  - __osx >=10.15
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - snappy >=1.1.10,<2.0a0
-  size: 935944
-  timestamp: 1711026766564
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  size: 975929
+  timestamp: 1727735239249
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2024.0.0
-  build: ha362bc9_4
-  build_number: 4
+  version: 2024.4.0
+  build: hf4e5e90_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.0.0-ha362bc9_4.conda
-  sha256: 0b2def68d9bfa021ed066f56cbbbeb304d749dc7e3f6a8b2aa6ab606ed9e6a42
-  md5: 06e6366a721b528d48d0190287c3d619
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-hf4e5e90_1.conda
+  sha256: 0dc25c998ce231e6bc33183e6013e96db013ca07fffb45ad140c3ad59c60b86e
+  md5: a82ca6e666d027e8fd369a14a51c97fc
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libopenvino 2024.0.0 hc2557fa_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - snappy >=1.1.10,<2.0a0
+  - libabseil >=20240722.0,<20240723.0a0
+  - libopenvino 2024.4.0 hfe1841e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - snappy >=1.2.1,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 841512
-  timestamp: 1711028696316
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.0.0
-  build: hca94c1a_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.0.0-hca94c1a_4.conda
-  sha256: 3037418cbf5e14964e4c4909ac4f15729db29e990b57d3b2d0b7cf6b0186a3d7
-  md5: bdbf11f760f1a3b35d766e03cebd9c42
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - snappy >=1.1.10,<2.0a0
-  size: 1270397
-  timestamp: 1711027568199
+  size: 880412
+  timestamp: 1727743277470
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2024.0.0
-  build: h2f0025b_4
-  build_number: 4
+  version: 2024.4.0
+  build: h4398f7a_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h4398f7a_1.conda
+  sha256: 4affc1a6d186f05be71b953d23e29cd7ea73bcb045b1db7e284de8a7f0c63fc3
+  md5: 74e6f266e094ba1014bc133b4583c8d7
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  size: 369174
+  timestamp: 1727735257807
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2024.4.0
+  build: h5888daf_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
+  sha256: a8f26058cf57159492c63fb0622ea2858763ea22338c507ff40a6e9bb792295e
+  md5: d48c774c40ea2047adbff043e9076e7a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hac27bb2_2
+  - libstdcxx >=13
+  size: 466563
+  timestamp: 1729594879557
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2024.4.0
+  build: h5ad3122_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.0.0-h2f0025b_4.conda
-  sha256: c2157867b42ad952bf707e04f98eb571ce39d47259b290ff296a1b4a7e4370b4
-  md5: 53c065cfdf622b4ba309b34615e6c31a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_1.conda
+  sha256: 6a6f7d6cdf0295befe14169c088466b4acb3b5c4327c5beac2bef1c2c5e57f85
+  md5: 4ab346a3b72352d33efbded20fe30dd4
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h3e0449b_4
-  - libstdcxx-ng >=12
-  size: 437346
-  timestamp: 1711021525232
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_1
+  - libstdcxx >=13
+  size: 429769
+  timestamp: 1727736364966
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2024.0.0
-  build: h59595ed_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h59595ed_4.conda
-  sha256: 792f3a7de81b92a85339082008281dc03359c64ab10d9a93c71856fbefac8333
-  md5: 4354ea9f30a8c5111403fa4b24a2ad66
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2024.0.0 h2e90f83_4
-  - libstdcxx-ng >=12
-  size: 477431
-  timestamp: 1711027605659
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.0.0
-  build: h63175ca_4
-  build_number: 4
+  version: 2024.4.0
+  build: he0c23c2_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h63175ca_4.conda
-  sha256: 652d3d74f013f0800a8c461bcb0123a7984b4c5a2f62bc7a10cada6d18b8048f
-  md5: 7c7e927452dfb65150bf447ac9ee789a
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_1.conda
+  sha256: 4d06a6d430f2c58793dd2c8ccd45641c57a7b1fbe130540ce9ed83f4e6809241
+  md5: a7e771ba26beb25c785a6d34f8b54aed
   depends:
-  - libopenvino 2024.0.0 hc2557fa_4
+  - libopenvino 2024.4.0 hfe1841e_1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 329890
-  timestamp: 1711028761582
+  size: 324141
+  timestamp: 1727743317824
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2024.0.0
-  build: hd427752_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.0.0-hd427752_4.conda
-  sha256: 7458435a72afd7648cdce5da233407750f14c11e78cb4219b6d30a4a57a7a741
-  md5: ab2a53b0b8a50397a71b58ad4792c615
-  depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 h113ac47_4
-  size: 377031
-  timestamp: 1711026835681
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.0.0
-  build: hebf3989_4
-  build_number: 4
+  version: 2024.4.0
+  build: hf9b8971_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.0.0-hebf3989_4.conda
-  sha256: de941d13292bb24caf0a906818058257b042668e53f7399a1dd7b858d6ef9a24
-  md5: 46de308a60f4d3361fa07c9ff23e3f08
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-hf9b8971_1.conda
+  sha256: 1abe1c27fb21b6afcc5b3ecc575ebf73fa0cd4a4bbede804b950ac3e611eaa83
+  md5: b8162158a8e105632fc89cc05ed4d9d4
   depends:
-  - libcxx >=16
-  - libopenvino 2024.0.0 he6dadac_4
-  size: 374273
-  timestamp: 1711025833025
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  size: 370223
+  timestamp: 1727734689422
 - kind: conda
   name: libopus
   version: 1.3.1
@@ -9365,82 +9843,90 @@ packages:
 - kind: conda
   name: libosqp
   version: 0.6.3
-  build: h13dd4ca_0
+  build: h5833ebf_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h13dd4ca_0.conda
-  sha256: fd38d8b20d904b3246db888fb26e7400a0a0ef50f1816a85c951ff47a570e392
-  md5: 3b83415bfa90262647c2cab6d25c4618
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h5833ebf_1.conda
+  sha256: 05740cc58df7a9c966a277331dea1987db485508c0a35d2ac9ef562f8061df06
+  md5: 7b4c6d7f35e9fe945e810e213d21b942
   depends:
-  - libcxx >=15.0.7
-  - libqdldl >=0.1.5,<0.1.6.0a0
+  - __osx >=11.0
+  - libcxx >=17
+  - libqdldl >=0.1.7,<0.1.8.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 64026
-  timestamp: 1685065777386
+  size: 360361
+  timestamp: 1729342406705
 - kind: conda
   name: libosqp
   version: 0.6.3
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h2f0025b_0.conda
-  sha256: 6e11bc7b8130617f0cf5f0613ec486cab2c5c0703b38549540299242206c39d6
-  md5: a6abebd4a87589b7bdc65a5b870c52ae
-  depends:
-  - libgcc-ng >=12
-  - libqdldl >=0.1.5,<0.1.6.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 69789
-  timestamp: 1685065325043
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h59595ed_0
+  build: h5888daf_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h59595ed_0.conda
-  sha256: 9ae82670f53a43b119ecb137de53f17822b772360a1083817d4fcc178f60b6fe
-  md5: af90a98ba90a4063f252848e2f3aa5e6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h5888daf_1.conda
+  sha256: 7c083bdff58df5cc3aed647020fef2a708d2fb57c8a504866db6a1e5e2f12b94
+  md5: 2a6b1aade375d6d404a0838c95793f6a
   depends:
-  - libgcc-ng >=12
-  - libqdldl >=0.1.5,<0.1.6.0a0
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libqdldl >=0.1.7,<0.1.8.0a0
+  - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 72079
-  timestamp: 1685065354843
+  size: 432789
+  timestamp: 1729342281763
 - kind: conda
   name: libosqp
   version: 0.6.3
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-h63175ca_0.conda
-  sha256: fc1e4e277e1e4572195f0ac9ce3dc93af8a0945f905977535af4924c5bcee84c
-  md5: 641bca9e7d6915ec4ffb338bf020423d
+  build: h5ad3122_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h5ad3122_1.conda
+  sha256: 005a3ff75e883f480f5b25644addcef31d8213106229b6d42b665f7fbdff0a2f
+  md5: 2620cfedf3f3d4722f4508cca423ecac
   depends:
-  - libqdldl >=0.1.5,<0.1.6.0a0
+  - libgcc >=13
+  - libqdldl >=0.1.7,<0.1.8.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 414572
+  timestamp: 1729342273243
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: h97d8b74_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-h97d8b74_1.conda
+  sha256: 96118e576c6efd4c1e26ea8809f50c75f52acc95251b71b6d9bcfd51eba0d67c
+  md5: a1b3121f636d0b0d68a78717d839dff0
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libqdldl >=0.1.7,<0.1.8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 382479
+  timestamp: 1729342338177
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: he0c23c2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-he0c23c2_1.conda
+  sha256: 4960d81fe9251fa0dd11b171716a1e5b76ea10f583c82766b27b219f739b97ec
+  md5: 3cb8c763b4cc0d0d99931fe296cb9df2
+  depends:
+  - libqdldl >=0.1.7,<0.1.8.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 73439
-  timestamp: 1685065686169
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: he965462_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-he965462_0.conda
-  sha256: 3be2e8c56fcfba797f04631e53fe23a1e9e9f9ccfa9c7c79ccfae4c9e3f258dd
-  md5: c416acec68a3ddeb7b6a65ce6de0eab7
-  depends:
-  - libcxx >=15.0.7
-  - libqdldl >=0.1.5,<0.1.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 74045
-  timestamp: 1685065544324
+  size: 268107
+  timestamp: 1729342615595
 - kind: conda
   name: libpciaccess
   version: '0.18'
@@ -9471,415 +9957,449 @@ packages:
   timestamp: 1707101388552
 - kind: conda
   name: libpng
-  version: 1.6.43
-  build: h091b4b1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
-  sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
-  md5: 77e684ca58d82cae9deebafb95b1a2b8
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: zlib-acknowledgement
-  size: 264177
-  timestamp: 1708780447187
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
-  sha256: 6f408f3d6854f86e223289f0dda12562b047c7a1fdf3636c67ec39afcd141f43
-  md5: 1123e504d9254dd9494267ab9aba95f0
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: zlib-acknowledgement
-  size: 294380
-  timestamp: 1708782876525
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h19919ed_0
+  version: 1.6.44
+  build: h3ca93ac_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
-  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
-  md5: 77e398acc32617a0384553aea29e866b
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
-  size: 347514
-  timestamp: 1708780763195
+  size: 348933
+  timestamp: 1726235196095
 - kind: conda
   name: libpng
-  version: 1.6.43
-  build: h2797004_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
-  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: zlib-acknowledgement
-  size: 288221
-  timestamp: 1708780443939
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h92b6c6a_0
+  version: 1.6.44
+  build: h4b8f8c9_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
-  sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
-  md5: 65dcddb15965c9de2c0365cb14910532
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
-  size: 268524
-  timestamp: 1708780496420
+  size: 268073
+  timestamp: 1726234803010
 - kind: conda
-  name: libpq
-  version: '16.2'
-  build: h0f8b458_1
-  build_number: 1
+  name: libpng
+  version: 1.6.44
+  build: hadc24fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- kind: conda
+  name: libpng
+  version: 1.6.44
+  build: hc14010f_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_1.conda
-  sha256: 7a6a195d37f6fe2f2d608033755f6e9522c9a2b7b07e52529159105f635c6cae
-  md5: e236a8e95b82a454e333f22418b9c879
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: PostgreSQL
-  size: 2452312
-  timestamp: 1710864761131
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
 - kind: conda
-  name: libpq
-  version: '16.2'
-  build: h33b98f1_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
-  sha256: e03a8439b79e013840c44c957d37dbce10316888b2b5dc7dcfcfc0cfe3a3b128
-  md5: 9e49ec2a61d02623b379dc332eb6889d
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: PostgreSQL
-  size: 2601973
-  timestamp: 1710863646063
-- kind: conda
-  name: libpq
-  version: '16.2'
-  build: h58720eb_1
-  build_number: 1
+  name: libpng
+  version: 1.6.44
+  build: hc4a20ef_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_1.conda
-  sha256: 41013bae4c01518394ed366de29d1d1b6851efee9f41b7fd4cd8c53bd74c1ba7
-  md5: 08197815d955b96d6ad5ac18e2c8f322
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
+  sha256: 23b5ce15cf9c6017641a8396bab00ae807dd9f662718cfa7f61de114d0c97647
+  md5: 5d25802b25fcc7419fa13e21affaeb3a
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: PostgreSQL
-  size: 2507128
-  timestamp: 1710863715662
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 294907
+  timestamp: 1726236639270
 - kind: conda
   name: libpq
-  version: '16.2'
-  build: ha925e61_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
-  sha256: bfb252cb14b88a75ba4af930c16dccae265dce0afdf5abde7de1718181aa2cea
-  md5: a10ef466bbc68a8e74112a8e26028d66
+  version: '16.4'
+  build: h2d7952a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
+  sha256: 51dddb6e5879960a1b9b3c5de0eb970373903977c0fa68a42f86bb7197c695cf
+  md5: 50e2dddb3417a419cbc2388d0b1c06f7
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - openssl >=3.2.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - openssl >=3.3.2,<4.0a0
   license: PostgreSQL
-  size: 2333894
-  timestamp: 1710864725862
+  size: 2530022
+  timestamp: 1729085009049
+- kind: conda
+  name: libpq
+  version: '16.4'
+  build: h365486b_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.4-h365486b_3.conda
+  sha256: 1a019cc7ccac5d7019d773f3e5b5054da858f35a1044cbde04765362412bdd31
+  md5: fe4f02d31e7679f2331ad9c640233e86
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: PostgreSQL
+  size: 2383857
+  timestamp: 1729085339189
+- kind: conda
+  name: libpq
+  version: '16.4'
+  build: hb7c570e_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
+  sha256: cd17b7b1fa11907c28319a80c18cd025ec8344be630a2b3f7dfe97b3ef682000
+  md5: 49e510416b386a1ea805edf38ce09956
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - openssl >=3.3.2,<4.0a0
+  license: PostgreSQL
+  size: 2661524
+  timestamp: 1729085053843
+- kind: conda
+  name: libpq
+  version: '16.4'
+  build: hfb0b52a_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-hfb0b52a_3.conda
+  sha256: 7c9766926fa1bfad284d27dc252eeddb189126ea5694da8f8045f1fb55c8f8d3
+  md5: ce76e2611f75bfe95efb239bd69be770
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: PostgreSQL
+  size: 2411968
+  timestamp: 1729085615848
 - kind: conda
   name: libprotobuf
-  version: 4.25.3
-  build: h08a7969_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
-  sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
-  md5: 6945825cebd2aeb16af4c69d97c32c13
+  version: 5.27.5
+  build: h029595c_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.27.5-h029595c_2.conda
+  sha256: 347a1fe304526efe23929c357c145c4917549ba1edd9da432e92a54f4ad4082d
+  md5: f789a1fe2a1f45e325a784b34c3c4baa
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2811207
-  timestamp: 1709514552541
+  size: 2879939
+  timestamp: 1727423311791
 - kind: conda
   name: libprotobuf
-  version: 4.25.3
-  build: h4e4d658_0
+  version: 5.27.5
+  build: h53f8970_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.27.5-h53f8970_2.conda
+  sha256: 787d86c041c03d33b24e28df5f881f47c74c3fe9053b791f14616dc51f32a687
+  md5: e9d021f82c48bb08b0b2c321b2f7778c
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2375066
+  timestamp: 1727423411355
+- kind: conda
+  name: libprotobuf
+  version: 5.27.5
+  build: h62b0dff_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
-  sha256: 3f126769fb5820387d436370ad48600e05d038a28689fdf9988b64e1059947a8
-  md5: 57b7ee4f1fd8573781cfdabaec4a7782
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.27.5-h62b0dff_2.conda
+  sha256: ac77bce3b9a58e6fa72bed339af0d47faf1dec3bc717e4e05e2e729dc42bd2b3
+  md5: e3b68d9a164d807f70df49e17bc54931
   depends:
   - __osx >=10.13
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2216001
-  timestamp: 1709514908146
+  size: 2332719
+  timestamp: 1727424047974
 - kind: conda
   name: libprotobuf
-  version: 4.25.3
-  build: h503648d_0
+  version: 5.27.5
+  build: hcaed137_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
-  sha256: 5d4c5592be3994657ebf47e52f26b734cc50b0ea9db007d920e2e31762aac216
-  md5: 4da7de0ba35777742edf67bf7a1075df
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.27.5-hcaed137_2.conda
+  sha256: f039a07e6a52542e298ad0cf39d95d261f02c62256c82a60e246f291b2535e1b
+  md5: 0155746155856bc39091b5242c9b52d7
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 5650604
-  timestamp: 1709514804631
+  size: 6090012
+  timestamp: 1727424307861
 - kind: conda
   name: libprotobuf
-  version: 4.25.3
-  build: h648ac29_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.3-h648ac29_0.conda
-  sha256: 76775a1457b2d4de1097bec2fda16b8e6e80f761d11aa7a525fa215bff4ab87c
-  md5: a239d63913ec9e008bdbe35899f677f4
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2576197
-  timestamp: 1709513627963
-- kind: conda
-  name: libprotobuf
-  version: 4.25.3
-  build: hbfab5d5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
-  sha256: d754519abc3ddbdedab2a38d0639170f5347c1573eef80c707f3a8dc5dff706a
-  md5: 5f70b2b945a9741cba7e6dfe735a02a7
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2154402
-  timestamp: 1709514097574
-- kind: conda
-  name: libqdldl
-  version: 0.1.5
-  build: h27087fc_1
-  build_number: 1
+  version: 5.28.2
+  build: h5b01275_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.5-h27087fc_1.tar.bz2
-  sha256: 367c6a2d87dedfa03db0024956c4343fdf88b004dfb0831163d67e17680b547f
-  md5: 931d743c4d1219d5efc3a97bdb578053
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+  md5: ab0bff36363bec94720275a681af8b83
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 16905
-  timestamp: 1667006397176
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2945348
+  timestamp: 1728565355702
 - kind: conda
   name: libqdldl
-  version: 0.1.5
-  build: h4de3ea5_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.5-h4de3ea5_1.tar.bz2
-  sha256: 02dd6747f15d482c2a76288340353f1a08d77f68a5083e1a41df4b767448508a
-  md5: 9ebc5a9309c3300c7f8afc229587618e
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 16947
-  timestamp: 1667006172086
-- kind: conda
-  name: libqdldl
-  version: 0.1.5
-  build: h63175ca_1
-  build_number: 1
+  version: 0.1.7
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.5-h63175ca_1.tar.bz2
-  sha256: 5d2050ea36f32b009712accc9eeb34d731a56f2d5dd27eb40f64870eb0f9d901
-  md5: 6a8beb414077e9aa543c0897541f69ad
+  url: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.7-h63175ca_0.conda
+  sha256: 706c0405c5d01e58d08dfc26a9b49b7121e25f4913f594692f05afe45dacca6f
+  md5: 0f2bbabcd06bfd6015a783a788f88b0f
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 20960
-  timestamp: 1667007089765
+  size: 21662
+  timestamp: 1680741889208
 - kind: conda
   name: libqdldl
-  version: 0.1.5
-  build: hb7217d7_1
-  build_number: 1
+  version: 0.1.7
+  build: hb7217d7_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.5-hb7217d7_1.tar.bz2
-  sha256: 826f50f825f6029c5b2b98cf864e9b2b5161a21b1838840df5b58845c7b7abba
-  md5: 22291aad1e4ad0f4904c4435bac91f15
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.7-hb7217d7_0.conda
+  sha256: 39bb718bca8ce87afdc592d857944ba39bfac54c31a1de4d669597b52bc668ea
+  md5: b4df6812b4ab33c1a520287f46d91220
   depends:
-  - libcxx >=14.0.4
+  - libcxx >=14.0.6
   license: Apache-2.0
   license_family: APACHE
-  size: 15863
-  timestamp: 1667006613955
+  size: 17189
+  timestamp: 1680741853527
 - kind: conda
   name: libqdldl
-  version: 0.1.5
-  build: hf0c8a7f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.5-hf0c8a7f_1.tar.bz2
-  sha256: 82b4100f17c858d24c94cbe7da602d6faa13ddecef0a88801b9a124fb415a268
-  md5: 65b35a6648f6e566d230f9af0d2735ae
+  version: 0.1.7
+  build: hcb278e6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.7-hcb278e6_0.conda
+  sha256: 62230c93e8f7508a97e5b3a439b2b981eda9aa192cbc08497cbcca220ebf3acc
+  md5: 9221c4cca4d44cf4103fbdd47595e3dd
   depends:
-  - libcxx >=14.0.4
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 16242
-  timestamp: 1667006655420
+  size: 18277
+  timestamp: 1680741612751
 - kind: conda
-  name: libsanitizer
-  version: 12.3.0
-  build: h0f45ef3_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
-  sha256: 70329cb8b0604273521cdae63520cb364a8d5477e156e65cdbd810984caeabee
-  md5: 11d1ceacff40054d5a74b12975d76f20
-  depends:
-  - libgcc-ng >=12.3.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3890717
-  timestamp: 1706819904612
-- kind: conda
-  name: libsanitizer
-  version: 12.3.0
-  build: h8ebda82_5
-  build_number: 5
+  name: libqdldl
+  version: 0.1.7
+  build: hd600fc2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
-  sha256: a30e1e297218c097ee715cc52bf4711e3f21d6f4fcf2a7e3e1ebae9a65903d04
-  md5: b23f5de2b160df4b83a5b16f4deab34a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.7-hd600fc2_0.conda
+  sha256: 231a460dd87408d1d07150ffd53c29a8d8aaa494f111c83a369d85b53bf4015d
+  md5: 07140396b010c957bf75471ea7fcb858
   depends:
-  - libgcc-ng >=12.3.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3912550
-  timestamp: 1706820192702
-- kind: conda
-  name: libscotch
-  version: 7.0.4
-  build: h16908e7_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h16908e7_1.conda
-  sha256: 75df1476d9d5a4dddd6a599e23619602b91c005ccc54b39f8fea1b5567301da2
-  md5: 8ffa038b339d3194d8197d723acedd69
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zlib
-  license: CECILL-C
-  size: 354651
-  timestamp: 1702326088455
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18380
+  timestamp: 1680741551284
 - kind: conda
-  name: libscotch
-  version: 7.0.4
-  build: h91e35bf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h91e35bf_1.conda
-  sha256: 7113e233da8f2cd73e838ed914045c3d3cee970d1eb99551288446af668177ea
-  md5: 5716a9d2428758c0b7d3ad3d62491918
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zlib
-  license: CECILL-C
-  size: 339683
-  timestamp: 1702323132649
-- kind: conda
-  name: libscotch
-  version: 7.0.4
-  build: hc2ac6e5_1
-  build_number: 1
+  name: libqdldl
+  version: 0.1.7
+  build: hf0c8a7f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.4-hc2ac6e5_1.conda
-  sha256: a04a5618dc77705c050c42ba79d283321a1d95ddb46506115da3a82913fb199d
-  md5: 09bac22f45db314b1ad5774b336f27c7
+  url: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.7-hf0c8a7f_0.conda
+  sha256: 3af1a36d6770737103c97926b1d3ca432f638e3692850355add84062adcabf5f
+  md5: dfa2f71b0d4132cf202d707aee23dfb5
   depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zlib
-  license: CECILL-C
-  size: 300388
-  timestamp: 1702323427663
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17698
+  timestamp: 1680741819397
+- kind: conda
+  name: librsvg
+  version: 2.58.4
+  build: hc0ffecb_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+  sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
+  md5: 83f045969988f5c7a65f3950b95a8b35
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  size: 6390511
+  timestamp: 1726227212382
+- kind: conda
+  name: libsanitizer
+  version: 13.3.0
+  build: ha58e236_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_1.conda
+  sha256: 6892c7e723dbfb3a7e65c9c21ad7396dee5c73fd988e039045ca96145632ee71
+  md5: ed8a2074f0afb09450a009e02de65e3c
+  depends:
+  - libgcc >=13.3.0
+  - libstdcxx >=13.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 4105930
+  timestamp: 1724802022367
+- kind: conda
+  name: libsanitizer
+  version: 13.3.0
+  build: heb74ff8_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
+  sha256: c86d130f0a3099e46ff51aa7ffaab73cb44fc420d27a96076aab3b9a326fc137
+  md5: c4cb22f270f501f5c59a122dc2adf20a
+  depends:
+  - libgcc >=13.3.0
+  - libstdcxx >=13.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 4133922
+  timestamp: 1724801171589
 - kind: conda
   name: libscotch
-  version: 7.0.4
-  build: hc938e73_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.4-hc938e73_1.conda
-  sha256: 7144f8d48a5d495d66d30d775ba0e04e885cee47f7ae45202a2f56f54d59e199
-  md5: 9e6ba692678598a5471087831d8db21e
+  version: 7.0.5
+  build: h3428b0d_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_2.conda
+  sha256: 18d517b71e832698477ce58be8a77dd83326c1b82745e61dc6be25c68f319cbd
+  md5: f32423a30fe0f5634ce1a16916d3bc76
   depends:
+  - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
   - zlib
   license: CECILL-C
-  size: 280127
-  timestamp: 1702323402640
+  size: 343836
+  timestamp: 1728823102739
+- kind: conda
+  name: libscotch
+  version: 7.0.5
+  build: h57f7dbb_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_2.conda
+  sha256: f7981a98752f5115049c41922bff8f84b4beae663bb5e036c395f96b01b11d00
+  md5: 537c6cc6087ef85bc75e323508bb43c6
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 358635
+  timestamp: 1728825149231
+- kind: conda
+  name: libscotch
+  version: 7.0.5
+  build: h8e19eb7_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.5-h8e19eb7_2.conda
+  sha256: 51ffb52fd3b15e90cf26b7f2163684f119ef84752c727c378493db81e9b264fc
+  md5: 9478f4c127e455d0c155a82d4d48fdb1
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 288602
+  timestamp: 1728823135377
+- kind: conda
+  name: libscotch
+  version: 7.0.5
+  build: h9f781f6_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
+  sha256: 589231872f000f96c4f27ee8fadd388631a7edd2c68b06c4987d77981681bb95
+  md5: 588d606a602d0058bd6c63a81fc4cfc8
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 270272
+  timestamp: 1728823368136
 - kind: conda
   name: libsndfile
   version: 1.2.2
@@ -9926,123 +10446,127 @@ packages:
   timestamp: 1695747735668
 - kind: conda
   name: libspral
-  version: 2023.09.07
-  build: h6aa6db2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspral-2023.09.07-h6aa6db2_2.conda
-  sha256: 9f6ead98e3048f9f834e27701cbd460dc180b66da674077282efedc33c2e4385
-  md5: f6edcc565451deb910b65fc670991bfb
+  version: 2024.05.08
+  build: h2fd7c63_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-h2fd7c63_3.conda
+  sha256: 6f8c85252ede9e4b5809663e64992a95687fab8818dffeaab40f4baf69d0a706
+  md5: 876ad3096aa012894dda4f4c6419e3f3
   depends:
   - _openmp_mutex >=4.5
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
   - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - libhwloc >=2.9.3,<2.9.4.0a0
+  - libgfortran5 >=12.4.0
+  - libhwloc >=2.11.1,<2.11.2.0a0
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - metis >=5.1.0,<5.1.1.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 284486
-  timestamp: 1706172132015
+  size: 341454
+  timestamp: 1722957510875
 - kind: conda
   name: libspral
-  version: 2023.09.07
-  build: h98a5362_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2023.09.07-h98a5362_2.conda
-  sha256: dd90d120301994da5ec3d3b9bfbd431e2fd035e88e234e3f523e9a66c285b318
-  md5: b922d0858beaaaa81bcbe37d3b50d3d0
+  version: 2024.05.08
+  build: h831f25b_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h831f25b_3.conda
+  sha256: aa46c3372d9ab0bfa27bda084a6b550b06d63f5cc8fa23bd314cb9dba11cf650
+  md5: ece7dcd9811f9f5c49852da2a14928ab
   depends:
+  - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
   - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - libhwloc >=2.9.3,<2.9.4.0a0
+  - libgfortran5 >=12.4.0
+  - libhwloc >=2.11.1,<2.11.2.0a0
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - metis >=5.1.0,<5.1.1.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 277170
-  timestamp: 1706177768929
+  size: 355926
+  timestamp: 1722955364533
 - kind: conda
   name: libsqlite
-  version: 3.45.2
-  build: h091b4b1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
-  sha256: 7c234320a1a2132b9cc972aaa06bb215bb220a5b1addb0bed7a5a321c805920e
-  md5: 9d07427ee5bd9afd1e11ce14368a48d6
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 825300
-  timestamp: 1710255078823
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
-  sha256: 0ce6de6369c04386cfc8696b1f795f425843789609ae2e04e7a1eb7deae62a8b
-  md5: bf4c96a21fbfc6a6ef6a7781a534a4e0
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 1038462
-  timestamp: 1710253998432
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h2797004_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
-  sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
-  md5: 866983a220e27a80cb75e85cb30466a1
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 857489
-  timestamp: 1710254744982
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h92b6c6a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
-  sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
-  md5: 086f56e13a96a6cfb1bf640505ae6b70
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 902355
-  timestamp: 1710254991672
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: hcfcfb64_0
+  version: 3.47.0
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
-  sha256: 4bb24b986550275a6d02835150d943c4c675808d05c0efc5c2a22154d007a69f
-  md5: f95359f8dc5abf7da7776ece9ef10bc5
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_0.conda
+  sha256: 4f3cd0477c831eab48fb7fa3ed91d918aeb644fad9b4014726d445339750cdcc
+  md5: 964bef59135d876c596ae67b3315e812
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
-  size: 869606
-  timestamp: 1710255095740
+  size: 884970
+  timestamp: 1729592254351
+- kind: conda
+  name: libsqlite
+  version: 3.47.0
+  build: h2f8c449_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_0.conda
+  sha256: 6bae3280dc402c9d306275363f3a88f6a667b8e3bfa68859b7928d42f0f1495a
+  md5: 9dbe833ae53f6756fd87e32bd5fa508e
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915473
+  timestamp: 1729591970061
+- kind: conda
+  name: libsqlite
+  version: 3.47.0
+  build: hadc24fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_0.conda
+  sha256: 76ffc7a5823b51735c11d535f3666b3c9c7d1519f9fbb6fa9cdff79db01960b9
+  md5: 540296f0ce9d3352188c15a89b30b9ac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 874704
+  timestamp: 1729591931557
+- kind: conda
+  name: libsqlite
+  version: 3.47.0
+  build: hbaaea75_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_0.conda
+  sha256: 76aa4bbbaa2334689b16048f04ac4c7406e9bfb1f225ac7107fd2a73f85329cf
+  md5: 5bbe4802d5460b80620411fe1da8fec3
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837789
+  timestamp: 1729592072314
+- kind: conda
+  name: libsqlite
+  version: 3.47.0
+  build: hc4a20ef_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_0.conda
+  sha256: 469ed05e9a1622b0204a2b6cf620c9054bf6904e2ed818a1f91ee96a7bc64517
+  md5: ccbe261fb8c1f1cd1a3122592247d3c4
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 1042108
+  timestamp: 1729592001716
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -10053,7 +10577,7 @@ packages:
   md5: 1f5a58e686b13bcfde88b93f547d23fe
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10069,7 +10593,7 @@ packages:
   md5: 45532845e121677ad328c9af9953f161
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10084,7 +10608,7 @@ packages:
   sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
   md5: 029f7dc931a3b626b94823bc77830b01
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10099,7 +10623,7 @@ packages:
   sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
   md5: dc262d03aae04fe26825062879141a41
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -10117,313 +10641,254 @@ packages:
   sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
   md5: ca3a72efba692c59a90d4b9fc0dfe774
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   size: 259556
   timestamp: 1685837820566
 - kind: conda
-  name: libstdcxx-devel_linux-64
-  version: 12.3.0
-  build: h8bca6fd_105
-  build_number: 105
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
-  sha256: efcd4b4cba79cd0fb5a87757c7ca63171cf3b7b06446192364bae7defb50b94c
-  md5: b3c6062c84a8e172555ee104ea6a01ab
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 11597918
-  timestamp: 1706819775415
-- kind: conda
-  name: libstdcxx-devel_linux-aarch64
-  version: 12.3.0
-  build: h8b5ab12_105
-  build_number: 105
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
-  sha256: f38714920c850eac02b4b8175146188a3657c7ea5a3be22ae644b9d5e2356663
-  md5: 47f23759d39c3d993dc189ce4ab7f79c
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 10380824
-  timestamp: 1706820045043
-- kind: conda
-  name: libstdcxx-ng
-  version: 13.2.0
-  build: h7e041cc_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
-  sha256: a56c5b11f1e73a86e120e6141a42d9e935a99a2098491ac9e15347a1476ce777
-  md5: f6f6600d18a4047b54f803cf708b868a
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3834139
-  timestamp: 1706819252496
-- kind: conda
-  name: libstdcxx-ng
-  version: 13.2.0
-  build: h9a76618_5
-  build_number: 5
+  name: libstdcxx
+  version: 14.2.0
+  build: h3f4de04_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
-  sha256: c209f23a8a497fc87107a68b6bbc8d2089cf15fd4015b558dfdce63544379b05
-  md5: 1b79d37dce0fad96bdf3de03925f43b4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+  sha256: 519556d2c93f1b487091ce046d62e762286177f4a670ec10e16005177d0bcab3
+  md5: 37f489acd39e22b623d2d1e5ac6d195c
+  depends:
+  - libgcc 14.2.0 he277a41_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3752658
-  timestamp: 1706820778418
+  size: 3816794
+  timestamp: 1729089463404
 - kind: conda
-  name: libsystemd0
-  version: '255'
-  build: h3516f8a_1
+  name: libstdcxx
+  version: 14.2.0
+  build: hc0a3c3a_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
-  sha256: af27b0d225435d03f378a119f8eab6b280c53557a3c84cdb3bb8fd3167615aed
-  md5: 3366af27f0b593544a6cd453c7932ac5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- kind: conda
+  name: libstdcxx-devel_linux-64
+  version: 13.3.0
+  build: h84ea5a7_101
+  build_number: 101
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
+  sha256: 0a9226c1b994f996229ffb54fa40d608cd4e4b48e8dc73a66134bea8ce949412
+  md5: 29b5a4ed4613fa81a07c21045e3f5bf6
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 14074676
+  timestamp: 1724801075448
+- kind: conda
+  name: libstdcxx-devel_linux-aarch64
+  version: 13.3.0
+  build: h0c07274_101
+  build_number: 101
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+  sha256: a2cc4cc3ef5d470c25a872a05485cf322a525950f9e1472e22cc97030d0858b1
+  md5: a7fdc5d75d643dd46f4e3d6092a13036
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 12182186
+  timestamp: 1724801911954
+- kind: conda
+  name: libstdcxx-ng
+  version: 14.2.0
+  build: h4852527_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- kind: conda
+  name: libstdcxx-ng
+  version: 14.2.0
+  build: hf1166c9_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
+  sha256: 9f97461bd55a2745a7a0941f3502a047f15bfe7bb2952dc7fb204b3202f866fd
+  md5: 0e75771b8a03afae5a2c6ce71bc733f5
+  depends:
+  - libstdcxx 14.2.0 h3f4de04_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54133
+  timestamp: 1729089498541
+- kind: conda
+  name: libsystemd0
+  version: '256.7'
+  build: h2774228_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
+  sha256: fa9cfbacaa2f14072b07ff9c832a8750627755346a1472f116a94aecea28f08e
+  md5: ad328c530a12a8798776e5f03942090f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.69,<2.70.0a0
-  - libgcc-ng >=12
-  - libgcrypt >=1.10.3,<2.0a0
+  - libgcc >=13
+  - libgcrypt >=1.11.0,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: LGPL-2.1-or-later
-  size: 402592
-  timestamp: 1709568499820
+  size: 411535
+  timestamp: 1729786797378
 - kind: conda
   name: libsystemd0
-  version: '255'
-  build: h91e93f8_1
+  version: '256.7'
+  build: hd54d049_1
   build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_1.conda
-  sha256: ff2fb8af038371bce24930d0913a90ac525be39f947c93099bdda88da80559b1
-  md5: afcd3dddcdc93fee67fb67fc950f6099
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
+  sha256: 6deceabf4a4109293aacba77a61a83d5bdef028b879b29d3b819937c80de8909
+  md5: c44e82f6be3d65cf0589f1182e162ce8
   depends:
   - libcap >=2.69,<2.70.0a0
-  - libgcc-ng >=12
-  - libgcrypt >=1.10.3,<2.0a0
+  - libgcc >=13
+  - libgcrypt >=1.11.0,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: LGPL-2.1-or-later
-  size: 420184
-  timestamp: 1709568302419
+  size: 430774
+  timestamp: 1729786916983
 - kind: conda
-  name: libtasn1
-  version: 4.19.0
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
-  sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
-  md5: 93840744a8552e9ebf6bb1a5dffc125a
+  name: libtiff
+  version: 4.7.0
+  build: h583c2ba_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
+  md5: 4b78bcdcc8780cede8b3d090deba874d
   depends:
-  - libgcc-ng >=12
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 116878
-  timestamp: 1661325701583
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.23.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 395980
+  timestamp: 1728232302162
 - kind: conda
-  name: libtasn1
-  version: 4.19.0
-  build: h1a8c8d9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
-  sha256: 912e96644ea22b49921c71c9c94bcdd2b6463e9313da895c2fcee298a8c0e44c
-  md5: c35bc17c31579789c76739486fc6d27a
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 116745
-  timestamp: 1661325945767
+  name: libtiff
+  version: 4.7.0
+  build: he137b08_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+  sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
+  md5: 63872517c98aa305da58a757c443698e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428156
+  timestamp: 1728232228989
 - kind: conda
-  name: libtasn1
-  version: 4.19.0
-  build: h4e544f5_0
+  name: libtiff
+  version: 4.7.0
+  build: hec21d91_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
-  sha256: 96310724113f6f2ed2f3e55e19e87fe29e1678d0ee21386e4037c3703d542743
-  md5: a94c6aaaaac3c2c9dcff6967ed1064be
-  depends:
-  - libgcc-ng >=12
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 124954
-  timestamp: 1661325677442
-- kind: conda
-  name: libtasn1
-  version: 4.19.0
-  build: hb7f2c08_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
-  sha256: 4197c155fb460fae65288c6c098c39f22495a53838356d29b79b31b8e33486dc
-  md5: 73f67fb011b4477b101a95a082c74f0a
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 118785
-  timestamp: 1661325967954
-- kind: conda
-  name: libtiff
-  version: 4.6.0
-  build: h07db509_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-h07db509_3.conda
-  sha256: 6df3e129682f6dc43826e5028e1807624b2a7634c4becbb50e56be9f77167f25
-  md5: 28c9f8c6dd75666dfb296aea06c49cb8
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
+  sha256: 14ecb9e129b1b5ffd6d4bee48de95cd2cd0973c712e1b965d3ef977cca23936d
+  md5: 1f80061f5ba6956fcdc381f34618cd8d
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libcxx >=16
-  - libdeflate >=1.20,<1.21.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc >=13
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: HPND
-  size: 238349
-  timestamp: 1711218119201
+  size: 464938
+  timestamp: 1728232266969
 - kind: conda
   name: libtiff
-  version: 4.6.0
-  build: h129831d_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
-  sha256: f9b35c5ec1aea9a2cc20e9275a0bb8f056482faa8c5a62feb243ed780755ea30
-  md5: 568593071d2e6cea7b5fc1f75bfa10ca
-  depends:
-  - lerc >=4.0.0,<5.0a0
-  - libcxx >=16
-  - libdeflate >=1.20,<1.21.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: HPND
-  size: 257489
-  timestamp: 1711218113053
-- kind: conda
-  name: libtiff
-  version: 4.6.0
-  build: h1dd3fc0_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
-  sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
-  md5: 66f03896ffbe1a110ffda05c7a856504
-  depends:
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.20,<1.21.0a0
-  - libgcc-ng >=12
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx-ng >=12
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: HPND
-  size: 282688
-  timestamp: 1711217970425
-- kind: conda
-  name: libtiff
-  version: 4.6.0
-  build: hddb2be6_3
-  build_number: 3
+  version: 4.7.0
+  build: hfc51747_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
-  sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
-  md5: 6d1828c9039929e2f185c5fa9d133018
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.20,<1.21.0a0
+  - libdeflate >=1.22,<1.23.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: HPND
-  size: 787198
-  timestamp: 1711218639912
+  size: 978865
+  timestamp: 1728232594877
 - kind: conda
   name: libtiff
-  version: 4.6.0
-  build: hf980d43_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-hf980d43_3.conda
-  sha256: 8f578c4e5acf94479b698aea284b2ebfeb32dc3ae99a60c7ef5e07c7003d98cc
-  md5: b6f3abf5726ae33094bee238b4eb492f
-  depends:
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.20,<1.21.0a0
-  - libgcc-ng >=12
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx-ng >=12
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: HPND
-  size: 316525
-  timestamp: 1711218038581
-- kind: conda
-  name: libunistring
-  version: 0.9.10
-  build: h0d85af4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
-  sha256: c5805a58cd2b211bffdc8b7cdeba9af3cee456196ab52ab9a30e0353bc95beb7
-  md5: 40f27dc16f73256d7b93e53c4f03d92f
-  license: GPL-3.0-only OR LGPL-3.0-only
-  size: 1392865
-  timestamp: 1626955817826
-- kind: conda
-  name: libunistring
-  version: 0.9.10
-  build: h3422bc3_0
+  version: 4.7.0
+  build: hfce79cd_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
-  sha256: a1afe12ab199f82f339eae83405d293d197f2485d45346a709703bc7e8299949
-  md5: d88e77a4861e20bd96bde6628ee7a5ae
-  license: GPL-3.0-only OR LGPL-3.0-only
-  size: 1577561
-  timestamp: 1626955172521
-- kind: conda
-  name: libunistring
-  version: 0.9.10
-  build: h7f98852_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
-  sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
-  md5: 7245a044b4a1980ed83196176b78b73a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+  sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
+  md5: b9abf45f7c64caf3303725f1aa0e9a4d
   depends:
-  - libgcc-ng >=9.3.0
-  license: GPL-3.0-only OR LGPL-3.0-only
-  size: 1433436
-  timestamp: 1626955018689
-- kind: conda
-  name: libunistring
-  version: 0.9.10
-  build: hf897c2e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
-  sha256: 03acebd5a01a255fe40d47f941c6cab4dc7829206d86d990b0c88cf0ff66e646
-  md5: 7c68521243dc20afba4c4c05eb09586e
-  depends:
-  - libgcc-ng >=9.3.0
-  license: GPL-3.0-only OR LGPL-3.0-only
-  size: 1409624
-  timestamp: 1626959749923
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.23.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 366323
+  timestamp: 1728232400072
 - kind: conda
   name: libuuid
   version: 2.38.1
@@ -10454,89 +10919,103 @@ packages:
   timestamp: 1680113474501
 - kind: conda
   name: libuv
-  version: 1.48.0
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.48.0-h31becfc_0.conda
-  sha256: 8be03c6a43e17fdf574e2c29f1f8b917ba2842b5f4662b51d577960a3083fc2c
-  md5: 97f754b22f63a943345bd807e1d51e01
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 635472
-  timestamp: 1709913320273
-- kind: conda
-  name: libuv
-  version: 1.48.0
-  build: h67532ce_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
-  sha256: fb87f7bfd464a3a841d23f418c86a206818da0c4346984392071d9342c9ea367
-  md5: c8e7344c74f0d86584f7ecdc9f25c198
-  license: MIT
-  license_family: MIT
-  size: 407040
-  timestamp: 1709913680478
-- kind: conda
-  name: libuv
-  version: 1.48.0
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
-  sha256: 60bed2a7a85096387ab0381cbc32ea2da7f8dd99bd90e440983019c0cdd96ad1
-  md5: abfd49e80f13453b62a56be226120ea8
-  license: MIT
-  license_family: MIT
-  size: 405988
-  timestamp: 1709913494015
-- kind: conda
-  name: libuv
-  version: 1.48.0
-  build: hcfcfb64_0
+  version: 1.49.2
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
-  sha256: 6151c51857c2407139ce22fdc956022353e675b2bc96991a9201d51cceaa90b4
-  md5: 485e49e1d500d996844df14cabf64d73
+  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.49.2-h2466b09_0.conda
+  sha256: d598c536f0e432901ba8b489564799f6f570471b2a3ce9b76e152ee0a961a380
+  md5: 30ebb43533efcdc8c357ef409bad86b6
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 289753
-  timestamp: 1709913743184
+  size: 290376
+  timestamp: 1729322844056
 - kind: conda
   name: libuv
-  version: 1.48.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
-  sha256: b7c0e8a0c93c2621be7645b37123d4e8d27e8a974da26a3fba47a9c37711aa7f
-  md5: 7e8b914b1062dd4386e3de4d82a3ead6
+  version: 1.49.2
+  build: h7ab814d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.49.2-h7ab814d_0.conda
+  sha256: 0e5176af1e788ad5006cf261c4ea5a288a935fda48993b0240ddd2e562dc3d02
+  md5: 4bc348e3a1a74d20a3f9beb866d75e0a
   depends:
-  - libgcc-ng >=12
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 899979
-  timestamp: 1709913354710
+  size: 410500
+  timestamp: 1729322654121
+- kind: conda
+  name: libuv
+  version: 1.49.2
+  build: h86ecc28_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.49.2-h86ecc28_0.conda
+  sha256: adf4eca89339ac7780f2394e7e6699be81259eb91f79f9d9fdf2c1bc6b26f210
+  md5: 1899e1ec2be63386c41c4db31d3056af
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 627484
+  timestamp: 1729322575379
+- kind: conda
+  name: libuv
+  version: 1.49.2
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.49.2-hb9d3cd8_0.conda
+  sha256: a35cd81cd1a9add11024097da83cc06b0aae83186fe4124b77710876f37d8f31
+  md5: 070e3c9ddab77e38799d5c30b109c633
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 884647
+  timestamp: 1729322566955
+- kind: conda
+  name: libuv
+  version: 1.49.2
+  build: hd79239c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.49.2-hd79239c_0.conda
+  sha256: a2083200357513f932b44e88858a50a638d1a751a050bc62b2cbee2ac54f102c
+  md5: ec36c2438046ca8d2b4368d62dd5c38c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 413607
+  timestamp: 1729322686826
 - kind: conda
   name: libva
-  version: 2.21.0
-  build: hd590300_0
+  version: 2.22.0
+  build: h8a09558_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
-  sha256: b4e3a3fa523a5ddd1eca7981c9d6a9b831a182950116cc5bda18c94a040b63bc
-  md5: e50a2609159a3e336fe4092738c00687
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
+  sha256: 0bd81019e02cce8d9d4077c96b82ca03c9b0ece67831c7437f977ca1f5a924a3
+  md5: 139262125a3eac8ff6eef898598745a3
   depends:
-  - libdrm >=2.4.120,<2.5.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libdrm >=2.4.123,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglx >=1.7.0,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - wayland >=1.23.1,<2.0a0
+  - wayland-protocols
+  - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxfixes
   license: MIT
   license_family: MIT
-  size: 189313
-  timestamp: 1710242676665
+  size: 217708
+  timestamp: 1726828458441
 - kind: conda
   name: libvorbis
   version: 1.3.7
@@ -10617,206 +11096,211 @@ packages:
   timestamp: 1610609991029
 - kind: conda
   name: libvpx
-  version: 1.14.0
-  build: h078ce10_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.0-h078ce10_0.conda
-  sha256: e202f23fca763d88ad8170f90fa380510c65f29b86cfe6fb29706843462cee4f
-  md5: 8a515c7875e4d61734f4ac964851f4a5
-  depends:
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1174097
-  timestamp: 1707175717608
-- kind: conda
-  name: libvpx
-  version: 1.14.0
-  build: h2f0025b_0
+  version: 1.14.1
+  build: h0a1ffab_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.0-h2f0025b_0.conda
-  sha256: 8f89f9183df7ab6bb45fa16443b6d4de123b2aa5e7149d1b0d39b97f1f50bf2c
-  md5: a4fe92babed93075982b95096ce13136
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
+  md5: 3cb63f822a49e4c406639ebf8b5d87d7
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 1208251
-  timestamp: 1707175363916
+  size: 1211700
+  timestamp: 1717859955539
 - kind: conda
   name: libvpx
-  version: 1.14.0
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.0-h59595ed_0.conda
-  sha256: b0e0500fc92f626baaa2cf926dece5ce7571c42a2db2d993a250d4c5da4d68ca
-  md5: 01c76c6d71097a0f3bd8683a8f255123
+  version: 1.14.1
+  build: h7bae524_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
+  sha256: 5d6458b5395cba0804846f156574aa8a34eef6d5f05d39e9932ddbb4215f8bd0
+  md5: 95bee48afff34f203e4828444c2b2ae9
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1019593
-  timestamp: 1707175376125
-- kind: conda
-  name: libvpx
-  version: 1.14.0
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.0-h73e2aa4_0.conda
-  sha256: d3980ecf1e65bfbf7e1c57d6f41a66ab4f33c4fe6b71bf9414bb823e2db186fb
-  md5: 2c087711228029c8eab3301ddff1c386
-  depends:
+  - __osx >=11.0
   - libcxx >=16
   license: BSD-3-Clause
   license_family: BSD
-  size: 1294811
-  timestamp: 1707175761017
+  size: 1178981
+  timestamp: 1717860096742
 - kind: conda
-  name: libwebp-base
-  version: 1.3.2
-  build: h0dc2134_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
-  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
-  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
-  constrains:
-  - libwebp 1.3.2
+  name: libvpx
+  version: 1.14.1
+  build: hac33072_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+  sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
+  md5: cde393f461e0c169d9ffb2fc70f81c33
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 346599
-  timestamp: 1694709233836
+  size: 1022466
+  timestamp: 1717859935011
+- kind: conda
+  name: libvpx
+  version: 1.14.1
+  build: hf036a51_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
+  sha256: 47e70e76988c11de97d539794fd4b03db69b75289ac02cdc35ae5a595ffcd973
+  md5: 9b8744a702ffb1738191e094e6eb67dc
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1297054
+  timestamp: 1717860051058
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
+  build: h10d778d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- kind: conda
+  name: libwebp-base
+  version: 1.4.0
   build: h31becfc_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
-  sha256: a85484d8399bfa310512fe94863c8da3b224ac13f5e97736da65be6f509a8bf8
-  md5: 1490de434d2a2c06a98af27641a2ffff
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+  sha256: 10dded60f274e29c573cfacf6e96f5d0fc374ee431250374a44cbd773916ab9d
+  md5: 5fd7ab3e5f382c70607fbac6335e6e19
   depends:
   - libgcc-ng >=12
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 363462
-  timestamp: 1694710436617
+  size: 363577
+  timestamp: 1713201785160
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
-  build: hb547adb_0
+  version: 1.4.0
+  build: h93a5062_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
-  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
-  md5: 85dbc11098cdbe4244cd73f29a3ab795
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 273844
-  timestamp: 1694709510635
+  size: 287750
+  timestamp: 1713200194013
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
-  md5: dcde8820959e64378d4e06147ffecfdd
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 268870
-  timestamp: 1694709461733
+  size: 274359
+  timestamp: 1713200524021
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
-  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
   depends:
   - libgcc-ng >=12
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 401830
-  timestamp: 1694709121323
+  size: 438953
+  timestamp: 1713199854503
 - kind: conda
   name: libxcb
-  version: '1.15'
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
-  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
-  md5: 33277193f5b92bad9fdd230eb700929c
-  depends:
-  - libgcc-ng >=12
-  - pthread-stubs
-  - xorg-libxau
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 384238
-  timestamp: 1682082368177
-- kind: conda
-  name: libxcb
-  version: '1.15'
-  build: h2a766a3_0
+  version: 1.17.0
+  build: h262b8f6_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
-  sha256: d159fcdb8b74187b0bd32f2d9b3a9191bc8b786a97e413aa66e19c39ba7050a0
-  md5: eb3d8c8170e3d03f2564ed2024aa00c8
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+  md5: cd14ee5cca2464a425b1dbfc24d90db2
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   - pthread-stubs
-  - xorg-libxau
+  - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 388526
-  timestamp: 1682083614077
+  size: 397493
+  timestamp: 1727280745441
 - kind: conda
   name: libxcb
-  version: '1.15'
-  build: hb7f2c08_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
-  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
-  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  version: 1.17.0
+  build: h8a09558_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
   depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   - pthread-stubs
-  - xorg-libxau
+  - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 313793
-  timestamp: 1682083036825
+  size: 395888
+  timestamp: 1727278577118
 - kind: conda
   name: libxcb
-  version: '1.15'
-  build: hf346824_0
+  version: 1.17.0
+  build: hdb1d25a_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
-  sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
-  md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
   depends:
+  - __osx >=11.0
   - pthread-stubs
-  - xorg-libxau
+  - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 334770
-  timestamp: 1682082734262
+  size: 323658
+  timestamp: 1727278733917
+- kind: conda
+  name: libxcb
+  version: 1.17.0
+  build: hf1f96e2_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
 - kind: conda
   name: libxcrypt
   version: 4.4.36
@@ -10848,186 +11332,225 @@ packages:
 - kind: conda
   name: libxkbcommon
   version: 1.7.0
-  build: h2555907_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
-  sha256: 5075106adf56dfd586d889be9c151692a8507a2d00df8ba4a9e28a6aaac6074d
-  md5: 3663134cd650738ad46bd0d643246f51
+  build: h2c5496b_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+  sha256: 6804c2a7062d10de6f159f7106dc45ebccc8d42bfb925f7919e26e567fa6da6b
+  md5: e2eaefa4de2b7237af7c907b8bbc760a
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.6,<3.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 595967
-  timestamp: 1711303495028
+  size: 593336
+  timestamp: 1718819935698
 - kind: conda
   name: libxkbcommon
   version: 1.7.0
-  build: h662e7e4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
-  sha256: 3d97d7f964237f42452295d461afdbc51e93f72e2c80be516f56de80e3bb6621
-  md5: b32c0da42b1f24a98577bb3d7fc0b995
+  build: h46f2afe_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
+  sha256: 8ed470f72c733aea32bb5d272bf458041add7923d7716d5046bd40edf7ddd67c
+  md5: 78a24e611ab9c09c518f519be49c2e46
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.6,<3.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 593534
-  timestamp: 1711303445595
+  size: 596053
+  timestamp: 1718819931537
 - kind: conda
   name: libxml2
-  version: 2.12.6
-  build: h0d0cfa8_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_1.conda
-  sha256: f18775ca8494ead5451d4acfc53fa7ebf7a8b5ed04c43bcc50fab847c9780cb3
-  md5: c08526c957192192e1e7b4f622761144
-  depends:
-  - icu >=73.2,<74.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 588539
-  timestamp: 1711318256840
-- kind: conda
-  name: libxml2
-  version: 2.12.6
-  build: h232c23b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
-  sha256: c0bd693bb1a7e5aba388a0c79be16ff92e2411e03aaa920f94b4b33bf099e254
-  md5: 6853448e9ca1cfd5f15382afd2a6d123
-  depends:
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 705994
-  timestamp: 1711318087106
-- kind: conda
-  name: libxml2
-  version: 2.12.6
-  build: h3091e33_1
-  build_number: 1
+  version: 2.12.7
+  build: h00a45b3_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.6-h3091e33_1.conda
-  sha256: 109031dbe6ff873fb5e5617b27e774d8e465a4e82aa9a2967b18d4afacb4314d
-  md5: d39c279ae11d5574ec893dd3c173328e
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h00a45b3_4.conda
+  sha256: 1ce32ab0ffbc8938f0820949ea733eb11f2f05355034af12fc6fe708f184fac1
+  md5: d25c3e16ee77cd25342e4e235424c758
   depends:
-  - icu >=73.2,<74.0a0
+  - icu >=75.1,<76.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 750797
-  timestamp: 1711318216186
+  size: 753275
+  timestamp: 1721031124841
 - kind: conda
   name: libxml2
-  version: 2.12.6
-  build: hc0ae0f7_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_1.conda
-  sha256: 07a5dc7316d4c1ff3d924df6a76e6a13380d702fa5b3b1889e56d0672e5b8201
-  md5: bd85e0ca9e1ffaadc3b56079fd956035
+  version: 2.12.7
+  build: h01dff8b_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h01dff8b_4.conda
+  sha256: a9a76cdc6e93c0182bc2ac58b1ea0152be1a16a5d23f4dc7b8df282a7aef8d20
+  md5: 1265488dc5035457b729583119ad4a1b
   depends:
-  - icu >=73.2,<74.0a0
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 620164
-  timestamp: 1711318305209
+  size: 588990
+  timestamp: 1721031045514
 - kind: conda
   name: libxml2
-  version: 2.12.6
-  build: hc3477c8_1
-  build_number: 1
+  version: 2.12.7
+  build: h0f24e4e_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_1.conda
-  sha256: 1846c1318a5987e7315ca3648b55b38e5cfd9853370803a0f5159bc0071609c1
-  md5: eb9f59dd51f50f5aa369813fa63ba569
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+  sha256: ae78197961b09b0eef4ee194a44e4adc4555c0f2f20c348086b0cd8aaf2f7731
+  md5: ed4d301f0d2149b34deb9c4fecafd836
   depends:
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 1640801
-  timestamp: 1711318467301
+  size: 1682090
+  timestamp: 1721031296951
+- kind: conda
+  name: libxml2
+  version: 2.12.7
+  build: he7c6b58_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
+  sha256: 10e9e0ac52b9a516a17edbc07f8d559e23778e54f1a7721b2e0e8219284fed3b
+  md5: 08a9265c637230c37cb1be4a6cad4536
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 707169
+  timestamp: 1721031016143
+- kind: conda
+  name: libxml2
+  version: 2.12.7
+  build: heaf3512_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
+  sha256: ed18a2d8d428c0b88d47751ebcc7cc4e6202f99c3948fffd776cba83c4f0dad3
+  md5: ea1be6ecfe814da889e882c8b6ead79d
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 619901
+  timestamp: 1721031175411
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: h6d2be9b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_2.conda
-  sha256: 2a96712e6d762671735ad32003a565118215b0060923491abdf3fa8d8c44a3b1
-  md5: 10784ba3d7d4d12722ba41148e494080
+  build: h0ed339e_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h0ed339e_6.conda
+  sha256: e3a7f487ab6c095d2a38360928291cb07da52eecd3ae07a4852a173ceb800aa5
+  md5: 9e128dd2c202031e51a8c09ed872e2bb
   depends:
-  - ace >=7.1.3,<7.1.4.0a0
+  - __osx >=10.13
+  - ace >=8.0.1,<8.0.2.0a0
   - eigen
-  - ffmpeg >=6.1.1,<7.0a0
+  - ffmpeg >=6.1.2,<7.0a0
+  - libcxx >=17
   - libedit >=3.1.20191231,<3.2.0a0
-  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 7569001
+  timestamp: 1727889180670
+- kind: conda
+  name: libyarp
+  version: 3.9.0
+  build: h31b8c72_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h31b8c72_6.conda
+  sha256: 0844802b019fdac7c21ea2a58270925fe8a8edc08b24d93a850980ad9e7021e3
+  md5: 95e4c446bc9d4ad75f17f20eaa4c7c9b
+  depends:
+  - ace >=8.0.1,<8.0.2.0a0
+  - eigen
+  - ffmpeg >=6.1.2,<7.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
   - libi2c >=4.3,<5.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
   - robot-testing-framework >=2.0.1,<2.0.2.0a0
   - sdl >=1.2.68,<1.3.0a0
   - soxr >=0.1.3,<0.1.4.0a0
   - tinyxml
+  - xorg-libxfixes >=6.0.1,<7.0a0
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 10728595
-  timestamp: 1711027867844
+  size: 10727534
+  timestamp: 1727889622110
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: h9c0c770_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_2.conda
-  sha256: 4650c1f3d6df8aa9fddb7bb68386690ee344bddb829c215b60ad4ce08b6c14f3
-  md5: 540a665d37a2ef57ae2d73b761b2f26c
+  build: h35b7655_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h35b7655_6.conda
+  sha256: 4972e3ec65c1006de02330a790c2e6ee16cc19fab3ecf5ee53db84a333789b1b
+  md5: 0ae95375f9fd510e1c682d3d4bf296ab
   depends:
-  - ace >=7.1.3,<7.1.4.0a0
+  - __osx >=11.0
+  - ace >=8.0.1,<8.0.2.0a0
   - eigen
-  - ffmpeg >=6.1.1,<7.0a0
-  - libcxx >=16
+  - ffmpeg >=6.1.2,<7.0a0
+  - libcxx >=17
   - libedit >=3.1.20191231,<3.2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
   - robot-testing-framework >=2.0.1,<2.0.2.0a0
@@ -11036,61 +11559,32 @@ packages:
   - tinyxml
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 7633482
-  timestamp: 1711028877959
+  size: 7498450
+  timestamp: 1727889164876
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: ha0ae21b_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_2.conda
-  sha256: d3fb5f802579655b0951b15ac9c569bc012309d83eb05545552b2869d3af7f0f
-  md5: 05494ca8d0446dc269cdf6f862b80dfc
-  depends:
-  - ace >=7.1.3,<7.1.4.0a0
-  - eigen
-  - ffmpeg >=6.1.1,<7.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - portaudio >=19.6.0,<19.7.0a0
-  - qt-main >=5.15.8,<5.16.0a0
-  - robot-testing-framework >=2.0.1,<2.0.2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - soxr >=0.1.3,<0.1.4.0a0
-  - tinyxml
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ycm-cmake-modules
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 9297114
-  timestamp: 1711029347523
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: ha614a09_2
-  build_number: 2
+  build: h564f6a6_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_2.conda
-  sha256: e65ed048ca864c1caca7d84856f8376299aea2a361f3d2ad2c4b1599970c1a7b
-  md5: 91311b595caa11b3de437ed4919ff6d6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-h564f6a6_6.conda
+  sha256: c169f24238eeb50bb5aa3eb58c8afb3f11ebe8cddc7098a113e56e601cf25c89
+  md5: 0e085c829f738f08547fe5e8958e6649
   depends:
-  - ace >=7.1.3,<7.1.4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ace >=8.0.1,<8.0.2.0a0
   - eigen
-  - ffmpeg >=6.1.1,<7.0a0
+  - ffmpeg >=7.1.0,<8.0a0
   - libedit >=3.1.20191231,<3.2.0a0
-  - libgcc-ng >=12
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
   - libi2c >=4.3,<5.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
   - robot-testing-framework >=2.0.1,<2.0.2.0a0
@@ -11099,120 +11593,127 @@ packages:
   - tinyxml
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 10090055
-  timestamp: 1711027782866
+  size: 10594881
+  timestamp: 1727889822933
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: hff4382b_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_2.conda
-  sha256: 31f8bfbb019bf2d136e463250cd42d09ce15bf606ed7b5004a8a848a33f8b009
-  md5: 29efca2ccae313f55c70adedee4b0600
+  build: h71b8b94_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-h71b8b94_6.conda
+  sha256: f2837483c62ed450419570cf1a04165433769709e329924f0ce257bfafeb1636
+  md5: 324f1b2f7947dfedc4d45680b7517c7c
   depends:
+  - ace >=8.0.1,<8.0.2.0a0
   - eigen
-  - ffmpeg >=6.1.1,<7.0a0
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
+  - ffmpeg >=6.1.2,<7.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
   - robot-testing-framework >=2.0.1,<2.0.2.0a0
   - sdl >=1.2.68,<1.3.0a0
   - soxr >=0.1.3,<0.1.4.0a0
   - tinyxml
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 7177892
-  timestamp: 1711029042235
+  size: 9322634
+  timestamp: 1727890415974
 - kind: conda
   name: libzlib
-  version: 1.2.13
-  build: h31becfc_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
-  sha256: aeeefbb61e5e8227e53566d5e42dbb49e120eb99109996bf0dbfde8f180747a7
-  md5: b213aa87eea9491ef7b129179322e955
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 67036
-  timestamp: 1686575148440
-- kind: conda
-  name: libzlib
-  version: 1.2.13
-  build: h53f4e23_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
-  md5: 1a47f5236db2e06a320ffa0392f81bd8
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 48102
-  timestamp: 1686575426584
-- kind: conda
-  name: libzlib
-  version: 1.2.13
-  build: h8a1eda9_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
-  md5: 4a3ad23f6e16f99c04e166767193d700
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 59404
-  timestamp: 1686575566695
-- kind: conda
-  name: libzlib
-  version: 1.2.13
-  build: hcfcfb64_5
-  build_number: 5
+  version: 1.3.1
+  build: h2466b09_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
-  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - zlib 1.2.13 *_5
+  - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
-  size: 55800
-  timestamp: 1686575452215
+  size: 55476
+  timestamp: 1727963768015
 - kind: conda
   name: libzlib
-  version: 1.2.13
-  build: hd590300_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  md5: f36c115f1ee199da648e0597ec2047ad
+  version: 1.3.1
+  build: h8359307_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
   depends:
-  - libgcc-ng >=12
+  - __osx >=11.0
   constrains:
-  - zlib 1.2.13 *_5
+  - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
-  size: 61588
-  timestamp: 1686575217516
+  size: 46438
+  timestamp: 1727963202283
+- kind: conda
+  name: libzlib
+  version: 1.3.1
+  build: h86ecc28_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
+  md5: 08aad7cbe9f5a6b460d0976076b6ae64
+  depends:
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 66657
+  timestamp: 1727963199518
+- kind: conda
+  name: libzlib
+  version: 1.3.1
+  build: hb9d3cd8_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- kind: conda
+  name: libzlib
+  version: 1.3.1
+  build: hd23fc13_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
 - kind: conda
   name: llvm-meta
   version: 5.0.0
@@ -11227,78 +11728,113 @@ packages:
   size: 2667
 - kind: conda
   name: llvm-openmp
-  version: 18.1.2
-  build: hb6ac08f_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
-  sha256: dc40b678f5be2caf4e89ee3dc9037399d0bcd46543bc258dc46e1b92d241c6a6
-  md5: e7f7e91cfabd8c7172c9ae405214dd68
+  version: 19.1.2
+  build: h013ceaa_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-19.1.2-h013ceaa_0.conda
+  sha256: e1c8265187d98cb486b946ec89effdff88494ae1560cc83b1410961c7c9d5121
+  md5: d51a2e037784c2604ba616b4fd9508e3
   constrains:
-  - openmp 18.1.2|18.1.2.*
+  - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 300480
-  timestamp: 1711010792383
+  size: 3088536
+  timestamp: 1729145272074
 - kind: conda
   name: llvm-openmp
-  version: 18.1.2
-  build: hcd81f8e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.2-hcd81f8e_0.conda
-  sha256: 2ed8ae5a4c6122d542564a9bb9d4961ed7d2fb9581f0ea8bd81e3a83e614b110
-  md5: 34646dc152f3949a2f8a67136d406dce
+  version: 19.1.2
+  build: h024ca30_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.2-h024ca30_0.conda
+  sha256: 77ef4713b1762ec2c0326400e5009e15595d3c27a10e5bbe91a29d63c99ee9b9
+  md5: 51ee2f29348ec593205c30ebc52aa0c0
+  depends:
+  - __glibc >=2.17,<3.0.a0
   constrains:
-  - openmp 18.1.2|18.1.2.*
+  - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 276238
-  timestamp: 1711010656300
+  size: 3189011
+  timestamp: 1729145283078
 - kind: conda
-  name: llvm-tools
-  version: 16.0.6
-  build: haab561b_3
-  build_number: 3
+  name: llvm-openmp
+  version: 19.1.2
+  build: hb52a8e5_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
-  sha256: 64cc3547a2b0a3700a9fa0bd1fd3258156900b48ae73fc1a4b391002ca1462bf
-  md5: ca8e3771122c520fbe72af7c83d6d4cd
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
+  sha256: a1836fa9eddf8b3fa2209db4a3423b13fdff93a8eacc9fe8360a6867e7f440d0
+  md5: 7ad59f95f091ed6a99a7cbcd6f201be0
   depends:
-  - libllvm16 16.0.6 haab561b_3
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - __osx >=11.0
   constrains:
-  - llvmdev   16.0.6
-  - clang 16.0.6.*
-  - clang-tools 16.0.6.*
-  - llvm 16.0.6.*
+  - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 20685770
-  timestamp: 1701375136405
+  license_family: APACHE
+  size: 280737
+  timestamp: 1729145191646
+- kind: conda
+  name: llvm-openmp
+  version: 19.1.2
+  build: hf78d878_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
+  sha256: 92231d391886bca0c0dabb42f02a37e7acb8ea84399843173fe8c294814735dd
+  md5: ca5f963676a9ad5383b7441368e1d107
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.2|19.1.2.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305589
+  timestamp: 1729145249496
 - kind: conda
   name: llvm-tools
-  version: 16.0.6
-  build: hbedff68_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
-  sha256: dff3ca83c6945f020ee6d3c62ddb3ed175ae8a357be3689a8836bcfe25ad9882
-  md5: e9356b0807462e8f84c1384a8da539a5
+  version: 17.0.6
+  build: h5090b49_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
+  sha256: a8011fffc1ab3b49f2027fbdba0887e90a2d288240484a4ba4c1b80617522541
+  md5: df635fb4c27fc012c0caf53adf61f043
   depends:
-  - libllvm16 16.0.6 hbedff68_3
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - __osx >=11.0
+  - libllvm17 17.0.6 h5090b49_2
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - llvmdev   16.0.6
-  - clang 16.0.6.*
-  - clang-tools 16.0.6.*
-  - llvm 16.0.6.*
+  - clang-tools 17.0.6
+  - llvm        17.0.6
+  - llvmdev     17.0.6
+  - clang       17.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 22221159
-  timestamp: 1701379965425
+  size: 21864486
+  timestamp: 1718321368877
+- kind: conda
+  name: llvm-tools
+  version: 17.0.6
+  build: hbedff68_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
+  sha256: 2380e9ac72aba8ef351ec13c9d5b1b233057c70bf4b9b3cea0b3f5bfb5a4e211
+  md5: 4260f86b3dd201ad7ea758d783cd5613
+  depends:
+  - libllvm17 17.0.6 hbedff68_1
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - llvm        17.0.6
+  - clang       17.0.6
+  - clang-tools 17.0.6
+  - llvmdev     17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23219165
+  timestamp: 1701378990823
 - kind: conda
   name: lz4-c
   version: 1.9.4
@@ -11332,179 +11868,219 @@ packages:
 - kind: conda
   name: metis
   version: 5.1.0
-  build: h13dd4ca_1007
+  build: h15f6cfe_1007
   build_number: 1007
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
-  sha256: fae516bee76df367128cf81dae13e7d11ce039ff61665ca59a1c57dee0731973
-  md5: afefade086a45ae6703dffe83516010a
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3832170
-  timestamp: 1693403045166
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h2f0025b_1007
-  build_number: 1007
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h2f0025b_1007.conda
-  sha256: e6f99a2a253a6bad928267789a8357a7fead6f56c33bb7377459c935b99c7d33
-  md5: 9d5f344e56601a9de6ea09121049881d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h15f6cfe_1007.conda
+  sha256: f54ad3e5d47a0235ba2830848fee590faad550639336fe1e2413ab16fee7ac39
+  md5: 7687ec5796288536947bf616179726d8
   depends:
-  - libgcc-ng >=12
+  - __osx >=11.0
   license: Apache-2.0
   license_family: APACHE
-  size: 3861349
-  timestamp: 1693403154007
+  size: 3898314
+  timestamp: 1728064659078
 - kind: conda
   name: metis
   version: 5.1.0
-  build: h59595ed_1007
-  build_number: 1007
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
-  sha256: 446bf794497284e2ffa28ab9191d70c38d372c51e3fd073f0d8b35efb51e7e02
-  md5: 40ccb8318df2500f83bd868dd8fcd201
-  depends:
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3890263
-  timestamp: 1693402645559
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h63175ca_1007
-  build_number: 1007
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/metis-5.1.0-h63175ca_1007.conda
-  sha256: 08279c753d27e5bce681fa00d2c599a808cb82f2b569fa7d3e5a2d9daaa76f4f
-  md5: da23929d48643d80504f80f00a455e87
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4052316
-  timestamp: 1693403006265
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: he965462_1007
+  build: h3023b02_1007
   build_number: 1007
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
-  sha256: a79b36e0c623dfab95cc2c0fce1870e90de5f2328fefa9a1b17351eb0f3ac02e
-  md5: 0c64ad59bbcae7772c16a55cbd353e25
+  url: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-h3023b02_1007.conda
+  sha256: 9443014f00a78a216c59f17a1309e49beb24b96082d198b4ab1626522fc7da40
+  md5: 4e4566c484361d6a92478f57db53fb08
+  depends:
+  - __osx >=10.13
   license: Apache-2.0
   license_family: APACHE
-  size: 3881273
-  timestamp: 1693402943049
+  size: 3949838
+  timestamp: 1728064564171
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: h670dfbf_1007
+  build_number: 1007
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h670dfbf_1007.conda
+  sha256: 453f4733b1803452b8169c31749d92d46bf6fe7e467897d89535d3fcb6f16b6f
+  md5: e6672417b63f335358d90f5ba939c4ab
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3844618
+  timestamp: 1728064627281
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: hd0bcaf9_1007
+  build_number: 1007
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
+  sha256: e8a00971e6d00bd49f375c5d8d005b37a9abba0b1768533aed0f90a422bf5cc7
+  md5: 28eb714416de4eb83e2cbc47e99a1b45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3923560
+  timestamp: 1728064567817
 - kind: conda
   name: mkl
-  version: 2024.0.0
-  build: h66d3029_49657
-  build_number: 49657
+  version: 2024.2.2
+  build: h66d3029_14
+  build_number: 14
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
-  sha256: 928bed978827e4c891d0879d79ecda6c9104ed7df1f1d4e2e392c9c80b471be7
-  md5: 006b65d9cd436247dfe053df772e041d
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
   depends:
   - intel-openmp 2024.*
   - tbb 2021.*
-  license: LicenseRef-ProprietaryIntel
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
-  size: 108505947
-  timestamp: 1701973497498
+  size: 103019089
+  timestamp: 1727378392081
 - kind: conda
   name: mpg123
-  version: 1.32.4
-  build: h2f0025b_0
+  version: 1.32.8
+  build: h65af167_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.4-h2f0025b_0.conda
-  sha256: 5e0e3585a050b4e0412a55521ab7a739275f33aaed38f97a537edcb2fa6c4c54
-  md5: 6ccb0eb784f3c544f6c1f48e61787de4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.8-h65af167_0.conda
+  sha256: e76f42e9156b5c0b5f92b5291b3a49dbb57cfa59fe47ae63277636a663457389
+  md5: 954ee7649e85e975a6d0b2c1bacb96d6
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libstdcxx >=13
   license: LGPL-2.1-only
   license_family: LGPL
-  size: 559635
-  timestamp: 1704980202901
+  size: 559226
+  timestamp: 1729968939562
 - kind: conda
   name: mpg123
-  version: 1.32.4
-  build: h59595ed_0
+  version: 1.32.8
+  build: hc50e24c_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.4-h59595ed_0.conda
-  sha256: 512f4ad7eda3b2c9a1cc9f7931932aefa6e79567e35b76de03895e769cb3b43c
-  md5: 3f1017b4141e943d9bc8739237f749e8
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.8-hc50e24c_0.conda
+  sha256: 5b3e9fe0ce303429f82def3a37d9f3227c69cd6a45a26753351c3c86d2454c75
+  md5: 7a7229e20b7b4c6840d6fe2378646a77
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   license: LGPL-2.1-only
   license_family: LGPL
-  size: 491061
-  timestamp: 1704980200966
+  size: 492429
+  timestamp: 1729968968920
 - kind: conda
   name: mumps-include
-  version: 5.6.2
-  build: h694c41f_4
-  build_number: 4
+  version: 5.7.3
+  build: h694c41f_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.6.2-h694c41f_4.conda
-  sha256: 4fc4b6a338fb27135407a92a059d8d3336804398b6bae05366bbf483221ec9ab
-  md5: a2d3c3b01692735b48d280a2e37036be
+  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.7.3-h694c41f_5.conda
+  sha256: 41649e1cfdfae5530a76949616a4ecaf862748d6048e49bac2991920e868bdab
+  md5: 235cf2d095ba79dac99a25a3abdeeae6
   license: CECILL-C
-  size: 26883
-  timestamp: 1705868512099
+  size: 23156
+  timestamp: 1727303586187
 - kind: conda
   name: mumps-include
-  version: 5.6.2
-  build: h8af1aa0_4
-  build_number: 4
+  version: 5.7.3
+  build: h8af1aa0_5
+  build_number: 5
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.6.2-h8af1aa0_4.conda
-  sha256: af30dac3907f64968c2e82e8a40e9fa4ae646d476cc357d4aaa9186df79e57a0
-  md5: 72800868cafcc23cf736229bd60648d7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
+  sha256: 29a9527b286203881328f5057b4e75953884ae1a75d01a5119bf10776a150c61
+  md5: 2b8630bd5e0b25e53ee5fbe4844c3b4c
   license: CECILL-C
-  size: 26708
-  timestamp: 1705868478968
+  size: 23025
+  timestamp: 1727303578959
 - kind: conda
   name: mumps-include
-  version: 5.6.2
-  build: ha770c72_4
-  build_number: 4
+  version: 5.7.3
+  build: ha770c72_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.6.2-ha770c72_4.conda
-  sha256: 7fe56f8c2cfbb3d3074e8f6b0db1ee61d61af4d9ec93cba50d60cfc5d7406989
-  md5: 254bd79da732863782b5d9d53b9881ea
+  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
+  sha256: 23749d8c3695d95255c21fa4ebf73c70a07b098262c052a854d1504416e69478
+  md5: 1f49bbeab690751b93f54cb61b0722aa
   license: CECILL-C
-  size: 26642
-  timestamp: 1705868386041
+  size: 22999
+  timestamp: 1727303528508
 - kind: conda
   name: mumps-include
-  version: 5.6.2
-  build: hce30654_4
-  build_number: 4
+  version: 5.7.3
+  build: hce30654_5
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.6.2-hce30654_4.conda
-  sha256: ea072f0657d96842627b836fb265b28ac0acad6cca8dfa7e30822443638c9d8a
-  md5: 1e40cbb966ca2d707d7143ff978eb543
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
+  sha256: 957568ea03765a383d1f2413f701bb4179705f879f4028dfa2653c723f8ec038
+  md5: 1a1380f7da054ed3327d40b3abe732f3
   license: CECILL-C
-  size: 26903
-  timestamp: 1705868560071
+  size: 23186
+  timestamp: 1727303612860
 - kind: conda
   name: mumps-seq
-  version: 5.6.2
-  build: h1f49738_4
-  build_number: 4
+  version: 5.7.3
+  build: h3416ed2_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.7.3-h3416ed2_5.conda
+  sha256: 4a6cfb691beca7d108b534e08dee86a3b2e8523e8ece183189995e30d3ff82c7
+  md5: 87efba371ce4e0058862983c1f1faf84
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch >=7.0.5,<7.0.6.0a0
+  - llvm-openmp >=17.0.6
+  - llvm-openmp >=18.1.8
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include 5.7.3 h694c41f_5
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  size: 2278066
+  timestamp: 1727303832161
+- kind: conda
+  name: mumps-seq
+  version: 5.7.3
+  build: h505cb68_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
+  sha256: 27d4b8d78cb662e0406e42f34474f18565b3c46e893f9e938edf1dbafab30547
+  md5: 2ac9aea3b26d7de591223671b3fe0de2
+  depends:
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch >=7.0.5,<7.0.6.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include 5.7.3 h8af1aa0_5
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  size: 2363904
+  timestamp: 1727303927035
+- kind: conda
+  name: mumps-seq
+  version: 5.7.3
+  build: h7c2359a_5
+  build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.6.2-h1f49738_4.conda
-  sha256: b7b3928a5ca5bf369205b5d5ab3740c61748a48782ada62bf565e740098040bb
-  md5: 1e1b07df56800ec678333303390da9c3
+  url: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
+  sha256: 00e65d0dff5d773612c742d2ad48e041fbeb0bd779cf7a3fa85ed91b479254e4
+  md5: 943cbd250d41f9c1f3ac2004deea7a31
   depends:
   - libblas >=3.9.0,<4.0a0
   - libflang >=5.0.0,<6.0.0.a0
@@ -11512,558 +12088,537 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas * *openmp*
   license: CECILL-C
-  size: 3350137
-  timestamp: 1705869313801
+  size: 3074465
+  timestamp: 1727304479582
 - kind: conda
   name: mumps-seq
-  version: 5.6.2
-  build: hae18a20_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.6.2-hae18a20_4.conda
-  sha256: a774fdfcbdb942aeb3393d54cf55da915ba4fefa32c1e8d07cb03a8bf232fcff
-  md5: 322dfa7d9e1e1a890b334238c09233cd
+  version: 5.7.3
+  build: hcd84eb1_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
+  sha256: 94da4438e92a53bb8670971cb1247787e8f4d91ce06f28e9d31fdb3f6afa33e2
+  md5: 46d52291d856e44ff8b81bc3b480b228
   depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
   - libblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
   - liblapack >=3.9.0,<4.0a0
-  - libscotch
+  - libscotch >=7.0.5,<7.0.6.0a0
   - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include >=5.6.2,<5.6.3.0a0
-  - scotch >=7.0.4,<7.0.5.0a0
+  - mumps-include 5.7.3 ha770c72_5
+  constrains:
+  - libopenblas * *openmp*
   license: CECILL-C
-  size: 1722199
-  timestamp: 1705868719507
+  size: 2440160
+  timestamp: 1727303788976
 - kind: conda
   name: mumps-seq
-  version: 5.6.2
-  build: hbbab245_4
-  build_number: 4
+  version: 5.7.3
+  build: he17653c_5
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.6.2-hbbab245_4.conda
-  sha256: 33318f81594893644b02821cee7dc8f7c54d98645ce265cd5355b95713b58746
-  md5: 30f960e2ecf9040c54261c2592fb3e6a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
+  sha256: fa605c3028d958cbe670620ee583ef8f0551d79fdc0d41a61e43478c9c42b3ee
+  md5: 364d512567d810c33ed77207f898129e
   depends:
-  - libblas >=3.9.0,<4.0a0
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - libscotch
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include >=5.6.2,<5.6.3.0a0
-  - scotch >=7.0.4,<7.0.5.0a0
-  license: CECILL-C
-  size: 1701696
-  timestamp: 1705868911584
-- kind: conda
-  name: mumps-seq
-  version: 5.6.2
-  build: he3629b0_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.6.2-he3629b0_4.conda
-  sha256: 73107b41dc48a3ddd0dfce6d1e5f7819f6f99b869925c4a5ef3cb21a41a43296
-  md5: 192e16838874d6171a32cb93f90acde2
-  depends:
+  - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
   - libgfortran 5.*
-  - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - libscotch
+  - libscotch >=7.0.5,<7.0.6.0a0
+  - llvm-openmp >=17.0.6
+  - llvm-openmp >=18.1.8
   - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include >=5.6.2,<5.6.3.0a0
-  - scotch >=7.0.4,<7.0.5.0a0
+  - mumps-include 5.7.3 hce30654_5
+  constrains:
+  - libopenblas * *openmp*
   license: CECILL-C
-  size: 1860366
-  timestamp: 1705868832832
-- kind: conda
-  name: mumps-seq
-  version: 5.6.2
-  build: hfef103a_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.6.2-hfef103a_4.conda
-  sha256: 311d01882fe43677ddb8f0eb7382ac5b072c51fb1b64b69e3ec54c2a3ca2f61c
-  md5: 04a7b59399685952f5af225bf3d9c131
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libscotch
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include >=5.6.2,<5.6.3.0a0
-  - scotch >=7.0.4,<7.0.5.0a0
-  license: CECILL-C
-  size: 1956627
-  timestamp: 1705868645516
+  size: 2178444
+  timestamp: 1727304238416
 - kind: conda
   name: mysql-common
-  version: 8.3.0
-  build: hb6794ad_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.3.0-hb6794ad_4.conda
-  sha256: e8a60765c9dd6c48a0b5e5059dfc2f0a3d5334c02999badc73e23e2938ebc50a
-  md5: 7ceea44b2ea6113e0945cc06f73f7b71
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 778523
-  timestamp: 1709913295771
-- kind: conda
-  name: mysql-common
-  version: 8.3.0
-  build: hd1853d3_4
-  build_number: 4
+  version: 9.0.1
+  build: h0887d5e_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-8.3.0-hd1853d3_4.conda
-  sha256: 4ed97297f0278c01ea21eb20335141d5bfb29f5820fabd03f8bc1cb74d3fe9a7
-  md5: f93a6079f12ef00195d7d0b96ff98191
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h0887d5e_2.conda
+  sha256: 7769d67c3b9463e45ec8e57ea3e0adfdd2f17c0c2b32226e1e88ed669baf14fe
+  md5: 7643ebb29dae0a548c356c5c4d44b79e
   depends:
-  - libcxx >=16
-  - openssl >=3.2.1,<4.0a0
+  - __osx >=11.0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 800889
-  timestamp: 1709915847564
+  size: 630582
+  timestamp: 1729802112289
 - kind: conda
   name: mysql-common
-  version: 8.3.0
-  build: hf1915f5_4
-  build_number: 4
+  version: 9.0.1
+  build: h266115a_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.3.0-hf1915f5_4.conda
-  sha256: 4cf6d29e091398735348550cb74cfd5006e04892d54b6b1ba916935f1af1a151
-  md5: 784a4df6676c581ca624fbe460703a6d
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
+  sha256: bf0c230c35ca70e2c98530eb064a99f0c4d4596793a0be3ca8a3cbd92094ef82
+  md5: 85c0dc0bcd110c998b01856975486ee7
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.2.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 784844
-  timestamp: 1709910607121
+  size: 649443
+  timestamp: 1729804130603
 - kind: conda
   name: mysql-common
-  version: 8.3.0
-  build: hfd7a639_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-8.3.0-hfd7a639_4.conda
-  sha256: 1829b8a277bf7f078c9e3c78a4404b31d77b9e9c006b890435e68438c22c2caf
-  md5: 65af0764c5a5617539d07c9d243250e3
-  depends:
-  - libcxx >=16
-  - openssl >=3.2.1,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 776212
-  timestamp: 1709914020238
-- kind: conda
-  name: mysql-libs
-  version: 8.3.0
-  build: ha9146f8_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-8.3.0-ha9146f8_4.conda
-  sha256: eaabfabb3c39f569a062f1235ff97eb208716ed847ab98b0d2040b2d8acea73b
-  md5: 507610a153e96fad858e1735779b3781
-  depends:
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common 8.3.0 hfd7a639_4
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1527176
-  timestamp: 1709914179461
-- kind: conda
-  name: mysql-libs
-  version: 8.3.0
-  build: hca2cd23_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.3.0-hca2cd23_4.conda
-  sha256: c39cdd1a5829aeffc611f789bdfd4dbd4ce1aa829c73d728defec180b5265d91
-  md5: 1b50eebe2a738a3146c154d2eceaa8b6
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common 8.3.0 hf1915f5_4
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1537884
-  timestamp: 1709910705541
-- kind: conda
-  name: mysql-libs
-  version: 8.3.0
-  build: hf036fc4_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-8.3.0-hf036fc4_4.conda
-  sha256: a48101c076f9a038bd3cfa822df2b20fdc0ccce88f9000c7bee8f6d53a1cc64e
-  md5: 9cb8011d749d99db2cba868053bcd8cb
-  depends:
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common 8.3.0 hd1853d3_4
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1541174
-  timestamp: 1709915999617
-- kind: conda
-  name: mysql-libs
-  version: 8.3.0
-  build: hf629957_4
-  build_number: 4
+  version: 9.0.1
+  build: h3f5c77f_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.3.0-hf629957_4.conda
-  sha256: 9e96ff766597214e87a6bfdd4f308523cacca1f2da67fc4eeafefcf83d47d0aa
-  md5: ba9e44922978812b7e07562738f7a1a7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
+  sha256: 27cb52f00b2fedb89ed4e7ed2527caf7c5b245dac76a809d0aed58514e08d325
+  md5: cc7bc11893dd1aee492dae85f317769e
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common 8.3.0 hb6794ad_4
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 1581004
-  timestamp: 1709913458504
+  size: 636837
+  timestamp: 1729806881403
+- kind: conda
+  name: mysql-common
+  version: 9.0.1
+  build: h918ca22_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-9.0.1-h918ca22_2.conda
+  sha256: d46a234777afaa7f7c4aa1898067a89f43d86db348909fee1b418713809e8836
+  md5: 6adefe5eada0fb37f098288127961ac9
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 644932
+  timestamp: 1729801807155
+- kind: conda
+  name: mysql-libs
+  version: 9.0.1
+  build: h11569fd_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
+  sha256: 0c014ecbb449cd10bab96bf036cae646068ce42827f582244117adc805850d04
+  md5: 94c70f21e0a1f8558941d901027215a4
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h3f5c77f_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1408789
+  timestamp: 1729806960210
+- kind: conda
+  name: mysql-libs
+  version: 9.0.1
+  build: h502887b_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-9.0.1-h502887b_2.conda
+  sha256: df608e92b025d8f83c10a5a932d2b3c16b983571016a04fc21d3660d04e820fe
+  md5: 901d570614d2c0c58a6e3800d9261cf4
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h918ca22_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1329554
+  timestamp: 1729802009317
+- kind: conda
+  name: mysql-libs
+  version: 9.0.1
+  build: he0572af_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+  sha256: e376189cd11304f4089971b372dac8a1cbbab6eacda8ca978ead2c220d16b8a4
+  md5: 57a9e7ee3c0840d3c8c9012473978629
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h266115a_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1372671
+  timestamp: 1729804203990
+- kind: conda
+  name: mysql-libs
+  version: 9.0.1
+  build: he9bc4e1_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-he9bc4e1_2.conda
+  sha256: ca89f4accacfc2297b5036aa847c2387c53aa937c8f9050ceec275c1be32eec1
+  md5: f36d1cf1ffeb604bac5870c04cb4ee8f
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h0887d5e_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1346928
+  timestamp: 1729802330351
 - kind: conda
   name: ncurses
-  version: 6.4.20240210
-  build: h0425590_0
+  version: '6.5'
+  build: h7bae524_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- kind: conda
+  name: ncurses
+  version: '6.5'
+  build: hcccb83c_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4.20240210-h0425590_0.conda
-  sha256: 4223dc34e2bddd37bf995158ae481e00be375b287d539bc7a0532634c0fc63b7
-  md5: c1a1612ddaee95c83abfa0b2ec858626
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
+  sha256: acad4cf1f57b12ee1e42995e6fac646fa06aa026529f05eb8c07eb0a84a47a84
+  md5: 91d49c85cacd92caa40cf375ef72a25d
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
-  size: 926594
-  timestamp: 1710866633409
+  size: 924472
+  timestamp: 1724658573518
 - kind: conda
   name: ncurses
-  version: 6.4.20240210
-  build: h078ce10_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
-  sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
-  md5: 616ae8691e6608527d0071e6766dcb81
-  license: X11 AND BSD-3-Clause
-  size: 820249
-  timestamp: 1710866874348
-- kind: conda
-  name: ncurses
-  version: 6.4.20240210
-  build: h59595ed_0
+  version: '6.5'
+  build: he02047a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
-  sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
-  md5: 97da8860a0da5413c7c98a3b3838a645
-  depends:
-  - libgcc-ng >=12
-  license: X11 AND BSD-3-Clause
-  size: 895669
-  timestamp: 1710866638986
-- kind: conda
-  name: ncurses
-  version: 6.4.20240210
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
-  sha256: 50b72acf08acbc4e5332807653e2ca6b26d4326e8af16fad1fd3f2ce9ea55503
-  md5: 50f28c512e9ad78589e3eab34833f762
-  license: X11 AND BSD-3-Clause
-  size: 823010
-  timestamp: 1710866856626
-- kind: conda
-  name: nettle
-  version: 3.9.1
-  build: h40ed0f5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
-  sha256: 5de149b6e35adac11e22ae02516a7466412348690da52049f80ea07fe544896d
-  md5: b157977e1ec1dde3ba7ebc6e0dde363f
-  license: GPL 2 and LGPL3
-  license_family: GPL
-  size: 510164
-  timestamp: 1686310071126
-- kind: conda
-  name: nettle
-  version: 3.9.1
-  build: h7ab15ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
-  sha256: 1ef1b7efa69c7fb4e2a36a88316f307c115713698d1c12e19f55ae57c0482995
-  md5: 2bf1915cc107738811368afcb0993a59
-  depends:
-  - libgcc-ng >=12
-  license: GPL 2 and LGPL3
-  license_family: GPL
-  size: 1011638
-  timestamp: 1686309814836
-- kind: conda
-  name: nettle
-  version: 3.9.1
-  build: h8e11ae5_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
-  sha256: 62de51fc44f1595a06c5b24bb717b949b4b9fb4c4acaf127b92ce99ddb546ca7
-  md5: 400dffe5d2fbb9813b51948d3e9e9ab1
-  license: GPL 2 and LGPL3
-  license_family: GPL
-  size: 509519
-  timestamp: 1686310097670
-- kind: conda
-  name: nettle
-  version: 3.9.1
-  build: h9d1147b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
-  sha256: 27d70a4292515e948d6a16d03d7e5f2ec64396ccf2dd81aa9725667794fd71d8
-  md5: bf4b290d849247be4a5b89cfbd30b4d7
-  depends:
-  - libgcc-ng >=12
-  license: GPL 2 and LGPL3
-  license_family: GPL
-  size: 1123356
-  timestamp: 1686311968059
-- kind: conda
-  name: ninja
-  version: 1.11.1
-  build: h91493d7_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
-  sha256: 0ffb1912768af8354a930f482368ef170bf3d8217db328dfea1c8b09772c8c71
-  md5: 44a99ef26178ea98626ff8e027702795
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 279200
-  timestamp: 1676838681615
-- kind: conda
-  name: ninja
-  version: 1.11.1
-  build: h924138e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
-  sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
-  md5: 73a4953a2d9c115bdc10ff30a52f675f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 2251263
-  timestamp: 1676837602636
-- kind: conda
-  name: ninja
-  version: 1.11.1
-  build: hb8565cd_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
-  sha256: 6f738d9a26fa275317b95b2b96832daab9059ef64af9a338f904a3cb684ae426
-  md5: 49ad513efe39447aa51affd47e3aa68f
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 121284
-  timestamp: 1676837793132
-- kind: conda
-  name: ninja
-  version: 1.11.1
-  build: hdd96247_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
-  sha256: 2ba2e59f619c58d748f4b1b858502587691a7ed0fa9ac2c26ac04091908d95ae
-  md5: 58f4c67113cda9171e3c03d3e62731e1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 2398482
-  timestamp: 1676839419214
-- kind: conda
-  name: ninja
-  version: 1.11.1
-  build: hffc8910_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
-  sha256: a594e90b0ed8202c280fff4a008f6a355d0db54a62b17067dc4a950370ddffc0
-  md5: fdecec4002f41cf6ea1eea5b52947ee0
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 107047
-  timestamp: 1676837935565
-- kind: conda
-  name: nspr
-  version: '4.35'
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-  sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
-  md5: da0ec11a6454ae19bff5b02ed881a2b1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 226848
-  timestamp: 1669784948267
-- kind: conda
-  name: nspr
-  version: '4.35'
-  build: h4de3ea5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
-  sha256: 23ff7274a021dd87966277b271e5d0944fcc8b893f4920cb46dd4224604218cc
-  md5: 7a392f26f76fc55354c8ed60c2b99162
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 232844
-  timestamp: 1669784904844
-- kind: conda
-  name: nspr
-  version: '4.35'
-  build: hb7217d7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
-  sha256: 35959d36ea9e8a2c422db9f113ee0ac91a9b0c19c51b05f75d0793c3827cfa3a
-  md5: f81b5ec944dbbcff3dd08375eb036efa
-  depends:
-  - libcxx >=14.0.6
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 220745
-  timestamp: 1669785182058
-- kind: conda
-  name: nspr
-  version: '4.35'
-  build: hea0b92c_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
-  sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
-  md5: a9e56c98d13d8b7ce72bf4357317c29b
-  depends:
-  - libcxx >=14.0.6
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 230071
-  timestamp: 1669785313586
-- kind: conda
-  name: nss
-  version: '3.98'
-  build: h1d7d5a4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
-  sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
-  md5: 54b56c2fdf973656b748e0378900ec13
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  - libsqlite >=3.45.1,<4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 2019716
-  timestamp: 1708065114928
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
 - kind: conda
-  name: nss
-  version: '3.98'
-  build: h5ce2875_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.98-h5ce2875_0.conda
-  sha256: eecb5718c43dd68cf8150b1e75c91518dae457348828361034639e9e2ea82c82
-  md5: db0d8f4d11186e4cb3f1a3e0385ca075
-  depends:
-  - libcxx >=16
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 1809748
-  timestamp: 1708065511899
-- kind: conda
-  name: nss
-  version: '3.98'
-  build: ha05da47_0
+  name: ncurses
+  version: '6.5'
+  build: hf036a51_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
-  sha256: 3d99dd976aeb8678e4ac5fcbd574e1de50cdc57b742e22855f294c8047d5c68e
-  md5: 79d062716d8e1f77cf806c6fe0f4405c
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
   depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- kind: conda
+  name: ninja
+  version: 1.12.1
+  build: h297d8ca_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
+  sha256: 40f7b76b07067935f8a5886aab0164067b7aa71eb5ad20b7278618c0c2c98e06
+  md5: 3aa1c7e292afeff25a0091ddd7c69b72
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 2198858
+  timestamp: 1715440571685
+- kind: conda
+  name: ninja
+  version: 1.12.1
+  build: h3c5361c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.12.1-h3c5361c_0.conda
+  sha256: 230f11a2f73955b67550be09a0c1fd053772f5e01e98d5873547d63ebea73229
+  md5: a0ebabd021c8191aeb82793fe43cfdcb
+  depends:
+  - __osx >=10.13
   - libcxx >=16
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 124942
+  timestamp: 1715440780183
+- kind: conda
+  name: ninja
+  version: 1.12.1
+  build: h420ef59_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
+  sha256: 11528acfa0f05d0c51639f6b09b51dc6611b801668449bb36c206c4b055be4f4
+  md5: 9166c10405d41c95ffde8fcb8e5c3d51
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 112576
+  timestamp: 1715440927034
+- kind: conda
+  name: ninja
+  version: 1.12.1
+  build: h70be974_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.12.1-h70be974_0.conda
+  sha256: a42f12c03a69cdcd2e7d5f95fd4e0f1e5fc43ef482aff2b8ee16a3730cc642de
+  md5: 216635cea46498d8045c7cf0f03eaf72
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 2329583
+  timestamp: 1715442512963
+- kind: conda
+  name: ninja
+  version: 1.12.1
+  build: hc790b64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
+  sha256: b821cb72cb3ef08fab90a9bae899510e6cf3c23b5da6070d1ec30099dfe6a5be
+  md5: a557dde55343e03c68cd7e29e7f87279
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 285150
+  timestamp: 1715441052517
+- kind: conda
+  name: nspr
+  version: '4.36'
+  build: h5833ebf_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
+  sha256: 71f790d3dafe309e46c2214a6354d8d1818d646d637b2f5f9f84c5aa5c315a42
+  md5: 026a08bd5b6a2a2f240c00c32446156d
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
   license: MPL-2.0
   license_family: MOZILLA
-  size: 1908769
-  timestamp: 1708065399315
+  size: 202873
+  timestamp: 1729545964601
+- kind: conda
+  name: nspr
+  version: '4.36'
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
+  sha256: a87471d9265a7c02a98c20debac8b13afd80963968ed7b1c1c2ac7b80955ce31
+  md5: de9cd5bca9e4918527b9b72b6e2e1409
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 230204
+  timestamp: 1729545773406
+- kind: conda
+  name: nspr
+  version: '4.36'
+  build: h5ad3122_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
+  sha256: 404a4ec0430fbdce53fee00d9acf9f307aa9b3a6d06b5696c38ca3f92195a490
+  md5: 6170d131ea39ca6e8f6695507c9d3388
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 235389
+  timestamp: 1729545760194
+- kind: conda
+  name: nspr
+  version: '4.36'
+  build: h97d8b74_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.36-h97d8b74_0.conda
+  sha256: c98566d1280b73d8660f9e9db5a735afb2512a93e04dff0de1e51b2af9133d21
+  md5: 9367273bb726a8991cd9bf9b1a022f57
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 208747
+  timestamp: 1729546041279
 - kind: conda
   name: nss
-  version: '3.98'
-  build: hc5a5cc2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.98-hc5a5cc2_0.conda
-  sha256: d1506d21d8375c1dbdd5fee11cbb6799f8f129a54bc837ca5b8baa43fbe3d36d
-  md5: 7b72650a6c08894c36bed9aebb3b32dc
+  version: '3.106'
+  build: h6f44f80_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.106-h6f44f80_0.conda
+  sha256: de7cc89e24b7e72c9f842534af205b566d7bceb95307aad0434a40e2ec13e73e
+  md5: 243f6ae13f81edd8e82f0baddab0aaf2
   depends:
-  - libgcc-ng >=12
-  - libsqlite >=3.45.1,<4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
+  - __osx >=11.0
+  - libcxx >=17
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 2011672
-  timestamp: 1708065149436
+  size: 1814292
+  timestamp: 1729811695707
 - kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312h470d778_0
+  name: nss
+  version: '3.106'
+  build: hbde9d96_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.106-hbde9d96_0.conda
+  sha256: 3d1fbe1972d2106d06d211d95857d1836608fa1d27f5d4ab14b8788205bf59df
+  md5: daf45dad51ce90d321897cca2d1036da
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1902087
+  timestamp: 1729811793532
+- kind: conda
+  name: nss
+  version: '3.106'
+  build: hcffee33_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
-  sha256: 23767677a7790bee5457d5e75ebd508b9a31c5354216f4310dd1acfca3f7a6f9
-  md5: 9cebf5a06cb87d4569cd68df887af476
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
+  sha256: 76115ba1a5b5fbb7e3b471c84e983b514394c800adee30b158799ecdc15ded66
+  md5: e132b0f4cec9a1476c5c4da3722fc124
+  depends:
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1990164
+  timestamp: 1729814601835
+- kind: conda
+  name: nss
+  version: '3.106'
+  build: hdf54f9c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
+  sha256: e5dd3e57498decdef87ff641fa6b7bd5484fce3f2783811ee5ec278bc9e71281
+  md5: efe735c7dc47dddbb14b3433d11c6feb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2001391
+  timestamp: 1729811441549
+- kind: conda
+  name: numpy
+  version: 2.1.2
+  build: py311h394b0bb_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.2-py311h394b0bb_0.conda
+  sha256: 70bbd9d0d8b71230fbcd15b70abd2fc25296bf9f5d0998cb4505becee72021fc
+  md5: 530bb67b583c4411577ae86f601cc91f
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8099526
+  timestamp: 1728240345835
+- kind: conda
+  name: numpy
+  version: 2.1.2
+  build: py311h71ddf71_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.2-py311h71ddf71_0.conda
+  sha256: da4c6cf1a51afc95aeeecf403cd1efbaed0ab19567d59a3e2e316313073476e4
+  md5: 4e72b55892331ada8fbcf5954df582f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9099547
+  timestamp: 1728240501130
+- kind: conda
+  name: numpy
+  version: 2.1.2
+  build: py312h2eb110b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.2-py312h2eb110b_0.conda
+  sha256: eba7ea647685325e7c09d4c4445047d36e754e2444389c8b6aa41e8a4171216c
+  md5: 548aab48a0d2bf1a2a6a6542b4fd3c7c
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
+  - libgcc >=13
   - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
+  - libstdcxx >=13
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -12071,20 +12626,21 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6614296
-  timestamp: 1707225994762
+  size: 7129746
+  timestamp: 1728240412984
 - kind: conda
   name: numpy
-  version: 1.26.4
-  build: py312h8442bc7_0
+  version: 2.1.2
+  build: py312h801f5e3_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
-  sha256: c8841d6d6f61fd70ca80682efbab6bdb8606dc77c68d8acabfbd7c222054f518
-  md5: d83fc83d589e2625a3451c9a7e21047c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.2-py312h801f5e3_0.conda
+  sha256: 7e6840963d5395a59cb0aca32d43fd4e539c00a0677fcad16e4a3ab1f5c7aab7
+  md5: 3f9101c02190f155b6525490238fc794
   depends:
+  - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
+  - libcxx >=17
   - liblapack >=3.9.0,<4.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
@@ -12093,16 +12649,16 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6073136
-  timestamp: 1707226249608
+  size: 6436873
+  timestamp: 1728240394809
 - kind: conda
   name: numpy
-  version: 1.26.4
-  build: py312h8753938_0
+  version: 2.1.2
+  build: py312hf10105a_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-  sha256: 73570817a5109d396b4ebbe5124a89525959269fd33fa33fd413700289fbe0ef
-  md5: f9ac74c3b07c396014434aca1e58d362
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.2-py312hf10105a_0.conda
+  sha256: 81aadbcee02b5cbf74b543c29b0bbb7917431ee07d83351267f1fcad35d787c8
+  md5: ff10ff589eedbf2006ccda86d11150a2
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -12116,51 +12672,8 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6495445
-  timestamp: 1707226412944
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312he3a82b2_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
-  sha256: 6152b73fba3e227afa4952df8753128fc9669bbaf142ee8f9972bf9df3bf8856
-  md5: 96c61a21c4276613748dba069554846b
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6990646
-  timestamp: 1707226178262
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312heda63a1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
-  sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
-  md5: d8285bea2a350f63fab23bf460221f3f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7484186
-  timestamp: 1707225809722
+  size: 7048272
+  timestamp: 1728665362128
 - kind: conda
   name: ocl-icd
   version: 2.3.2
@@ -12179,92 +12692,96 @@ packages:
 - kind: conda
   name: openexr
   version: 3.2.2
-  build: h2c51e1d_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-h2c51e1d_1.conda
-  sha256: 243b221c708bbe7f5c0fd72bdbd944a08f4ea9bc1e52b4f12f7fdb5f59633e13
-  md5: 4ccfab8e79256a8480165969dd1d350c
-  depends:
-  - imath >=3.1.11,<3.1.12.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1361156
-  timestamp: 1709261019544
-- kind: conda
-  name: openexr
-  version: 3.2.2
-  build: h3f0570e_1
-  build_number: 1
+  build: h2627bef_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h3f0570e_1.conda
-  sha256: 6d2b2adb875b8b5a052f423dd9c6b9df90fbecd9d726aefafcd18f3b74a9118f
-  md5: 95bd8b6b83801d99b064c785585bd15d
+  url: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h2627bef_2.conda
+  sha256: a0eef2672e778c22416dbbedd0be47fb32d745c402f8a250f3015e0cacbe1d9a
+  md5: e54052079776261c205927064e54b921
   depends:
-  - imath >=3.1.11,<3.1.12.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
+  - __osx >=10.13
+  - imath >=3.1.12,<3.1.13.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1329934
-  timestamp: 1709261129338
+  size: 1287176
+  timestamp: 1726024906174
 - kind: conda
   name: openexr
   version: 3.2.2
-  build: h72640d8_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
-  sha256: 23a080dc31c2d557719c928c2685e2952d5b36b70aecbfd962824bd0b414cf9c
-  md5: 3cecd7892a09d59f64a3e119647630f9
+  build: h78594a9_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-h78594a9_2.conda
+  sha256: 031f9b050ab64367a7da975e8165fa6ff8ad1324b07876debbbeddee81f1c8be
+  md5: 274ed28a7ca293e2a38fa599555ebcaa
   depends:
-  - imath >=3.1.11,<3.1.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1394661
+  timestamp: 1726024774994
+- kind: conda
+  name: openexr
+  version: 3.2.2
+  build: h9aba623_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h9aba623_2.conda
+  sha256: e4807540184853f758386c62656bd5f9c7d93470b3fb43a6b33de21076dd87d6
+  md5: 742b266c64e3ed5d170d5972eed9bfd5
+  depends:
+  - imath >=3.1.12,<3.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 1208041
-  timestamp: 1709260904190
+  size: 1201419
+  timestamp: 1726025286785
 - kind: conda
   name: openexr
   version: 3.2.2
-  build: haf962dd_1
-  build_number: 1
+  build: hab01212_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-hab01212_2.conda
+  sha256: 5317b63c63fb57f0de109dcecb38ffb8ff05747eaee90b6771697dec198f5c8d
+  md5: 104fb7fbb910fe9d66fe81d1611baf2c
+  depends:
+  - __osx >=11.0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1248482
+  timestamp: 1726024848729
+- kind: conda
+  name: openexr
+  version: 3.3.1
+  build: hccdc605_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-haf962dd_1.conda
-  sha256: 01d773a14124929abd6c26169d900ce439f9df8a9e37d3ea197c7f71f61e7906
-  md5: 34e58e21fc28e404207d6ce4287da264
+  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
+  sha256: de1abf7be0caca0cd83174ea77a9dbfeb1d36d748508e524cd2b9253ec3d86f6
+  md5: 907ffbb8a276c12c5a8a8aed2c5a10f9
   depends:
-  - imath >=3.1.11,<3.1.12.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - __glibc >=2.17,<3.0.a0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1466865
-  timestamp: 1709260550301
-- kind: conda
-  name: openexr
-  version: 3.2.2
-  build: hdf561d4_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-hdf561d4_1.conda
-  sha256: 138e7306bce957fda18199270997dfedca1acd6d835b0ba3e9a3090998674a6b
-  md5: 0372e30a92ab93025acce24df8eed52a
-  depends:
-  - imath >=3.1.11,<3.1.12.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1388438
-  timestamp: 1709260386569
+  size: 1405340
+  timestamp: 1729546542495
 - kind: conda
   name: openh264
   version: 2.4.1
@@ -12357,94 +12874,82 @@ packages:
   size: 590466
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: h0d3ecfb_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
-  sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
-  md5: eb580fb888d93d5d550c557323ac5cee
-  depends:
-  - ca-certificates
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2855250
-  timestamp: 1710793435903
-- kind: conda
-  name: openssl
-  version: 3.2.1
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_1.conda
-  sha256: 055a26e99ebc12ae0cf23266a0e62e71b59b8ce8cafb1ebb87e375ef9c758d7b
-  md5: e95eb18d256edc72058e0dc9be5338a0
-  depends:
-  - ca-certificates
-  - libgcc-ng >=12
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 3380844
-  timestamp: 1710793424665
-- kind: conda
-  name: openssl
-  version: 3.2.1
-  build: hcfcfb64_1
-  build_number: 1
+  version: 3.3.2
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
-  sha256: 61ce4e11c3c26ed4e4d9b7e7e2483121a1741ad0f9c8db0a91a28b6e05182ce6
-  md5: 958e0418e93e50c575bff70fbcaa12d8
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+  sha256: a45c42f3577294e22ac39ddb6ef5a64fd5322e8a6725afefbf4f2b4109340bf9
+  md5: 1dc86753693df5e3326bb8a85b74c589
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  constrains:
-  - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 8230112
-  timestamp: 1710796158475
+  size: 8396053
+  timestamp: 1725412961673
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hd590300_1
-  build_number: 1
+  version: 3.3.2
+  build: h8359307_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
+  sha256: 940fa01c4dc6152158fe8943e05e55a1544cab639df0994e3b35937839e4f4d1
+  md5: 1773ebccdc13ec603356e8ff1db9e958
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2882450
+  timestamp: 1725410638874
+- kind: conda
+  name: openssl
+  version: 3.3.2
+  build: h86ecc28_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
+  sha256: 4669d26dbf81e4d72093d8260f55d19d57204d82b1d9440be83d11d313b5990c
+  md5: 9e1e477b3f8ee3789297883faffa708b
+  depends:
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 3428083
+  timestamp: 1725412266679
+- kind: conda
+  name: openssl
+  version: 3.3.2
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
-  sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
-  md5: 9d731343cff6ee2e5a25c4a091bf8e2a
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
+  md5: 4d638782050ab6faa27275bed57e9b4e
   depends:
+  - __glibc >=2.17,<3.0.a0
   - ca-certificates
-  - libgcc-ng >=12
-  constrains:
-  - pyopenssl >=22.1
+  - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 2865379
-  timestamp: 1710793235846
+  size: 2891789
+  timestamp: 1725410790053
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hd75f5a5_1
-  build_number: 1
+  version: 3.3.2
+  build: hd23fc13_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
-  sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
-  md5: 570a6f04802df580be529f3a72d2bbf7
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
+  sha256: 2b75d4b56e45992adf172b158143742daeb316c35274b36f385ccb6644e93268
+  md5: 2ff47134c8e292868a4609519b1ea3b6
   depends:
+  - __osx >=10.13
   - ca-certificates
-  constrains:
-  - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2506344
-  timestamp: 1710793930515
+  size: 2544654
+  timestamp: 1725410973572
 - kind: conda
   name: osqp-eigen
   version: 0.8.1
@@ -12535,147 +13040,130 @@ packages:
   size: 35336
   timestamp: 1709559434463
 - kind: conda
-  name: p11-kit
-  version: 0.24.1
-  build: h29577a5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
-  sha256: 3e124859307956f9f390f39c74b9700be4843eaaf56891c4b09da75b1bd5b57f
-  md5: 8f111d56c8c7c1895bde91a942c43d93
+  name: packaging
+  version: '24.1'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+  md5: cbe1bb1f21567018ce595d9c2be0f0db
   depends:
-  - libffi >=3.4.2,<3.5.0a0
-  - libtasn1 >=4.18.0,<5.0a0
-  license: MIT
-  license_family: MIT
-  size: 890711
-  timestamp: 1654869118646
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50290
+  timestamp: 1718189540074
 - kind: conda
-  name: p11-kit
-  version: 0.24.1
-  build: h65f8906_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
-  sha256: e16fbaadb2714c0965cb76de32fe7d13a21874cec02c97efef8ac51f4fda86fc
-  md5: e936a0ee28be948846108582f00e2d61
-  depends:
-  - libffi >=3.4.2,<3.5.0a0
-  - libtasn1 >=4.18.0,<5.0a0
-  license: MIT
-  license_family: MIT
-  size: 834487
-  timestamp: 1654869241699
-- kind: conda
-  name: p11-kit
-  version: 0.24.1
-  build: h9f2702f_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
-  sha256: 24c37c8d131e3e72350a398060ec163eb48db75f19339b09bcf2d860ad0367fe
-  md5: a27524877b697f8e18d38ad30ba022f5
-  depends:
-  - libffi >=3.4.2,<3.5.0a0
-  - libgcc-ng >=12
-  - libtasn1 >=4.18.0,<5.0a0
-  license: MIT
-  license_family: MIT
-  size: 4947687
-  timestamp: 1654869375890
-- kind: conda
-  name: p11-kit
-  version: 0.24.1
-  build: hc5aa10d_0
+  name: pango
+  version: 1.54.0
+  build: h4c5309f_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
-  sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
-  md5: 56ee94e34b71742bbdfa832c974e47a8
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+  sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
+  md5: 7df02e445367703cd87a574046e3a6f0
   depends:
-  - libffi >=3.4.2,<3.5.0a0
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0,<10.0a0
   - libgcc-ng >=12
-  - libtasn1 >=4.18.0,<5.0a0
-  license: MIT
-  license_family: MIT
-  size: 4702497
-  timestamp: 1654868759643
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  license: LGPL-2.1-or-later
+  size: 447117
+  timestamp: 1719839527713
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: h0ad2156_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
-  sha256: 226714bbf89d45bf7da4c7551e21b8a833f51d33379fe3dfbfe31b72832d4dba
-  md5: 9c8651803886ce9d5983e107a0df4ea8
+  version: '10.44'
+  build: h070dd5b_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
+  sha256: e9f4b912e48514771d477f2ee955f59d4ff4ef799c3d4d16e4d0f335ce91df67
+  md5: 94022de9682cb1a0bb18a99cbc3541b3
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 836581
-  timestamp: 1708118455741
+  size: 884590
+  timestamp: 1723488793100
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: h17e33f8_0
+  version: '10.44'
+  build: h297a79d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+  sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
+  md5: 147c83e5e44780c7492998acbacddf52
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 618973
+  timestamp: 1723488853807
+- kind: conda
+  name: pcre2
+  version: '10.44'
+  build: h3d7b363_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
-  sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
-  md5: d0485b8aa2cedb141a7bd27b4efa4c9c
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+  sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
+  md5: a3a3baddcfb8c80db84bec3cb7746fb8
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 818317
-  timestamp: 1708118868321
+  size: 820831
+  timestamp: 1723489427046
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: h26f9a81_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
-  sha256: 4bf7b5fa091f5e7ab0b78778458be1e81c1ffa182b63795734861934945a63a7
-  md5: 1ddc87f00014612830f3235b5ad6d821
+  version: '10.44'
+  build: h7634a1b_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+  sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
+  md5: 58cde0663f487778bcd7a0c8daf50293
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 615219
-  timestamp: 1708118184900
+  size: 854306
+  timestamp: 1723488807216
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: hcad00b1_0
+  version: '10.44'
+  build: hba22ea6_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
-  sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
-  md5: 8292dea9e022d9610a11fce5e0896ed8
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
   depends:
+  - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 950847
-  timestamp: 1708118050286
-- kind: conda
-  name: pcre2
-  version: '10.43'
-  build: hd0f9c67_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
-  sha256: 1bac2077caa28f0764f955e522468b98316b99b2d0904e9d93a01297fe1b7ba2
-  md5: 1275fa549338ecdc8b7793589ac09150
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 880930
-  timestamp: 1708117999756
+  size: 952308
+  timestamp: 1723488734144
 - kind: conda
   name: pixman
   version: 0.43.2
@@ -12753,81 +13241,86 @@ packages:
 - kind: conda
   name: pkg-config
   version: 0.29.2
-  build: h2bf4dc2_1008
-  build_number: 1008
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
-  sha256: f2f64c4774eea3b789c9568452d8cd776bdcf7e2cda0f24bfa9dbcbd7fbb9f6f
-  md5: 8ff5bccb4dc5d153e79b068e0bb301c5
-  depends:
-  - libglib >=2.64.6,<3.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 33990
-  timestamp: 1604184834061
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: h36c2ea0_1008
-  build_number: 1008
+  build: h4bc722e_1009
+  build_number: 1009
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h36c2ea0_1008.tar.bz2
-  sha256: 8b35a077ceccdf6888f1e82bd3ea281175014aefdc2d4cf63d7a4c7e169c125c
-  md5: fbef41ff6a4c8140c30057466a1cdd47
+  url: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+  sha256: c9601efb1af5391317e04eca77c6fe4d716bf1ca1ad8da2a05d15cb7c28d7d4e
+  md5: 1bee70681f504ea424fb07cdb090c001
   depends:
-  - libgcc-ng >=7.5.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 123341
-  timestamp: 1604184579935
+  size: 115175
+  timestamp: 1720805894943
 - kind: conda
   name: pkg-config
   version: 0.29.2
-  build: ha3d46e9_1008
-  build_number: 1008
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-ha3d46e9_1008.tar.bz2
-  sha256: f60d1c03c7d10e8926e767981872fdd6002d2094925df598a53c58261524c151
-  md5: 352bc6fb446a7ca608c61b33c1d5eb98
+  build: h88c491f_1009
+  build_number: 1009
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
+  sha256: 86b0c40c8b569dbc164cb1de098ddabf4c240a5e8f38547aab00493891fa67f3
+  md5: 122d6514d415fbe02c9b58aee9f6b53e
   depends:
-  - libiconv >=1.16,<2.0.0a0
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 269087
-  timestamp: 1650238856925
+  size: 36118
+  timestamp: 1720806338740
 - kind: conda
   name: pkg-config
   version: 0.29.2
-  build: hab62308_1008
-  build_number: 1008
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2
-  sha256: e59e69111709d097f9938e72ba19811ec1ef36aababdbed77bd7c767f15639e0
-  md5: 8d173d52214679033079d1b0582075aa
-  depends:
-  - libglib >=2.70.2,<3.0a0
-  - libiconv >=1.16,<2.0.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 46049
-  timestamp: 1650239029040
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: hb9de7d4_1008
-  build_number: 1008
+  build: hce167ba_1009
+  build_number: 1009
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2
-  sha256: 0d6af1ebd78e231281f570ad7ddd1e2789e485c94fba6b5cef4e8ad23ff7f3bf
-  md5: 1d0a81d5da1378d9b989383556c20eac
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
+  md5: 05eda637f6465f7e8c5ab7e341341ea9
   depends:
-  - libgcc-ng >=7.5.0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 298687
-  timestamp: 1604185362484
+  size: 54834
+  timestamp: 1720806008171
+- kind: conda
+  name: pkg-config
+  version: 0.29.2
+  build: hde07d2e_1009
+  build_number: 1009
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
+  sha256: d82f4655b2d67fe12eefe1a3eea4cd27d33fa41dbc5e9aeab5fd6d3d2c26f18a
+  md5: b4f41e19a8c20184eec3aaf0f0953293
+  depends:
+  - __osx >=11.0
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 49724
+  timestamp: 1720806128118
+- kind: conda
+  name: pkg-config
+  version: 0.29.2
+  build: hf7e621a_1009
+  build_number: 1009
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
+  sha256: 636122606556b651ad4d0ac60c7ab6b379e98f390359a1f0c05ad6ba6fb3837f
+  md5: 0b1b9f9e420e4a0e40879b61f94ae646
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 239818
+  timestamp: 1720806136579
 - kind: conda
   name: portaudio
   version: 19.6.0
@@ -12912,73 +13405,80 @@ packages:
 - kind: conda
   name: pthread-stubs
   version: '0.4'
-  build: h27ca646_1001
-  build_number: 1001
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
-  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
-  md5: d3f26c6494d4105d4ecb85203d687102
-  license: MIT
-  license_family: MIT
-  size: 5696
-  timestamp: 1606147608402
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h36c2ea0_1001
-  build_number: 1001
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
-  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
-  md5: 22dad4df6e8630e8dff2428f6f6a7036
-  depends:
-  - libgcc-ng >=7.5.0
-  license: MIT
-  license_family: MIT
-  size: 5625
-  timestamp: 1606147468727
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hb9de7d4_1001
-  build_number: 1001
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
-  sha256: f1d7ff5e06cc515ec82010537813c796369f8e9dde46ce3f4fa1a9f70bc7db7d
-  md5: d0183ec6ce0b5aaa3486df25fa5f0ded
-  depends:
-  - libgcc-ng >=7.5.0
-  license: MIT
-  license_family: MIT
-  size: 5657
-  timestamp: 1606147738742
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hc929b4f_1001
-  build_number: 1001
+  build: h00291cd_1002
+  build_number: 1002
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
-  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
-  md5: addd19059de62181cd11ae8f4ef26084
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 5653
-  timestamp: 1606147699844
+  size: 8364
+  timestamp: 1726802331537
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: h86ecc28_1002
+  build_number: 1002
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+  sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+  md5: bb5a90c93e3bac3d5690acf76b4a6386
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8342
+  timestamp: 1726803319942
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hb9d3cd8_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hd74edd7_1002
+  build_number: 1002
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
 - kind: conda
   name: pthreads-win32
   version: 2.9.1
-  build: hfa6e2cd_3
-  build_number: 3
+  build: h2466b09_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
-  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
-  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
+  sha256: b989bdcf0a22ba05a238adac1ad3452c11871681f565e509f629e225a26b7d45
+  md5: cf98a67a1ec8040b42455002a24f0b0b
   depends:
-  - vc 14.*
-  license: LGPL 2
-  size: 144301
-  timestamp: 1537755684331
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 265827
+  timestamp: 1728400965968
 - kind: conda
   name: pugixml
   version: '1.14'
@@ -13095,248 +13595,121 @@ packages:
   timestamp: 1705690081905
 - kind: conda
   name: pybind11
-  version: 2.12.0
-  build: py312h0d7def4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.12.0-py312h0d7def4_0.conda
-  sha256: 72c89925043009f7c8c6d0d27e8a2f926238470d25d5d9c28ca41d40cad9e6e8
-  md5: bc52c4cd9153f85fd295ecd088ee9d7c
+  version: 2.13.6
+  build: pyh085cc03_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+  sha256: fbcf9f6dfaf4877afe64f3b8a3eb848bfe896ef98b4b3761542cd08095f3d0a0
+  md5: 7b029bb9de2902139df04ddb0477713b
   depends:
-  - pybind11-global 2.12.0 py312h0d7def4_0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - pybind11-global 2.13.6 pyh085cc03_1
+  - python
   constrains:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 241777
-  timestamp: 1711604433336
-- kind: conda
-  name: pybind11
-  version: 2.12.0
-  build: py312h0fef576_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.12.0-py312h0fef576_0.conda
-  sha256: 181f659f133172770a18dbb1a5da47e101ca88eb33a5bf33c70cd219618f2c08
-  md5: 4ca78040c1ef06d56ac2ac1bd4101fba
-  depends:
-  - libcxx >=16
-  - pybind11-global 2.12.0 py312h0fef576_0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 192825
-  timestamp: 1711604237302
-- kind: conda
-  name: pybind11
-  version: 2.12.0
-  build: py312h8572e83_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.12.0-py312h8572e83_0.conda
-  sha256: 0471931cc9dda3ead2fe4483d28ab3aae64c6eca660532c7e8eb7e344dee2e22
-  md5: 9435d1879698bab6a762b0763a18759d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pybind11-global 2.12.0 py312h8572e83_0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 192343
-  timestamp: 1711603930338
-- kind: conda
-  name: pybind11
-  version: 2.12.0
-  build: py312h8f0b210_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-2.12.0-py312h8f0b210_0.conda
-  sha256: c2945f5ff8eda18af66ca00bcc8feb2b19ff7616d58888880a0e069b42709b4f
-  md5: 36914f5874317a88e16f88bf27e9bbc6
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pybind11-global 2.12.0 py312h8f0b210_0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 192664
-  timestamp: 1711604073917
-- kind: conda
-  name: pybind11
-  version: 2.12.0
-  build: py312h9230928_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.12.0-py312h9230928_0.conda
-  sha256: 9564c5d37a2a9e0fbb37f8f6189df0e7a6646666012de2b6f96dd86e242abcde
-  md5: e7e7a38cae33814d2afd22d95dd3dee9
-  depends:
-  - libcxx >=16
-  - pybind11-global 2.12.0 py312h9230928_0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 193309
-  timestamp: 1711604188798
+  size: 185569
+  timestamp: 1729256651326
 - kind: conda
   name: pybind11-global
-  version: 2.12.0
-  build: py312h0d7def4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.12.0-py312h0d7def4_0.conda
-  sha256: 5f45ff09090a1c2cc3ade77c830eda87add2d04f9c2e5dcc4e1f5076ec5f9883
-  md5: be7831ba7087efe60342f4f97f62d24b
+  version: 2.13.6
+  build: pyh085cc03_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+  sha256: 4ba255f3aa2d72fcc992d1a8939a758d045f4d2ac946feabc6ce85fb6b2507aa
+  md5: 9092fb5f6e54792440ced2323da305e7
   depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - python
   constrains:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 176749
-  timestamp: 1711604106092
-- kind: conda
-  name: pybind11-global
-  version: 2.12.0
-  build: py312h0fef576_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.12.0-py312h0fef576_0.conda
-  sha256: 34b7aa102cce80efa8524971f67bd96b749281a2cde93b3da67d0fd6e6b1d26f
-  md5: ce44a1834f0637f779573cf27a2474e4
-  depends:
-  - libcxx >=16
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 177898
-  timestamp: 1711604149332
-- kind: conda
-  name: pybind11-global
-  version: 2.12.0
-  build: py312h8572e83_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.12.0-py312h8572e83_0.conda
-  sha256: 50fb911217de2da9fabb188a0802d90ae9417e83355da430c595fa55537b4f04
-  md5: 63c1f3c4d0e0f8c6faeb8f87ea399e1a
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 176899
-  timestamp: 1711603910629
-- kind: conda
-  name: pybind11-global
-  version: 2.12.0
-  build: py312h8f0b210_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-global-2.12.0-py312h8f0b210_0.conda
-  sha256: 0c8c472ce83edfc0341f39db3310477d72ba0f25a91d953e48ac6928c0832135
-  md5: 6f5496e5f363347b5f32bd04bec5fbb9
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 176982
-  timestamp: 1711604016096
-- kind: conda
-  name: pybind11-global
-  version: 2.12.0
-  build: py312h9230928_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.12.0-py312h9230928_0.conda
-  sha256: a45d11fcf75821bb13ba6c03305747317d41e5162ac4f4c593d69999054f643a
-  md5: 2e195e96d1f285c8b47ce056195af079
-  depends:
-  - libcxx >=16
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 177407
-  timestamp: 1711604116976
+  size: 181129
+  timestamp: 1729256629202
 - kind: conda
   name: python
-  version: 3.12.2
-  build: h2628c8c_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
-  sha256: b8eda863b48ae4531635e23fd15e759d93212b6204c6847d591e25fa5fd67477
-  md5: be8803e9f75a477df61d4aabea3c1246
+  version: 3.11.10
+  build: ha513fb2_3_cpython
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
+  md5: 1a88c32ab9e997380ba1f9306624f805
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   constrains:
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 16083296
-  timestamp: 1708116662336
+  size: 15442415
+  timestamp: 1729043110107
 - kind: conda
   name: python
-  version: 3.12.2
-  build: h43d1f9e_0_cpython
+  version: 3.11.10
+  build: hc5c86c4_3_cpython
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+  sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
+  md5: 9e1ad55c87368e662177661a998feed5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30543977
+  timestamp: 1729043512711
+- kind: conda
+  name: python
+  version: 3.12.7
+  build: h5d932e8_0_cpython
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.2-h43d1f9e_0_cpython.conda
-  sha256: 16c8e77c01b814d836af632ef77eac21b64b9e398a11e1403a3a1802bb5be366
-  md5: 3a41090f2ef0868f119825593948ed46
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.7-h5d932e8_0_cpython.conda
+  sha256: 25570873d92d4d9490c6db780cc85e6c28bd3ff61dc1ece79f602cf82bc73bc1
+  md5: e6cab21bb5787270388939cf41cc5f43
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-aarch64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
+  - libgcc >=13
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -13344,79 +13717,25 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 13823577
-  timestamp: 1708116074721
+  size: 13762126
+  timestamp: 1728057461028
 - kind: conda
   name: python
-  version: 3.12.2
-  build: h9f0c242_0_cpython
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
-  sha256: 7647ac06c3798a182a4bcb1ff58864f1ef81eb3acea6971295304c23e43252fb
-  md5: 0179b8007ba008cf5bec11f3b3853902
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 14596811
-  timestamp: 1708118065292
-- kind: conda
-  name: python
-  version: 3.12.2
-  build: hab00c5b_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
-  sha256: ddb7a2d8d78046bda5d7631e6814f9468d2eb054e10f86f4648c9d1fdaa30c0f
-  md5: ad7b68400f3a6ebe72b00be093c7f301
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 32312631
-  timestamp: 1708118077305
-- kind: conda
-  name: python
-  version: 3.12.2
-  build: hdf0ec26_0_cpython
+  version: 3.12.7
+  build: h739c21a_0_cpython
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
-  sha256: ccd6c55a286d51d907c878ed2bfa7d1becce0fee71374a9386c5eb90d803ac72
-  md5: 85e91138ae921a2771f57a50120272bd
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
+  sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
+  md5: e0d82e57ebb456077565e6d82cd4a323
   depends:
+  - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -13424,456 +13743,429 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 13085901
-  timestamp: 1708117361381
+  size: 12975439
+  timestamp: 1728057819519
 - kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
-  sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
-  md5: dccc2d142812964fcc6abdc97b672dff
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6385
-  timestamp: 1695147396604
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-4_cp312.conda
-  sha256: 4f4c3389b722cac9bf39183221332ab69e468351030ec5359042b50c5d975a15
-  md5: 6c09f8e580146d88f649780cebed01de
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6417
-  timestamp: 1695147418374
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
-  sha256: 82c154d95c1637604671a02a89e72f1382e89a4269265a03506496bd928f6f14
-  md5: 87201ac4314b911b74197e588cca3639
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6496
-  timestamp: 1695147498447
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
-  sha256: db25428e4f24f8693ffa39f3ff6dfbb8fd53bc298764b775b57edab1c697560f
-  md5: bbb3a02c78b2d8219d7213f76d644a2a
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6508
-  timestamp: 1695147497048
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
+  name: python
+  version: 3.12.7
+  build: hce54a09_0_cpython
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-  sha256: 488f8519d04b48f59bd6fde21ebe2d7a527718ff28aac86a8b53aa63658bdef6
-  md5: 17f4ccf6be9ded08bd0a376f489ac1a6
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
+  sha256: 2308cfa9ec563360d29ced7fd13a6b60b9a7b3cf8961a95c78c69f486211d018
+  md5: 21f1f7c6ccf6b747c5086d2422c230e1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  size: 15987537
+  timestamp: 1728057382072
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- kind: conda
+  name: python_abi
+  version: '3.12'
+  build: 5_cp312
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
+  sha256: 5ccdad9981753cc4a2d126e356673a21c0cd5b34e209cb8d476a3947d4ad9b39
+  md5: 62b20f305498284a07dc6c45fd0e5c87
   constrains:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6785
-  timestamp: 1695147430513
+  size: 6329
+  timestamp: 1723823366253
 - kind: conda
-  name: qt-main
-  version: 5.15.8
-  build: h07f8ed4_20
-  build_number: 20
+  name: python_abi
+  version: '3.12'
+  build: 5_cp312
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-h07f8ed4_20.conda
-  sha256: 3ce363d5822ae9addd3cda2b73e19889115803adf8cb45e0529752f38ad77cf4
-  md5: ad3ad3b5da9a52286814a2323eb3552b
-  depends:
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libclang13 >=15.0.7
-  - libcxx >=14
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.3.0,<8.4.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+  sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
+  md5: b76f9b1c862128e56ac7aa8cd2333de9
   constrains:
-  - qt 5.15.8
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 50049276
-  timestamp: 1711311604244
+  - python 3.12.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6278
+  timestamp: 1723823099686
+- kind: conda
+  name: python_abi
+  version: '3.12'
+  build: 5_cp312
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
+  sha256: 9486662af81a219e96d343449eff242f38d7c5128ced5ce5acf85857265058d6
+  md5: e8681f534453af7afab4cd2bc1423eec
+  constrains:
+  - python 3.12.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6730
+  timestamp: 1723823139725
 - kind: conda
   name: qt-main
-  version: 5.15.8
-  build: h112747c_20
-  build_number: 20
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h112747c_20.conda
-  sha256: 14f9075640d1abc7f8834420564f80aeaaf4da75e40dc3e4187f93d39f952418
-  md5: cea58006ee5e891fc2a70c6b64d41363
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
-  - dbus >=1.13.6,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libclang13 >=15.0.7
-  - libcups >=2.3.3,<2.4.0a0
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libxkbcommon >=1.6.0,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.3.0,<8.4.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
-  - xcb-util-wm >=0.4.1,<0.5.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-xf86vidmodeproto
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - qt 5.15.8
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 60849352
-  timestamp: 1711304658310
-- kind: conda
-  name: qt-main
-  version: 5.15.8
-  build: h5d96f70_20
-  build_number: 20
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5d96f70_20.conda
-  sha256: b3ba0dfaea58d64ec3d0a6eb5364a3d81b0157a02fc8c5ac86977a459822d0cc
-  md5: e5ed7c7330fdacd9be39c0dc198e4685
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
-  - dbus >=1.13.6,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libclang13 >=15.0.7
-  - libcups >=2.3.3,<2.4.0a0
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libxkbcommon >=1.6.0,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.3.0,<8.4.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
-  - xcb-util-wm >=0.4.1,<0.5.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-xf86vidmodeproto
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - qt 5.15.8
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 59974404
-  timestamp: 1711127651522
-- kind: conda
-  name: qt-main
-  version: 5.15.8
-  build: h98f5cd4_20
-  build_number: 20
+  version: 5.15.15
+  build: h07d6d3d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-h98f5cd4_20.conda
-  sha256: 166415427f27bbc7ee91a11eb5f263c964b5193d70172df7a52af889db7effea
-  md5: dc6ff6bc77f3326d1a0d6eea39a3ae7c
+  url: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.15-h07d6d3d_0.conda
+  sha256: 1776e3acf620e01c15164d02816ff7fba2332b1d3155921345186790d669c54e
+  md5: 525048cba1b5aa9c88c56e093b743ac9
   depends:
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libclang13 >=15.0.7
-  - libcxx >=14
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.3.0,<8.4.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
   - __osx >=10.13
-  - qt 5.15.8
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp17 >=17.0.6,<17.1.0a0
+  - libclang13 >=17.0.6
+  - libcxx >=17
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=16.4,<17.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.106,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 45779349
-  timestamp: 1711310440876
+  size: 46035885
+  timestamp: 1729903901466
 - kind: conda
   name: qt-main
-  version: 5.15.8
-  build: h9e85ed6_20
-  build_number: 20
+  version: 5.15.15
+  build: h264fbc2_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_20.conda
-  sha256: 548e948eb70174dad20151714a70319b9b2d220b75d407a88f4f5812f14fcdd2
-  md5: 312511ef95bf1418f20dd50041a4bc85
+  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
+  sha256: 77c78ce62e5c53ed529f035535283b96ee617ffd64ae1ea6a2dfdea186e39608
+  md5: e6e473c620bc0c3772dbed14f9eb4ab2
   depends:
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang13 >=15.0.7
-  - libglib >=2.80.0,<3.0a0
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=19.1.2
+  - libglib >=2.82.2,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - qt 5.15.8
+  - qt 5.15.15
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 60012507
-  timestamp: 1711306247296
+  size: 60059195
+  timestamp: 1729904868434
 - kind: conda
-  name: qt6-main
-  version: 6.6.3
-  build: h5dee92f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.6.3-h5dee92f_0.conda
-  sha256: 69ca8baf3402c9b56aa8080bffb98394e72d68379d0adf362dd7ac0d298445dd
-  md5: 13fa92ab9ec5b48198545c63083d13cb
-  depends:
-  - double-conversion >=3.3.0,<3.4.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang13 >=18.1.2
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - qt 6.6.3
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 96962467
-  timestamp: 1711465833681
-- kind: conda
-  name: qt6-main
-  version: 6.6.3
-  build: h993b442_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.6.3-h993b442_0.conda
-  sha256: 3a43895795ca2ea9ddf2b254fc248530ef0539f2aa498c4ed3e35e4552e575dc
-  md5: 48ba52e7d2342e117fad8e676837604c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
-  - dbus >=1.13.6,<2.0a0
-  - double-conversion >=3.3.0,<3.4.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang-cpp18.1 >=18.1.2,<18.2.0a0
-  - libclang13 >=18.1.2
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.120,<2.5.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm18 >=18.1.2,<18.2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libxkbcommon >=1.7.0,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.3.0,<8.4.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
-  - xcb-util-cursor >=0.1.4,<0.2.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
-  - xcb-util-wm >=0.4.1,<0.5.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - qt 6.6.3
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 51756563
-  timestamp: 1711468833910
-- kind: conda
-  name: qt6-main
-  version: 6.6.3
-  build: hd0aab4e_0
+  name: qt-main
+  version: 5.15.15
+  build: h374914d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.6.3-hd0aab4e_0.conda
-  sha256: 58d68b96706d57ac5cbda471c38868845e8d3fcfe6609b58cf0d30e4d11af0bd
-  md5: 7f418c52b72b52a4d96b91c85c9053b2
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
+  sha256: 333be9817b492b7303d3a01073d3cff71719e72ba11507141ddfdd89732dc7a8
+  md5: 26e8b00e73c114c9b787d36edcbf4424
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
+  - alsa-lib >=1.2.12,<1.3.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp19.1 >=19.1.2,<19.2.0a0
+  - libclang13 >=19.1.2
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.123,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=16.4,<17.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.7.0,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.106,<4.0a0
+  - openssl >=3.3.2,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  - xorg-xf86vidmodeproto
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 52549288
+  timestamp: 1729904847636
+- kind: conda
+  name: qt-main
+  version: 5.15.15
+  build: h3c8598d_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
+  sha256: efe565fbe7f0b0c39f3c179d383a8a3f39582934e225775927b9c05c9b9792ea
+  md5: 2b6e3e9f306565824c25f64df8953f39
+  depends:
+  - alsa-lib >=1.2.12,<1.3.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp19.1 >=19.1.2,<19.2.0a0
+  - libclang13 >=19.1.2
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.123,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=16.4,<17.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.7.0,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.106,<4.0a0
+  - openssl >=3.3.2,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  - xorg-xf86vidmodeproto
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  size: 51848391
+  timestamp: 1729887971802
+- kind: conda
+  name: qt-main
+  version: 5.15.15
+  build: h7d33341_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h7d33341_0.conda
+  sha256: 995563c7c2ae112179cb1cec67837af1624234a1e39e1ca86f6b5de44cbc6af8
+  md5: 065abdbfa76bdb7b89cee314a594055e
+  depends:
+  - __osx >=11.0
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp17 >=17.0.6,<17.1.0a0
+  - libclang13 >=17.0.6
+  - libcxx >=17
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=16.4,<17.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.106,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 50010318
+  timestamp: 1729905112196
+- kind: conda
+  name: qt6-main
+  version: 6.7.3
+  build: h20baabe_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
+  sha256: ea392f29b89505f878f4654f297674cd18a068abba764fd9b84802804ba97d23
+  md5: 1b22804cf94e520ff2bafc0a908dd6a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.12,<1.3.0a0
   - dbus >=1.13.6,<2.0a0
   - double-conversion >=3.3.0,<3.4.0a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.22.9,<1.23.0a0
-  - gstreamer >=1.22.9,<1.23.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang-cpp18.1 >=18.1.2,<18.2.0a0
-  - libclang13 >=18.1.2
+  - harfbuzz >=9.0.0,<10.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp19.1 >=19.1.0,<19.2.0a0
+  - libclang13 >=19.1.0
   - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.120,<2.5.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - libdrm >=2.4.123,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.82.1,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm18 >=18.1.2,<18.2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxcb >=1.15,<1.16.0a0
+  - libllvm19 >=19.1.0,<19.2.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=16.4,<17.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
   - libxkbcommon >=1.7.0,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.3.0,<8.4.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
-  - xcb-util-cursor >=0.1.4,<0.2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-cursor >=0.1.5,<0.2.0a0
   - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
-  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
   - xorg-libice >=1.1.1,<2.0a0
   - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - qt 6.6.3
+  - qt 6.7.3
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 52929664
-  timestamp: 1711464313685
+  size: 47296097
+  timestamp: 1727454717035
+- kind: conda
+  name: qt6-main
+  version: 6.7.3
+  build: hfb098fa_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_1.conda
+  sha256: c10933396b409f74f05fe7036ddf2b129e219dd3939170c3ebb0fd0790cd14ac
+  md5: 3dd4b78a610e48def640c3c9acd0c7e7
+  depends:
+  - double-conversion >=3.3.0,<3.4.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=19.1.0
+  - libglib >=2.82.1,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 6.7.3
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 88587578
+  timestamp: 1727941590323
 - kind: conda
   name: readline
   version: '8.2'
@@ -13938,56 +14230,61 @@ packages:
   timestamp: 1679532707590
 - kind: conda
   name: rhash
-  version: 1.4.4
-  build: h0dc2134_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
-  sha256: f1ae47e8c4e46f856faf5d8ee1e5291f55627aa93401b61a877f18ade5780c87
-  md5: 55a2ada70c8a208c01f77978f2783121
-  license: MIT
-  license_family: MIT
-  size: 177229
-  timestamp: 1693456080514
-- kind: conda
-  name: rhash
-  version: 1.4.4
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.4-h31becfc_0.conda
-  sha256: 11c44602ac8f3054da83bfcfff0d8e04e83e231b51b0f8c660ff007669de14ff
-  md5: 8e4df96fa39923f420006095785a0e4b
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 199565
-  timestamp: 1693455889616
-- kind: conda
-  name: rhash
-  version: 1.4.4
-  build: hb547adb_0
+  version: 1.4.5
+  build: h7ab814d_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
-  sha256: 3ab595e2280ed2118b6b1e8ce7e5949da2047846c81b6af1bbf5ac859d062edd
-  md5: 710c4b1abf65b697c1d9716eba16dbb0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.5-h7ab814d_0.conda
+  sha256: e6a3e9dbfcb5ad5d69a20c8ac237d37a282a95983314a28912fc54208c5db391
+  md5: 352b210f81798ae1e2f25a98ef4b3b54
+  depends:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 177491
-  timestamp: 1693456037505
+  size: 177240
+  timestamp: 1728886815751
 - kind: conda
   name: rhash
-  version: 1.4.4
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
-  sha256: 12711d2d4a808a503c2e49b25d26ecb351435521e814c154e682dd2be71c2611
-  md5: ec972a9a2925ac8d7a19eb9606561fff
+  version: 1.4.5
+  build: h86ecc28_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.5-h86ecc28_0.conda
+  sha256: 82f3555c8f4fa76faf111622766457a8d17755bf493c0ac72ee59f4dad71d994
+  md5: 93bac703d92dafc337db454e6e93a520
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 185144
-  timestamp: 1693455923632
+  size: 201958
+  timestamp: 1728886717057
+- kind: conda
+  name: rhash
+  version: 1.4.5
+  build: ha44c9a9_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.5-ha44c9a9_0.conda
+  sha256: 8680069a88f33e96046cf09c3c973074976064c5f13c282bf0e6d6a798f4f7ab
+  md5: a7a3324229bba7fd1c06bcbbb26a420a
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 178400
+  timestamp: 1728886821902
+- kind: conda
+  name: rhash
+  version: 1.4.5
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.5-hb9d3cd8_0.conda
+  sha256: 04677caac29ec64a5d41d0cca8dbec5f60fa166d5458ff5a4393e4dc08a4799e
+  md5: 9af0e7981755f09c81421946c4bcea04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 186921
+  timestamp: 1728886721623
 - kind: conda
   name: robot-testing-framework
   version: 2.0.1
@@ -14067,62 +14364,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 186609
   timestamp: 1674117260864
-- kind: conda
-  name: scotch
-  version: 7.0.4
-  build: h23d43cc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scotch-7.0.4-h23d43cc_1.conda
-  sha256: 63bed3999eb07598cb249b670fb36f8f3278cf4abebdafd3b9d908fba904e8bf
-  md5: 29663db7f60e56db7a2576ddf5a7fdc2
-  depends:
-  - libscotch 7.0.4 h91e35bf_1
-  license: CECILL-C
-  size: 92023
-  timestamp: 1702323154062
-- kind: conda
-  name: scotch
-  version: 7.0.4
-  build: h52a132a_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/scotch-7.0.4-h52a132a_1.conda
-  sha256: e9d98aeb38ddde3c3ea537a24818b4bce19fe331ec1ab0390aab03ef6a82ea6a
-  md5: 20861af41e8b87c54ae231a00d801df9
-  depends:
-  - libscotch 7.0.4 hc2ac6e5_1
-  license: CECILL-C
-  size: 78475
-  timestamp: 1702323468906
-- kind: conda
-  name: scotch
-  version: 7.0.4
-  build: habe6132_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scotch-7.0.4-habe6132_1.conda
-  sha256: 66cd82be2e4989a76be489b453d97b9fb18b16976ebd13684f5c6c8e2de31bad
-  md5: 8e201be4922a66725150d863544926b7
-  depends:
-  - libscotch 7.0.4 h16908e7_1
-  license: CECILL-C
-  size: 99530
-  timestamp: 1702326258817
-- kind: conda
-  name: scotch
-  version: 7.0.4
-  build: heaa5b5c_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scotch-7.0.4-heaa5b5c_1.conda
-  sha256: 912b497b2adde2647d9ed31325abfff0944a02e6e2819d87315bfef1081b4b70
-  md5: a30162091e3e0c0940f459ac73813192
-  depends:
-  - libscotch 7.0.4 hc938e73_1
-  license: CECILL-C
-  size: 81912
-  timestamp: 1702323453484
 - kind: conda
   name: sdl
   version: 1.2.68
@@ -14204,79 +14445,82 @@ packages:
   timestamp: 1695759902673
 - kind: conda
   name: sdl2
-  version: 2.30.2
-  build: h63175ca_0
+  version: 2.30.7
+  build: h2a74887_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
+  sha256: 6c21954d98a915d7617c0944440167e5ac695117ca7410f37eea4af0a9f0821c
+  md5: 719245709dd47dbc3f93ce85fa544f43
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1317383
+  timestamp: 1725255076176
+- kind: conda
+  name: sdl2
+  version: 2.30.7
+  build: h3ed165c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
+  sha256: 80691a3ce313f0f7908480c0af216520d655e9480e036feb489c2095ad37950a
+  md5: be75875082c99c7a9f9fe930a1bd2bb1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1391142
+  timestamp: 1725255009793
+- kind: conda
+  name: sdl2
+  version: 2.30.7
+  build: hac325c4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.7-hac325c4_0.conda
+  sha256: b2785777b22ff8a883210f81c4e6a14f0c4f4ab83595ddef6f0d8560fa4ecc0a
+  md5: 9e4fe70a7b62b7c82a06bfd5b5af48e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: Zlib
+  size: 1232457
+  timestamp: 1725255027620
+- kind: conda
+  name: sdl2
+  version: 2.30.7
+  build: he0c23c2_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.2-h63175ca_0.conda
-  sha256: 2f8020bffb8fcaca01638c44fb845f223140baf04f8766ecca2eb8bc2f7443f0
-  md5: 18017f8551ce74d2281f5684f16eb71f
+  url: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
+  sha256: bf850eba90ff5103c2a92d3ab0395edd078b7c95cbabc4254462d9bea7850c48
+  md5: e452497e0b9824c0be7f6670adbabc63
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Zlib
-  size: 2155390
-  timestamp: 1712091452523
+  size: 2243873
+  timestamp: 1725255268158
 - kind: conda
   name: sdl2
-  version: 2.30.2
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.2-h73e2aa4_0.conda
-  sha256: 15932a4125f27daf6bfa35ebff879326a7bae91078874f62cbc0b7f8f38a61b8
-  md5: fb62c1528129a067f3162e723a54446d
-  depends:
-  - libcxx >=16
-  license: Zlib
-  size: 1184131
-  timestamp: 1712091348007
-- kind: conda
-  name: sdl2
-  version: 2.30.2
-  build: hd75414b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.2-hd75414b_0.conda
-  sha256: d5cac6074779caaeb206ae8a6c5d79b5ecb343f97cabb13abf26c7d786187d4c
-  md5: 326d88f1f04a6794424263a678b902e1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1317756
-  timestamp: 1712091024920
-- kind: conda
-  name: sdl2
-  version: 2.30.2
-  build: hdbcbe63_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.2-hdbcbe63_0.conda
-  sha256: 64b7ba181c585065fafb6e3ba8fe5a2fdf3b1b544f00f7c97625a737aafa3b95
-  md5: 384fc41d2db4062cd67c5073810049fa
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1391428
-  timestamp: 1712091106383
-- kind: conda
-  name: sdl2
-  version: 2.30.2
-  build: hebf3989_0
+  version: 2.30.7
+  build: hf9b8971_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.2-hebf3989_0.conda
-  sha256: 5c78cf48fdc1d08ed2c68f1312a357aa0c6ec207e3d24d2fbb89e241ca7d429f
-  md5: b962526879a8bad545c671b2a1a97549
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
+  sha256: d86b4f39c09efb6febd5e2e5a2c0894c82f7ac4b8b4aebb24e4fbd9acf797d60
+  md5: 33f5451441cbc0ce083b3d37c181519e
   depends:
-  - libcxx >=16
+  - __osx >=11.0
+  - libcxx >=17
   license: Zlib
-  size: 1254538
-  timestamp: 1712091426929
+  size: 1256184
+  timestamp: 1725254933792
 - kind: conda
   name: sigtool
   version: 0.1.3
@@ -14307,78 +14551,80 @@ packages:
   timestamp: 1643442169866
 - kind: conda
   name: snappy
-  version: 1.1.10
-  build: h17c5cce_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
-  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
-  md5: ac82a611d1a67a598096ebaa857198e3
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 33879
-  timestamp: 1678534968831
-- kind: conda
-  name: snappy
-  version: 1.1.10
-  build: h225ccf5_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
-  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
-  md5: 4320a8781f14cd959689b86e349f3b73
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 34657
-  timestamp: 1678534768395
-- kind: conda
-  name: snappy
-  version: 1.1.10
-  build: h9fff704_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  md5: e6d228cd0bb74a51dd18f5bfce0b4115
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38865
-  timestamp: 1678534590321
-- kind: conda
-  name: snappy
-  version: 1.1.10
-  build: he8610fa_0
+  version: 1.2.1
+  build: h1088aeb_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
-  sha256: 5a7d6cf781cbaaea4effce4d8f2677cd6173af5e8b744912e1283a704eb91946
-  md5: 11c25e55894bb8207a81a87e6a32b6e7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
+  sha256: 79f5d0a9098acf2ed16e6ecc4c11472b50ccf59feea37a7d585fd43888d7e41f
+  md5: e4ed5b015f525b56f95c26d85a4ea208
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 38265
-  timestamp: 1678534683114
+  size: 42888
+  timestamp: 1720003817527
 - kind: conda
   name: snappy
-  version: 1.1.10
-  build: hfb803bf_0
+  version: 1.2.1
+  build: h23299a8_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
-  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
-  md5: cff1df79c9cff719460eb2dd172568de
+  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
+  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 57065
-  timestamp: 1678534804734
+  size: 59350
+  timestamp: 1720004197144
+- kind: conda
+  name: snappy
+  version: 1.2.1
+  build: ha2e4443_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- kind: conda
+  name: snappy
+  version: 1.2.1
+  build: hd02b534_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- kind: conda
+  name: snappy
+  version: 1.2.1
+  build: he1e6707_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
 - kind: conda
   name: soxr
   version: 0.1.3
@@ -14455,304 +14701,311 @@ packages:
   timestamp: 1674059996047
 - kind: conda
   name: svt-av1
-  version: 1.8.0
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
-  sha256: bcf42cef4cf08e0b79a71f4978e16ba92bd70624b25eb32a324a0be3edc79f4c
-  md5: 64801dba0cb1972e64a568b7234331e1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1798999
-  timestamp: 1702362756845
-- kind: conda
-  name: svt-av1
-  version: 1.8.0
-  build: h463b476_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.8.0-h463b476_0.conda
-  sha256: 176ddc0f0b579038b028d03cf51cf5c70740e16f451ee60e6eb0567560331568
-  md5: bdc78f014823b0fe7be5bed84909e8c3
-  depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1388702
-  timestamp: 1702359462579
-- kind: conda
-  name: svt-av1
-  version: 1.8.0
-  build: h59595ed_0
+  version: 2.2.1
+  build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
-  sha256: 6d64facdcdaadc5a3e5e4382ee195b4fde3c84ae3d4156fdd9b78ba7de358ba7
-  md5: a9fb862e9d3beb0ebc61c10806056a7d
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.2.1-h5888daf_0.conda
+  sha256: a1c197ea17dac43ad6c223e42d78726b9f37f31f63d65e0c062e418cb98c7a8f
+  md5: 0d9c441855be3d8dfdb2e800fe755059
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
   license: BSD-2-Clause
   license_family: BSD
-  size: 2644060
-  timestamp: 1702359203835
+  size: 2404332
+  timestamp: 1724459503486
 - kind: conda
   name: svt-av1
-  version: 1.8.0
-  build: h63175ca_0
+  version: 2.2.1
+  build: h5ad3122_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.2.1-h5ad3122_0.conda
+  sha256: f8b36c7a715b5069a802502e3cae788dd2ef2ec29d09dfa28a5c81265d7649d7
+  md5: 8c8509c168215d15d790fb5ad5c2e69a
+  depends:
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1769578
+  timestamp: 1724459367826
+- kind: conda
+  name: svt-av1
+  version: 2.2.1
+  build: ha39b806_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.2.1-ha39b806_0.conda
+  sha256: 4199d3344d4f305e2d9c5f2fd58d4ac744b08565ee0ea8c08944e3fc9129ad76
+  md5: b2761a20146810d3c03380576ae5c4fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1326484
+  timestamp: 1724459521607
+- kind: conda
+  name: svt-av1
+  version: 2.2.1
+  build: hac325c4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.2.1-hac325c4_0.conda
+  sha256: 9e229a7e34d0526c9e52bac85e3aa4c3d8c25df4f8618274bc135f9c19140a5d
+  md5: 07799aecfd86318fa5b4c5202b7acdce
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2153628
+  timestamp: 1724459465920
+- kind: conda
+  name: svt-av1
+  version: 2.2.1
+  build: he0c23c2_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.8.0-h63175ca_0.conda
-  sha256: fe24efc86bf0dab4eeed3fa88f8a2592a729c1bc835f9975aff763cb91d3075e
-  md5: 89b2c7d39a898b83e71152beafd6e312
+  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
+  sha256: 79985e6ea3e93f8e6a71f06dbe7ca1f5f61c1948b7a45d1d5ac7e71f46461cad
+  md5: c34bbf7ec0696702f361d1c791ed3246
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  size: 2358109
-  timestamp: 1702359801424
-- kind: conda
-  name: svt-av1
-  version: 1.8.0
-  build: h93d8f39_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.8.0-h93d8f39_0.conda
-  sha256: ce33415f2ffd1643e26a3e464c416a96b68e409f985021f5314efe4f402a8c09
-  md5: 5cfb5476c2e9308c77afe3427da3b3b3
-  depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2376471
-  timestamp: 1702362435425
+  size: 1704957
+  timestamp: 1724459941490
 - kind: conda
   name: swig
-  version: 4.2.1
-  build: h089f89f_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.2.1-h089f89f_0.conda
-  sha256: 310971e420283c885bddc28b228561dedbfad96bae63ca8366daf0ef90bc4114
-  md5: a2d4824633c72c8fff22003e5ca9a06b
+  version: 4.3.0
+  build: h051d1ac_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.3.0-h051d1ac_0.conda
+  sha256: 40093468f8983fe331d8a4e8e631a8dbcee0167edcbb2f68aef6db2ab68aa816
+  md5: 2a8e52dc5014460dc890041d31f79f93
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pcre2 >=10.43,<10.44.0a0
+  - __osx >=11.0
+  - libcxx >=17
+  - pcre2 >=10.44,<10.45.0a0
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 1232635
-  timestamp: 1708777631076
+  size: 1113443
+  timestamp: 1729589137221
 - kind: conda
   name: swig
-  version: 4.2.1
-  build: hb8d0685_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/swig-4.2.1-hb8d0685_0.conda
-  sha256: 04f78e0fd72d594402e4180e766654eaec274dd351331203c89df5d91fa07a54
-  md5: 0ae897392bb2fd7f79b6b6789098f352
+  version: 4.3.0
+  build: h05d4bff_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/swig-4.3.0-h05d4bff_0.conda
+  sha256: 5d1accf5609d7152c8ee0961b7a83aa73519866f549e4e75aa0b8e2fe365db65
+  md5: e977150e8f2dd12aa3fa3c94c87e5b8f
   depends:
-  - pcre2 >=10.43,<10.44.0a0
+  - __osx >=10.13
+  - libcxx >=17
+  - pcre2 >=10.44,<10.45.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 1160596
+  timestamp: 1729589065015
+- kind: conda
+  name: swig
+  version: 4.3.0
+  build: h2f4baa9_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.3.0-h2f4baa9_0.conda
+  sha256: 50b8b93bd1cef4451c6a659f59ad48ca886990f1123a71dbe54c49562f64ac30
+  md5: 3004200698c3e9599b255fb357628f48
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - pcre2 >=10.44,<10.45.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 1299652
+  timestamp: 1729589010660
+- kind: conda
+  name: swig
+  version: 4.3.0
+  build: h51fbe9b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.0-h51fbe9b_0.conda
+  sha256: b6f66e27dac7799a844e530f2b946713223106b8df66c809a6dda4a96ae68ba3
+  md5: f076cd8282f1c164e57990a1daf70fd1
+  depends:
+  - pcre2 >=10.44,<10.45.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 1038501
-  timestamp: 1708778206972
+  size: 1079944
+  timestamp: 1729589112085
 - kind: conda
   name: swig
-  version: 4.2.1
-  build: hc959ec8_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/swig-4.2.1-hc959ec8_0.conda
-  sha256: 592537aaae04a23bea8098c570686b6b9e8417009dd4fe82c58e422aa84f9c92
-  md5: 345f6c247388d050cacbe686a20b0904
-  depends:
-  - libcxx >=16
-  - pcre2 >=10.43,<10.44.0a0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1105425
-  timestamp: 1708777850390
-- kind: conda
-  name: swig
-  version: 4.2.1
-  build: hc9a1274_0
+  version: 4.3.0
+  build: heed6a68_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/swig-4.2.1-hc9a1274_0.conda
-  sha256: dedd9bf1e2c143114cd2902526a51d4c6f0b0f78e8c16ca9987a566f0e01029e
-  md5: 74674247e54fa302581d0927157f068e
+  url: https://conda.anaconda.org/conda-forge/linux-64/swig-4.3.0-heed6a68_0.conda
+  sha256: 4771f7a2323d7f3c4d42b1c8ed670335ede7e78b80d8ba17d3c40b781dedcbdc
+  md5: 0e4da15e507b716140699aca1a279a88
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pcre2 >=10.43,<10.44.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - pcre2 >=10.44,<10.45.0a0
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 1191026
-  timestamp: 1708777550808
-- kind: conda
-  name: swig
-  version: 4.2.1
-  build: hfe15c3f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.2.1-hfe15c3f_0.conda
-  sha256: 78573cb3c2a2a0bb0c121b96fce8bde59ce19c5a49129e28c1f56bc31961bac9
-  md5: 34a6208a5b597a8f9ebd3fd6cae6e0f6
-  depends:
-  - libcxx >=16
-  - pcre2 >=10.43,<10.44.0a0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1069773
-  timestamp: 1708777829963
+  size: 1248414
+  timestamp: 1729588950292
 - kind: conda
   name: sysroot_linux-64
-  version: '2.12'
-  build: he073ed8_17
-  build_number: 17
+  version: '2.17'
+  build: h4a8ded7_18
+  build_number: 18
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_17.conda
-  sha256: b4e4d685e41cb36cfb16f0cb15d2c61f8f94f56fab38987a44eff95d8a673fb5
-  md5: 595db67e32b276298ff3d94d07d47fbf
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
+  sha256: 23c7ab371c1b74d01a187e05aa7240e3f5654599e364a9adff7f0b02e26f471f
+  md5: 0ea96f90a10838f58412aa84fdd9df09
   depends:
-  - kernel-headers_linux-64 2.6.32 he073ed8_17
+  - kernel-headers_linux-64 3.10.0 he073ed8_18
+  - tzdata
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 15127123
-  timestamp: 1708000843849
+  size: 15500960
+  timestamp: 1729794510631
 - kind: conda
   name: sysroot_linux-aarch64
   version: '2.17'
-  build: h5b4a56d_14
-  build_number: 14
+  build: h5b4a56d_18
+  build_number: 18
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
-  sha256: d239232cff55b45a1fbdea9fc660492afca16ba950785d9da3504f16de8fe765
-  md5: ba47875acf57f2717bcd55b26f4c3e00
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_18.conda
+  sha256: 769a720e0066e3b5c4168d6de455dbde12c2ee11ee3a19fc614659d04f726370
+  md5: d42f4bece921c5e59f56a36414106dc1
   depends:
-  - _sysroot_linux-aarch64_curr_repodata_hack 4.*
-  - kernel-headers_linux-aarch64 4.18.0 h5b4a56d_14
+  - kernel-headers_linux-aarch64 4.18.0 h05a177a_18
+  - tzdata
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 16253097
-  timestamp: 1708000911838
+  size: 15669544
+  timestamp: 1729794509305
 - kind: conda
   name: tapi
-  version: 1100.0.11
-  build: h9ce4665_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
-  sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
-  md5: f9ff42ccf809a21ba6f8607f8de36108
-  depends:
-  - libcxx >=10.0.0.a0
-  license: NCSA
-  license_family: MIT
-  size: 201044
-  timestamp: 1602664232074
-- kind: conda
-  name: tapi
-  version: 1100.0.11
-  build: he4954df_0
+  version: 1300.6.5
+  build: h03f4b80_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
-  sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
-  md5: d83362e7d0513f35f454bc50b0ca591d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+  sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
+  md5: b703bc3e6cba5943acf0e5f987b5d0e2
   depends:
-  - libcxx >=11.0.0.a0
+  - __osx >=11.0
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
   license: NCSA
   license_family: MIT
-  size: 191416
-  timestamp: 1602687595316
+  size: 207679
+  timestamp: 1725491499758
 - kind: conda
-  name: tbb
-  version: 2021.11.0
-  build: h00ab1b0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
-  sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
-  md5: 4531d2927578e7e254ff3bcf6457518c
+  name: tapi
+  version: 1300.6.5
+  build: h390ca13_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+  sha256: f97372a1c75b749298cb990405a690527e8004ff97e452ed2c59e4bc6a35d132
+  md5: c6ee25eb54accb3f1c8fc39203acfaf1
   depends:
-  - libgcc-ng >=12
-  - libhwloc >=2.9.3,<2.9.4.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 195540
-  timestamp: 1706163436794
+  - __osx >=10.13
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
+  license: NCSA
+  license_family: MIT
+  size: 221236
+  timestamp: 1725491044729
 - kind: conda
   name: tbb
-  version: 2021.11.0
-  build: h2a328a1_1
-  build_number: 1
+  version: 2021.13.0
+  build: h17cf362_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
-  sha256: eb8a3fb326828c2ff7ba8e2879bf11b3bd52f34c317d0faebe59772533d7d1de
-  md5: 4e385c984b98c7cbf28af64041d21cc4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.13.0-h17cf362_0.conda
+  sha256: 7961f725106210e904741a5668cb2f4ad975d337c4dad1810bf7adee299a6a78
+  md5: dc63ae8c472c97bccc9607ece78116db
   depends:
-  - libgcc-ng >=12
-  - libhwloc >=2.9.3,<2.9.4.0a0
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 161613
-  timestamp: 1706166156098
+  size: 143697
+  timestamp: 1725533999201
 - kind: conda
   name: tbb
-  version: 2021.11.0
-  build: h2ffa867_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
-  sha256: 35aa1918c901fb784c74f3d322f21a87d5bf57fbf02e5586778152b5c4cd82da
-  md5: e5584996979b373d50560a28321547e9
-  depends:
-  - libcxx >=15
-  - libhwloc >=2.9.3,<2.9.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 128174
-  timestamp: 1706163796739
-- kind: conda
-  name: tbb
-  version: 2021.11.0
-  build: h7728843_1
-  build_number: 1
+  version: 2021.13.0
+  build: h37c8870_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
-  sha256: 6d531daba5ccf150b58d434fa72b1da0da04e8f14ab71bdad289a90d355f47e8
-  md5: 29e29beba9deb0ef66bee015c5bf3c14
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-h37c8870_0.conda
+  sha256: 9a20a60ebf743f99e38a7be049f8ca90f264851c13dc8cb41eb09d854a631e31
+  md5: 89742f5ac7aeb5c44ec2b4c3c6692c3c
   depends:
-  - libcxx >=15
-  - libhwloc >=2.9.3,<2.9.4.0a0
+  - __osx >=10.13
+  - libcxx >=17
+  - libhwloc >=2.11.1,<2.11.2.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 173117
-  timestamp: 1706163682083
+  size: 159453
+  timestamp: 1725532728568
 - kind: conda
   name: tbb
-  version: 2021.11.0
-  build: h91493d7_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
-  sha256: aa30c089fdd6f66c7808592362e29963586e094159964a5fb61fb8efa9e349bc
-  md5: 21069f3ed16812f9f4f2700667b6ec86
+  version: 2021.13.0
+  build: h7b3277c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
+  sha256: 4a16118d5f71da9e8177921be996da87112a55fe53a700ab5dffe14ae2b6ecba
+  md5: a8a0feb11d51d4a0a2e56fbd53c628cf
   depends:
-  - libhwloc >=2.9.3,<2.9.4.0a0
+  - __osx >=11.0
+  - libcxx >=17
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 115213
+  timestamp: 1725532720037
+- kind: conda
+  name: tbb
+  version: 2021.13.0
+  build: h84d6215_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
+  sha256: 7d4d3ad608dc6ae5a7e0f431f784985398a18bcde2ba3ce19cc32f61e2defd98
+  md5: ee6f7fd1e76061ef1fa307d41fa86a96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 175779
+  timestamp: 1725532539822
+- kind: conda
+  name: tbb
+  version: 2021.13.0
+  build: hc790b64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+  sha256: 990dbe4fb42f14700c22bd434d8312607bf8d0bd9f922b054e51fda14c41994c
+  md5: 28496a1e6af43c63927da4f80260348d
+  depends:
+  - libhwloc >=2.11.1,<2.11.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 161382
-  timestamp: 1706164225098
+  size: 151494
+  timestamp: 1725532984828
 - kind: conda
   name: tinyxml
   version: 2.6.2
@@ -14836,7 +15089,7 @@ packages:
   md5: f75105e0585851f818e0009dd1dde4dc
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
   size: 3351802
@@ -14851,7 +15104,7 @@ packages:
   sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
   md5: bf830ba5afc507c6232d4ef0fb1a882d
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
   size: 3270220
@@ -14866,7 +15119,7 @@ packages:
   sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
   md5: b50a57ba89c32b62428b71a875291c9b
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
   size: 3145523
@@ -14899,37 +15152,37 @@ packages:
   md5: d453b98d9c83e71da0741bb0ff4d76bc
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
   size: 3318875
   timestamp: 1699202167581
 - kind: conda
   name: tzdata
-  version: 2024a
-  build: h0c530f3_0
+  version: 2024b
+  build: hc8b5060_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-  sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
-  md5: 161081fc7cec0bfda0d86d7cb595f8d8
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
   license: LicenseRef-Public-Domain
-  size: 119815
-  timestamp: 1706886945727
+  size: 122354
+  timestamp: 1728047496079
 - kind: conda
   name: ucrt
   version: 10.0.22621.0
-  build: h57928b3_0
+  build: h57928b3_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
-  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
   constrains:
   - vs2015_runtime >=14.29.30037
-  license: LicenseRef-Proprietary
-  license_family: PROPRIETARY
-  size: 1283972
-  timestamp: 1666630199266
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
 - kind: conda
   name: unixodbc
   version: 2.3.12
@@ -14995,117 +15248,133 @@ packages:
 - kind: conda
   name: vc
   version: '14.3'
-  build: hcf57466_18
-  build_number: 18
+  build: ha32ba9b_22
+  build_number: 22
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
-  sha256: 447a8d8292a7b2107dcc18afb67f046824711a652725fc0f522c368e7a7b8318
-  md5: 20e1e652a4c740fa719002a8449994a2
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
+  sha256: 2a47c5bd8bec045959afada7063feacd074ad66b170c1ea92dd139b389fcf8fd
+  md5: 311c9ba1dfdd2895a8cb08346ff26259
   depends:
-  - vc14_runtime >=14.38.33130
+  - vc14_runtime >=14.38.33135
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 16977
-  timestamp: 1702511255313
+  size: 17447
+  timestamp: 1728400826998
 - kind: conda
   name: vc14_runtime
-  version: 14.38.33130
-  build: h82b7239_18
-  build_number: 18
+  version: 14.40.33810
+  build: hcc2c482_22
+  build_number: 22
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
-  sha256: bf94c9af4b2e9cba88207001197e695934eadc96a5c5e4cd7597e950aae3d8ff
-  md5: 8be79fdd2725ddf7bbf8a27a4c1f79ba
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
+  sha256: 4c669c65007f88a7cdd560192f7e6d5679d191ac71610db724e18b2410964d64
+  md5: ce23a4b980ee0556a118ed96550ff3f3
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.38.33130.* *_18
-  license: LicenseRef-ProprietaryMicrosoft
+  - vs2015_runtime 14.40.33810.* *_22
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  size: 749868
-  timestamp: 1702511239004
+  size: 750719
+  timestamp: 1728401055788
 - kind: conda
   name: vs2015_runtime
-  version: 14.38.33130
-  build: hcb4865c_18
-  build_number: 18
+  version: 14.40.33810
+  build: h3bf8584_22
+  build_number: 22
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
-  sha256: a2fec221f361d6263c117f4ea6d772b21c90a2f8edc6f3eb0eadec6bfe8843db
-  md5: 10d42885e3ed84e575b454db30f1aa93
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+  sha256: 80aa9932203d65a96f817b8be4fafc176fb2b3fe6cf6899ede678b8f0317fbff
+  md5: 8c6b061d44cafdfc8e8c6eb5f100caf0
   depends:
-  - vc14_runtime >=14.38.33130
+  - vc14_runtime >=14.40.33810
   license: BSD-3-Clause
   license_family: BSD
-  size: 16988
-  timestamp: 1702511261442
+  size: 17453
+  timestamp: 1728400827536
 - kind: conda
   name: vs2019_win-64
   version: 19.29.30139
-  build: he1865b1_18
-  build_number: 18
+  build: he1865b1_22
+  build_number: 22
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_18.conda
-  sha256: b8f5128fc767fc04b48ec10df7ac6eea5d07df0efa2d91fff6d872e3dcde9029
-  md5: 6d9d317010ece223fc46a69360d0eb84
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_22.conda
+  sha256: d22e90a4012dae3e67c912c80ab9876eff2ba58c5735e47442ab8bcf3df8525d
+  md5: 8bcfb79dfd0ca4e9bc3a645c6bd9f16a
   depends:
   - vswhere
+  constrains:
+  - vs_win-64 2019.11
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 19488
-  timestamp: 1702511289992
+  size: 19994
+  timestamp: 1728401194337
 - kind: conda
   name: vswhere
-  version: 3.1.4
+  version: 3.1.7
   build: h57928b3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
-  sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
-  md5: b1d1d6a1f874d8c93a57b5efece52f03
+  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
+  sha256: 8caeda9c0898cb8ee2cf4f45640dbbbdf772ddc01345cfb0f7b352c58b4d8025
+  md5: ba83df93b48acfc528f5464c9a882baa
   license: MIT
   license_family: MIT
-  size: 218421
-  timestamp: 1682376911339
+  size: 219013
+  timestamp: 1719460515960
 - kind: conda
   name: wayland
-  version: 1.22.0
-  build: h8c25dac_1
-  build_number: 1
+  version: 1.23.1
+  build: h3e06ad9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.22.0-h8c25dac_1.conda
-  sha256: 9bf43998c0a4c7bff53849c8ef7638415020f9033f397a63537dfca1bf66e26a
-  md5: bfe70f700e76c87e0074c3e308513e79
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+  sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
+  md5: 0a732427643ae5e0486a727927791da1
   depends:
-  - libexpat >=2.5.0,<3.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
   license: MIT
   license_family: MIT
-  size: 306491
-  timestamp: 1684198293803
+  size: 321561
+  timestamp: 1724530461598
 - kind: conda
   name: wayland
-  version: 1.22.0
-  build: hce5310f_1
-  build_number: 1
+  version: 1.23.1
+  build: h698ed42_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.22.0-hce5310f_1.conda
-  sha256: 5e1ef10ec934065c8d49ec118319e97e4d632f88bd5043968f7ca92429711a43
-  md5: 50fa64a18cc82742e04f29c1b4537a43
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
+  sha256: 71c591803459e1f68f9ad206a4f2fa3971147502bad8791e94fd18d8362f8ce6
+  md5: 2661f9252065051914f1cdf5835e7430
   depends:
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
   license: MIT
   license_family: MIT
-  size: 309547
-  timestamp: 1684198451014
+  size: 324815
+  timestamp: 1724530528414
+- kind: conda
+  name: wayland-protocols
+  version: '1.37'
+  build: hd8ed1ab_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
+  sha256: f6cac1efd4d2a6e30c1671f0566d4e6ac3fe2dc34c9ff7f309bbbc916520ebcf
+  md5: 73ec79a77d31eb7e4a3276cd246b776c
+  depends:
+  - wayland
+  license: MIT
+  license_family: MIT
+  size: 95953
+  timestamp: 1725657284103
 - kind: conda
   name: x264
   version: 1!164.3095
@@ -15258,962 +15527,871 @@ packages:
   timestamp: 1646610147365
 - kind: conda
   name: xcb-util
-  version: 0.4.0
-  build: h31becfc_1
-  build_number: 1
+  version: 0.4.1
+  build: h5c728e9_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
-  sha256: 28d5d383128cf869ac7db173c3ae5d37fa15953bf8f836942b59f6f4e3951a94
-  md5: cd63fffc384ebf7ef90c3e03640089d9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
+  sha256: 59f586defd3c1295a32d8eb587036302ab254300d88e605354e8eaa4a27563ec
+  md5: b4cf8ba6cff9cdf1249bcfe1314222b0
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 21121
-  timestamp: 1684640370585
+  size: 20597
+  timestamp: 1718844955591
 - kind: conda
   name: xcb-util
-  version: 0.4.0
-  build: hd590300_1
-  build_number: 1
+  version: 0.4.1
+  build: hb711507_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
-  sha256: 0c91d87f0efdaadd4e56a5f024f8aab20ec30f90aa2ce9e4ebea05fbc20f71ad
-  md5: 9bfac7ccd94d54fd21a0501296d60424
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+  sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
+  md5: 8637c3e5821654d0edf97e2b0404b443
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 19728
-  timestamp: 1684639166048
+  size: 19965
+  timestamp: 1718843348208
 - kind: conda
   name: xcb-util-cursor
-  version: 0.1.4
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-cursor-0.1.4-h31becfc_1.conda
-  sha256: a689aaf0cb6324f1c3c32b83ab33ca73f0a9a57291a4138851e5f57b2c27fc62
-  md5: b29cfa244b93e48b8dc61d6beda337ab
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
-  license: MIT
-  license_family: MIT
-  size: 21044
-  timestamp: 1684687691830
-- kind: conda
-  name: xcb-util-cursor
-  version: 0.1.4
-  build: hd590300_1
-  build_number: 1
+  version: 0.1.5
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.4-hd590300_1.conda
-  sha256: df147500874761501030227d6bb8889443480cd6fe00361bb046d9840f04d17b
-  md5: 1ecae8461689e44fe0f0e3d18e58e799
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+  sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
+  md5: eb44b3b6deb1cab08d72cb61686fe64c
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
   license: MIT
   license_family: MIT
-  size: 20170
-  timestamp: 1684687482843
+  size: 20296
+  timestamp: 1726125844850
 - kind: conda
   name: xcb-util-image
   version: 0.4.0
-  build: h8ee46fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
-  sha256: 92ffd68d2801dbc27afe223e04ae7e78ef605fc8575f107113c93c7bafbd15b0
-  md5: 9d7bcddf49cbf727730af10e71022c73
+  build: h5c728e9_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
+  md5: b82e5c78dbbfa931980e8bfe83bce913
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
   license: MIT
   license_family: MIT
-  size: 24474
-  timestamp: 1684679894554
+  size: 24910
+  timestamp: 1718880504308
 - kind: conda
   name: xcb-util-image
   version: 0.4.0
-  build: hcb25cf1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
-  sha256: 94f546f2d8f5053bd21ccc656be364cfa5b1b8736f95befecadda4343a55b871
-  md5: 395256583f9ba09af83bd2875e2dd43e
+  build: hb711507_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
   license: MIT
   license_family: MIT
-  size: 24820
-  timestamp: 1684680024607
+  size: 24551
+  timestamp: 1718880534789
 - kind: conda
   name: xcb-util-keysyms
-  version: 0.4.0
-  build: h8ee46fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
-  sha256: 8451d92f25d6054a941b962179180728c48c62aab5bf20ac10fef713d5da6a9a
-  md5: 632413adcd8bc16b515cab87a2932913
+  version: 0.4.1
+  build: h5c728e9_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
+  md5: 57ca8564599ddf8b633c4ea6afee6f3a
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 14186
-  timestamp: 1684680497805
+  size: 14343
+  timestamp: 1718846624153
 - kind: conda
   name: xcb-util-keysyms
-  version: 0.4.0
-  build: hcb25cf1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
-  sha256: a6d14beea8c0fca033a375a3ac3059d909bdf3e19d9e0c683358b34247b7f6f7
-  md5: befa651eadbd51987c8ebc462497a8ff
+  version: 0.4.1
+  build: hb711507_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 14261
-  timestamp: 1684680602585
+  size: 14314
+  timestamp: 1718846569232
 - kind: conda
   name: xcb-util-renderutil
-  version: 0.3.9
-  build: h31becfc_1
-  build_number: 1
+  version: 0.3.10
+  build: h5c728e9_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
-  sha256: 037a9be6da2afed4fdbfcfb0ea13a60c1d80a025b023e879c89f3fe572571b4c
-  md5: 15c02e09b3441d567b83199173abc1f9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
+  md5: 7beeda4223c5484ef72d89fb66b7e8c1
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 18016
-  timestamp: 1684640014593
+  size: 18139
+  timestamp: 1718849914457
 - kind: conda
   name: xcb-util-renderutil
-  version: 0.3.9
-  build: hd590300_1
-  build_number: 1
+  version: 0.3.10
+  build: hb711507_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
-  sha256: 6987588e6fff5892056021c2ea52f7a0deefb2c7348e70d24750e2d60dabf009
-  md5: e995b155d938b6779da6ace6c6b13816
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 16955
-  timestamp: 1684639112393
+  size: 16978
+  timestamp: 1718848865819
 - kind: conda
   name: xcb-util-wm
-  version: 0.4.1
-  build: h8ee46fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
-  sha256: 08ba7147c7579249b6efd33397dc1a8c2404278053165aaecd39280fee705724
-  md5: 90108a432fb5c6150ccfee3f03388656
+  version: 0.4.2
+  build: h5c728e9_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
+  md5: f14dcda6894722e421da2b7dcffb0b78
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 52114
-  timestamp: 1684679248466
+  size: 50772
+  timestamp: 1718845072660
 - kind: conda
   name: xcb-util-wm
-  version: 0.4.1
-  build: hcb25cf1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
-  sha256: 19e4883076c87f998cf3bef532d6e731208f0ef4d65414cde32d7454eb2d1890
-  md5: 615e8be7baf44b5205f8a4f5908f57f7
+  version: 0.4.2
+  build: hb711507_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 49952
-  timestamp: 1684680157286
+  size: 51689
+  timestamp: 1718844051451
 - kind: conda
   name: xkeyboard-config
-  version: '2.41'
-  build: h31becfc_0
+  version: '2.43'
+  build: h86ecc28_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.41-h31becfc_0.conda
-  sha256: 95cedc415f7b056e5ccb76ba21c6f48644a5585617b953ad44b0d0088a1622b7
-  md5: 1df80651a2a70e3004cfc72e03fe55bd
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+  sha256: b3f09cc99b6b7707aa8812bbc7556fd431999ad3a48292e4ff82335b5fda976c
+  md5: a809b8e3776fbc05696c82f8cf6f5a92
   depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.7,<2.0a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
-  size: 896792
-  timestamp: 1707104436982
+  size: 391011
+  timestamp: 1727840308426
 - kind: conda
   name: xkeyboard-config
-  version: '2.41'
-  build: hd590300_0
+  version: '2.43'
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
-  sha256: 56955610c0747ea7cb026bb8aa9ef165ff41d616e89894538173b8b7dd2ee49a
-  md5: 81f740407b45e3f9047b3174fa94eb9e
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+  sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
+  md5: f725c7425d6d7c15e31f3b99a88ea02f
   depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.7,<2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
-  size: 898045
-  timestamp: 1707104384997
-- kind: conda
-  name: xorg-fixesproto
-  version: '5.0'
-  build: h3557bc0_1002
-  build_number: 1002
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-fixesproto-5.0-h3557bc0_1002.tar.bz2
-  sha256: f22351d3ca1bc6130b474c52d35b02078941ba65e3c3621b630d853ed7ffe946
-  md5: d83ed0a123097ef38c744f8aa8a814f4
-  depends:
-  - libgcc-ng >=9.3.0
-  - xorg-xextproto
-  license: MIT
-  license_family: MIT
-  size: 9135
-  timestamp: 1617480316800
-- kind: conda
-  name: xorg-fixesproto
-  version: '5.0'
-  build: h7f98852_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
-  sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
-  md5: 65ad6e1eb4aed2b0611855aff05e04f6
-  depends:
-  - libgcc-ng >=9.3.0
-  - xorg-xextproto
-  license: MIT
-  license_family: MIT
-  size: 9122
-  timestamp: 1617479697350
-- kind: conda
-  name: xorg-inputproto
-  version: 2.3.2
-  build: h3557bc0_1002
-  build_number: 1002
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-inputproto-2.3.2-h3557bc0_1002.tar.bz2
-  sha256: d75eaa12b1e57c8e4fc6548006da94ee15175c3efe483069b77c2cc82ba846a1
-  md5: 4930bec8521a4673b69db6e60cc3da08
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 19680
-  timestamp: 1610028138894
-- kind: conda
-  name: xorg-inputproto
-  version: 2.3.2
-  build: h7f98852_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
-  sha256: 6c8c2803de0f643f8bad16ece3f9a7259e4a49247543239c182d66d5e3a129a7
-  md5: bcd1b3396ec6960cbc1d2855a9e60b2b
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 19602
-  timestamp: 1610027678228
-- kind: conda
-  name: xorg-kbproto
-  version: 1.0.7
-  build: h27ca646_1002
-  build_number: 1002
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-kbproto-1.0.7-h27ca646_1002.tar.bz2
-  sha256: 265d5ba719fe05d227a6ccd897b1f53bacf6bc9c9c728dcbf917b2d47e9dfac6
-  md5: 7fb248f07fec67488000ebd466a5b73d
-  license: MIT
-  license_family: MIT
-  size: 27417
-  timestamp: 1610027770456
-- kind: conda
-  name: xorg-kbproto
-  version: 1.0.7
-  build: h3557bc0_1002
-  build_number: 1002
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h3557bc0_1002.tar.bz2
-  sha256: 421c0a115b31f02082f95c8f06dbba48b2274718f66a72d64d5102141e5a8731
-  md5: ec8ce6b3dac3945a4010559a6284b755
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 27369
-  timestamp: 1610028170368
-- kind: conda
-  name: xorg-kbproto
-  version: 1.0.7
-  build: h35c211d_1002
-  build_number: 1002
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-kbproto-1.0.7-h35c211d_1002.tar.bz2
-  sha256: ea4e792e48f28023668ce3e716ebee9b7d04e2d397d678f8f3aef4c7a66f4449
-  md5: 41302c2bc60a15ca4a018775fd20b442
-  license: MIT
-  license_family: MIT
-  size: 27396
-  timestamp: 1610027854580
-- kind: conda
-  name: xorg-kbproto
-  version: 1.0.7
-  build: h7f98852_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
-  md5: 4b230e8381279d76131116660f5a241a
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 27338
-  timestamp: 1610027759842
+  size: 389475
+  timestamp: 1727840188958
 - kind: conda
   name: xorg-libice
   version: 1.1.1
-  build: h7935292_0
+  build: h57736b2_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h7935292_0.conda
-  sha256: c889673c9313798372bea7c93640e853561bda5ba361b265ad4b14d7d1295235
-  md5: 025968e2637bca910b9b3e7f6743beff
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
+  sha256: 525f197136d0c136dcba68b16d8f3636f27be111d677b2a06d8b99cf3f45ba4a
+  md5: 99a9c8245a1cc6dacd292ffeca39425f
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 60321
-  timestamp: 1685308489806
+  size: 60151
+  timestamp: 1727533134400
 - kind: conda
   name: xorg-libice
   version: 1.1.1
-  build: hd590300_0
+  build: hb9d3cd8_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
-  sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  md5: b462a33c0be1421532f28bfe8f4a7514
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+  sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
+  md5: 19608a9656912805b2b9a2f6bd257b04
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 58469
-  timestamp: 1685307573114
+  size: 58159
+  timestamp: 1727531850109
 - kind: conda
   name: xorg-libsm
   version: 1.2.4
-  build: h5a01bc2_0
+  build: hbac51e1_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
-  sha256: 2678975d4001f1123752ceabf9e2810cab51f740624320077de1ab12b537b498
-  md5: d788eca20ecd63bad8eea7219e5c5fb7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
+  sha256: 3d3c78a2e2a915d96b8bf8a670ba91e5abba50f55dc3ff699d345c958118e94c
+  md5: 18655ac9fc6624db89b33a89fed51c5f
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   - libuuid >=2.38.1,<3.0a0
   - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 28634
-  timestamp: 1685454576261
+  size: 28357
+  timestamp: 1727635998392
 - kind: conda
   name: xorg-libsm
   version: 1.2.4
-  build: h7391055_0
+  build: he73a12e_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-  sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  md5: 93ee23f12bc2e684548181256edd2cf6
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+  sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
+  md5: 05a8ea5f446de33006171a7afe6ae857
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   - libuuid >=2.38.1,<3.0a0
   - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 27433
-  timestamp: 1685453649160
+  size: 27516
+  timestamp: 1727634669421
 - kind: conda
   name: xorg-libx11
-  version: 1.8.7
-  build: h055a233_0
+  version: 1.8.9
+  build: he755bbd_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
-  sha256: dc688480f6afa3b5880b9d4e11e25e6c8dd10e961a07cfa30b2dc5e529e250bb
-  md5: b3ff774afbb2cd7678044e1fed24f59e
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
+  sha256: bcd9ebdd7ca25d8ab1eb4f3f919113e264a8ad84fa713c48e737e9167a82fb4b
+  md5: 7acc45f80415e6ec352b729105dc0375
   depends:
-  - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-kbproto
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
   license: MIT
   license_family: MIT
-  size: 854309
-  timestamp: 1697056918786
+  size: 863528
+  timestamp: 1727352755656
 - kind: conda
   name: xorg-libx11
-  version: 1.8.7
-  build: h8ee46fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
-  sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
-  md5: 49e482d882669206653b095f5206c05b
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-kbproto
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
-  license: MIT
-  license_family: MIT
-  size: 828692
-  timestamp: 1697056910935
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.7
-  build: hbd0b022_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.7-hbd0b022_0.conda
-  sha256: 696c8e8dd7bf76a2075373640b3fa171c20e2b9a706a48b0e57bea3ec74d83e6
-  md5: 1861bf782a55f2cc66478a46b053159a
-  depends:
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-kbproto
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
-  license: MIT
-  license_family: MIT
-  size: 777870
-  timestamp: 1697057121760
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.7
-  build: hfd9643e_0
+  version: 1.8.10
+  build: h2321a68_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.7-hfd9643e_0.conda
-  sha256: d89b74e67c6bf6bec4ad732d9c1cfa843ac7ee604afeccb496a0833db399598b
-  md5: 62362b81bf9d497d283ae2b8fd5e6a99
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
+  sha256: d7b68c1a67cc074b14cda8ccc90d52291ee78607fb2294fdf84cfe49eecaeea8
+  md5: 8daa358aecb1dbba214ea468a17f934c
   depends:
-  - libxcb >=1.15,<1.16.0a0
-  - xorg-kbproto
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
+  - __osx >=11.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
   license: MIT
   license_family: MIT
-  size: 767300
-  timestamp: 1697057150709
+  size: 753888
+  timestamp: 1727356859339
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.10
+  build: h4f16b4b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+  sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
+  md5: 0b666058a179b744a622d0a4a0c56353
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 838308
+  timestamp: 1727356837875
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.10
+  build: ha6c16c8_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.10-ha6c16c8_0.conda
+  sha256: 228b538e083a61c546f0252ed3195b57ab7c7d37a8bdc701224f9569c3db76de
+  md5: e0b36043f72afb8e46b71f31e8cc143d
+  depends:
+  - __osx >=10.13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 780923
+  timestamp: 1727356879017
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: h0dc2134_0
+  build: h00291cd_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
-  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
-  md5: 9566b4c29274125b0266d0177b5eb97b
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 13071
-  timestamp: 1684638167647
+  size: 13176
+  timestamp: 1727034772877
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: h31becfc_0
+  build: h86ecc28_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
-  sha256: c00a8909e783ba7f4ada7256f0385ae46fc21322f4090fa396c80b4481abd5f4
-  md5: 13de34f69cb73165dbe08c1e9148bedb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
+  sha256: a00c4c6054209c84fb460c5e4ae7193c335a9ee1851645c9ad59312438e853f7
+  md5: c5f72a733c461aa7785518d29b997cc8
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 15380
-  timestamp: 1684638889756
+  size: 15690
+  timestamp: 1727036097294
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
-  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
-  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  build: hb9d3cd8_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 13667
-  timestamp: 1684638272445
+  size: 14679
+  timestamp: 1727034741045
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
-  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
-  md5: 2c80dc38fface310c9bd81b17037fee5
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 14468
-  timestamp: 1684637984591
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.3
-  build: h27ca646_0
+  build: hd74edd7_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
-  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
-  md5: 6738b13f7fadc18725965abdd4129c36
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 18164
-  timestamp: 1610071737668
+  size: 13515
+  timestamp: 1727034783560
 - kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.3
-  build: h3557bc0_0
+  name: xorg-libxdamage
+  version: 1.1.6
+  build: h86ecc28_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
-  sha256: 2aad9a0b57796170b8fb40317598fd79cfc7ae27fa7fb68c417d815e44499d59
-  md5: a6c9016ae1ca5c47a3603ed4cd65fedd
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
+  md5: d5773c4e4d64428d7ddaa01f6f845dc7
   depends:
-  - libgcc-ng >=9.3.0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 19916
-  timestamp: 1610072242320
+  size: 13794
+  timestamp: 1727891406431
+- kind: conda
+  name: xorg-libxdamage
+  version: 1.1.6
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13217
+  timestamp: 1727891438799
 - kind: conda
   name: xorg-libxdmcp
-  version: 1.1.3
-  build: h35c211d_0
+  version: 1.1.5
+  build: h00291cd_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
-  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
-  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 17225
-  timestamp: 1610071995461
+  size: 18465
+  timestamp: 1727794980957
 - kind: conda
   name: xorg-libxdmcp
-  version: 1.1.3
-  build: h7f98852_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
-  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
-  md5: be93aabceefa2fac576e971aef407908
+  version: 1.1.5
+  build: h57736b2_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
+  md5: 25a5a7b797fe6e084e04ffe2db02fc62
   depends:
-  - libgcc-ng >=9.3.0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 19126
-  timestamp: 1610071769228
+  size: 20615
+  timestamp: 1727796660574
 - kind: conda
-  name: xorg-libxext
-  version: 1.3.4
-  build: h0b41bf4_2
-  build_number: 2
+  name: xorg-libxdmcp
+  version: 1.1.5
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
-  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  md5: 82b6df12252e6f32402b96dacc656fec
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
   depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-xextproto
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 50143
-  timestamp: 1677036907815
+  size: 19901
+  timestamp: 1727794976192
 - kind: conda
-  name: xorg-libxext
-  version: 1.3.4
-  build: h1a8c8d9_2
-  build_number: 2
+  name: xorg-libxdmcp
+  version: 1.1.5
+  build: hd74edd7_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.4-h1a8c8d9_2.conda
-  sha256: 073e673a9b4ef748c256d655d1ab5f368e5e3972ad3332c96c1d4c2cf0c7b9af
-  md5: 0ea792d9a253b64752e9fcfaafe8d529
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
   depends:
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-xextproto
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 41541
-  timestamp: 1677037316516
+  size: 18487
+  timestamp: 1727795205022
 - kind: conda
   name: xorg-libxext
-  version: 1.3.4
-  build: h2a766a3_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
-  sha256: 16eff29fb70b2f89b9120d112d2d5df1bf7bd4e95d1e5baafabc61dac4977fa8
-  md5: 0cea7d840c8eeaa4e349e0b4775c826d
-  depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-xextproto
-  license: MIT
-  license_family: MIT
-  size: 50856
-  timestamp: 1677037784530
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.4
-  build: hb7f2c08_2
-  build_number: 2
+  version: 1.3.6
+  build: h00291cd_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.4-hb7f2c08_2.conda
-  sha256: 56ca81c5e6d493e7a991f2beac1c38dec36d732c83495ef08f57a34c260a5aaa
-  md5: 0f98aff18e0455f0bdc4326c04f98883
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.6-h00291cd_0.conda
+  sha256: 26c88c5629895d7df5722320931377aa1ba3dea3950faa77e0c9fe5af29f78e5
+  md5: 62f4f9d7a6c176be164329b4a1fc2616
   depends:
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-xextproto
+  - __osx >=10.13
+  - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
-  size: 43076
-  timestamp: 1677037100444
+  size: 42572
+  timestamp: 1727752240262
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.6
+  build: h57736b2_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+  sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
+  md5: bd1e86dd8aa3afd78a4bfdb4ef918165
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50746
+  timestamp: 1727754268156
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.6
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+  sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
+  md5: febbab7d15033c913d53c7a2c102309d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50060
+  timestamp: 1727752228921
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.6
+  build: hd74edd7_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
+  sha256: 4526fcd879b74400e66cc2a041ca00c0ecd210486459cc65610b135be7c6a2d2
+  md5: acf6c394865f1b7a51c8e57fec6fcde3
+  depends:
+  - __osx >=11.0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 41870
+  timestamp: 1727752280756
 - kind: conda
   name: xorg-libxfixes
-  version: 5.0.3
-  build: h3557bc0_1004
-  build_number: 1004
+  version: 6.0.1
+  build: h57736b2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-5.0.3-h3557bc0_1004.tar.bz2
-  sha256: c6d38bfb9d9a9ab4c1331700a29970d6fa4894bb1e2585300a21d75ac3c0ee8d
-  md5: 8c639389f12135ddc2bb23497d6d1918
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
+  md5: 78f8715c002cc66991d7c11e3cf66039
   depends:
-  - libgcc-ng >=9.3.0
-  - xorg-fixesproto
-  - xorg-libx11 >=1.7.0,<2.0a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
-  size: 18684
-  timestamp: 1617718455442
+  size: 20289
+  timestamp: 1727796500830
 - kind: conda
   name: xorg-libxfixes
-  version: 5.0.3
-  build: h7f98852_1004
-  build_number: 1004
+  version: 6.0.1
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
-  sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
-  md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+  sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
+  md5: 4bdb303603e9821baf5fe5fdff1dc8f8
   depends:
-  - libgcc-ng >=9.3.0
-  - xorg-fixesproto
-  - xorg-libx11 >=1.7.0,<2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
-  size: 18145
-  timestamp: 1617717802636
+  size: 19575
+  timestamp: 1727794961233
 - kind: conda
   name: xorg-libxi
-  version: 1.7.10
-  build: h3557bc0_0
+  version: 1.8.2
+  build: h57736b2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h3557bc0_0.tar.bz2
-  sha256: cc750f04be99affd279ed11741d4921a56ae45d85472dbf1c84c0503a95c0020
-  md5: 02eaabe40f65695705a288757f1d56b5
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
+  md5: eeee3bdb31c6acde2b81ad1b8c287087
   depends:
-  - libgcc-ng >=9.3.0
-  - xorg-inputproto
-  - xorg-libx11 >=1.7.0,<2.0a0
-  - xorg-libxext 1.3.*
-  - xorg-libxfixes 5.0.*
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 48543
-  timestamp: 1620071478169
+  size: 48197
+  timestamp: 1727801059062
 - kind: conda
   name: xorg-libxi
-  version: 1.7.10
-  build: h7f98852_0
+  version: 1.8.2
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
-  sha256: 745c1284a96b4282fe6fe122b2643e1e8c26a7ff40b733a8f4b61357238c4e68
-  md5: e77615e5141cad5a2acaa043d1cf0ca5
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
   depends:
-  - libgcc-ng >=9.3.0
-  - xorg-inputproto
-  - xorg-libx11 >=1.7.0,<2.0a0
-  - xorg-libxext 1.3.*
-  - xorg-libxfixes 5.0.*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 47287
-  timestamp: 1620070911951
+  size: 47179
+  timestamp: 1727799254088
 - kind: conda
   name: xorg-libxinerama
   version: 1.1.5
-  build: h27087fc_0
+  build: h5888daf_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
-  sha256: 0dc50f019ab9871bd9a8be0b00a1e0fa98172ef9c775a13e2dac2924844bb75e
-  md5: 2e1c65825c586444df23784f68bef90e
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+  sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
+  md5: 5e2eb9bf77394fc2e5918beefec9f9ab
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
-  size: 13350
-  timestamp: 1667399989190
+  size: 13891
+  timestamp: 1727908521531
 - kind: conda
   name: xorg-libxinerama
   version: 1.1.5
-  build: h4de3ea5_0
+  build: h5ad3122_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
-  sha256: 3ad05b332c87f6486de67571dc4450a5d077215789e1820f6e278345aec45746
-  md5: dde29991cafb378facde5dfe371989d9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+  sha256: 5f84f820397db504e187754665d48d385e0a2a49f07ffc2372c7f42fa36dd972
+  md5: a7b99f104e14b99ca773d2fe2d195585
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
-  size: 13876
-  timestamp: 1667399792390
+  size: 14388
+  timestamp: 1727908606602
 - kind: conda
   name: xorg-libxrender
   version: 0.9.11
-  build: h7935292_0
+  build: h57736b2_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h7935292_0.conda
-  sha256: 15ab433c3b565d92bbd9dc83e469bb4ff1076f9002f7cd142b8a39e1b6cbcfab
-  md5: 8c96b84f7fb97a3cd533a14dbdcd6626
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+  sha256: 50c000a26e828313b668902c2ae5ff7956d9d34418b4fc6fc15f73cba31b45e0
+  md5: 19fb476dc5cdd51b67719a6342fab237
   depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-renderproto
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-xorgproto
   license: MIT
   license_family: MIT
-  size: 37477
-  timestamp: 1688300682978
+  size: 38052
+  timestamp: 1727530023529
 - kind: conda
   name: xorg-libxrender
   version: 0.9.11
-  build: hd590300_0
+  build: hb9d3cd8_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
-  sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  md5: ed67c36f215b310412b2af935bf3e530
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+  sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
+  md5: a7a49a8b85122b49214798321e2e96b4
   depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-renderproto
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xorgproto
   license: MIT
   license_family: MIT
-  size: 37770
-  timestamp: 1688300707994
+  size: 37780
+  timestamp: 1727529943015
 - kind: conda
-  name: xorg-renderproto
-  version: 0.11.1
-  build: h3557bc0_1002
-  build_number: 1002
+  name: xorg-libxtst
+  version: 1.2.5
+  build: hb9d3cd8_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 32808
+  timestamp: 1727964811275
+- kind: conda
+  name: xorg-libxxf86vm
+  version: 1.1.5
+  build: h57736b2_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-renderproto-0.11.1-h3557bc0_1002.tar.bz2
-  sha256: e57e8b4a58f8c3b5011bf6cd66f499fca9fc5067981bb33f828750b168c3698d
-  md5: 01cbfe96ce66b78a9a270ac305791dd2
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
+  sha256: db7455e84e3427e800e4830296247e8a465a13f2cd0b389415a5aec989f5fab0
+  md5: 82fa1f5642ef7ac7172e295327ce20e2
   depends:
-  - libgcc-ng >=9.3.0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
-  size: 9612
-  timestamp: 1614866892676
+  size: 18392
+  timestamp: 1728920054223
 - kind: conda
-  name: xorg-renderproto
-  version: 0.11.1
-  build: h7f98852_1002
-  build_number: 1002
+  name: xorg-libxxf86vm
+  version: 1.1.5
+  build: hb9d3cd8_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
-  sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  md5: 06feff3d2634e3097ce2fe681474b534
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+  sha256: 0b8f062a5b4a2c3833267285b7d41b3542f54d2c935c86ca98504c3e5296354c
+  md5: 7da9007c0582712c4bad4131f89c8372
   depends:
-  - libgcc-ng >=9.3.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
-  size: 9621
-  timestamp: 1614866326326
+  size: 18072
+  timestamp: 1728920051869
 - kind: conda
   name: xorg-xextproto
   version: 7.3.0
-  build: h0b41bf4_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
-  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
-  md5: bce9f945da8ad2ae9b1d7165a64d0f87
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 30270
-  timestamp: 1677036833037
-- kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: h1a8c8d9_1003
-  build_number: 1003
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-h1a8c8d9_1003.conda
-  sha256: 6e5500675070d5bd07ab790f81e6a768c7d1424185a10e896dd03e1ad6e37199
-  md5: e054e2dd816a8907ac9d8d67a6020b37
-  license: MIT
-  license_family: MIT
-  size: 30550
-  timestamp: 1677037030945
-- kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: h2a766a3_1003
-  build_number: 1003
+  build: h57736b2_1004
+  build_number: 1004
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h2a766a3_1003.conda
-  sha256: 62298f1c7b963f3a5921a65d9cb6aae82c3ec8b3069319c8264c5b0a3d190286
-  md5: 32de1e4422c986e3b6eff59e7edc4d04
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+  sha256: 00e2bb1f05e7737002165a4523300c1c28dda127de099288c38ce4a62789183e
+  md5: 4589bf66785ace0f78e8d59d403aad98
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 30267
-  timestamp: 1677037618141
+  size: 30717
+  timestamp: 1726847443586
 - kind: conda
   name: xorg-xextproto
   version: 7.3.0
-  build: hb7f2c08_1003
-  build_number: 1003
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-xextproto-7.3.0-hb7f2c08_1003.conda
-  sha256: 53f1690e46c31c93f9899c6e6524bd1ddd4c8928caff5570b1d30e4ed89858f6
-  md5: e4db268e1dc61ab3dcbbb302f6519f66
+  build: hb9d3cd8_1004
+  build_number: 1004
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+  sha256: f302a3f6284ee9ad3b39e45251d7ed15167896564dc33e006077a896fd3458a6
+  md5: bc4cd53a083b6720d61a1519a1900878
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 30477
-  timestamp: 1677037035675
+  size: 30549
+  timestamp: 1726846235301
 - kind: conda
   name: xorg-xf86vidmodeproto
   version: 2.3.1
-  build: h7f98852_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
-  sha256: 43398aeacad5b8753b7a1c12cb6bca36124e0c842330372635879c350c430791
-  md5: 3ceea9668625c18f19530de98b15d5b0
+  build: h57736b2_1004
+  build_number: 1004
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1004.conda
+  sha256: db4373a3c910ceaf821ecf0e79c0263d727813c21b94995c3b5629955cf934ef
+  md5: c63c8de70afa2fd9848375d27ef92a66
   depends:
-  - libgcc-ng >=9.3.0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 23875
-  timestamp: 1620067286978
+  size: 26277
+  timestamp: 1728918984977
 - kind: conda
   name: xorg-xf86vidmodeproto
   version: 2.3.1
-  build: hf897c2e_1002
-  build_number: 1002
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-hf897c2e_1002.tar.bz2
-  sha256: 097cbc95fbbc9f97571493b0ab1bdd950be8e38395631b32d87d115613abdf4f
-  md5: 8fff0d5f50da4c73f752365c85b5e922
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 23841
-  timestamp: 1620067236301
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: h27ca646_1007
-  build_number: 1007
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
-  sha256: 0ab583e40897d4f3ad414d768371839508bb2a46c5c99e2e5f504aedce5ecf84
-  md5: fca1f15eca1f9fd68a5f2433cb8e5a3f
-  license: MIT
-  license_family: MIT
-  size: 74988
-  timestamp: 1607291556181
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: h3557bc0_1007
-  build_number: 1007
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
-  sha256: 7711ca1898e6f74a8434931fe6c0593ff7201277778aa09ea012d8be8bc7a7f5
-  md5: 987e98faa0ad2c667bbea6b6aae260bc
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 74831
-  timestamp: 1607291481791
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: h35c211d_1007
-  build_number: 1007
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
-  sha256: 433fa2cf3282e0e6f13cf5e73280cd1add4d3be76f19f2674cbd127c9ec70dd4
-  md5: e1b279e3b8c03f88a90e81480a8f319a
-  license: MIT
-  license_family: MIT
-  size: 74832
-  timestamp: 1607291623383
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: h7f98852_1007
-  build_number: 1007
+  build: hb9d3cd8_1004
+  build_number: 1004
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-  md5: b4a4381d54784606820704f7b5f05a15
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1004.conda
+  sha256: f649e15e53d82fe5cece0b1fcc82deea3cd71a01ea4b3ebdc2cef1cdfeaf19b3
+  md5: 24831329718daa6cbe35fcd071b778d4
   depends:
-  - libgcc-ng >=9.3.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 74922
-  timestamp: 1607291557628
+  size: 26209
+  timestamp: 1728918994652
+- kind: conda
+  name: xorg-xorgproto
+  version: '2024.1'
+  build: h00291cd_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-xorgproto-2024.1-h00291cd_1.conda
+  sha256: 34049565572408df1417c16d234841d00cdd8c7ddad632f372c28bdffddb3c65
+  md5: 8d29dcaff88cd231bb16ca7ec4819701
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 567510
+  timestamp: 1726846480273
+- kind: conda
+  name: xorg-xorgproto
+  version: '2024.1'
+  build: h86ecc28_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
+  md5: 91cef7867bf2b47f614597b59705ff56
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 566948
+  timestamp: 1726847598167
+- kind: conda
+  name: xorg-xorgproto
+  version: '2024.1'
+  build: hb9d3cd8_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
+  md5: 7c21106b851ec72c037b162c216d8f05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 565425
+  timestamp: 1726846388217
+- kind: conda
+  name: xorg-xorgproto
+  version: '2024.1'
+  build: hd74edd7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
+  sha256: f76eb03c674719ccaf599c7f5e50a02747382928bdc0927509ef946d450edfa6
+  md5: 1b974e05b976e33edb29a0475013ac60
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 567698
+  timestamp: 1726846426361
 - kind: conda
   name: xz
   version: 5.2.6
@@ -16279,407 +16457,418 @@ packages:
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: h57928b3_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_2.conda
-  sha256: b66c7e0724f87191e82153a80edec11b724ecbd55e59674b9415b40d7346a092
-  md5: f0a2805f5860c1f0e1f8d05b720b0b04
-  depends:
-  - libyarp 3.9.0 ha0ae21b_2
-  - yarp-python >=3.9.0,<3.9.1.0a0
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23710
-  timestamp: 1711031566614
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: h694c41f_2
-  build_number: 2
+  build: h7013b1f_6
+  build_number: 6
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_2.conda
-  sha256: 17bf62f15a4ae584baa06ea7f410261897dee6194806d2fb0ac28b903947d5fd
-  md5: c7ec14a9432115c96d89947510040554
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h7013b1f_6.conda
+  sha256: 7901cf3a8e252b59d69515e0305b4a2f423ef834e92be7b36e325143fcbf4bcc
+  md5: e6b4679b73ad73edad1a930f903c96b8
   depends:
-  - libyarp 3.9.0 h9c0c770_2
+  - libyarp 3.9.0 h0ed339e_6
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23355
-  timestamp: 1711030426760
+  size: 25204
+  timestamp: 1727889672135
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: h8af1aa0_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_2.conda
-  sha256: c48c812c31b1dd440d94c17594eda018c9c88f9ff5d989057038704fd1da0573
-  md5: becf9dd80909549b1e02bc9263092ebe
-  depends:
-  - libyarp 3.9.0 h6d2be9b_2
-  - yarp-python >=3.9.0,<3.9.1.0a0
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23295
-  timestamp: 1711029221232
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: ha770c72_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_2.conda
-  sha256: b562749df529373eb3a1f7b322b9fa386d441d7c9eb79137efa7ac39d700c191
-  md5: 72c8bb1b7239f0ddd4d1dc2d411493f6
-  depends:
-  - libyarp 3.9.0 ha614a09_2
-  - yarp-python >=3.9.0,<3.9.1.0a0
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23327
-  timestamp: 1711028805857
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: hce30654_2
-  build_number: 2
+  build: h7176fba_6
+  build_number: 6
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_2.conda
-  sha256: 8054baa57e0868d222d2f14c359b346bf4ae41dca085abad65e799c2022bc694
-  md5: 8fac77dcee3e39c0e0ecadfdcc3eca40
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-h7176fba_6.conda
+  sha256: 5a5635f3cff9221b6b9185c8cb0d54e0eca992df91ce511ed64dd7288bf58eee
+  md5: 3d64fa11c16123162380e06bfc636991
   depends:
-  - libyarp 3.9.0 hff4382b_2
+  - libyarp 3.9.0 h35b7655_6
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23443
-  timestamp: 1711030519803
+  size: 25148
+  timestamp: 1727889519799
 - kind: conda
-  name: yarp-python
+  name: yarp
   version: 3.9.0
-  build: py312h013081d_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py312h013081d_2.conda
-  sha256: 098aa3aef608306cbc8c1149fc996ef4e09d9d530a14c1c2a6722b4ec6d55da8
-  md5: a2756b066faf58f7dfb5be2da5b07bd3
+  build: hca90a2c_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-hca90a2c_6.conda
+  sha256: 8b4acd77ec8b8850a8558b15bf3114e9f2d4145603a7db8d398fd518fc864f3d
+  md5: 1cf6806c64fbe61292d15777e1b9ed34
   depends:
-  - libcxx >=16
-  - libyarp 3.9.0 h9c0c770_2
-  - numpy
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - libyarp 3.9.0 h564f6a6_6
+  - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1031141
-  timestamp: 1711029395706
+  size: 25051
+  timestamp: 1727890037319
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: hcac4619_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-hcac4619_6.conda
+  sha256: 577079221982011d2403c46ced359e9b5d1c9902f7acac8c099ee66a19cf8fbe
+  md5: 897e1ed084e69ddb3edea1277c26fc99
+  depends:
+  - libyarp 3.9.0 h71b8b94_6
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 25687
+  timestamp: 1727890748773
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: hded75bf_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-hded75bf_6.conda
+  sha256: 15b4fb29a0a3fc2e39e6677e21d24472f31a04784f55b309173afc371b0827f4
+  md5: 78ff0ce4c7a150eba280db71f00ec4ee
+  depends:
+  - libyarp 3.9.0 h31b8c72_6
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 25150
+  timestamp: 1727890244738
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py312h0a24697_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h0a24697_2.conda
-  sha256: fee229c42a0315a72bf3aaf09625560cda7a931ba072a2d9836cd8c1f045b2ea
-  md5: 382f67c91c19ce09cf92434c29077710
+  build: py311h328aa9c_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h328aa9c_6.conda
+  sha256: 426a4a0f5ac6d2d528254006d8d1e0eed84678d0de7d12c8a994286e3844c02e
+  md5: 00f4cca64ceda79c9134de21f6bf56b1
   depends:
-  - libyarp 3.9.0 ha0ae21b_2
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libyarp 3.9.0 h564f6a6_6
   - numpy
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 1169183
+  timestamp: 1727889982400
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py311h7a96f56_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h7a96f56_6.conda
+  sha256: c7912ce32b23c769f9c6165e005347a3531909d434f169a65c06e243262e8dd4
+  md5: 2a67e22b73fada071124fcadae48d952
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libyarp 3.9.0 h0ed339e_6
+  - numpy
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 1028144
+  timestamp: 1727889661962
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py312h3ccbe7c_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h3ccbe7c_6.conda
+  sha256: e3d35a596fc30a13e4523032fce9d68b6414c7d433245c6ab0edf855874f5375
+  md5: b282a343f62e0f361fec6425eafb583b
+  depends:
+  - libyarp 3.9.0 h71b8b94_6
+  - numpy
+  - openssl >=3.3.2,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 897659
-  timestamp: 1711031206524
+  size: 900108
+  timestamp: 1727890740953
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py312h293aecf_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312h293aecf_2.conda
-  sha256: 17a2881764391177606ac06c55d8685643ce7f1d7269a23f4b9be2b016a3a4ae
-  md5: 44e8ddc44180b81bc47588d9df66b710
+  build: py312h53f4ca0_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h53f4ca0_6.conda
+  sha256: 81144f88f478d1507cd5c0904d72928d9505c6aa6ee14abb7f2e4f809d140b98
+  md5: e55980b5418af34efb05b00c6e2128e9
   depends:
-  - libcxx >=16
-  - libyarp 3.9.0 hff4382b_2
+  - libgcc >=13
+  - libstdcxx >=13
+  - libyarp 3.9.0 h31b8c72_6
   - numpy
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.2,<4.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 949024
-  timestamp: 1711029665116
+  size: 1027832
+  timestamp: 1727889802708
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py312h6a62f5c_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h6a62f5c_2.conda
-  sha256: 9d48971b4784668b4c33cb5cf0e068c90b7969d2a8b3f57f094128f240ea4c9b
-  md5: 6394e414ce3127af57c6f4d8eae8fcb2
+  build: py312hd1b4365_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312hd1b4365_6.conda
+  sha256: 5cdcfbb569771e90a3a7cc5a9e62b7fede16728545582ac0fc0af99a45509959
+  md5: 87280f87fdcb238bd619231a5c01e083
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libyarp 3.9.0 h6d2be9b_2
+  - __osx >=11.0
+  - libcxx >=17
+  - libyarp 3.9.0 h35b7655_6
   - numpy
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.2,<4.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1001563
-  timestamp: 1711028997846
+  size: 985449
+  timestamp: 1727889336370
 - kind: conda
-  name: yarp-python
-  version: 3.9.0
-  build: py312hebe80a8_2
+  name: ycm-cmake-modules
+  version: 0.16.9
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
+  sha256: 6769b34a14f710a93d16f620d49f41941ca3ba1e2d4dc632e3b337560646c7f1
+  md5: 26683374f411369c90da91947a126287
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143998
+  timestamp: 1725628711468
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.9
+  build: h5ad3122_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
+  sha256: e561dfc7b3ff30940424359b06efdd1ac74abcf0331433dc787c417bcb794787
+  md5: ac96ccc881727dafb5a5418487255769
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143813
+  timestamp: 1725628825447
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.9
+  build: hac325c4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.9-hac325c4_0.conda
+  sha256: 9e4c9097be9c097cc2d3673c54b32f4866d71a9b17f3d9f3fdd64b9eddf6dae2
+  md5: d94d8d85229f42f27f7aca74f15ba635
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143537
+  timestamp: 1725628779879
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.9
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
+  sha256: 25e574e6e8588830e2e5d8227f12c5d61043b9111bc8bf826588355a4fe74246
+  md5: 68ae20bf2e6f6787994c17789885cdf0
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 144067
+  timestamp: 1725628982924
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.9
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
+  sha256: 094b959a13f5c90407dd84c82221a8187b787cf571a6ed70110f8d13c4e6027b
+  md5: 53e254d12b23ee5c301e625932a6aa77
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143788
+  timestamp: 1725628834144
+- kind: conda
+  name: zlib
+  version: 1.3.1
+  build: h2466b09_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+  sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
+  md5: be60c4e8efa55fddc17b4131aa47acbd
+  depends:
+  - libzlib 1.3.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107439
+  timestamp: 1727963788936
+- kind: conda
+  name: zlib
+  version: 1.3.1
+  build: h8359307_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- kind: conda
+  name: zlib
+  version: 1.3.1
+  build: h86ecc28_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
+  md5: bc230abb5d21b63ff4799b0e75204783
+  depends:
+  - libgcc >=13
+  - libzlib 1.3.1 h86ecc28_2
+  license: Zlib
+  license_family: Other
+  size: 95582
+  timestamp: 1727963203597
+- kind: conda
+  name: zlib
+  version: 1.3.1
+  build: hb9d3cd8_2
   build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py312hebe80a8_2.conda
-  sha256: f8ee77e019cc5b1b3726ff9fa823bb2e820febd043fb1629cad4a0e810568cef
-  md5: a507d746c385c13a917908b1f9e7c19e
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libyarp 3.9.0 ha614a09_2
-  - numpy
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1159071
-  timestamp: 1711028309813
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
 - kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.2
-  build: h2f0025b_0
+  name: zlib
+  version: 1.3.1
+  build: hd23fc13_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: h02f22dd_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.2-h2f0025b_0.conda
-  sha256: 5e3e70bafbae59286829d60e7871f11c7bd2943e4358a554e454b1d451f4d444
-  md5: 75ca6899cc4bc94e30892dd765da4401
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+  sha256: 484f9d0722c77685ae379fbff3ccd662af9ead7e59eb39cd6d0c677cdf25ff6c
+  md5: be8d5f8cf21aed237b8b182ea86b3dd6
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 141938
-  timestamp: 1703084956263
+  size: 539937
+  timestamp: 1714723130243
 - kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.2
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.2-h59595ed_0.conda
-  sha256: 40cdc7a2c32531b186363359da840af525b1d394214e9158e8d10e509d581229
-  md5: 7a923f74bc92d761e6d4abedc047bdac
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 141265
-  timestamp: 1703084908727
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.2
-  build: h63175ca_0
+  name: zstd
+  version: 1.5.6
+  build: h0ea2cb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.2-h63175ca_0.conda
-  sha256: 84284eb0e30b1c6acb8749092291f2d2bafc0bd37b6ec6cdd292314a33dc38e4
-  md5: 72023d3fa5103039e275f11f5a8882ee
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
   depends:
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 141585
-  timestamp: 1703085171511
+  size: 349143
+  timestamp: 1714723445995
 - kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.2
-  build: h73e2aa4_0
+  name: zstd
+  version: 1.5.6
+  build: h915ae27_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.2-h73e2aa4_0.conda
-  sha256: 964c3839758f9c2e59042c7b4514f7de3838e62ede00e26a0206a342af79406d
-  md5: 78ec16ea9b285eaa46dcc9e41d0520f8
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
   depends:
-  - libcxx >=15
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 141935
-  timestamp: 1703085317380
+  size: 498900
+  timestamp: 1714723303098
 - kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.2
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.2-hebf3989_0.conda
-  sha256: a3fe8fc080fdeccd6b676865c5de667817f4af24f195ee87f7cd5043edb41c69
-  md5: 88b9231e9d85d3cbd6b6d1f2f481d390
-  depends:
-  - libcxx >=15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 141873
-  timestamp: 1703085124368
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: h31becfc_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
-  sha256: aa3e9d46b13d1959faf634f03d929d7dec950dc1b84a8ff109f7f0e3f364b562
-  md5: 96866c7301479abaf8308c50958c71a4
-  depends:
-  - libgcc-ng >=12
-  - libzlib 1.2.13 h31becfc_5
-  license: Zlib
-  license_family: Other
-  size: 95842
-  timestamp: 1686575155348
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: h53f4e23_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
-  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
-  md5: a08383f223b10b71492d27566fafbf6c
-  depends:
-  - libzlib 1.2.13 h53f4e23_5
-  license: Zlib
-  license_family: Other
-  size: 79577
-  timestamp: 1686575471024
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: h8a1eda9_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
-  md5: 75a8a98b1c4671c5d2897975731da42d
-  depends:
-  - libzlib 1.2.13 h8a1eda9_5
-  license: Zlib
-  license_family: Other
-  size: 90764
-  timestamp: 1686575574678
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: hcfcfb64_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
-  sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
-  md5: a318e8622e11663f645cc7fa3260f462
-  depends:
-  - libzlib 1.2.13 hcfcfb64_5
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  license_family: Other
-  size: 107711
-  timestamp: 1686575474476
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: hd590300_5
-  build_number: 5
+  name: zstd
+  version: 1.5.6
+  build: ha6fb4c9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
-  md5: 68c34ec6149623be41a1933ab996a209
-  depends:
-  - libgcc-ng >=12
-  - libzlib 1.2.13 hd590300_5
-  license: Zlib
-  license_family: Other
-  size: 92825
-  timestamp: 1686575231103
-- kind: conda
-  name: zstd
-  version: 1.5.5
-  build: h12be248_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 343428
-  timestamp: 1693151615801
-- kind: conda
-  name: zstd
-  version: 1.5.5
-  build: h4c53e97_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
-  sha256: d1e070029e9d07a3f25e6ed082d507b0f3cff1b109dd18d0b091a5c7b86dd07b
-  md5: b74eb9dbb5c3c15cb3cee7cbdf198c75
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 528989
-  timestamp: 1693151197934
+  size: 554846
+  timestamp: 1714722996770
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: h4f39d0f_0
+  version: 1.5.6
+  build: hb46c0d2_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
-  md5: 5b212cfb7f9d71d603ad891879dc7933
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 400508
-  timestamp: 1693151393180
-- kind: conda
-  name: zstd
-  version: 1.5.5
-  build: h829000d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
-  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 499383
-  timestamp: 1693151312586
-- kind: conda
-  name: zstd
-  version: 1.5.5
-  build: hfc55251_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  md5: 04b88013080254850d6c01ed54810589
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 545199
-  timestamp: 1693151163452
+  size: 405089
+  timestamp: 1714723101397

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,9 @@ configure = { cmd = [
     "-DCMAKE_BUILD_TYPE=Release",
     "-DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX",
     "-DBUILD_TESTING:BOOL=ON",
+    "-DIDYNTREE_USES_PYTHON:BOOL=ON",
+    "-DIDYNTREE_USES_PYTHON_PYBIND11:BOOL=ON",
+    "-DIDYNTREE_DETECT_ACTIVE_PYTHON_SITEPACKAGES:BOOL=ON",
     # Use the cross-platform Ninja generator
     "-G",
     "Ninja",


### PR DESCRIPTION
Update `numpy.i` vendored from numpy repo to include the fix https://github.com/numpy/numpy/pull/27579 . The change should be backward compatible for older versions of SWIG.

To validate the change, I run `pixi update` and enabled Python bindings in the pixi build tasks.

Fix https://github.com/robotology/idyntree/issues/1212 .

Related issues:
* https://github.com/numpy/numpy/issues/27578
* https://github.com/numpy/numpy/issues/27577
* https://sourceforge.net/p/swig/mailman/message/58825934/
* https://github.com/numpy/numpy/pull/27579
* https://github.com/diegoferigo/cmake-build-extension/pull/55