### PR TITLE
 Enable runtime window system selection on Linux in `iDynTree::Visualizer`

### DIFF
--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -97,6 +97,25 @@ if(IDYNTREE_USES_IRRLICHT)
         find_library(IOKIT_LIBRARY IOKit)
         target_link_libraries(${libraryname} LINK_PRIVATE ${CARBON_LIBRARY} ${COCOA_LIBRARY} ${IOKIT_LIBRARY})
     endif ()
+
+    # On Linux, in some system for some reason creating a windows with X does not work, but creating it with Wayland
+    # yes. For this reason, we expose an option to permit to try to create a glfw window via wayland. This is an
+    # option and is not enabled by default as the glfw version shipped via apt with Ubuntu version before 24.10, so
+    # we expose this as an option and we enable it by default only if we are configuring inside a conda environment
+    # Once we drop support for apt dependencies on Ubuntu 24.04, we will be able to remove this code and always
+    # try wayland first
+    if(NOT WIN32 AND NOT APPLE)
+        if(DEFINED ENV{CONDA_PREFIX})
+            set(IDYNTREE_GLFW_TRY_WAYLAND_FIRST_DEFAULT_VALUE ON)
+        else()
+            set(IDYNTREE_GLFW_TRY_WAYLAND_FIRST_DEFAULT_VALUE OFF)
+        endif()
+        option(IDYNTREE_GLFW_TRY_WAYLAND_FIRST "If enabled, when creating a window iDynTree will try first to use wayland and only on failure X11" ${IDYNTREE_GLFW_TRY_WAYLAND_FIRST_DEFAULT_VALUE})
+        mark_as_advanced(IDYNTREE_GLFW_TRY_WAYLAND_FIRST)
+        if(IDYNTREE_GLFW_TRY_WAYLAND_FIRST)
+            add_definitions(-DIDYNTREE_GLFW_TRY_WAYLAND_FIRST)
+        endif()
+    endif()
 endif()
 
 if(IDYNTREE_USES_MESHCATCPP)

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -26,7 +26,9 @@
  #define GLFW_EXPOSE_NATIVE_NSGL
 #elif defined(__linux__)
  #define GLFW_EXPOSE_NATIVE_X11
- #define GLFW_EXPOSE_NATIVE_WAYLAND
+ #if defined(IDYNTREE_GLFW_TRY_WAYLAND_FIRST)
+   #define GLFW_EXPOSE_NATIVE_WAYLAND
+ #endif
  #define GLFW_EXPOSE_NATIVE_GLX
 #endif
 
@@ -509,7 +511,7 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
 
     void* nativeWindow = nullptr;
 
-    #ifdef IDYNTREE_USES_WAYLAND
+    #ifdef IDYNTREE_GLFW_TRY_WAYLAND_FIRST
         // Try Wayland first
         struct wl_surface* waylandWindow = glfwGetWaylandWindow(pimpl->m_window);
     #else

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -28,7 +28,6 @@
  #define GLFW_EXPOSE_NATIVE_X11
  #define GLFW_EXPOSE_NATIVE_WAYLAND
  #define GLFW_EXPOSE_NATIVE_GLX
- #define IDYNTREE_USES_WAYLAND
 #endif
 
 #include <GLFW/glfw3.h>

--- a/src/visualization/src/Visualizer.cpp
+++ b/src/visualization/src/Visualizer.cpp
@@ -28,6 +28,7 @@
  #define GLFW_EXPOSE_NATIVE_X11
  #define GLFW_EXPOSE_NATIVE_WAYLAND
  #define GLFW_EXPOSE_NATIVE_GLX
+ #define IDYNTREE_USES_WAYLAND
 #endif
 
 #include <GLFW/glfw3.h>
@@ -506,10 +507,16 @@ bool Visualizer::init(const VisualizerOptions &visualizerOptions)
     pimpl->m_windowId = glfwGetCocoaWindow(pimpl->m_window);
     irrDevParams.WindowId = (void*)(pimpl->m_windowId);
 #elif defined(__linux__)
+
     void* nativeWindow = nullptr;
 
-    // Try Wayland first
-    struct wl_surface* waylandWindow = glfwGetWaylandWindow(pimpl->m_window);
+    #ifdef IDYNTREE_USES_WAYLAND
+        // Try Wayland first
+        struct wl_surface* waylandWindow = glfwGetWaylandWindow(pimpl->m_window);
+    #else
+        void* waylandWindow = nullptr;
+    #endif
+
     if (waylandWindow)
     {
         nativeWindow = static_cast<void*>(waylandWindow);


### PR DESCRIPTION
This PR introduces support for Wayland in the `iDynTree::Visualizer`, allowing it to use Wayland surfaces and fallback to X11 when necessary.

Fixes #1210 