### PR TITLE
Cleanup additional Linux dependencies on conda and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Linux
-        # See https://github.com/robotology/robotology-superbuild/issues/477
-        micromamba install xorg-libx11 xorg-libxrandr freeglut mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
+        micromamba install xorg-xorgproto libgl-devel
 
     - name: Print used environment [Conda]
       shell: bash -l {0}


### PR DESCRIPTION
More and less ~1 week ago the conda CI job started failing with error:

~~~
2024-12-23T13:18:19.1027269Z FAILED: src/visualization/CMakeFiles/idyntree-visualization.dir/src/Visualizer.cpp.o 
2024-12-23T13:18:19.1035277Z /home/runner/micromamba/envs/idyntreedev/bin/x86_64-conda-linux-gnu-c++ -DIDYNTREE_USES_ASSIMP -DIDYNTREE_USES_IRRLICHT -Didyntree_visualization_EXPORTS -I/home/runner/work/idyntree/idyntree/src/visualization/include -I/home/runner/work/idyntree/idyntree/src/core/include -I/home/runner/work/idyntree/idyntree/build/src/core -I/home/runner/work/idyntree/idyntree/src/model/include -I/home/runner/work/idyntree/idyntree/build/src/model -isystem /home/runner/micromamba/envs/idyntreedev/include/eigen3 -isystem /home/runner/micromamba/envs/idyntreedev/include/irrlicht -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /home/runner/micromamba/envs/idyntreedev/include -O3 -DNDEBUG -fPIC -Wall -Wextra -Woverloaded-virtual -pedantic -MD -MT src/visualization/CMakeFiles/idyntree-visualization.dir/src/Visualizer.cpp.o -MF src/visualization/CMakeFiles/idyntree-visualization.dir/src/Visualizer.cpp.o.d -o src/visualization/CMakeFiles/idyntree-visualization.dir/src/Visualizer.cpp.o -c /home/runner/work/idyntree/idyntree/src/visualization/src/Visualizer.cpp
2024-12-23T13:18:19.1043701Z In file included from /home/runner/micromamba/envs/idyntreedev/include/GLFW/glfw3native.h:118,
2024-12-23T13:18:19.1044811Z                  from /home/runner/work/idyntree/idyntree/src/visualization/src/Visualizer.cpp:33:
2024-12-23T13:18:19.1046506Z /home/runner/micromamba/envs/idyntreedev/include/X11/Xlib.h:44:10: fatal error: X11/X.h: No such file or directory
2024-12-23T13:18:19.1047459Z    44 | #include <X11/X.h>
~~~

I am not sure what changed, but anyhow switching to `xorg-xorgproto` and `libgl-devel` is the right thing to do, see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6688 and https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6816 .

