### PR TITLE
CI: Replace deprecated macos-12 images with macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-13, windows-2019]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -1,4 +1,4 @@
-name: MATLAB Tests Workflow
+maname: MATLAB Tests Workflow
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-13]
         matlab_version: [R2022a, R2022b, R2023a]
 
     steps:


### PR DESCRIPTION
The `macos-12` is now deprecated and will be removed soon, see https://github.com/actions/runner-images/issues/10721 . To continue testing macOS with Intel processor, we can switch to use `macos-13`.