### PR TITLE
Enhance MeshcatVisualizer to support base frame in load_model method

### DIFF
--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -636,7 +636,7 @@ class MeshcatVisualizer:
         if base_link is None:
             self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
         else:
-            base_link_index = self.model[model_name].getFrameIndex(base_link)
+            base_link_index = self.model[model_name].getLinkIndex(base_link)
             self.model[model_name].computeFullTreeTraversal(self.traversal[model_name], base_link_index)
 
         self.link_pos[model_name].resize(self.model[model_name])

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -590,7 +590,7 @@ class MeshcatVisualizer:
             else:
                 with self._animation.at_frame(self.viewer, self._current_frame) as frame:
                     raise NotImplementedError("The set_property method is not implemented for animations.")
-    
+
     def load_model_from_file(
         self, model_path: str, considered_joints=None, model_name="iDynTree", color=None
     ):
@@ -621,7 +621,7 @@ class MeshcatVisualizer:
 
         self.load_model(model=model_loader.model(), model_name=model_name, color=color)
 
-    def load_model(self, model: idyn.Model, model_name="iDynTree", color=None):
+    def load_model(self, model: idyn.Model, base_frame = None, model_name="iDynTree", color=None):
 
         # check if the model already exist
         if self.__model_exists(model_name):
@@ -633,7 +633,12 @@ class MeshcatVisualizer:
         self.traversal[model_name] = idyn.Traversal()
         self.link_pos[model_name] = idyn.LinkPositions()
 
-        self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
+        if base_frame is None:
+            self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
+        else:
+            base_frame_index = self.model[model_name].getFrameIndex(base_frame)
+            self.model[model_name].computeFullTreeTraversal(self.traversal[model_name], base_frame_index)
+
         self.link_pos[model_name].resize(self.model[model_name])
 
         self.__add_model_geometry_to_viewer(

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -621,7 +621,7 @@ class MeshcatVisualizer:
 
         self.load_model(model=model_loader.model(), model_name=model_name, color=color)
 
-    def load_model(self, model: idyn.Model, base_frame = None, model_name="iDynTree", color=None):
+    def load_model(self, model: idyn.Model, base_link = None, model_name="iDynTree", color=None):
 
         # check if the model already exist
         if self.__model_exists(model_name):
@@ -636,8 +636,8 @@ class MeshcatVisualizer:
         if base_frame is None:
             self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
         else:
-            base_frame_index = self.model[model_name].getFrameIndex(base_frame)
-            self.model[model_name].computeFullTreeTraversal(self.traversal[model_name], base_frame_index)
+            base_link_index = self.model[model_name].getFrameIndex(base_link)
+            self.model[model_name].computeFullTreeTraversal(self.traversal[model_name], base_link_index)
 
         self.link_pos[model_name].resize(self.model[model_name])
 

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -640,7 +640,8 @@ class MeshcatVisualizer:
                 return False
         else:
             base_link_index = self.model[model_name].getLinkIndex(base_link)
-            if base_link_index == idyn.LINK_INVALID_INDEX:
+            link_invalid_index = -1 # idyn.LINK_INVALID_INDEX
+            if base_link_index == link_invalid_index:
                 msg = "The link " + base_link + " not found in the model named: " + model_name + "."
                 warnings.warn(msg, category=UserWarning, stacklevel=2)
                 return False

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -627,17 +627,28 @@ class MeshcatVisualizer:
         if self.__model_exists(model_name):
             msg = "The model named: " + model_name + " already exists."
             warnings.warn(msg, category=UserWarning, stacklevel=2)
-            return
+            return False
 
         self.model[model_name] = model.copy()
         self.traversal[model_name] = idyn.Traversal()
         self.link_pos[model_name] = idyn.LinkPositions()
 
         if base_link is None:
-            self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
+            if not self.model[model_name].computeFullTreeTraversal(self.traversal[model_name]):
+                msg = "Unable to compute the full traversal for the model named:" + model_name + "."
+                warnings.warn(msg, category=UserWarning, stacklevel=2)
+                return False
         else:
             base_link_index = self.model[model_name].getLinkIndex(base_link)
-            self.model[model_name].computeFullTreeTraversal(self.traversal[model_name], base_link_index)
+            if base_link_index == idyn.LINK_INVALID_INDEX:
+                msg = "The link " + base_link + " not found in the model named: " + model_name + "."
+                warnings.warn(msg, category=UserWarning, stacklevel=2)
+                return False
+
+            if not self.model[model_name].computeFullTreeTraversal(self.traversal[model_name], base_link_index):
+                msg = "Unable to compute the full traversal for the model named: " + model_name + " starting from the link " + base_link + "."
+                warnings.warn(msg, category=UserWarning, stacklevel=2)
+                return False
 
         self.link_pos[model_name].resize(self.model[model_name])
 
@@ -646,6 +657,8 @@ class MeshcatVisualizer:
             model_name=model_name,
             color=color,
         )
+
+        return True
 
     def load_sphere(self, radius, shape_name="iDynTree", color=None):
         sphere = idyn.Sphere()

--- a/bindings/python/visualize/meshcat_visualizer.py
+++ b/bindings/python/visualize/meshcat_visualizer.py
@@ -633,7 +633,7 @@ class MeshcatVisualizer:
         self.traversal[model_name] = idyn.Traversal()
         self.link_pos[model_name] = idyn.LinkPositions()
 
-        if base_frame is None:
+        if base_link is None:
             self.model[model_name].computeFullTreeTraversal(self.traversal[model_name])
         else:
             base_link_index = self.model[model_name].getFrameIndex(base_link)


### PR DESCRIPTION
This pull request includes modifications to the `bindings/python/visualize/meshcat_visualizer.py` file to enhance the `load_model` method by adding support for an optional `base_frame` parameter. This change allows for more flexible model loading by specifying a base frame for the model's traversal computation.