### PR TITLE
Add option to print the model in idyntree-model-view

### DIFF
--- a/src/tools/idyntree-model-view.cpp
+++ b/src/tools/idyntree-model-view.cpp
@@ -28,6 +28,7 @@ void addOptions(cmdline::parser &cmd)
     cmd.add<std::string>("color-palette", 'c',
                          "Color palette.",
                          false);
+    cmd.add("print", 'p', "Print the model.");
 }
 
 int main(int argc, char** argv)
@@ -45,6 +46,11 @@ int main(int argc, char** argv)
     {
         std::cerr << "Impossible to read model at file " << modelPath << std::endl;
         return EXIT_FAILURE;
+    }
+
+    if (cmd.exist("print"))
+    {
+        std::cout << mdlLoader.model().toString() << std::endl;
     }
 
     // Visualize the model


### PR DESCRIPTION
I found myself in some occasions using first ``idyntree-model-info`` to get the list of frames, and then ``idyntree-model-view`` to visualize the frames I wanted. I thought we could use the same tool to first print and then visualize the frames of interest