### PR TITLE
Implement the possibility to use FromPython to generate JointPosDoubleArray and JointDOFsDoubleArray in the python bindings

### DIFF
--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -250,6 +250,52 @@ import_array();
 };
 
 //
+// JointPosDoubleArray
+//
+%extend iDynTree::JointPosDoubleArray {
+    static iDynTree::JointPosDoubleArray FromPython(double* in, int size) {
+        iDynTree::JointPosDoubleArray jntPos;
+        jntPos.resize(static_cast<unsigned>(size));
+        for (int i = 0; i < size; i++) {
+            jntPos(static_cast<unsigned>(i)) = in[i];
+        }
+        return jntPos;
+    }
+
+    JointPosDoubleArray(const double* in_data, const unsigned in_size) {
+        iDynTree::JointPosDoubleArray* jntPos = new iDynTree::JointPosDoubleArray();
+        jntPos->resize(in_size);
+        for (unsigned i = 0; i < in_size; i++) {
+            (*jntPos)(i) = in_data[i];
+        }
+        return jntPos;
+    }
+}
+
+//
+// JointDOFsDoubleArray
+//
+%extend iDynTree::JointDOFsDoubleArray {
+    static iDynTree::JointDOFsDoubleArray FromPython(double* in, int size) {
+        iDynTree::JointDOFsDoubleArray jntDOFs;
+        jntDOFs.resize(static_cast<unsigned>(size));
+        for (int i = 0; i < size; i++) {
+            jntDOFs(static_cast<unsigned>(i)) = in[i];
+        }
+        return jntDOFs;
+    }
+
+    JointDOFsDoubleArray(const double* in_data, const unsigned in_size) {
+        iDynTree::JointDOFsDoubleArray* jntDOFs = new iDynTree::JointDOFsDoubleArray();
+        jntDOFs->resize(in_size);
+        for (unsigned i = 0; i < in_size; i++) {
+            (*jntDOFs)(i) = in_data[i];
+        }
+        return jntDOFs;
+    }
+}
+
+//
 // SpatialVector
 //
 %extend iDynTree::SpatialVector {


### PR DESCRIPTION
With this PR it is possible to use FromPython methods to covert a python array into a JointPosDoubleArray or JointDOFsDoubleArray.

Before the behaviour was:
```python
>>> import idyntree.bindings as idyn
>>> import numpy
>>> x_py = numpy.zeros(6)
>>> x_idyn = idyn.JointPosDoubleArray(6)
>>> x_idyn = x_idyn.FromPython(x_py)
>>> print(type(x_idyn))
<class 'idyntree.swig.VectorDynSize'>
```

Now we have:
```python
>>> import idyntree.bindings as idyn
>>> import numpy
>>> x_py = numpy.zeros(6)
>>> x_idyn = idyn.JointPosDoubleArray(6)
>>> x_idyn = x_idyn.FromPython(x_py)
>>> print(type(x_idyn))
<class 'idyntree.swig.JointPosDoubleArray'>
```

This PR wants to fix https://github.com/robotology/idyntree/issues/999#issuecomment-2777834474.

cc @Gianlucamilani @traversaro 