### PR TITLE
Add xorg-libxrandr and wayland dependency in conda CI and pixi.toml in Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Linux
-        micromamba install xorg-xorgproto libgl-devel
+        micromamba install xorg-xorgproto libgl-devel xorg-libxrandr wayland
 
     - name: Print used environment [Conda]
       shell: bash -l {0}

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        conda install xorg-libxrandr libgl-devel
+        conda install xorg-xorgproto libgl-devel xorg-libxrandr wayland
 
     # Additional dependencies useful only on Windows
     - name: Dependencies [Conda/Windows]

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -21,3 +21,4 @@ dependencies:
   - yarp
   - icub-main 
   - osqp-eigen
+  - xorg-libxrandr

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,4 @@
-version: 5
+version: 6
 environments:
   default:
     channels:
@@ -84,7 +84,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
@@ -99,11 +99,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
@@ -231,6 +233,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
@@ -320,7 +323,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
@@ -335,11 +338,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.1-default_h3030c0e_1000.conda
@@ -458,6 +463,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
@@ -958,24 +964,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
 packages:
-- kind: conda
-  name: _libgcc_mutex
-  version: '0.1'
-  build: conda_forge
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
   size: 2562
   timestamp: 1578324546067
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_kmp_llvm
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
   md5: 562b26ba2e19059551a811e72ab7f793
   depends:
@@ -985,13 +981,8 @@ packages:
   license_family: BSD
   size: 5744
   timestamp: 1650742457817
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_kmp_llvm
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   sha256: 7ef8a15d19133d82014945d3b7fd3bb4202b51c06a5522bf99e13c731f2396c3
   md5: 98a1185182fec3c434069fa74e6473d6
   depends:
@@ -1000,26 +991,7 @@ packages:
   license_family: BSD
   size: 5802
   timestamp: 1650742448370
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: h00cdb27_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
-  sha256: 48df3d15ec38ca23e09bf0f15f1852c9646c26880ca2ddec8437e196ef1d1870
-  md5: 2eb7794e38928e7a4fe8cfcf0bb52e1b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: DOC
-  size: 1824080
-  timestamp: 1722623136969
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: he02047a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
   sha256: 287025e0deee445b3e6fc849852466a153dcdceba81824536647e75d64b22017
   md5: 8cbfcc4b8e11a401ed8400c4d0145fea
   depends:
@@ -1029,12 +1001,34 @@ packages:
   license: DOC
   size: 5449099
   timestamp: 1722622759964
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
+  sha256: d60b603ac170c8907623252792ff3cfa5e75b2bff0e7378243d74527da645e7a
+  md5: c9db7894fbe35f235d75aded931010ac
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: DOC
+  size: 5338955
+  timestamp: 1722626386604
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ace-8.0.1-hf036a51_0.conda
+  sha256: ac3a301d5bd4dd0dbc04884f7f8dda21281ca4677a5730eefec2e0182846c4b4
+  md5: 2b5e5281bef8d92713ae911697628a8a
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: DOC
+  size: 1796328
+  timestamp: 1722622941798
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
+  sha256: 48df3d15ec38ca23e09bf0f15f1852c9646c26880ca2ddec8437e196ef1d1870
+  md5: 2eb7794e38928e7a4fe8cfcf0bb52e1b
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: DOC
+  size: 1824080
+  timestamp: 1722623136969
+- conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
   sha256: 7bdd85ba11690416f29200421a7b546884896c4bdff0a4f9e2fbe24292e692d6
   md5: 0382a1b8ce5bc60a11a8510dc20c44f8
   depends:
@@ -1044,40 +1038,7 @@ packages:
   license: DOC
   size: 2005656
   timestamp: 1722623567537
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: hf036a51_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ace-8.0.1-hf036a51_0.conda
-  sha256: ac3a301d5bd4dd0dbc04884f7f8dda21281ca4677a5730eefec2e0182846c4b4
-  md5: 2b5e5281bef8d92713ae911697628a8a
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  license: DOC
-  size: 1796328
-  timestamp: 1722622941798
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: hf9b3779_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
-  sha256: d60b603ac170c8907623252792ff3cfa5e75b2bff0e7378243d74527da645e7a
-  md5: c9db7894fbe35f235d75aded931010ac
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: DOC
-  size: 5338955
-  timestamp: 1722626386604
-- kind: conda
-  name: alsa-lib
-  version: 1.2.12
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
   sha256: 64b95dd06d7ca6b54cea03b02da8f1657b9899ca376d0ca7b47823064f55fb16
   md5: 7ed427f0871fd41cb1d9c17727c17589
   depends:
@@ -1086,12 +1047,7 @@ packages:
   license_family: GPL
   size: 555868
   timestamp: 1718118368236
-- kind: conda
-  name: alsa-lib
-  version: 1.2.12
-  build: h68df207_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
   sha256: 40328d34c61f6e37873828566c9b4f704a11223a0577511226b5287803e69661
   md5: 65448d015f05afb3c68ea92d0483a466
   depends:
@@ -1100,48 +1056,7 @@ packages:
   license_family: GPL
   size: 585566
   timestamp: 1718118473054
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: h05efe27_1006
-  build_number: 1006
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
-  sha256: f178cb90d1fb76453a712573c4229de353962e21b53be47f5d10f66af9226bad
-  md5: 4bd9e551560df784b4c998f56cc83b4a
-  depends:
-  - libgcc-ng >=9.4.0
-  - libgfortran-ng
-  - libgfortran5 >=9.4.0
-  - libstdcxx-ng >=9.4.0
-  - unixodbc >=2.3.9,<2.4.0a0
-  license: HPND
-  size: 1275764
-  timestamp: 1645060845399
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: h2beb688_1006
-  build_number: 1006
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
-  sha256: 300f929bee9775b4d3625036376cd7d5f38e03fd949094e819f46e319bd53978
-  md5: 2ed1f1350aade6feacfcb7ea22aa8505
-  depends:
-  - libcxx >=11.1.0
-  - libgfortran 5.*
-  - libgfortran5 >=9.3.0
-  - unixodbc >=2.3.9,<2.4.0a0
-  license: HPND
-  size: 1076342
-  timestamp: 1645058227340
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: h2cc385e_1006
-  build_number: 1006
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
   sha256: ff6e942d6490496d98d670f783275078d2a30c694202304ecd49fb759b93c07f
   md5: 6c2f16f5650a7c66ffdfee57b890ea06
   depends:
@@ -1153,13 +1068,30 @@ packages:
   license: HPND
   size: 1137486
   timestamp: 1645057516176
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: hbec66e7_1006
-  build_number: 1006
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
+  sha256: f178cb90d1fb76453a712573c4229de353962e21b53be47f5d10f66af9226bad
+  md5: 4bd9e551560df784b4c998f56cc83b4a
+  depends:
+  - libgcc-ng >=9.4.0
+  - libgfortran-ng
+  - libgfortran5 >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  size: 1275764
+  timestamp: 1645060845399
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
+  sha256: 300f929bee9775b4d3625036376cd7d5f38e03fd949094e819f46e319bd53978
+  md5: 2ed1f1350aade6feacfcb7ea22aa8505
+  depends:
+  - libcxx >=11.1.0
+  - libgfortran 5.*
+  - libgfortran5 >=9.3.0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  size: 1076342
+  timestamp: 1645058227340
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
   sha256: 781ef33b48e2b9687dce2019db411994fea44e56c2d0265e197c3acb19bbefa2
   md5: 39bd6ea77989a38b163b971a54bb1aba
   depends:
@@ -1170,27 +1102,7 @@ packages:
   license: HPND
   size: 991108
   timestamp: 1645057976681
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: h7bae524_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
-  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
-  md5: 7adba36492a1bb22d98ffffe4f6fc6de
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2235747
-  timestamp: 1718551382432
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
   depends:
@@ -1200,12 +1112,7 @@ packages:
   license_family: BSD
   size: 2706396
   timestamp: 1718551242397
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hcccb83c_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
   sha256: ac438ce5d3d3673a9188b535fc7cda413b479f0d52536aeeac1bd82faa656ea0
   md5: cc744ac4efe5bcaa8cca51ff5b850df0
   depends:
@@ -1215,12 +1122,27 @@ packages:
   license_family: BSD
   size: 3250813
   timestamp: 1718551360260
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+  sha256: 3032f2f55d6eceb10d53217c2a7f43e1eac83603d91e21ce502e8179e63a75f5
+  md5: 3f17bc32cb7fcb2b4bf3d8d37f656eb8
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2749186
+  timestamp: 1718551450314
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
+  md5: 7adba36492a1bb22d98ffffe4f6fc6de
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2235747
+  timestamp: 1718551382432
+- conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
   sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
   md5: 3d7c14285d3eb3239a76ff79063f27a5
   depends:
@@ -1231,27 +1153,7 @@ packages:
   license_family: BSD
   size: 1958151
   timestamp: 1718551737234
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hf036a51_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
-  sha256: 3032f2f55d6eceb10d53217c2a7f43e1eac83603d91e21ce502e8179e63a75f5
-  md5: 3f17bc32cb7fcb2b4bf3d8d37f656eb8
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2749186
-  timestamp: 1718551450314
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: h8943939_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
   sha256: c9022ee34f756847f48907472514da3395a8c0549679cfd2a1b4f6833dd6298c
   md5: 5546062a59566def2fa6482acf531841
   depends:
@@ -1265,30 +1167,7 @@ packages:
   license_family: BSD
   size: 3535704
   timestamp: 1725086969417
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: ha9c0b8d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
-  sha256: d5c348d697abbb824f12bebb8da4de960e0ca2d62350745cfc08da3b984491c4
-  md5: 4f6abafa61c3c6d3ff9a1b012fe2e9fa
-  depends:
-  - __osx >=11.0
-  - libboost >=1.86.0,<1.87.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2478543
-  timestamp: 1725087172579
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: hdc325bc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
   sha256: e791fd005b413d1fc7aa7f84d8c83343c64b53ab02e7bd410cb1f2f61789baf9
   md5: 553a8f53d6d599fa15dcbdd95c3c8cee
   depends:
@@ -1301,12 +1180,33 @@ packages:
   license_family: BSD
   size: 3476475
   timestamp: 1725087034438
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: hf1e84b2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.4.3-hf9fe5ce_0.conda
+  sha256: 305e318014db5e6873bd94bfb14d675cbb209cc9b196743e73d1e0dc55df527b
+  md5: 8cc9a947c9e41d03600f8aa7eec34e42
+  depends:
+  - __osx >=10.13
+  - libboost >=1.86.0,<1.87.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2719322
+  timestamp: 1725087116119
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
+  sha256: d5c348d697abbb824f12bebb8da4de960e0ca2d62350745cfc08da3b984491c4
+  md5: 4f6abafa61c3c6d3ff9a1b012fe2e9fa
+  depends:
+  - __osx >=11.0
+  - libboost >=1.86.0,<1.87.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2478543
+  timestamp: 1725087172579
+- conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
   sha256: b3a651af288b4ef41323d1931a3042a050935096575a75e6e0df7f4bb974903a
   md5: af71c63135f00fd8522d5aa729996f98
   depends:
@@ -1320,31 +1220,7 @@ packages:
   license_family: BSD
   size: 11937899
   timestamp: 1725087701414
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: hf9fe5ce_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.4.3-hf9fe5ce_0.conda
-  sha256: 305e318014db5e6873bd94bfb14d675cbb209cc9b196743e73d1e0dc55df527b
-  md5: 8cc9a947c9e41d03600f8aa7eec34e42
-  depends:
-  - __osx >=10.13
-  - libboost >=1.86.0,<1.87.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2719322
-  timestamp: 1725087116119
-- kind: conda
-  name: attr
-  version: 2.5.1
-  build: h166bdaf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
   sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
   md5: d9c69a24ad678ffce24c6543a0176b00
   depends:
@@ -1353,13 +1229,7 @@ packages:
   license_family: GPL
   size: 71042
   timestamp: 1660065501192
-- kind: conda
-  name: attr
-  version: 2.5.1
-  build: h4e544f5_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
   sha256: 2c793b48e835a8fac93f1664c706442972a0206963bf8ca202e83f7f4d29a7d7
   md5: 1ef6c06fec1b6f5ee99ffe2152e53568
   depends:
@@ -1368,13 +1238,7 @@ packages:
   license_family: GPL
   size: 74992
   timestamp: 1660065534958
-- kind: conda
-  name: binutils
-  version: '2.43'
-  build: h4852527_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
   sha256: 92be0f8ccd501ceeb3c782e2182e6ea04dca46799038176de40a57bca45512c5
   md5: 348619f90eee04901f4a70615efff35b
   depends:
@@ -1383,13 +1247,7 @@ packages:
   license_family: GPL
   size: 33876
   timestamp: 1729655402186
-- kind: conda
-  name: binutils
-  version: '2.43'
-  build: hf1166c9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_2.conda
   sha256: 50962dd8b4de41c9dcd2d19f37683aff1a7c3fc01e6b1617dd250940f2b83055
   md5: 4afcab775fe2288fce420514cd92ae37
   depends:
@@ -1398,13 +1256,7 @@ packages:
   license_family: GPL
   size: 33870
   timestamp: 1729655405026
-- kind: conda
-  name: binutils_impl_linux-64
-  version: '2.43'
-  build: h4bf12b8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
   sha256: 267e78990247369b13234bda270f31beb56a600b4851a8244e31dd9ad85b3b17
   md5: cf0c5521ac2a20dfa6c662a4009eeef6
   depends:
@@ -1414,13 +1266,7 @@ packages:
   license_family: GPL
   size: 5682777
   timestamp: 1729655371045
-- kind: conda
-  name: binutils_impl_linux-aarch64
-  version: '2.43'
-  build: h4c662bb_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_2.conda
   sha256: 0bb8058bdb662e085f844f803a98e89314268c3e7aa79d495529992a8f41ecf1
   md5: 2eb09e329ee7030a4cab0269eeea97d4
   depends:
@@ -1430,13 +1276,7 @@ packages:
   license_family: GPL
   size: 6722685
   timestamp: 1729655379343
-- kind: conda
-  name: binutils_linux-64
-  version: '2.43'
-  build: h4852527_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
   sha256: df52bd8b8b2a20a0c529d9ad08aaf66093ac318aa8a33d270f18274341a77062
   md5: 18aba879ddf1f8f28145ca6fcb873d8c
   depends:
@@ -1445,13 +1285,7 @@ packages:
   license_family: GPL
   size: 34945
   timestamp: 1729655404893
-- kind: conda
-  name: binutils_linux-aarch64
-  version: '2.43'
-  build: hf1166c9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_2.conda
   sha256: 97fe7c2023fdbef453a2a05d53d81037a7e18c4b3946dd68a7ea122747e7d1fa
   md5: 5c308468fe391f32dc3bb57a4b4622aa
   depends:
@@ -1460,13 +1294,44 @@ packages:
   license_family: GPL
   size: 34879
   timestamp: 1729655407691
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h2466b09_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+  sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
+  md5: 56398c28220513b9ea13d7b450acfb20
+  depends:
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 189884
+  timestamp: 1720974504976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
   sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
   md5: 276e7ffe9ffe39688abc665ef0f45596
   depends:
@@ -1477,116 +1342,7 @@ packages:
   license_family: BSD
   size: 54927
   timestamp: 1720974860185
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h4bc722e_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
-  md5: 62ee74e96c5ebb0af99386de58cf9553
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 252783
-  timestamp: 1720974456583
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h68df207_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
-  sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
-  md5: 56398c28220513b9ea13d7b450acfb20
-  depends:
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 189884
-  timestamp: 1720974504976
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h99b78c6_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
-  depends:
-  - __osx >=11.0
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 122909
-  timestamp: 1720974522888
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: hfdf4475_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
-  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
-  md5: 7ed4301d437b59045be7e051a0308211
-  depends:
-  - __osx >=10.13
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 134188
-  timestamp: 1720974491916
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: h32b1619_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
-  sha256: 972d0403c92c9cd1d1c60e34d80991258125ee880cf5a9289ae83a443d8970cd
-  md5: 724edfea6dde646c1faf2ce1423e0faa
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 182342
-  timestamp: 1729006698430
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: h7ab814d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
-  sha256: 24d53d27397f9c2f0c168992690b5ec1bd62593fb4fc1f1e906ab91b10fd06c3
-  md5: 8a8cfc11064b521bc54bd2d8591cb137
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 177487
-  timestamp: 1729006763496
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: ha64f414_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
-  sha256: 06f67e6b2c18f1ff79391ffb032c752fcbbf754f6f6e7a786edde6cca1c92791
-  md5: 588af5337614cece17e61b6ac907f812
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 214916
-  timestamp: 1729006632022
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: heb4867d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
   sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
   md5: 2b780c0338fc0ffa678ac82c54af51fd
   depends:
@@ -1596,13 +1352,35 @@ packages:
   license_family: MIT
   size: 205797
   timestamp: 1729006575652
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: h2b85faf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
+  sha256: 06f67e6b2c18f1ff79391ffb032c752fcbbf754f6f6e7a786edde6cca1c92791
+  md5: 588af5337614cece17e61b6ac907f812
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 214916
+  timestamp: 1729006632022
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
+  sha256: 972d0403c92c9cd1d1c60e34d80991258125ee880cf5a9289ae83a443d8970cd
+  md5: 724edfea6dde646c1faf2ce1423e0faa
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 182342
+  timestamp: 1729006698430
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
+  sha256: 24d53d27397f9c2f0c168992690b5ec1bd62593fb4fc1f1e906ab91b10fd06c3
+  md5: 8a8cfc11064b521bc54bd2d8591cb137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 177487
+  timestamp: 1729006763496
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
   sha256: 009fced27be14e5ac750a04111a07eda79d73f80009300c1538cb83d5da71879
   md5: fa7b3bf2965b9d74a81a0702d9bb49ee
   depends:
@@ -1613,13 +1391,7 @@ packages:
   license_family: BSD
   size: 6085
   timestamp: 1728985300402
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: h6561dab_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.8.0-h6561dab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.8.0-h6561dab_1.conda
   sha256: f1b894a87a9bd8446de2ebd1820cc965e1fe2d5462e8c7df43a0b108732597a2
   md5: 715a2eea9897fb01de5dd6ba82728935
   depends:
@@ -1630,46 +1402,7 @@ packages:
   license_family: BSD
   size: 6190
   timestamp: 1728985292548
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_1.conda
-  sha256: 3fc7b2ceb03cc024e5f91f70fb576da71ff9cec787f3c481f3372d311ecc04f3
-  md5: 33c106164044a19c4e8d13277ae97c3f
-  depends:
-  - vs2019_win-64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6513
-  timestamp: 1728985389589
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: hf48404e_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
-  sha256: 64245f90755c314f61d48b38fc7b82270b709f88204789895f7c4b2b84204992
-  md5: 429476dcb80c4f9087cd8ac1fa2183d1
-  depends:
-  - cctools >=949.0.1
-  - clang_osx-arm64 17.*
-  - ld64 >=530
-  - llvm-openmp
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6220
-  timestamp: 1728985386241
-- kind: conda
-  name: c-compiler
-  version: 1.8.0
-  build: hfc4bf79_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.8.0-hfc4bf79_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.8.0-hfc4bf79_1.conda
   sha256: b5bff50c0792933c19bdf4c18b77c5aedabce4b01f86d3b68815534f3e9e3640
   md5: d6e3cf55128335736c8d4bb86e73c191
   depends:
@@ -1681,171 +1414,58 @@ packages:
   license_family: BSD
   size: 6210
   timestamp: 1728985474611
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: h56e8100_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
-  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
-  md5: 4c4fd67c18619be5aa65dc5b6c72e490
-  license: ISC
-  size: 158773
-  timestamp: 1725019107649
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: h8857fd0_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
-  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
-  md5: b7e5424e7f06547a903d28e4651dbb21
-  license: ISC
-  size: 158665
-  timestamp: 1725019059295
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hbcca054_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
+  sha256: 64245f90755c314f61d48b38fc7b82270b709f88204789895f7c4b2b84204992
+  md5: 429476dcb80c4f9087cd8ac1fa2183d1
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-arm64 17.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6220
+  timestamp: 1728985386241
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_1.conda
+  sha256: 3fc7b2ceb03cc024e5f91f70fb576da71ff9cec787f3c481f3372d311ecc04f3
+  md5: 33c106164044a19c4e8d13277ae97c3f
+  depends:
+  - vs2019_win-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6513
+  timestamp: 1728985389589
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
   sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   md5: c27d1c142233b5bc9ca570c6e2e0c244
   license: ISC
   size: 159003
   timestamp: 1725018903918
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hcefe29a_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
   sha256: 2a2d827bee3775a85f0f1b2f2089291475c4416336d1b3a8cbce2964db547af8
   md5: 70e57e8f59d2c98f86b49c69e5074be5
   license: ISC
   size: 159106
   timestamp: 1725020043153
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hf0a4a13_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
   sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
   md5: 40dec13fd8348dbe303e57be74bd3d35
   license: ISC
   size: 158482
   timestamp: 1725019034582
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: h32b962e_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
-  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
-  md5: 8f43723a4925c51e55c2d81725a97db4
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  size: 1516680
-  timestamp: 1721139332360
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: h37bd5c4_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
-  sha256: 8d70fbca4887b9b580de0f3715026e05f9e74fad8a652364aa0bccd795b1fa87
-  md5: 448aad56614db52338dc4fd4c758cfb6
-  depends:
-  - __osx >=10.13
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  size: 892544
-  timestamp: 1721139116538
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hb4a6bf7_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
-  sha256: f7603b7f6ee7c6e07c23d77302420194f4ec1b8e8facfff2b6aab17c7988a102
-  md5: 08bd0752f3de8a2d8a35fd012f09531f
-  depends:
-  - __osx >=11.0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  size: 899126
-  timestamp: 1721139203735
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hdb1a16f_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
-  sha256: 8a747ad6ce32228a85c80bef8ec7387d71f8d2b0bf637edb56ff33e09794c616
-  md5: 080659f02bf2202c57f1cda4f9e51f21
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  size: 966709
-  timestamp: 1721138947987
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hebfffa5_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
   sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
   md5: fceaedf1cdbcb02df9699a0d9b005292
   depends:
@@ -1870,13 +1490,86 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 983604
   timestamp: 1721138900054
-- kind: conda
-  name: cctools
-  version: '1010.6'
-  build: h5b2de21_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h5b2de21_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
+  sha256: 8a747ad6ce32228a85c80bef8ec7387d71f8d2b0bf637edb56ff33e09794c616
+  md5: 080659f02bf2202c57f1cda4f9e51f21
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 966709
+  timestamp: 1721138947987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+  sha256: 8d70fbca4887b9b580de0f3715026e05f9e74fad8a652364aa0bccd795b1fa87
+  md5: 448aad56614db52338dc4fd4c758cfb6
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 892544
+  timestamp: 1721139116538
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+  sha256: f7603b7f6ee7c6e07c23d77302420194f4ec1b8e8facfff2b6aab17c7988a102
+  md5: 08bd0752f3de8a2d8a35fd012f09531f
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 899126
+  timestamp: 1721139203735
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
+  md5: 8f43723a4925c51e55c2d81725a97db4
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1516680
+  timestamp: 1721139332360
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h5b2de21_1.conda
   sha256: 3881b38dcb1e6a129617a270396e85a65b4202cf5e02a2d133caaff8643ae489
   md5: 5a08ae55869b0b1eb7fbee910aa30d19
   depends:
@@ -1887,13 +1580,7 @@ packages:
   license_family: Other
   size: 21528
   timestamp: 1726771688744
-- kind: conda
-  name: cctools
-  version: '1010.6'
-  build: hf67d63f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_1.conda
   sha256: b85469a1277da76dbbc71639b03014143cec96fe2e86dc11b1c3e299b9d29e2f
   md5: f9138a6ffe696dadea9374101856747b
   depends:
@@ -1904,13 +1591,7 @@ packages:
   license_family: Other
   size: 21681
   timestamp: 1726771723258
-- kind: conda
-  name: cctools_osx-64
-  version: '1010.6'
-  build: h98e843e_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-h98e843e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-h98e843e_1.conda
   sha256: e28e55f55af27b66fbf4afc45f521f9a869e4495bd260c7c721dd2ac51e017a1
   md5: ed757b98aaa22a9e38c5a76191fb477c
   depends:
@@ -1929,13 +1610,7 @@ packages:
   license_family: Other
   size: 1096895
   timestamp: 1726771657226
-- kind: conda
-  name: cctools_osx-arm64
-  version: '1010.6'
-  build: h4208deb_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4208deb_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4208deb_1.conda
   sha256: 7122430e69ab8e38d382553bf7225b0887158341fe6879be4220e4e495b93aac
   md5: bca79601bdb3a3dfa4c3917701a79f81
   depends:
@@ -1954,28 +1629,7 @@ packages:
   license_family: Other
   size: 1089821
   timestamp: 1726771687683
-- kind: conda
-  name: clang
-  version: 17.0.6
-  build: default_h360f5da_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
-  sha256: 3caeb933e74561c834074ef1617aa721c10e6b08c1fed9d5180c82a9ba18b5f2
-  md5: c98bdbd4985530fac68ea4831d053ba1
-  depends:
-  - clang-17 17.0.6 default_h146c034_7
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 24105
-  timestamp: 1725505775351
-- kind: conda
-  name: clang
-  version: 17.0.6
-  build: default_he371ed4_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-17.0.6-default_he371ed4_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang-17.0.6-default_he371ed4_7.conda
   sha256: 0bcc3fa29482ac32847bd5baac89563e285978fdc3f9d0c5d0844d647ecba821
   md5: fd6888f26c44ddb10c9954a2df5765c7
   depends:
@@ -1984,36 +1638,16 @@ packages:
   license_family: Apache
   size: 23890
   timestamp: 1725506037908
-- kind: conda
-  name: clang-17
-  version: 17.0.6
-  build: default_h146c034_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
-  sha256: f9e40e5402ab78543553e7bc0437dfeed42d43f486395b66dd55ea0fd819b789
-  md5: 585064b6856cb3e719343e3362ea828b
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
+  sha256: 3caeb933e74561c834074ef1617aa721c10e6b08c1fed9d5180c82a9ba18b5f2
+  md5: c98bdbd4985530fac68ea4831d053ba1
   depends:
-  - __osx >=11.0
-  - libclang-cpp17 17.0.6 default_h146c034_7
-  - libcxx >=17.0.6
-  - libllvm17 >=17.0.6,<17.1.0a0
-  constrains:
-  - clangxx 17.0.6
-  - clang-tools 17.0.6
-  - clangdev 17.0.6
-  - llvm-tools 17.0.6
+  - clang-17 17.0.6 default_h146c034_7
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 715930
-  timestamp: 1725505694198
-- kind: conda
-  name: clang-17
-  version: 17.0.6
-  build: default_hb173f14_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-17-17.0.6-default_hb173f14_7.conda
+  size: 24105
+  timestamp: 1725505775351
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang-17-17.0.6-default_hb173f14_7.conda
   sha256: 95cb7cc541e45757b2cc586b1db6fb2f27796316723fe07c8c225f7ea12f6c9b
   md5: 809e36447b1bfb87ed1b7fb46339561a
   depends:
@@ -2030,13 +1664,24 @@ packages:
   license_family: Apache
   size: 719083
   timestamp: 1725505951220
-- kind: conda
-  name: clang_impl_osx-64
-  version: 17.0.6
-  build: h1af8efd_21
-  build_number: 21
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-17.0.6-h1af8efd_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
+  sha256: f9e40e5402ab78543553e7bc0437dfeed42d43f486395b66dd55ea0fd819b789
+  md5: 585064b6856cb3e719343e3362ea828b
+  depends:
+  - __osx >=11.0
+  - libclang-cpp17 17.0.6 default_h146c034_7
+  - libcxx >=17.0.6
+  - libllvm17 >=17.0.6,<17.1.0a0
+  constrains:
+  - clangxx 17.0.6
+  - clang-tools 17.0.6
+  - clangdev 17.0.6
+  - llvm-tools 17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 715930
+  timestamp: 1725505694198
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-17.0.6-h1af8efd_21.conda
   sha256: 739050856565443f5568370f9a0a28f803579eb5dbee635c65b83056e52e42c9
   md5: 6ef491cbc462aae64eaa0213e7ae6222
   depends:
@@ -2049,13 +1694,7 @@ packages:
   license_family: BSD
   size: 17526
   timestamp: 1728550487882
-- kind: conda
-  name: clang_impl_osx-arm64
-  version: 17.0.6
-  build: he47c785_21
-  build_number: 21
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_21.conda
   sha256: e3e2038b22b425f4fd4bae6d50c15be1a6da2075c3ff5072c7f98bff14072b4a
   md5: 2417a85d8d37df3df2bd37b6ae0514aa
   depends:
@@ -2068,13 +1707,7 @@ packages:
   license_family: BSD
   size: 17585
   timestamp: 1728550578755
-- kind: conda
-  name: clang_osx-64
-  version: 17.0.6
-  build: hb91bd55_21
-  build_number: 21
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-17.0.6-hb91bd55_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-17.0.6-hb91bd55_21.conda
   sha256: 446ff91c60c6266e4e5bcaab20377116ef59e1e3b712da7aa37faad644ae8065
   md5: d94a0f2c03e7a50203d2b78d7dd9fa25
   depends:
@@ -2083,13 +1716,7 @@ packages:
   license_family: BSD
   size: 20624
   timestamp: 1728550493227
-- kind: conda
-  name: clang_osx-arm64
-  version: 17.0.6
-  build: h54d7cd3_21
-  build_number: 21
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h54d7cd3_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h54d7cd3_21.conda
   sha256: f71a0285bba6695a3d1693563d43b4b3f31f611dccf2b8c3be2a480cf1da2b7a
   md5: 83a80f491ac81d81f28cb9a46d3f5439
   depends:
@@ -2098,29 +1725,7 @@ packages:
   license_family: BSD
   size: 20608
   timestamp: 1728550586726
-- kind: conda
-  name: clangxx
-  version: 17.0.6
-  build: default_h360f5da_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
-  sha256: 73a87fe4a31494cdc5d74aacf9d08f560e4468795547f06290ee6a7bb128f61c
-  md5: 0bb5cea65ab3457812707537603a3619
-  depends:
-  - clang 17.0.6 default_h360f5da_7
-  - libcxx-devel 17.0.6.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 24168
-  timestamp: 1725505786435
-- kind: conda
-  name: clangxx
-  version: 17.0.6
-  build: default_he371ed4_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-17.0.6-default_he371ed4_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-17.0.6-default_he371ed4_7.conda
   sha256: 8f7e1d2759b5bd33577054cd72631dc7a4154e7a2b92880040b37c5be0a38255
   md5: 4f110486af1272f0d4dee6adc5041fbf
   depends:
@@ -2130,13 +1735,17 @@ packages:
   license_family: Apache
   size: 23975
   timestamp: 1725506051851
-- kind: conda
-  name: clangxx_impl_osx-64
-  version: 17.0.6
-  build: hc3430b7_21
-  build_number: 21
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-17.0.6-hc3430b7_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
+  sha256: 73a87fe4a31494cdc5d74aacf9d08f560e4468795547f06290ee6a7bb128f61c
+  md5: 0bb5cea65ab3457812707537603a3619
+  depends:
+  - clang 17.0.6 default_h360f5da_7
+  - libcxx-devel 17.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 24168
+  timestamp: 1725505786435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-17.0.6-hc3430b7_21.conda
   sha256: 68bfcd5f17945497582cb91a44737a94a2600a0dab7f0ef6c9118e1d5fb089de
   md5: 9dbdec57445cac0f0c39aefe3d3900bc
   depends:
@@ -2148,13 +1757,7 @@ packages:
   license_family: BSD
   size: 17588
   timestamp: 1728550507978
-- kind: conda
-  name: clangxx_impl_osx-arm64
-  version: 17.0.6
-  build: h50f59cd_21
-  build_number: 21
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_21.conda
   sha256: bfdf0b768b36694707fab931ccbe9971bd1b9a258c0806c62596d5c93167e972
   md5: a78eb1ab3aad5251ff9c6da5a99d59be
   depends:
@@ -2166,13 +1769,7 @@ packages:
   license_family: BSD
   size: 17648
   timestamp: 1728550606508
-- kind: conda
-  name: clangxx_osx-64
-  version: 17.0.6
-  build: hb91bd55_21
-  build_number: 21
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-17.0.6-hb91bd55_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-17.0.6-hb91bd55_21.conda
   sha256: 780cd56526c835bb5ca867939b3a8613af4ea67c9c37cc952bfaad438974b098
   md5: cfcbb6790123280b5be7992d392e8194
   depends:
@@ -2182,13 +1779,7 @@ packages:
   license_family: BSD
   size: 19261
   timestamp: 1728550514642
-- kind: conda
-  name: clangxx_osx-arm64
-  version: 17.0.6
-  build: h54d7cd3_21
-  build_number: 21
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h54d7cd3_21.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h54d7cd3_21.conda
   sha256: 02bc5ed5f37a6e3d4e244d09e4e5db7bfc9ad2b7342f14a68f2b971511b7afc7
   md5: 594c1db6262e284e928c9d4f28dc8846
   depends:
@@ -2198,82 +1789,7 @@ packages:
   license_family: BSD
   size: 19257
   timestamp: 1728550613321
-- kind: conda
-  name: cmake
-  version: 3.30.5
-  build: h400e5d1_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.5-h400e5d1_0.conda
-  sha256: f1df2ab533ffed1a544ab0672bd09abeaee36cadf59c12f8564b03237779b3d3
-  md5: 4b84d88fe13e33dd1cad2deaac3fbcf4
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libuv >=1.49.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14357142
-  timestamp: 1728417628536
-- kind: conda
-  name: cmake
-  version: 3.30.5
-  build: h7243fc2_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.30.5-h7243fc2_0.conda
-  sha256: 09aa49a9f068233e4d98688268465f431426a338c115c56517c3c3193198d07b
-  md5: 826e05dc51e8a9e4d10680f37e267b68
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libcxx >=17
-  - libexpat >=2.6.3,<3.0a0
-  - libuv >=1.49.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17507220
-  timestamp: 1728417253023
-- kind: conda
-  name: cmake
-  version: 3.30.5
-  build: hbb72600_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.30.5-hbb72600_0.conda
-  sha256: 6127125b954ae5115d67234218a6482724517ba35e0cd33ccaf211b77d51448d
-  md5: c60805ad9292ba829ba61ff6c9b8789d
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libuv >=1.49.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19150524
-  timestamp: 1728416996527
-- kind: conda
-  name: cmake
-  version: 3.30.5
-  build: hf9cb763_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.30.5-hf9cb763_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.30.5-hf9cb763_0.conda
   sha256: 9b775bbdee337d67b180b6fbc6c93fa1ba73a18b167c242d792dee2797245148
   md5: b3b88a7ec6372b6f2c0ddb31ee009ebd
   depends:
@@ -2293,12 +1809,45 @@ packages:
   license_family: BSD
   size: 19606674
   timestamp: 1728416480376
-- kind: conda
-  name: cmake
-  version: 3.30.5
-  build: hfbcbe4a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.30.5-hfbcbe4a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.30.5-hbb72600_0.conda
+  sha256: 6127125b954ae5115d67234218a6482724517ba35e0cd33ccaf211b77d51448d
+  md5: c60805ad9292ba829ba61ff6c9b8789d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19150524
+  timestamp: 1728416996527
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.30.5-h7243fc2_0.conda
+  sha256: 09aa49a9f068233e4d98688268465f431426a338c115c56517c3c3193198d07b
+  md5: 826e05dc51e8a9e4d10680f37e267b68
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libexpat >=2.6.3,<3.0a0
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17507220
+  timestamp: 1728417253023
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.30.5-hfbcbe4a_0.conda
   sha256: a6df9f06a5f7037c80782b9dc16ff2eceb24348f665beaca1ce9de7041cfe4e5
   md5: 22394eb25181c0dcadd3ccd473f6b90a
   depends:
@@ -2317,13 +1866,24 @@ packages:
   license_family: BSD
   size: 16345134
   timestamp: 1728417146512
-- kind: conda
-  name: compiler-rt
-  version: 17.0.6
-  build: h1020d70_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-17.0.6-h1020d70_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.5-h400e5d1_0.conda
+  sha256: f1df2ab533ffed1a544ab0672bd09abeaee36cadf59c12f8564b03237779b3d3
+  md5: 4b84d88fe13e33dd1cad2deaac3fbcf4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libuv >=1.49.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14357142
+  timestamp: 1728417628536
+- conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-17.0.6-h1020d70_2.conda
   sha256: 463107bc5ac7ebe925cded4412fb7158bd2c1a2b062a4a2e691aab8b1ff6ccf3
   md5: be4cb4531d4cee9df94bf752455d68de
   depends:
@@ -2335,13 +1895,7 @@ packages:
   license_family: APACHE
   size: 94907
   timestamp: 1725251294237
-- kind: conda
-  name: compiler-rt
-  version: 17.0.6
-  build: h856b3c1_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
   sha256: 91f4a6b80b7802432146a399944c20410e058dfb57ca6d738c0affb79cbdebbb
   md5: 2d00ff8e98c163de45a7c85774094012
   depends:
@@ -2353,14 +1907,7 @@ packages:
   license_family: APACHE
   size: 94878
   timestamp: 1725251190741
-- kind: conda
-  name: compiler-rt_osx-64
-  version: 17.0.6
-  build: hf2b8a54_2
-  build_number: 2
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-17.0.6-hf2b8a54_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-17.0.6-hf2b8a54_2.conda
   sha256: bab564aff76e0c55a681f687dffb64282d643aa501c6848789071b1e29fdbce1
   md5: 98e6d83e484e42f6beebba4276e38145
   depends:
@@ -2372,14 +1919,7 @@ packages:
   license_family: APACHE
   size: 10450866
   timestamp: 1725251223089
-- kind: conda
-  name: compiler-rt_osx-arm64
-  version: 17.0.6
-  build: h832e737_2
-  build_number: 2
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
   sha256: 74d63f7f91a9482262d80490fafd39275121f4cb273f293e7d9fe91934837666
   md5: 58fd1fa30d8b0795f33a7e79893b11cc
   depends:
@@ -2391,29 +1931,7 @@ packages:
   license_family: APACHE
   size: 10369238
   timestamp: 1725251155195
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h18dbf2f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-h18dbf2f_1.conda
-  sha256: bcadda695b13087920650adf43a599b66745dfb4bfc3b425169547d76082dcf2
-  md5: a1bc5417ab20b451ee141ca3290df479
-  depends:
-  - c-compiler 1.8.0 hf48404e_1
-  - clangxx_osx-arm64 17.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6261
-  timestamp: 1728985417226
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h1a2810e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_1.conda
   sha256: cca0450bbc0d19044107d0f90fa36126a11b007fbfb62bd2a1949b2bb59a21a4
   md5: 3bb4907086d7187bf01c8bec397ffa5e
   depends:
@@ -2424,44 +1942,7 @@ packages:
   license_family: BSD
   size: 6059
   timestamp: 1728985302835
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h385f146_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.8.0-h385f146_1.conda
-  sha256: bbb8097e20601a1c78b3ad4aba165dbfe9a61f27e0b42475ba6177222825adad
-  md5: b72f72f89de328cc907bcdf88b85447d
-  depends:
-  - c-compiler 1.8.0 hfc4bf79_1
-  - clangxx_osx-64 17.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6235
-  timestamp: 1728985479382
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: h91493d7_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_1.conda
-  sha256: c6065df2e055a0392207f512bfa12d7a0e849f5e1a5435a3db9c60ae20bded9b
-  md5: 54d722a127a10b59596b5640d58f7ae6
-  depends:
-  - vs2019_win-64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6549
-  timestamp: 1728985390855
-- kind: conda
-  name: cxx-compiler
-  version: 1.8.0
-  build: heb6c788_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.8.0-heb6c788_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.8.0-heb6c788_1.conda
   sha256: 92cd5ba51d0d450cd69ae934107932d2b28cfbb652b1d5f5c0b8e2773ae90491
   md5: d655e8bc7e615b6965afe20522e4ed1a
   depends:
@@ -2472,24 +1953,45 @@ packages:
   license_family: BSD
   size: 6154
   timestamp: 1728985293216
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: h0dc2134_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
-  sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
-  md5: 9d88733c715300a39f8ca2e936b7808d
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.8.0-h385f146_1.conda
+  sha256: bbb8097e20601a1c78b3ad4aba165dbfe9a61f27e0b42475ba6177222825adad
+  md5: b72f72f89de328cc907bcdf88b85447d
+  depends:
+  - c-compiler 1.8.0 hfc4bf79_1
+  - clangxx_osx-64 17.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6235
+  timestamp: 1728985479382
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-h18dbf2f_1.conda
+  sha256: bcadda695b13087920650adf43a599b66745dfb4bfc3b425169547d76082dcf2
+  md5: a1bc5417ab20b451ee141ca3290df479
+  depends:
+  - c-compiler 1.8.0 hf48404e_1
+  - clangxx_osx-arm64 17.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6261
+  timestamp: 1728985417226
+- conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_1.conda
+  sha256: c6065df2e055a0392207f512bfa12d7a0e849f5e1a5435a3db9c60ae20bded9b
+  md5: 54d722a127a10b59596b5640d58f7ae6
+  depends:
+  - vs2019_win-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6549
+  timestamp: 1728985390855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 668439
-  timestamp: 1685696184631
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
   sha256: 33fe66d025cf5bac7745196d1a3dd7a437abcf2dbce66043e9745218169f7e17
   md5: 6e5a87182d66b2d1328a96b61ca43a62
   depends:
@@ -2498,24 +2000,21 @@ packages:
   license_family: BSD
   size: 347363
   timestamp: 1685696690003
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+  sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
+  md5: 9d88733c715300a39f8ca2e936b7808d
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 668439
+  timestamp: 1685696184631
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   md5: 5a74cdee497e6b65173e10d94582fae6
   license: BSD-2-Clause
   license_family: BSD
   size: 316394
   timestamp: 1685695959391
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
   sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
   md5: ed2c27bda330e3f0ab41577cf8b9b585
   depends:
@@ -2526,44 +2025,7 @@ packages:
   license_family: BSD
   size: 618643
   timestamp: 1685696352968
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
-  md5: 418c6ca5929a611cbd69204907a83995
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 760229
-  timestamp: 1685695754230
-- kind: conda
-  name: dbus
-  version: 1.13.6
-  build: h12b9eeb_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
-  sha256: 5fe76bdf27a142cfb9da0fb3197c562e528d2622b573765bee5c9904cf5e6b6b
-  md5: f3d63805602166bac09386741e00935e
-  depends:
-  - expat >=2.4.2,<3.0a0
-  - libgcc-ng >=9.4.0
-  - libglib >=2.70.2,<3.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 672759
-  timestamp: 1640113663539
-- kind: conda
-  name: dbus
-  version: 1.13.6
-  build: h5008d03_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
   sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
   md5: ecfff944ba3960ecb334b9a2663d708d
   depends:
@@ -2574,12 +2036,18 @@ packages:
   license_family: GPL
   size: 618596
   timestamp: 1640112124844
-- kind: conda
-  name: double-conversion
-  version: 3.3.0
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
+  sha256: 5fe76bdf27a142cfb9da0fb3197c562e528d2622b573765bee5c9904cf5e6b6b
+  md5: f3d63805602166bac09386741e00935e
+  depends:
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 672759
+  timestamp: 1640113663539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
   sha256: 9eee491a73b67fd64379cf715f85f8681568ebc1f02f9e11b4c50d46a3323544
   md5: c2f83a5ddadadcdb08fe05863295ee97
   depends:
@@ -2589,12 +2057,7 @@ packages:
   license_family: BSD
   size: 78645
   timestamp: 1686489937183
-- kind: conda
-  name: double-conversion
-  version: 3.3.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
   sha256: 735d40b44a0f39386d1e2988384b6d78a98efd4fa1818e7f2f6fb01f91e16b64
   md5: 1a8bc18b24014167b2184c5afbe6037e
   depends:
@@ -2605,12 +2068,7 @@ packages:
   license_family: BSD
   size: 70425
   timestamp: 1686490368655
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h00ab1b0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
   sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
   md5: b1b879d6d093f55dd40d58b5eb2f0699
   depends:
@@ -2620,40 +2078,7 @@ packages:
   license_family: MOZILLA
   size: 1088433
   timestamp: 1690272126173
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h1995070_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
-  sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
-  md5: 3691ea3ff568ba38826389bafc717909
-  depends:
-  - libcxx >=15.0.7
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 1087751
-  timestamp: 1690275869049
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h1c7c39f_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
-  sha256: 187c0677e0cdcdc39aed716687a6290dd5b7f52b49eedaef2ed76be6cd0a5a3d
-  md5: 5b2cfc277e3d42d84a2a648825761156
-  depends:
-  - libcxx >=15.0.7
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 1090184
-  timestamp: 1690272503232
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h2a328a1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
   sha256: f9c763805938ebaa43183b07caadce8eb3e1af8c21df8792f2793c3dd5210b4e
   md5: 0057b28f7ed26d80bd2277a128f324b2
   depends:
@@ -2663,12 +2088,25 @@ packages:
   license_family: MOZILLA
   size: 1090421
   timestamp: 1690273745233
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h91493d7_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
+  sha256: 187c0677e0cdcdc39aed716687a6290dd5b7f52b49eedaef2ed76be6cd0a5a3d
+  md5: 5b2cfc277e3d42d84a2a648825761156
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1090184
+  timestamp: 1690272503232
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+  sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
+  md5: 3691ea3ff568ba38826389bafc717909
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1087751
+  timestamp: 1690275869049
+- conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
   sha256: 633a6a8db1f9a010cb0619f3446fb61f62dea348b09615ffae9744ab1001c24c
   md5: 305b3ca7023ac046b9a42a48661f6512
   depends:
@@ -2679,12 +2117,7 @@ packages:
   license_family: MOZILLA
   size: 1089706
   timestamp: 1690273089254
-- kind: conda
-  name: expat
-  version: 2.6.3
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
   sha256: 65bd479c75ce876f26600cb230d6ebc474086e31fa384af9b4282b36842ed7e2
   md5: 6595440079bed734b113de44ffd3cd0a
   depends:
@@ -2695,12 +2128,7 @@ packages:
   license_family: MIT
   size: 137891
   timestamp: 1725568750673
-- kind: conda
-  name: expat
-  version: 2.6.3
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.3-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.3-h5ad3122_0.conda
   sha256: c827521e080d0f3395655924f1c364d48a1eac1ff3e193a12d0441e9c3b51e91
   md5: 901a44b341632b0c233756ed5abcd78b
   depends:
@@ -2710,12 +2138,7 @@ packages:
   license_family: MIT
   size: 130283
   timestamp: 1725568848182
-- kind: conda
-  name: expat
-  version: 2.6.3
-  build: hac325c4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.3-hac325c4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.3-hac325c4_0.conda
   sha256: 79b0da6ca997f7a939bfb9631356afbc519343944fc81cc4261c6b3a85f6db32
   md5: 474cd8746e9f896fc5ae84af3c951796
   depends:
@@ -2725,12 +2148,17 @@ packages:
   license_family: MIT
   size: 128253
   timestamp: 1725568880679
-- kind: conda
-  name: expat
-  version: 2.6.3
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.3-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
+  sha256: 4d52ad7a7eb39f71a38bbf2b6377183024bd3bf4cfb5dcd33b31636a6f9a7abc
+  md5: 726bbcf3549fe22b4556285d946fed2d
+  depends:
+  - __osx >=11.0
+  - libexpat 2.6.3 hf9b8971_0
+  license: MIT
+  license_family: MIT
+  size: 125005
+  timestamp: 1725568799108
+- conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.3-he0c23c2_0.conda
   sha256: 627651a36fe659ce08d79e8bcad00dc5fc35c6e63eb51e5d15a30a7605251998
   md5: a85588222941f75577eb39711058e1de
   depends:
@@ -2742,212 +2170,7 @@ packages:
   license_family: MIT
   size: 230615
   timestamp: 1725569133557
-- kind: conda
-  name: expat
-  version: 2.6.3
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
-  sha256: 4d52ad7a7eb39f71a38bbf2b6377183024bd3bf4cfb5dcd33b31636a6f9a7abc
-  md5: 726bbcf3549fe22b4556285d946fed2d
-  depends:
-  - __osx >=11.0
-  - libexpat 2.6.3 hf9b8971_0
-  license: MIT
-  license_family: MIT
-  size: 125005
-  timestamp: 1725568799108
-- kind: conda
-  name: ffmpeg
-  version: 6.1.2
-  build: gpl_h4bdba66_705
-  build_number: 705
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.2-gpl_h4bdba66_705.conda
-  sha256: 3a2875e6a33bcbbf6b3a2f26e5d4d5fcb7d32c51cf6fced31b3565407d98ed68
-  md5: 2742d883dbffa1cb433c4a5d73fb744e
-  depends:
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx >=13
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxcb >=1.16,<2.0.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.2.1,<2.2.2.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9513369
-  timestamp: 1726961395082
-- kind: conda
-  name: ffmpeg
-  version: 6.1.2
-  build: gpl_h63732f7_105
-  build_number: 105
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.2-gpl_h63732f7_105.conda
-  sha256: 7f7616b01e16c71cd58e359699083c21cf367357189269885b77bb8525cc917f
-  md5: 8afe2b968ea735af23203a7aaf272503
-  depends:
-  - __osx >=10.13
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libcxx >=17
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.2.1,<2.2.2.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9735061
-  timestamp: 1726961267052
-- kind: conda
-  name: ffmpeg
-  version: 6.1.2
-  build: gpl_h9673905_705
-  build_number: 705
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h9673905_705.conda
-  sha256: 493fdf46d0ef24adb5bf8870a2f957ca5e0f6c44d488d016cfd105d860c139c3
-  md5: 3106e26566f230104d83312fc1fb9b17
-  depends:
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libiconv >=1.17,<2.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.2.1,<2.2.2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9560526
-  timestamp: 1726962540565
-- kind: conda
-  name: ffmpeg
-  version: 6.1.2
-  build: gpl_he9820c9_105
-  build_number: 105
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.2-gpl_he9820c9_105.conda
-  sha256: e80371364f6bcd9d81fba51635201521bfcb766e345cb2f9d7d3dbbc94973bf8
-  md5: 5c1fb06044be6587e043804fa2c559e3
-  depends:
-  - __osx >=11.0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libcxx >=17
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.2.1,<2.2.2.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 8656928
-  timestamp: 1726961188053
-- kind: conda
-  name: ffmpeg
-  version: 7.1.0
-  build: gpl_he2fd91e_702
-  build_number: 702
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_he2fd91e_702.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_he2fd91e_702.conda
   sha256: 9799acf36bad3b3feca722872430b26da908abcb5df30333b661afb03844fbde
   md5: fc3e332855b9124c7ea71218985037c1
   depends:
@@ -2998,65 +2221,195 @@ packages:
   license_family: GPL
   size: 10323945
   timestamp: 1729893831196
-- kind: conda
-  name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  build: hab24e00_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.2-gpl_h4bdba66_705.conda
+  sha256: 3a2875e6a33bcbbf6b3a2f26e5d4d5fcb7d32c51cf6fced31b3565407d98ed68
+  md5: 2742d883dbffa1cb433c4a5d73fb744e
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx >=13
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9513369
+  timestamp: 1726961395082
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.2-gpl_h63732f7_105.conda
+  sha256: 7f7616b01e16c71cd58e359699083c21cf367357189269885b77bb8525cc917f
+  md5: 8afe2b968ea735af23203a7aaf272503
+  depends:
+  - __osx >=10.13
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9735061
+  timestamp: 1726961267052
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.2-gpl_he9820c9_105.conda
+  sha256: e80371364f6bcd9d81fba51635201521bfcb766e345cb2f9d7d3dbbc94973bf8
+  md5: 5c1fb06044be6587e043804fa2c559e3
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 8656928
+  timestamp: 1726961188053
+- conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h9673905_705.conda
+  sha256: 493fdf46d0ef24adb5bf8870a2f957ca5e0f6c44d488d016cfd105d860c139c3
+  md5: 3106e26566f230104d83312fc1fb9b17
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.2.1,<2.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9560526
+  timestamp: 1726962540565
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
   license: BSD-3-Clause
   license_family: BSD
   size: 397370
   timestamp: 1566932522327
-- kind: conda
-  name: font-ttf-inconsolata
-  version: '3.000'
-  build: h77eed37_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
   md5: 34893075a5c9e55cdafac56607368fc6
   license: OFL-1.1
   license_family: Other
   size: 96530
   timestamp: 1620479909603
-- kind: conda
-  name: font-ttf-source-code-pro
-  version: '2.038'
-  build: h77eed37_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
   md5: 4d59c254e01d9cde7957100457e2d5fb
   license: OFL-1.1
   license_family: Other
   size: 700814
   timestamp: 1620479612257
-- kind: conda
-  name: font-ttf-ubuntu
-  version: '0.83'
-  build: h77eed37_3
-  build_number: 3
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
   md5: 49023d73832ef61042f6a237cb2687e7
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
   size: 1620504
   timestamp: 1727511233259
-- kind: conda
-  name: fontconfig
-  version: 2.14.2
-  build: h14ed4e7_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
   sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
   md5: 0f69b688f52ff6da70bccb7ff7001d1d
   depends:
@@ -3069,44 +2422,7 @@ packages:
   license_family: MIT
   size: 272010
   timestamp: 1674828850194
-- kind: conda
-  name: fontconfig
-  version: 2.14.2
-  build: h5bb23bf_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
-  sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
-  md5: 86cc5867dfbee4178118392bae4a3c89
-  depends:
-  - expat >=2.5.0,<3.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 237068
-  timestamp: 1674829100063
-- kind: conda
-  name: fontconfig
-  version: 2.14.2
-  build: h82840c6_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
-  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
-  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
-  depends:
-  - expat >=2.5.0,<3.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 237668
-  timestamp: 1674829263740
-- kind: conda
-  name: fontconfig
-  version: 2.14.2
-  build: ha9a116f_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
   sha256: 71143b04d9beeb76264a54cb42a2953ff858a95f7383531fcb3a33ac6433e7f6
   md5: 6d2d19ea85f9d41534cd28fdefd59a25
   depends:
@@ -3119,12 +2435,29 @@ packages:
   license_family: MIT
   size: 280375
   timestamp: 1674830224830
-- kind: conda
-  name: fontconfig
-  version: 2.14.2
-  build: hbde0cde_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  md5: 86cc5867dfbee4178118392bae4a3c89
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237068
+  timestamp: 1674829100063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237668
+  timestamp: 1674829263740
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
   sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
   md5: 08767992f1a4f1336a257af1241034bd
   depends:
@@ -3139,13 +2472,7 @@ packages:
   license_family: MIT
   size: 190111
   timestamp: 1674829354122
-- kind: conda
-  name: fonts-conda-ecosystem
-  version: '1'
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   md5: fee5683a3f04bd15cbd8318b096a27ab
   depends:
@@ -3154,13 +2481,7 @@ packages:
   license_family: BSD
   size: 3667
   timestamp: 1566974674465
-- kind: conda
-  name: fonts-conda-forge
-  version: '1'
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
   md5: f766549260d6815b0c52253f1fb1bb29
   depends:
@@ -3172,35 +2493,7 @@ packages:
   license_family: BSD
   size: 4102
   timestamp: 1566932280397
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: h5eeb66e_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
-  sha256: 22a2104d5d6573e8445b7f264533bcd7595cff36d2b356cb1925af5ea62b6a47
-  md5: c6c65566e07fec709e1ea4bc95fc56e4
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes
-  - xorg-libxi
-  license: MIT
-  license_family: MIT
-  size: 144992
-  timestamp: 1719014317113
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: ha6d2627_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
   sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
   md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
   depends:
@@ -3216,13 +2509,23 @@ packages:
   license_family: MIT
   size: 144010
   timestamp: 1719014356708
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: he0c23c2_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+  sha256: 22a2104d5d6573e8445b7f264533bcd7595cff36d2b356cb1925af5ea62b6a47
+  md5: c6c65566e07fec709e1ea4bc95fc56e4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 144992
+  timestamp: 1719014317113
+- conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
   sha256: 8b41913ed6c8c0dadda463a649bc16f45e88faa58553efc6830f4de1138c97f2
   md5: 5872031ef7cba8435ff24af056777473
   depends:
@@ -3233,13 +2536,7 @@ packages:
   license_family: MIT
   size: 111956
   timestamp: 1719014753462
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: h267a509_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
   depends:
@@ -3249,13 +2546,17 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: h60636b9_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+  sha256: 7af93030f4407f076dce181062360efac2cd54dce863b5d7765287a6f5382537
+  md5: a5ab74c5bd158c3d5532b66d8d83d907
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 642092
+  timestamp: 1694617858496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
   sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
   md5: 25152fce119320c980e5470e64834b50
   depends:
@@ -3264,13 +2565,7 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 599300
   timestamp: 1694616137838
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hadb7bae_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
   sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
   md5: e6085e516a3e304ce41a8ee08b9b89ad
   depends:
@@ -3279,13 +2574,7 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 596430
   timestamp: 1694616332835
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hdaf720e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
   sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
   md5: 3761b23693f768dc75a8fd0a73ca053f
   depends:
@@ -3297,39 +2586,7 @@ packages:
   license: GPL-2.0-only OR FTL
   size: 510306
   timestamp: 1694616398888
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hf0a5ef3_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
-  sha256: 7af93030f4407f076dce181062360efac2cd54dce863b5d7765287a6f5382537
-  md5: a5ab74c5bd158c3d5532b66d8d83d907
-  depends:
-  - libgcc-ng >=12
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: GPL-2.0-only OR FTL
-  size: 642092
-  timestamp: 1694617858496
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: h27ca646_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
-  md5: c64443234ff91d70cb9c7dc926c58834
-  license: LGPL-2.1
-  size: 60255
-  timestamp: 1604417405528
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: h36c2ea0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
   sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
   md5: ac7bc6a654f8f41b352b38f4051135f8
   depends:
@@ -3337,12 +2594,7 @@ packages:
   license: LGPL-2.1
   size: 114383
   timestamp: 1604416621168
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: hb9de7d4_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
   sha256: bcb5a40f1aaf4ea8cda2fc6b2b12aa336403772121350281ce31fd2d9d3e214e
   md5: f6c91a43eace6fb926a8730b3b9a8a50
   depends:
@@ -3350,39 +2602,19 @@ packages:
   license: LGPL-2.1
   size: 115689
   timestamp: 1604417149643
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: hbcb3906_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
   sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
   md5: f1c6b41e0f56998ecd9a3e210faa1dc0
   license: LGPL-2.1
   size: 65388
   timestamp: 1604417213
-- kind: conda
-  name: gcc
-  version: 13.3.0
-  build: h8a56e6e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_1.conda
-  sha256: a65247a97374d871f12490aed847d975e513b70a1ba056c0908e9909e9a1945f
-  md5: 9548c9d315f1894dc311d56433e05e28
-  depends:
-  - gcc_impl_linux-aarch64 13.3.0.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 54122
-  timestamp: 1724802233653
-- kind: conda
-  name: gcc
-  version: 13.3.0
-  build: h9576a4e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
+  md5: c64443234ff91d70cb9c7dc926c58834
+  license: LGPL-2.1
+  size: 60255
+  timestamp: 1604417405528
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
   sha256: d0161362430183cbdbc3db9cf95f9a1af1793027f3ab8755b3d3586deb28bf84
   md5: 606924335b5bcdf90e9aed9a2f5d22ed
   depends:
@@ -3391,13 +2623,16 @@ packages:
   license_family: BSD
   size: 53864
   timestamp: 1724801360210
-- kind: conda
-  name: gcc_impl_linux-64
-  version: 13.3.0
-  build: hfea6d02_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_1.conda
+  sha256: a65247a97374d871f12490aed847d975e513b70a1ba056c0908e9909e9a1945f
+  md5: 9548c9d315f1894dc311d56433e05e28
+  depends:
+  - gcc_impl_linux-aarch64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54122
+  timestamp: 1724802233653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
   sha256: 998ade1d487e93fc8a7a16b90e2af69ebb227355bf4646488661f7ae5887873c
   md5: 0d043dbc126b64f79d915a0e96d3a1d5
   depends:
@@ -3412,13 +2647,7 @@ packages:
   license_family: GPL
   size: 67464415
   timestamp: 1724801227937
-- kind: conda
-  name: gcc_impl_linux-aarch64
-  version: 13.3.0
-  build: hcdea9b6_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-hcdea9b6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-hcdea9b6_1.conda
   sha256: cefdf28ab9639e0caa1ff50ec9c67911a5a22b216b685a56fcb82036b11f8758
   md5: 05d767292bb95666ecfacea481f8ca64
   depends:
@@ -3433,13 +2662,7 @@ packages:
   license_family: GPL
   size: 62293677
   timestamp: 1724802082737
-- kind: conda
-  name: gcc_linux-64
-  version: 13.3.0
-  build: hc28eda2_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_5.conda
   sha256: 6778f93159cfd967320f60473447b19e320f303378d4c9da0784caa40073fafa
   md5: ffbadbbc3345d9a315ba31c8a9188d4c
   depends:
@@ -3450,13 +2673,7 @@ packages:
   license_family: BSD
   size: 31909
   timestamp: 1729281963691
-- kind: conda
-  name: gcc_linux-aarch64
-  version: 13.3.0
-  build: h1cd514b_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_5.conda
   sha256: 5bea73704a3fa24c89c3f0f259740b897125ac62fcff7e7e7668ec3562595a23
   md5: ab35bdc9218e9f00161268237547a98c
   depends:
@@ -3467,12 +2684,7 @@ packages:
   license_family: BSD
   size: 31972
   timestamp: 1729281808212
-- kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: hb9ae30d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
   sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
   md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
   depends:
@@ -3485,33 +2697,7 @@ packages:
   license_family: LGPL
   size: 528149
   timestamp: 1715782983957
-- kind: conda
-  name: gettext
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
-  sha256: 25b0b40329537f374a7394474376b01fd226e31f3ff3aa9254e8d328b23c2145
-  md5: be78ccdd273e43e27e66fc1629df6576
-  depends:
-  - gettext-tools 0.22.5 h0a1ffab_3
-  - libasprintf 0.22.5 h87f4aca_3
-  - libasprintf-devel 0.22.5 h87f4aca_3
-  - libgcc-ng >=12
-  - libgettextpo 0.22.5 h0a1ffab_3
-  - libgettextpo-devel 0.22.5 h0a1ffab_3
-  - libstdcxx-ng >=12
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 481962
-  timestamp: 1723626297896
-- kind: conda
-  name: gettext
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
   sha256: c3d9a453f523acbf2b3e1c82a42edfc7c7111b4686a2180ab48cb9b51a274218
   md5: c7f243bbaea97cd6ea1edd693270100e
   depends:
@@ -3526,28 +2712,21 @@ packages:
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 479452
   timestamp: 1723626088190
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
-  sha256: 9846b9d2e3d081cc8cb9ac7800c7e02a7b63bceea8619e0c51cfa271f89afdb2
-  md5: 5fc8dfe3163ead62e0af82d97ce6b486
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+  sha256: 25b0b40329537f374a7394474376b01fd226e31f3ff3aa9254e8d328b23c2145
+  md5: be78ccdd273e43e27e66fc1629df6576
   depends:
+  - gettext-tools 0.22.5 h0a1ffab_3
+  - libasprintf 0.22.5 h87f4aca_3
+  - libasprintf-devel 0.22.5 h87f4aca_3
   - libgcc-ng >=12
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 2954814
-  timestamp: 1723626262722
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
+  - libgettextpo 0.22.5 h0a1ffab_3
+  - libgettextpo-devel 0.22.5 h0a1ffab_3
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 481962
+  timestamp: 1723626297896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
   sha256: 0fd003953ce1ce9f4569458aab9ffaa397e3be2bc069250e2f05fd93b0ad2976
   md5: fcd2016d1d299f654f81021e27496818
   depends:
@@ -3557,66 +2736,16 @@ packages:
   license_family: GPL
   size: 2750908
   timestamp: 1723626056740
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.4-h10d778d_0.conda
-  sha256: 4429c311b064e19f58b4484ff07346eed2fb862a93db322daaedd1cebd9f7df9
-  md5: 1e64b2a03d3978cc25b5b83985275272
-  license: Zlib
-  size: 114753
-  timestamp: 1708788983681
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
-  sha256: ec1037514938e6a582998c4f156c7165deb470d964dc2d53717e690ea25a22d3
-  md5: 48479e59b512a1dc883aa8d9ea2e29a6
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
+  sha256: 9846b9d2e3d081cc8cb9ac7800c7e02a7b63bceea8619e0c51cfa271f89afdb2
+  md5: 5fc8dfe3163ead62e0af82d97ce6b486
   depends:
   - libgcc-ng >=12
-  - libxkbcommon >=1.6.0,<2.0a0
-  - wayland >=1.22.0,<2.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxinerama >=1.1.5,<1.2.0a0
-  license: Zlib
-  size: 170592
-  timestamp: 1708788896757
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
-  sha256: fd01d62b690e42adf9b9d3fd7f4bbe7185dd8d9fa60aca315137f0367e9c989d
-  md5: b7bf4ccb27f1e75c9292a218974dcfac
-  license: Zlib
-  size: 113768
-  timestamp: 1708789054033
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
-  sha256: f7759a2d1e473d36b39a65096c1b0660fe3574b7aa8fa330ef13626926292d13
-  md5: 5d41478e933d70273686b267827d2ae6
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  size: 118348
-  timestamp: 1708789270458
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2954814
+  timestamp: 1723626262722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
   sha256: 852298b9d1b6e58d8653d943049f7bce0ef3774c87fccd5ac1e8b04d5d702d40
   md5: 4c7a044d25e000fef39b77c10a102ea1
   depends:
@@ -3628,12 +2757,41 @@ packages:
   license: Zlib
   size: 167421
   timestamp: 1708788896752
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: h44428e9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
+  sha256: ec1037514938e6a582998c4f156c7165deb470d964dc2d53717e690ea25a22d3
+  md5: 48479e59b512a1dc883aa8d9ea2e29a6
+  depends:
+  - libgcc-ng >=12
+  - libxkbcommon >=1.6.0,<2.0a0
+  - wayland >=1.22.0,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  license: Zlib
+  size: 170592
+  timestamp: 1708788896757
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.4-h10d778d_0.conda
+  sha256: 4429c311b064e19f58b4484ff07346eed2fb862a93db322daaedd1cebd9f7df9
+  md5: 1e64b2a03d3978cc25b5b83985275272
+  license: Zlib
+  size: 114753
+  timestamp: 1708788983681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
+  sha256: fd01d62b690e42adf9b9d3fd7f4bbe7185dd8d9fa60aca315137f0367e9c989d
+  md5: b7bf4ccb27f1e75c9292a218974dcfac
+  license: Zlib
+  size: 113768
+  timestamp: 1708789054033
+- conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
+  sha256: f7759a2d1e473d36b39a65096c1b0660fe3574b7aa8fa330ef13626926292d13
+  md5: 5d41478e933d70273686b267827d2ae6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 118348
+  timestamp: 1708789270458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
   sha256: f89540cbca9d981fd65d2f3913e8aaa3fe30bc76aa0f70015be4a2169539025b
   md5: f19f985ab043e8843045410f3b99de8a
   depends:
@@ -3645,12 +2803,47 @@ packages:
   license: LGPL-2.1-or-later
   size: 602771
   timestamp: 1729191500463
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: h7025463_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
+  sha256: 5735b3f53735ea78c0d7e98b112488576f03bcbf85fb7e5b0deb05dd35ea08b1
+  md5: 395da692fd81ebafd8c969683bb2bf41
+  depends:
+  - glib-tools 2.82.2 h78ca943_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 hc486b8e_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 616163
+  timestamp: 1729191610267
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glib-2.82.2-hbe7352d_0.conda
+  sha256: e8ff53ffd56974e99f344b8def5afbb038ee1c24e245078d51c2d5218779c718
+  md5: c78d6046de0379875d4df402452a1292
+  depends:
+  - glib-tools 2.82.2 h8a9f880_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 hb6ef654_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 588914
+  timestamp: 1729191809622
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.2-hb1db9eb_0.conda
+  sha256: 14efe746ba95154a89208e8478b71fb12ba5f25815029803d30196e561b9d94a
+  md5: 0642d868967b66fc7f0a5fda24bd7ac2
+  depends:
+  - glib-tools 2.82.2 h25d4a46_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 h07bd6cf_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 585193
+  timestamp: 1729191888264
+- conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
   sha256: 68632bb5aec001fcd09b7f9ea415fab09ad479eb640fb667141cbb747a8d48b5
   md5: c295bf0ccb6823efdf40ebc5992384c4
   depends:
@@ -3667,67 +2860,36 @@ packages:
   license: LGPL-2.1-or-later
   size: 573556
   timestamp: 1729192350624
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: hb1db9eb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.2-hb1db9eb_0.conda
-  sha256: 14efe746ba95154a89208e8478b71fb12ba5f25815029803d30196e561b9d94a
-  md5: 0642d868967b66fc7f0a5fda24bd7ac2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
+  sha256: 4d6d7175a841be9dd25f5041c9b9419b25f4f5e8de8f289b3c7914a76f5a24d4
+  md5: 12859f91830f58b1803e32846651c6f6
   depends:
-  - glib-tools 2.82.2 h25d4a46_0
-  - libffi >=3.4,<4.0a0
-  - libglib 2.82.2 h07bd6cf_0
-  - libintl >=0.22.5,<1.0a0
-  - libintl-devel
-  - packaging
-  - python *
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libglib 2.82.2 h2ff4ddf_0
   license: LGPL-2.1-or-later
-  size: 585193
-  timestamp: 1729191888264
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: hbe7352d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.82.2-hbe7352d_0.conda
-  sha256: e8ff53ffd56974e99f344b8def5afbb038ee1c24e245078d51c2d5218779c718
-  md5: c78d6046de0379875d4df402452a1292
+  size: 114038
+  timestamp: 1729191458625
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
+  sha256: 4f8eaa6d7fe07a6e6bc06787256a416b14d4ed424474b11875d0ca7aeff1256c
+  md5: 3053283d0c0e78ab5935c9e17f803358
   depends:
-  - glib-tools 2.82.2 h8a9f880_0
-  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libglib 2.82.2 hc486b8e_0
+  license: LGPL-2.1-or-later
+  size: 126325
+  timestamp: 1729191584153
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.82.2-h8a9f880_0.conda
+  sha256: 6ae574c24a9dd89b2361953e5cbb1d279c8462b6cc490f25f8b0f47b4e0c591e
+  md5: 23f4ee9e0e50445006507249bd39581b
+  depends:
+  - __osx >=10.13
   - libglib 2.82.2 hb6ef654_0
   - libintl >=0.22.5,<1.0a0
-  - libintl-devel
-  - packaging
-  - python *
   license: LGPL-2.1-or-later
-  size: 588914
-  timestamp: 1729191809622
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: hc486b8e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
-  sha256: 5735b3f53735ea78c0d7e98b112488576f03bcbf85fb7e5b0deb05dd35ea08b1
-  md5: 395da692fd81ebafd8c969683bb2bf41
-  depends:
-  - glib-tools 2.82.2 h78ca943_0
-  - libffi >=3.4,<4.0a0
-  - libglib 2.82.2 hc486b8e_0
-  - packaging
-  - python *
-  license: LGPL-2.1-or-later
-  size: 616163
-  timestamp: 1729191610267
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h25d4a46_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h25d4a46_0.conda
+  size: 100613
+  timestamp: 1729191743410
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h25d4a46_0.conda
   sha256: e9855cc94eb05894255811e070adefe158acf7e03e62b223cc27615a5b7bfcbd
   md5: a2a75ed0bf49f94478d356424f158c61
   depends:
@@ -3737,12 +2899,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 99919
   timestamp: 1729191855779
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h4394cf3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
   sha256: 2c502b66fb68ed3dd4ce9f8121ae8f613df08a83c354c55435994dd9a8ee780a
   md5: 5aa50df298dca67e20ad24c622d1a27c
   depends:
@@ -3754,87 +2911,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 96434
   timestamp: 1729192296587
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h4833e2c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
-  sha256: 4d6d7175a841be9dd25f5041c9b9419b25f4f5e8de8f289b3c7914a76f5a24d4
-  md5: 12859f91830f58b1803e32846651c6f6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libglib 2.82.2 h2ff4ddf_0
-  license: LGPL-2.1-or-later
-  size: 114038
-  timestamp: 1729191458625
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h78ca943_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
-  sha256: 4f8eaa6d7fe07a6e6bc06787256a416b14d4ed424474b11875d0ca7aeff1256c
-  md5: 3053283d0c0e78ab5935c9e17f803358
-  depends:
-  - libgcc >=13
-  - libglib 2.82.2 hc486b8e_0
-  license: LGPL-2.1-or-later
-  size: 126325
-  timestamp: 1729191584153
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h8a9f880_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.82.2-h8a9f880_0.conda
-  sha256: 6ae574c24a9dd89b2361953e5cbb1d279c8462b6cc490f25f8b0f47b4e0c591e
-  md5: 23f4ee9e0e50445006507249bd39581b
-  depends:
-  - __osx >=10.13
-  - libglib 2.82.2 hb6ef654_0
-  - libintl >=0.22.5,<1.0a0
-  license: LGPL-2.1-or-later
-  size: 100613
-  timestamp: 1729191743410
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h0a1ffab_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
-  sha256: a5e341cbf797c65d2477b27d99091393edbaa5178c7d69b7463bb105b0488e69
-  md5: 7cbfb3a8bb1b78a7f5518654ac6725ad
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 417323
-  timestamp: 1718980707330
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h7bae524_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
-  md5: eed7278dfbab727b56f2c0b64330814b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 365188
-  timestamp: 1718981343258
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: hac33072_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   md5: c94a5994ef49749880a8139cf9afcbe1
   depends:
@@ -3843,13 +2920,16 @@ packages:
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
   size: 460055
   timestamp: 1718980856608
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: hf036a51_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+  sha256: a5e341cbf797c65d2477b27d99091393edbaa5178c7d69b7463bb105b0488e69
+  md5: 7cbfb3a8bb1b78a7f5518654ac6725ad
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 417323
+  timestamp: 1718980707330
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
   sha256: 75aa5e7a875afdcf4903b7dc98577672a3dc17b528ac217b915f9528f93c85fc
   md5: 427101d13f19c4974552a4e5b072eef1
   depends:
@@ -3858,29 +2938,16 @@ packages:
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
   size: 428919
   timestamp: 1718981041839
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h2f0025b_1003
-  build_number: 1003
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
-  sha256: c7585e1fb536120583790080f3b3875c04d5f2d64eafbc87e9aa39895e4118c0
-  md5: f33009add6a08358bc12d114ceec1304
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
+  md5: eed7278dfbab727b56f2c0b64330814b
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 99453
-  timestamp: 1711634223220
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h59595ed_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+  - __osx >=11.0
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 365188
+  timestamp: 1718981343258
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
   sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
   md5: f87c7b7c2cb45f323ffbce941c78ab7c
   depends:
@@ -3890,13 +2957,35 @@ packages:
   license_family: LGPL
   size: 96855
   timestamp: 1711634169756
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h63175ca_1003
-  build_number: 1003
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
+  sha256: c7585e1fb536120583790080f3b3875c04d5f2d64eafbc87e9aa39895e4118c0
+  md5: f33009add6a08358bc12d114ceec1304
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 99453
+  timestamp: 1711634223220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
+  sha256: b71db966e47cd83b16bfcc2099b8fa87c07286f24a0742078fede4c84314f91a
+  md5: fc7124f86e1d359fc5d878accd9e814c
+  depends:
+  - libcxx >=16
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 84384
+  timestamp: 1711634311095
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
+  sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
+  md5: 339991336eeddb70076d8ca826dac625
+  depends:
+  - libcxx >=16
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 79774
+  timestamp: 1711634444608
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
   sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
   md5: 3194499ee7d1a67404a87d0eefdd92c6
   depends:
@@ -3907,42 +2996,7 @@ packages:
   license_family: LGPL
   size: 95406
   timestamp: 1711634622644
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h73e2aa4_1003
-  build_number: 1003
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
-  sha256: b71db966e47cd83b16bfcc2099b8fa87c07286f24a0742078fede4c84314f91a
-  md5: fc7124f86e1d359fc5d878accd9e814c
-  depends:
-  - libcxx >=16
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 84384
-  timestamp: 1711634311095
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: hebf3989_1003
-  build_number: 1003
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
-  sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
-  md5: 339991336eeddb70076d8ca826dac625
-  depends:
-  - libcxx >=16
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 79774
-  timestamp: 1711634444608
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: h0a52356_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
   sha256: 6606a2686c0aed281a60fb546703e62c66ea9afa1e46adcca5eb428a3ff67f9e
   md5: d368425fbd031a2f8e801a40c3415c72
   depends:
@@ -3968,35 +3022,7 @@ packages:
   license_family: LGPL
   size: 2822378
   timestamp: 1725536496791
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: h0ee1d58_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.24.7-h0ee1d58_0.conda
-  sha256: ed8a4e9f0918957e8c9d3983b91e8ab9f20643aadb8f3aa9ed3343964d8945fd
-  md5: f012d1ef168db3b601031bcef1c47343
-  depends:
-  - __osx >=10.13
-  - gstreamer 1.24.7 h3271b85_0
-  - libcxx >=17
-  - libglib >=2.80.3,<3.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2409409
-  timestamp: 1725536929071
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: h570c1df_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
   sha256: d6db93e096d0213dd14004a0bd084f11b2d5af4a35a7ac319611c2885f87dc28
   md5: 8d35b3a3d8b4a85ab93ab40314c9246a
   depends:
@@ -4021,34 +3047,25 @@ packages:
   license_family: LGPL
   size: 2761700
   timestamp: 1725540779840
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: hb0a98b8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
-  sha256: c8951e6af014cdeff2de740d1e6e4781ac6813853739c56c6e07266e7aefcf28
-  md5: 92edfae477856e97db6c2610dea95bb1
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.24.7-h0ee1d58_0.conda
+  sha256: ed8a4e9f0918957e8c9d3983b91e8ab9f20643aadb8f3aa9ed3343964d8945fd
+  md5: f012d1ef168db3b601031bcef1c47343
   depends:
-  - gstreamer 1.24.7 h5006eae_0
+  - __osx >=10.13
+  - gstreamer 1.24.7 h3271b85_0
+  - libcxx >=17
   - libglib >=2.80.3,<3.0a0
   - libintl >=0.22.5,<1.0a0
   - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.43,<1.7.0a0
   - libvorbis >=1.3.7,<1.4.0a0
   - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2061727
-  timestamp: 1725537068521
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: hb49d354_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
+  size: 2409409
+  timestamp: 1725536929071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
   sha256: 56b84bf80b6301e715312e6c1b8c44b2e2f0821854b1d05ec065b59bf38adad1
   md5: 3dfb86c12a1bc38d03be9f52225b8ef7
   depends:
@@ -4066,12 +3083,51 @@ packages:
   license_family: LGPL
   size: 1962829
   timestamp: 1725536921391
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: h3271b85_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.24.7-h3271b85_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
+  sha256: c8951e6af014cdeff2de740d1e6e4781ac6813853739c56c6e07266e7aefcf28
+  md5: 92edfae477856e97db6c2610dea95bb1
+  depends:
+  - gstreamer 1.24.7 h5006eae_0
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2061727
+  timestamp: 1725537068521
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
+  sha256: 9c059cc7dcb2732da8face18b1c0351da148ef26db0563fed08e818ea0515bb1
+  md5: c78bc4ef0afb3cd2365d9973c71fc876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.80.3,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx >=13
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2023966
+  timestamp: 1725536373253
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
+  sha256: 85a9acd103a2477506c3c92b27dcd4ec5f77bab353fa7a33817f0894bb11a824
+  md5: c672dd04a62139ba21f2ba130b88f235
+  depends:
+  - glib >=2.80.3,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx >=13
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2027297
+  timestamp: 1725538984316
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.24.7-h3271b85_0.conda
   sha256: e492fd4cd89ae8aede95134373dd43568386039c0e6b152de061935cfaabeea0
   md5: 9605eae5ac683af5aeb0aef5dc7871fb
   depends:
@@ -4085,30 +3141,21 @@ packages:
   license_family: LGPL
   size: 1806102
   timestamp: 1725536657384
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: h37d20eb_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
-  sha256: 85a9acd103a2477506c3c92b27dcd4ec5f77bab353fa7a33817f0894bb11a824
-  md5: c672dd04a62139ba21f2ba130b88f235
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
+  sha256: 414b1919b746ace641e8cc1eae99ee0bf616a62da2851e248cb04413dcc496b0
+  md5: 51a487eebf20e94bec393d83901ca5eb
   depends:
+  - __osx >=11.0
   - glib >=2.80.3,<3.0a0
-  - libgcc >=13
+  - libcxx >=17
   - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libstdcxx >=13
+  - libintl >=0.22.5,<1.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2027297
-  timestamp: 1725538984316
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: h5006eae_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
+  size: 1347352
+  timestamp: 1725536657414
+- conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
   sha256: bd3ad109ef3e2e49da8710ff49378b3fa5da916aa2351d932d1b9018b7123512
   md5: 58e1df95fdab219039e39033302771e8
   depends:
@@ -4123,67 +3170,7 @@ packages:
   license_family: LGPL
   size: 2022487
   timestamp: 1725536894511
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: hc3f5269_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
-  sha256: 414b1919b746ace641e8cc1eae99ee0bf616a62da2851e248cb04413dcc496b0
-  md5: 51a487eebf20e94bec393d83901ca5eb
-  depends:
-  - __osx >=11.0
-  - glib >=2.80.3,<3.0a0
-  - libcxx >=17
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1347352
-  timestamp: 1725536657414
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: hf3bb09a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
-  sha256: 9c059cc7dcb2732da8face18b1c0351da148ef26db0563fed08e818ea0515bb1
-  md5: c78bc4ef0afb3cd2365d9973c71fc876
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - glib >=2.80.3,<3.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx >=13
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2023966
-  timestamp: 1725536373253
-- kind: conda
-  name: gxx
-  version: 13.3.0
-  build: h8a56e6e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_1.conda
-  sha256: d94714da0135d592d2cd71998a19dc9f65e5a55857c11ec6aa357e5c23fb5a0d
-  md5: 838d6b64b84b1d17c564b146a839e988
-  depends:
-  - gcc 13.3.0.*
-  - gxx_impl_linux-aarch64 13.3.0.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 53580
-  timestamp: 1724802377970
-- kind: conda
-  name: gxx
-  version: 13.3.0
-  build: h9576a4e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
   sha256: 5446f5d1d609d996579f706d2020e83ef48e086d943bfeef7ab807ea246888a0
   md5: 209182ca6b20aeff62f442e843961d81
   depends:
@@ -4193,13 +3180,17 @@ packages:
   license_family: BSD
   size: 53338
   timestamp: 1724801498389
-- kind: conda
-  name: gxx_impl_linux-64
-  version: 13.3.0
-  build: hdbfa832_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_1.conda
+  sha256: d94714da0135d592d2cd71998a19dc9f65e5a55857c11ec6aa357e5c23fb5a0d
+  md5: 838d6b64b84b1d17c564b146a839e988
+  depends:
+  - gcc 13.3.0.*
+  - gxx_impl_linux-aarch64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 53580
+  timestamp: 1724802377970
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
   sha256: 746dff24bb1efc89ab0ec108838d0711683054e3bbbcb94d042943410a98eca1
   md5: 806367e23a0a6ad21e51875b34c57d7e
   depends:
@@ -4211,13 +3202,7 @@ packages:
   license_family: GPL
   size: 13337720
   timestamp: 1724801455825
-- kind: conda
-  name: gxx_impl_linux-aarch64
-  version: 13.3.0
-  build: h1211b58_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h1211b58_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h1211b58_1.conda
   sha256: 93eb04cf9ccf5860df113f299febfacad9c66728772d30aaf4bf33995083331a
   md5: 3721f68549df06c2b0664f8933bbf17f
   depends:
@@ -4229,13 +3214,7 @@ packages:
   license_family: GPL
   size: 12732645
   timestamp: 1724802335796
-- kind: conda
-  name: gxx_linux-64
-  version: 13.3.0
-  build: h6834431_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_5.conda
   sha256: 4ca452f7abc607d9f0ad45a7fa8c7d8436fca05b9cc6715d1ccd239bed90833b
   md5: 81ddb2db98fbe3031aa7ebbbf8bb3ffd
   depends:
@@ -4247,13 +3226,7 @@ packages:
   license_family: BSD
   size: 30284
   timestamp: 1729281975715
-- kind: conda
-  name: gxx_linux-aarch64
-  version: 13.3.0
-  build: h2864abd_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_5.conda
   sha256: 3079eea2326411009cd8e124d00bab1bf1ca7a244d3d5d8c36d58a9f492bda4c
   md5: 2d98b991b501e9f303f4feee10f4e794
   depends:
@@ -4265,98 +3238,7 @@ packages:
   license_family: BSD
   size: 30319
   timestamp: 1729281820071
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: h098a298_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h098a298_1.conda
-  sha256: dbc7783ea89faaf3a810d0e55979be02031551be8edad00de915807b3b148ff1
-  md5: 8dd3c790d5ce9f3bc94c46e5b218e5f8
-  depends:
-  - __osx >=10.13
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libglib >=2.80.3,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 1372588
-  timestamp: 1721186294497
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: h2bedf89_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
-  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
-  md5: 254f119aaed2c0be271c1114ae18d09b
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libglib >=2.80.3,<3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 1095620
-  timestamp: 1721187287831
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: h997cde5_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
-  sha256: 5f78f5dcbbfef59b3549ecb6cc2fa9de7b22abda7c8afaf0fa787ceea37a914f
-  md5: 50f6825d3c4a6fca6fefdefa98081554
-  depends:
-  - __osx >=11.0
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libglib >=2.80.3,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 1317509
-  timestamp: 1721186764931
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: hbf49d6b_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
-  sha256: 7496782c3bc0ebbb4de9bc92a3111f42b8a57417fa31ecb87058f250215fabc9
-  md5: ceb458f664cab8550fcd74fff26451db
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 1614644
-  timestamp: 1721188789883
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: hda332d3_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
   sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
   md5: 76b32dcf243444aea9c6b804bcfa40b8
   depends:
@@ -4372,35 +3254,68 @@ packages:
   license_family: MIT
   size: 1603653
   timestamp: 1721186240105
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h13f6c1a_101
-  build_number: 101
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_101.conda
-  sha256: 46a15f93b5d9baf916f65163f535e7be9f50d51bf7619ac42d349c9713c3878c
-  md5: 9516a667178e4336589fc9548cc317ff
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
+  sha256: 7496782c3bc0ebbb4de9bc92a3111f42b8a57417fa31ecb87058f250215fabc9
+  md5: ceb458f664cab8550fcd74fff26451db
   depends:
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgcc >=13
-  - libgfortran
-  - libgfortran5 >=13.3.0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4021637
-  timestamp: 1728050555561
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h2d575fe_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_101.conda
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1614644
+  timestamp: 1721188789883
+- conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h098a298_1.conda
+  sha256: dbc7783ea89faaf3a810d0e55979be02031551be8edad00de915807b3b148ff1
+  md5: 8dd3c790d5ce9f3bc94c46e5b218e5f8
+  depends:
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1372588
+  timestamp: 1721186294497
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+  sha256: 5f78f5dcbbfef59b3549ecb6cc2fa9de7b22abda7c8afaf0fa787ceea37a914f
+  md5: 50f6825d3c4a6fca6fefdefa98081554
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1317509
+  timestamp: 1721186764931
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
+  md5: 254f119aaed2c0be271c1114ae18d09b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1095620
+  timestamp: 1721187287831
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_101.conda
   sha256: fdc091d50eb0a2e5fcc5cab5b605bdaf57471c724aa897aaee67dd5c66d34d53
   md5: 09967792ea2191a0bdb461f9c889e510
   depends:
@@ -4417,13 +3332,23 @@ packages:
   license_family: BSD
   size: 3954807
   timestamp: 1728044935147
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h57e3b00_101
-  build_number: 101
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h57e3b00_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_101.conda
+  sha256: 46a15f93b5d9baf916f65163f535e7be9f50d51bf7619ac42d349c9713c3878c
+  md5: 9516a667178e4336589fc9548cc317ff
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4021637
+  timestamp: 1728050555561
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h57e3b00_101.conda
   sha256: 1ce5044901a8150fd82efc1cda1c513b5b4acbe08194d904f96abcc5bfe9211b
   md5: de2f49fee6cef6f922b3e7497219eb8b
   depends:
@@ -4439,13 +3364,7 @@ packages:
   license_family: BSD
   size: 3745605
   timestamp: 1728044987255
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h99fbd1e_101
-  build_number: 101
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_h99fbd1e_101.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_h99fbd1e_101.conda
   sha256: 2339506be886b37275039d33e7e4cfa30f3774d6b554f1ec3aea9e1805b10840
   md5: 719a03d8953ca6cbc5277fbff127e6c6
   depends:
@@ -4461,13 +3380,7 @@ packages:
   license_family: BSD
   size: 3490762
   timestamp: 1728044046987
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_hd5d9e70_101
-  build_number: 101
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_101.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_101.conda
   sha256: fa6696af3c73954849ad2b53674f13d7ea6df1d6e790524aff7332f18476b42c
   md5: 65175ce2be9c8885586039e0fb594f86
   depends:
@@ -4482,26 +3395,7 @@ packages:
   license_family: BSD
   size: 2050706
   timestamp: 1728044187427
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: h120a0e1_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
-  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
-  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 11761697
-  timestamp: 1720853679409
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: he02047a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
   depends:
@@ -4512,12 +3406,35 @@ packages:
   license_family: MIT
   size: 12129203
   timestamp: 1720853576813
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
+  md5: 268203e8b983fddb6412b36f2024e75c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12282786
+  timestamp: 1720853454991
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
   sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
   md5: 8579b6bb8d18be7c0b27fb08adeeeb40
   depends:
@@ -4528,73 +3445,7 @@ packages:
   license_family: MIT
   size: 14544252
   timestamp: 1720853966338
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: hf9b3779_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
-  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
-  md5: 268203e8b983fddb6412b36f2024e75c
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 12282786
-  timestamp: 1720853454991
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: hfee45f7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
-  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
-  md5: 5eb22c1d7b3fc4abb50d92d621583137
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 11857802
-  timestamp: 1720853997952
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: h025cafa_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
-  sha256: 8fcf6c3bf91993451412c0003b92044c9fc7980fe3f178ab3260f90ac4099072
-  md5: b7e259bd81b5a7432ca045083959b83a
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 153017
-  timestamp: 1725971790238
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: h2016aa1_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.12-h2016aa1_0.conda
-  sha256: 5bf9c041b97b1af21808938fcaa64acafe0d853de5478fa08005176664ee4552
-  md5: 326b3d68ab3f43396e7d7e0e9a496f73
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155534
-  timestamp: 1725971674035
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: h7955e40_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
   sha256: 4d8d07a4d5079d198168b44556fb86d094e6a716e8979b25a9f6c9c610e9fe56
   md5: 37f5e1ab0db3691929f37dee78335d1b
   depends:
@@ -4606,12 +3457,40 @@ packages:
   license_family: BSD
   size: 159630
   timestamp: 1725971591485
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: hbb528cf_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
+  md5: ae8535ff689663fe430bec00be24a854
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153368
+  timestamp: 1725971683794
+- conda: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.12-h2016aa1_0.conda
+  sha256: 5bf9c041b97b1af21808938fcaa64acafe0d853de5478fa08005176664ee4552
+  md5: 326b3d68ab3f43396e7d7e0e9a496f73
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155534
+  timestamp: 1725971674035
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
+  sha256: 8fcf6c3bf91993451412c0003b92044c9fc7980fe3f178ab3260f90ac4099072
+  md5: b7e259bd81b5a7432ca045083959b83a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153017
+  timestamp: 1725971790238
+- conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
   sha256: 184c796615cebaa73246f351144f164ee7b61ea809e4ba3c5d98fa9ca333e058
   md5: c25af729c8c1c41f96202f8a96652bbe
   depends:
@@ -4623,42 +3502,14 @@ packages:
   license_family: BSD
   size: 160408
   timestamp: 1725972042635
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: hf428078_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
-  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
-  md5: ae8535ff689663fe430bec00be24a854
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 153368
-  timestamp: 1725971683794
-- kind: conda
-  name: intel-openmp
-  version: 2024.2.1
-  build: h57928b3_1083
-  build_number: 1083
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
   sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
   md5: 2d89243bfb53652c182a7c73182cce4f
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   size: 1852356
   timestamp: 1723739573141
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h122424a_10
-  build_number: 10
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
   sha256: b146808eccf916f3186de8926be4ca14bca6d20d6e5fcde4454cae6f1de9d9eb
   md5: 4ebce336fae43577731ad413e94a6bfa
   depends:
@@ -4675,13 +3526,7 @@ packages:
   license: EPL-1.0
   size: 1030827
   timestamp: 1727440696766
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h202260e_10
-  build_number: 10
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
   sha256: 69fdeaab6a2528ef37cb8aebfeac7466e79a533f945d83ac56bab0deb642154c
   md5: b841bdb9ade7994c1a58b00790852046
   depends:
@@ -4697,13 +3542,7 @@ packages:
   license: EPL-1.0
   size: 1028588
   timestamp: 1727440811283
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h43feef9_10
-  build_number: 10
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.16-h43feef9_10.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.16-h43feef9_10.conda
   sha256: 0cc29d2491b0e26a2cb28014af1dc13f4e667e7c8d76a3cfc4315d53a36ca771
   md5: 8852f30689ef3d8dbdfc869a2838ddfa
   depends:
@@ -4718,13 +3557,7 @@ packages:
   license: EPL-1.0
   size: 823091
   timestamp: 1727440680726
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h920a7db_10
-  build_number: 10
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
   sha256: cbc2874efb6ef04c81eced387238ad1247174eee5859c68a7dca881eaef65027
   md5: 1e2c514b61859c1b37e680c20893c283
   depends:
@@ -4739,13 +3572,7 @@ packages:
   license: EPL-1.0
   size: 758539
   timestamp: 1727440718510
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: hfa42872_10
-  build_number: 10
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
   sha256: 041ed2b02518d06811391e797cc8a6d071cf9a802b746ebc58265642be3670a0
   md5: dd8754f62da46096a67bf87a7c6f00b6
   depends:
@@ -4759,82 +3586,7 @@ packages:
   license: EPL-1.0
   size: 908450
   timestamp: 1727441201593
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h20dfb44_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
-  sha256: aa2de7c7d1e924437438e57b5141a407bfd6a7c69ebedeb4d9f6cd07e683f724
-  md5: 662cf5b69d72c77dc16f6e30df616cc2
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  size: 1142127
-  timestamp: 1724165302309
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hc01355b_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-hc01355b_5.conda
-  sha256: 0c8e947236cb988f3c8216bc8d90f8af56a4b02ce68dbd3b9c51393e629e8efa
-  md5: 6dbd611bb92296e1c103d6cd07dddc8a
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - libcxx >=16
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1351009
-  timestamp: 1724165176986
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hc10942e_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-hc10942e_5.conda
-  sha256: ebe591797abc39462aec98f0eb7b037b71d13c3c14f645bcf20d576c2141025c
-  md5: 6806a2ea18a227f4db840b23df88f1d0
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libgl >=1.7.0,<2.0a0
-  - libglu
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  license: Zlib
-  size: 1906014
-  timestamp: 1724165028021
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hcce6d95_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-hcce6d95_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-hcce6d95_5.conda
   sha256: 72aa5d6348eeed5b8f6df1c711757c31dab061c9a355a72cc18ea4c77527a475
   md5: bd78280d5c89a7377e5b79d491aca6cb
   depends:
@@ -4855,13 +3607,43 @@ packages:
   license: Zlib
   size: 1947728
   timestamp: 1724164975931
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hdfd4c6d_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-hc10942e_5.conda
+  sha256: ebe591797abc39462aec98f0eb7b037b71d13c3c14f645bcf20d576c2141025c
+  md5: 6806a2ea18a227f4db840b23df88f1d0
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libgl >=1.7.0,<2.0a0
+  - libglu
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  license: Zlib
+  size: 1906014
+  timestamp: 1724165028021
+- conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-hc01355b_5.conda
+  sha256: 0c8e947236cb988f3c8216bc8d90f8af56a4b02ce68dbd3b9c51393e629e8efa
+  md5: 6dbd611bb92296e1c103d6cd07dddc8a
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1351009
+  timestamp: 1724165176986
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
   sha256: f13abda30c917f95b012a4552f84f505ce662ddcff0a563e39f0e60b9bc131ea
   md5: 2011bfec6849090eef9ca0e9b75abc66
   depends:
@@ -4877,12 +3659,22 @@ packages:
   license: Zlib
   size: 1202474
   timestamp: 1724165134357
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: h536e39c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
+  sha256: aa2de7c7d1e924437438e57b5141a407bfd6a7c69ebedeb4d9f6cd07e683f724
+  md5: 662cf5b69d72c77dc16f6e30df616cc2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 1142127
+  timestamp: 1724165302309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
   sha256: 0a5ca92ea0261f435c27a3c3c5c5bc5e8b4b1af1343b21ef0cbc7c33b62f5239
   md5: 9518ab7016cf4564778aef08b6bd8792
   depends:
@@ -4893,26 +3685,7 @@ packages:
   license: JasPer-2.0
   size: 675951
   timestamp: 1714298705230
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: h6c4e4ef_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
-  sha256: 9c874070f201b64d7ca02b59f1348354ae1c834e969cb83259133bb0406ee7fa
-  md5: 9019e1298c84b0185a60c62741d720dd
-  depends:
-  - __osx >=11.0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  size: 583310
-  timestamp: 1714298773123
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: ha25e7e8_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
   sha256: 01cf16b5df4f685ea5952498d2d3cc0bd9ef54460adfed28a43b6fe05e4743e8
   md5: f888b2805a130afa6f6657acc5afaa1a
   depends:
@@ -4923,12 +3696,7 @@ packages:
   license: JasPer-2.0
   size: 707709
   timestamp: 1714298735485
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: hb10263b_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
   sha256: da2c2fa393b89596cf0f81c8e73db2e9b589ae961058317f6fcb4867e05055dd
   md5: b7a6171ecee244e2b2a19177ec3c34a9
   depends:
@@ -4937,12 +3705,16 @@ packages:
   license: JasPer-2.0
   size: 571569
   timestamp: 1714298729445
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: hcb1a123_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+  sha256: 9c874070f201b64d7ca02b59f1348354ae1c834e969cb83259133bb0406ee7fa
+  md5: 9019e1298c84b0185a60c62741d720dd
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 583310
+  timestamp: 1714298773123
+- conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
   sha256: ecddfba94b78849dbde3c73fffb7877e9f1e7a8c1a71786135538af0c524b49b
   md5: 94e32e7c907c6c80c0d0db4c8b163baf
   depends:
@@ -4954,14 +3726,7 @@ packages:
   license: JasPer-2.0
   size: 442367
   timestamp: 1714299052957
-- kind: conda
-  name: kernel-headers_linux-64
-  version: 3.10.0
-  build: he073ed8_18
-  build_number: 18
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
   sha256: a922841ad80bd7b222502e65c07ecb67e4176c4fa5b03678a005f39fcc98be4b
   md5: ad8527bf134a90e1c9ed35fa0b64318c
   constrains:
@@ -4970,14 +3735,7 @@ packages:
   license_family: GPL
   size: 943486
   timestamp: 1729794504440
-- kind: conda
-  name: kernel-headers_linux-aarch64
-  version: 4.18.0
-  build: h05a177a_18
-  build_number: 18
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
   sha256: 99731884b26d5801c931f6ed4e1d40f0d1b2efc60ab2d1d49e9b3a6508a390df
   md5: 40ebaa9844bc99af99fc1beaed90b379
   constrains:
@@ -4986,12 +3744,7 @@ packages:
   license_family: GPL
   size: 1113306
   timestamp: 1729794501866
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
@@ -4999,12 +3752,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h4e544f5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
   sha256: 6d4233d97a9b38acbb26e1268bcf8c10a8e79c2aed7e5a385ec3769967e3e65b
   md5: 1f24853e59c68892452ef94ddd8afd4b
   depends:
@@ -5012,12 +3760,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 112327
   timestamp: 1646166857935
-- kind: conda
-  name: khronos-opencl-icd-loader
-  version: 2024.05.08
-  build: hc70643c_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
   sha256: 701357f02926bef5cb6d060a5471d50dc6528500fd045805ea785398fbb6d6d2
   md5: 22b22ac3be757e10705caa3b5f321e0d
   depends:
@@ -5028,67 +3771,7 @@ packages:
   license_family: APACHE
   size: 87736
   timestamp: 1727732609299
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h237132a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
-  md5: c6dc8a0fdec13a0565936655c33069a1
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1155530
-  timestamp: 1719463474401
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h37d8d59_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
-  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
-  md5: d4765c524b1d91567886bde656fb514b
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1185323
-  timestamp: 1719463492984
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h50a48e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
-  md5: 29c10432a2ca1472b53f299ffb2ffa37
-  depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1474620
-  timestamp: 1719463205834
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h659f571_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
@@ -5102,12 +3785,47 @@ packages:
   license_family: MIT
   size: 1370023
   timestamp: 1719463201255
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: hdf4eb48_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
+  md5: 29c10432a2ca1472b53f299ffb2ffa37
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1474620
+  timestamp: 1719463205834
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
   sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
   md5: 31aec030344e962fbd7dbbbbd68e60a9
   depends:
@@ -5119,13 +3837,7 @@ packages:
   license_family: MIT
   size: 712034
   timestamp: 1719463874284
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: h166bdaf_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
   sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
   md5: a8832b479f93521a9e7b5b743803be51
   depends:
@@ -5134,26 +3846,7 @@ packages:
   license_family: LGPL
   size: 508258
   timestamp: 1664996250081
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: h1a8c8d9_1003
-  build_number: 1003
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
-  md5: bff0e851d66725f78dc2fd8b032ddb7e
-  license: LGPL-2.0-only
-  license_family: LGPL
-  size: 528805
-  timestamp: 1664996399305
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: h4e544f5_1003
-  build_number: 1003
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
   sha256: 2502904a42df6d94bd743f7b73915415391dd6d31d5f50cb57c0a54a108e7b0a
   md5: ab05bcf82d8509b4243f07e93bada144
   depends:
@@ -5162,26 +3855,21 @@ packages:
   license_family: LGPL
   size: 604863
   timestamp: 1664997611416
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: hb7f2c08_1003
-  build_number: 1003
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
   sha256: 0f943b08abb4c748d73207594321b53bad47eea3e7d06b6078e0f6c59ce6771e
   md5: 3342b33c9a0921b22b767ed68ee25861
   license: LGPL-2.0-only
   license_family: LGPL
   size: 542681
   timestamp: 1664996421531
-- kind: conda
-  name: ld64
-  version: '951.9'
-  build: h0a3eb4e_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-h0a3eb4e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
+  md5: bff0e851d66725f78dc2fd8b032ddb7e
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 528805
+  timestamp: 1664996399305
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-h0a3eb4e_1.conda
   sha256: d6ce3be8687f7fb607173112901e72262a4608dc351bfcb27012c068a5f25fa6
   md5: 8b8e1a4bd8384bf4b884c9e41636038f
   depends:
@@ -5194,13 +3882,7 @@ packages:
   license_family: Other
   size: 18841
   timestamp: 1726771674999
-- kind: conda
-  name: ld64
-  version: '951.9'
-  build: h39a299f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_1.conda
   sha256: 7dc2adcb40f2bc61b7445980c882a690d1bdef5de206970da2779c2bec5fe876
   md5: b2f41d20ec157f81280e89bcb4f7164a
   depends:
@@ -5213,13 +3895,7 @@ packages:
   license_family: Other
   size: 18942
   timestamp: 1726771707244
-- kind: conda
-  name: ld64_osx-64
-  version: '951.9'
-  build: h38c89e5_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h38c89e5_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h38c89e5_1.conda
   sha256: 8370978550dd96479d8ba635a59a97231ccf602d3a189cd2a4cb234947cf61f2
   md5: 423183fc4729ed4b8e167a980aad83ce
   depends:
@@ -5237,13 +3913,7 @@ packages:
   license_family: Other
   size: 1088909
   timestamp: 1726771576050
-- kind: conda
-  name: ld64_osx-arm64
-  version: '951.9'
-  build: hc81425b_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-hc81425b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-hc81425b_1.conda
   sha256: 37b083cbee78393c511f6ddb21a6ce484ebc037bc3f85c2c293fbc0f418616f1
   md5: 99473e66ff9960be2995dd1b5fe04ace
   depends:
@@ -5261,13 +3931,7 @@ packages:
   license_family: Other
   size: 1013046
   timestamp: 1726771628233
-- kind: conda
-  name: ld_impl_linux-64
-  version: '2.43'
-  build: h712a8e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
   md5: 048b02e3962f066da18efe3a21b77672
   depends:
@@ -5278,13 +3942,7 @@ packages:
   license_family: GPL
   size: 669211
   timestamp: 1729655358674
-- kind: conda
-  name: ld_impl_linux-aarch64
-  version: '2.43'
-  build: h80caac9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
   sha256: 80ec7e8f006196808fac5bd4b3773a652847f97bbf08044cd87731424ac64f8b
   md5: fcbde5ea19d55468953bf588770c0501
   constrains:
@@ -5293,12 +3951,7 @@ packages:
   license_family: GPL
   size: 698245
   timestamp: 1729655345825
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
   sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
   md5: 76bbff344f0134279f225174e9064c8f
   depends:
@@ -5308,12 +3961,7 @@ packages:
   license_family: Apache
   size: 281798
   timestamp: 1657977462600
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h4de3ea5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
   sha256: 2d09ef9b7796d83364957e420b41c32d94e628c3f0520b61c332518a7b5cd586
   md5: 1a0ffc65e03ce81559dbcb0695ad1476
   depends:
@@ -5323,12 +3971,25 @@ packages:
   license_family: Apache
   size: 262096
   timestamp: 1657978241894
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
   sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
   md5: 1900cb3cab5055833cfddb0ba233b074
   depends:
@@ -5338,41 +3999,7 @@ packages:
   license_family: Apache
   size: 194365
   timestamp: 1657977692274
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h9a09cb3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
-  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
-  md5: de462d5aacda3b30721b512c5da4e742
-  depends:
-  - libcxx >=13.0.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 215721
-  timestamp: 1657977558796
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: hb486fe8_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
-  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
-  md5: f9d6a4c82889d5ecedec1d90eb673c55
-  depends:
-  - libcxx >=13.0.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 290319
-  timestamp: 1657977526749
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
   sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
   md5: e1f604644fe8d78e22660e2fec6756bc
   depends:
@@ -5386,13 +4013,7 @@ packages:
   license_family: Apache
   size: 1310521
   timestamp: 1727295454064
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
   sha256: 590e47dce38031a8893e70491f3b71e214de7781cab53b6f017aa6f6841cb076
   md5: 6fe6b3694c4792a8e26755d3b06f0b80
   depends:
@@ -5405,13 +4026,7 @@ packages:
   license_family: Apache
   size: 1328502
   timestamp: 1727295490806
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_hac325c4_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
   sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
   md5: 40373920232a6ac0404eee9cf39a9f09
   depends:
@@ -5424,13 +4039,20 @@ packages:
   license_family: Apache
   size: 1170354
   timestamp: 1727295597292
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
   sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
   md5: 3f59a73b07a05530b252ecb07dd882b9
   depends:
@@ -5444,46 +4066,7 @@ packages:
   license_family: Apache
   size: 1777570
   timestamp: 1727296115119
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
-  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
-  md5: 706da5e791c569a7b9814877098a6a0a
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  constrains:
-  - libabseil-static =20240722.0=cxx17*
-  - abseil-cpp =20240722.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1179072
-  timestamp: 1727295571173
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
-  sha256: 9c366233b4f4bf11e64ce886055aaac34445205a178061923300872e0564a4f2
-  md5: e52c4a30901a90354855e40992af907d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 35339
-  timestamp: 1711021162162
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
   sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
   md5: 5e97e271911b8b2001a8b71860c32faa
   depends:
@@ -5493,12 +4076,35 @@ packages:
   license_family: BSD
   size: 35446
   timestamp: 1711021212685
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+  sha256: 9c366233b4f4bf11e64ce886055aaac34445205a178061923300872e0564a4f2
+  md5: e52c4a30901a90354855e40992af907d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35339
+  timestamp: 1711021162162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
   sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
   md5: 8723000f6ffdbdaef16025f0a01b64c5
   depends:
@@ -5509,98 +4115,7 @@ packages:
   license_family: BSD
   size: 32567
   timestamp: 1711021603471
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
-  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
-  md5: 66d3c1f6dd4636216b4fca7a748d50eb
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 28602
-  timestamp: 1711021419744
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
-  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
-  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 28451
-  timestamp: 1711021498493
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
-  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
-  md5: 9f661052be1d477dcf61ee3cd77ce5ee
-  license: LGPL-2.1-or-later
-  size: 49776
-  timestamp: 1723629333404
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
-  sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
-  md5: 472b673c083175195965a48f2f4808f8
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: LGPL-2.1-or-later
-  size: 40657
-  timestamp: 1723626937704
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h87f4aca_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
-  sha256: b438814a7190a541950da68d3cde8ecbcc55629ce677eb65afbb01cfa1e4e651
-  md5: 332ce64c2dec75dc0849e7ffcdf7a3a4
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: LGPL-2.1-or-later
-  size: 42627
-  timestamp: 1723626204541
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: hdfe23c8_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
-  sha256: 9c6f3e2558e098dbbc63c9884b4af368ea6cc4185ea027563ac4f5ee8571b143
-  md5: 55363e1d53635b3497cdf753ab0690c1
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  license: LGPL-2.1-or-later
-  size: 40442
-  timestamp: 1723626787726
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: he8f35ee_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
   sha256: 2da5c735811cbf38c7f7844ab457ff8b25046bbf5fe5ebd5dc1c2fafdf4fbe1c
   md5: 4fab9799da9571266d05ca5503330655
   depends:
@@ -5610,28 +4125,40 @@ packages:
   license: LGPL-2.1-or-later
   size: 42817
   timestamp: 1723626012203
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: h87f4aca_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
-  sha256: c9eda86140a5a023b72a8997f82629f4b071df17d57d00ba75a66b65a0525a5e
-  md5: dbaa9d8c0030bda3e3d22d325ea48191
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+  sha256: b438814a7190a541950da68d3cde8ecbcc55629ce677eb65afbb01cfa1e4e651
+  md5: 332ce64c2dec75dc0849e7ffcdf7a3a4
   depends:
-  - libasprintf 0.22.5 h87f4aca_3
   - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: LGPL-2.1-or-later
-  size: 34359
-  timestamp: 1723626223953
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: he8f35ee_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+  size: 42627
+  timestamp: 1723626204541
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
+  sha256: 9c6f3e2558e098dbbc63c9884b4af368ea6cc4185ea027563ac4f5ee8571b143
+  md5: 55363e1d53635b3497cdf753ab0690c1
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LGPL-2.1-or-later
+  size: 40442
+  timestamp: 1723626787726
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+  sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
+  md5: 472b673c083175195965a48f2f4808f8
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LGPL-2.1-or-later
+  size: 40657
+  timestamp: 1723626937704
+- conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
+  md5: 9f661052be1d477dcf61ee3cd77ce5ee
+  license: LGPL-2.1-or-later
+  size: 49776
+  timestamp: 1723629333404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
   sha256: ccc7967e298ddf3124c8ad9741c7180dc6f778ae4135ec87978214f7b3c64dc2
   md5: 1091193789bb830127ed067a9e01ac57
   depends:
@@ -5641,12 +4168,16 @@ packages:
   license: LGPL-2.1-or-later
   size: 34172
   timestamp: 1723626026096
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: h1dc1e6a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
+  sha256: c9eda86140a5a023b72a8997f82629f4b071df17d57d00ba75a66b65a0525a5e
+  md5: dbaa9d8c0030bda3e3d22d325ea48191
+  depends:
+  - libasprintf 0.22.5 h87f4aca_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34359
+  timestamp: 1723626223953
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
   sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
   md5: 2a66267ba586dadd110cc991063cfff7
   depends:
@@ -5663,33 +4194,7 @@ packages:
   license_family: OTHER
   size: 133110
   timestamp: 1719985879751
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: h5386a9e_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.3-h5386a9e_0.conda
-  sha256: 2a19c0230f0d6d707a2f0d3fdfe50fb41fbf05e88fb4a79e8e2b5a29f66c4c55
-  md5: b6b8a0a32d77060c4431933a0ba11d3b
-  depends:
-  - __osx >=10.13
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: ISC
-  license_family: OTHER
-  size: 133998
-  timestamp: 1719986071273
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: hcc173ff_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
   sha256: 93d84d22f9fa360c175ce6b0bdd4ec33c0f6399eb6e6a17fcbf8b34375343528
   md5: 7a3fcba797d23512f55ef23e68ae4ec9
   depends:
@@ -5705,12 +4210,23 @@ packages:
   license_family: OTHER
   size: 145939
   timestamp: 1719986023948
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: hf20b609_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.3-h5386a9e_0.conda
+  sha256: 2a19c0230f0d6d707a2f0d3fdfe50fb41fbf05e88fb4a79e8e2b5a29f66c4c55
+  md5: b6b8a0a32d77060c4431933a0ba11d3b
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: ISC
+  license_family: OTHER
+  size: 133998
+  timestamp: 1719986071273
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
   sha256: 2c03d080b48e65e4c488b4824b817fbdce5b79e18f49fc4e823819268b74bb7d
   md5: 50f6b3ead2c75c7c4009a8ed477d8142
   depends:
@@ -5726,13 +4242,8 @@ packages:
   license_family: OTHER
   size: 116755
   timestamp: 1719986027249
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
   md5: 8ea26d42ca88ec5258802715fe1ee10b
   depends:
@@ -5747,13 +4258,8 @@ packages:
   license_family: BSD
   size: 15677
   timestamp: 1729642900350
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
   sha256: 5c08f78312874bb61307f5ea737377df2d0f6e7f7833ded21ca58d8820c794ca
   md5: f9b8a4a955ed2d0b68b1f453abcc1c9e
   depends:
@@ -5768,13 +4274,8 @@ packages:
   license_family: BSD
   size: 15808
   timestamp: 1729643002627
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_osx64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
   build_number: 25
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
   sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
   md5: da0a6f87958893e1d2e2bbc7e7a6541f
   depends:
@@ -5789,13 +4290,8 @@ packages:
   license_family: BSD
   size: 15952
   timestamp: 1729643159199
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
   sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
   md5: f8cf4d920ff36ce471619010eff59cac
   depends:
@@ -5810,13 +4306,8 @@ packages:
   license_family: BSD
   size: 15913
   timestamp: 1729643265495
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
   sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
   md5: 499208e81242efb6e5abc7366c91c816
   depends:
@@ -5830,58 +4321,7 @@ packages:
   license_family: BSD
   size: 3736641
   timestamp: 1729643534444
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: h29978a0_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
-  sha256: d9e080b69dc963cab704d33439a7ed6d76b6c9eb644b63163eda2a32e3a1a799
-  md5: 3f5b15eed5e82e7ea8358a161e974ced
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  size: 2004506
-  timestamp: 1725334277168
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: h444863b_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
-  sha256: a444cc7877f061b7f7c6195c806db183806f1f3a3b6ae26b1c9a89c89a049632
-  md5: 3208cfab6cdb23e6b49805a3771361f2
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  size: 2384613
-  timestamp: 1725335041520
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: hb8260a3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
   sha256: d2b5959c9d73486fba422b1f4f844447df110924860df5583847b7ca62e98a6e
   md5: 5e0ef327c03bb0092046cc9e964b3ceb
   depends:
@@ -5898,35 +4338,7 @@ packages:
   license: BSL-1.0
   size: 3075722
   timestamp: 1725333797199
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: hbe88bda_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.86.0-hbe88bda_2.conda
-  sha256: 92184cfa6b59e3176d9dcdd0662f55d72850bd429771e2ec19e1bd8b4af17cb4
-  md5: 639e62feb43b9d312657ca595410fdfb
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  size: 2138336
-  timestamp: 1725333992879
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: hcc9b45e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
   sha256: 4b8fc3d46b64ba4e690a3d6eb9a1a7c38ac2e6c20f54c2621d796f1749c7015b
   md5: 9098a06de7a66110540ca2974f69a6b4
   depends:
@@ -5942,12 +4354,56 @@ packages:
   license: BSL-1.0
   size: 3105189
   timestamp: 1725333795866
-- kind: conda
-  name: libcap
-  version: '2.69'
-  build: h0f662aa_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.86.0-hbe88bda_2.conda
+  sha256: 92184cfa6b59e3176d9dcdd0662f55d72850bd429771e2ec19e1bd8b4af17cb4
+  md5: 639e62feb43b9d312657ca595410fdfb
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 2138336
+  timestamp: 1725333992879
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
+  sha256: d9e080b69dc963cab704d33439a7ed6d76b6c9eb644b63163eda2a32e3a1a799
+  md5: 3f5b15eed5e82e7ea8358a161e974ced
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 2004506
+  timestamp: 1725334277168
+- conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
+  sha256: a444cc7877f061b7f7c6195c806db183806f1f3a3b6ae26b1c9a89c89a049632
+  md5: 3208cfab6cdb23e6b49805a3771361f2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 2384613
+  timestamp: 1725335041520
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
   sha256: 942f9564b4228609f017b6617425d29a74c43b8a030e12239fa4458e5cb6323c
   md5: 25cb5999faa414e5ccb2c1388f62d3d5
   depends:
@@ -5957,12 +4413,7 @@ packages:
   license_family: BSD
   size: 100582
   timestamp: 1684162447012
-- kind: conda
-  name: libcap
-  version: '2.69'
-  build: h883460d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
   sha256: c0944a372d2d2d961cb86726fad17950219f10837bed281ac22127cb3889b06d
   md5: fd395b538afc08d28c0db275a42c8078
   depends:
@@ -5972,13 +4423,8 @@ packages:
   license_family: BSD
   size: 103105
   timestamp: 1684162437148
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
   md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
   depends:
@@ -5991,13 +4437,8 @@ packages:
   license_family: BSD
   size: 15613
   timestamp: 1729642905619
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
   sha256: fde797e5528040fed0e9228dd75331be0cf5cbb0bc63641f53c3cca9eb86ec16
   md5: db6af51123c67814572a8c25542cb368
   depends:
@@ -6010,13 +4451,8 @@ packages:
   license_family: BSD
   size: 15700
   timestamp: 1729643006729
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_osx64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
   build_number: 25
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
   sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
   md5: ab304b75ea67f850cf7adf9156e3f62f
   depends:
@@ -6029,13 +4465,8 @@ packages:
   license_family: BSD
   size: 15842
   timestamp: 1729643166929
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
   sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
   md5: 4df0fae81f0b5bf47d48c882b086da11
   depends:
@@ -6048,13 +4479,8 @@ packages:
   license_family: BSD
   size: 15837
   timestamp: 1729643270793
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
   sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
   md5: 3ed189ba03a9888a8013aaee0d67c49d
   depends:
@@ -6067,30 +4493,7 @@ packages:
   license_family: BSD
   size: 3732258
   timestamp: 1729643561581
-- kind: conda
-  name: libclang-cpp17
-  version: 17.0.6
-  build: default_h146c034_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
-  sha256: 2e338629ae19faae0d1a85543b8c84441ead61957cf69a65c0031d5b18ebac08
-  md5: bc6797a6a66ec6f919cc8d4d9285b11c
-  depends:
-  - __osx >=11.0
-  - libcxx >=17.0.6
-  - libllvm17 >=17.0.6,<17.1.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 12408943
-  timestamp: 1725505311206
-- kind: conda
-  name: libclang-cpp17
-  version: 17.0.6
-  build: default_hb173f14_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp17-17.0.6-default_hb173f14_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp17-17.0.6-default_hb173f14_7.conda
   sha256: 59759d25952ac0fd0b07b56af9ab615e379ca4499c9d5277b0bd19a20afb33c9
   md5: 9fb4dfe8b2c3ba1b68b79fcd9a71cb76
   depends:
@@ -6101,13 +4504,18 @@ packages:
   license_family: Apache
   size: 13187621
   timestamp: 1725505540477
-- kind: conda
-  name: libclang-cpp19.1
-  version: 19.1.2
-  build: default_hb5137d0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.2-default_hb5137d0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
+  sha256: 2e338629ae19faae0d1a85543b8c84441ead61957cf69a65c0031d5b18ebac08
+  md5: bc6797a6a66ec6f919cc8d4d9285b11c
+  depends:
+  - __osx >=11.0
+  - libcxx >=17.0.6
+  - libllvm17 >=17.0.6,<17.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 12408943
+  timestamp: 1725505311206
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.2-default_hb5137d0_1.conda
   sha256: 2638abec6f79942a9176b30b2ea70bd47967e873d3d120822cbab38ab4895c14
   md5: 7e574c7499bc41f92537634a23fed79a
   depends:
@@ -6119,13 +4527,7 @@ packages:
   license_family: Apache
   size: 20533631
   timestamp: 1729290507675
-- kind: conda
-  name: libclang-cpp19.1
-  version: 19.1.2
-  build: default_he324ac1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.2-default_he324ac1_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.2-default_he324ac1_1.conda
   sha256: dab99fbd0fa84508e47871c764dfcb5f75ce4fc5c4827258a304763bed33e782
   md5: 6d4b791f9aa0523de4a8f46cd8b2e3ea
   depends:
@@ -6136,64 +4538,7 @@ packages:
   license_family: Apache
   size: 20098468
   timestamp: 1729292090129
-- kind: conda
-  name: libclang13
-  version: 19.1.2
-  build: default_h0c68bdf_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-19.1.2-default_h0c68bdf_1.conda
-  sha256: 069401db5b26480f380a472efc5991ebdc8a6e55ba0b71cfbb1347a7e68215f3
-  md5: 2243d33c31db0d6e6fc00e07959e3f38
-  depends:
-  - __osx >=10.13
-  - libcxx >=19.1.2
-  - libllvm19 >=19.1.2,<19.2.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 8605209
-  timestamp: 1729287659101
-- kind: conda
-  name: libclang13
-  version: 19.1.2
-  build: default_h4390ef5_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.2-default_h4390ef5_1.conda
-  sha256: 68751a926366aedc38943d8250f45339f7aca37cd82826e826647a90322dcfcb
-  md5: 0aed30adc7dd7e5929596bde6659785d
-  depends:
-  - libgcc >=13
-  - libllvm19 >=19.1.2,<19.2.0a0
-  - libstdcxx >=13
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11604370
-  timestamp: 1729292368607
-- kind: conda
-  name: libclang13
-  version: 19.1.2
-  build: default_h5f28f6d_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.2-default_h5f28f6d_1.conda
-  sha256: 550b742557e2c18cc05fddce485a88a015d76bb278d704275bf614ed283709bc
-  md5: 6f9992d748b402ffeefd0ab66ff24dde
-  depends:
-  - __osx >=11.0
-  - libcxx >=19.1.2
-  - libllvm19 >=19.1.2,<19.2.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 8060643
-  timestamp: 1729287131146
-- kind: conda
-  name: libclang13
-  version: 19.1.2
-  build: default_h9c6a7e4_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.2-default_h9c6a7e4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.2-default_h9c6a7e4_1.conda
   sha256: 8a38fb764bf65cc18f03006db6aeb345d390102182db2e46fd3f452a1b2dcfcc
   md5: cb5c5ff12b37aded00d9aaa7b9a86a78
   depends:
@@ -6205,13 +4550,40 @@ packages:
   license_family: Apache
   size: 11819644
   timestamp: 1729290739883
-- kind: conda
-  name: libclang13
-  version: 19.1.2
-  build: default_ha5278ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.2-default_ha5278ca_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.2-default_h4390ef5_1.conda
+  sha256: 68751a926366aedc38943d8250f45339f7aca37cd82826e826647a90322dcfcb
+  md5: 0aed30adc7dd7e5929596bde6659785d
+  depends:
+  - libgcc >=13
+  - libllvm19 >=19.1.2,<19.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11604370
+  timestamp: 1729292368607
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-19.1.2-default_h0c68bdf_1.conda
+  sha256: 069401db5b26480f380a472efc5991ebdc8a6e55ba0b71cfbb1347a7e68215f3
+  md5: 2243d33c31db0d6e6fc00e07959e3f38
+  depends:
+  - __osx >=10.13
+  - libcxx >=19.1.2
+  - libllvm19 >=19.1.2,<19.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 8605209
+  timestamp: 1729287659101
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.2-default_h5f28f6d_1.conda
+  sha256: 550b742557e2c18cc05fddce485a88a015d76bb278d704275bf614ed283709bc
+  md5: 6f9992d748b402ffeefd0ab66ff24dde
+  depends:
+  - __osx >=11.0
+  - libcxx >=19.1.2
+  - libllvm19 >=19.1.2,<19.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 8060643
+  timestamp: 1729287131146
+- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.2-default_ha5278ca_1.conda
   sha256: 4349ba29e57a7487e3abe243037dc53185a523afe4d7a889c227e05ab3dfd5b9
   md5: c38f43ef7461c7fac0d5010153ae8d42
   depends:
@@ -6224,31 +4596,7 @@ packages:
   license_family: Apache
   size: 26750034
   timestamp: 1729293730509
-- kind: conda
-  name: libcups
-  version: 2.3.3
-  build: h405e4a8_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-  sha256: f9007d5ca44741de72f9d7be03e74c911b61af062ed7a3761594675f30f5890c
-  md5: d42c670b0c96c1795fd859d5e0275a55
-  depends:
-  - krb5 >=1.21.1,<1.22.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 4551247
-  timestamp: 1689195336749
-- kind: conda
-  name: libcups
-  version: 2.3.3
-  build: h4637d8d_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
   md5: d4529f4dff3057982a7617c7ac58fde3
   depends:
@@ -6260,91 +4608,19 @@ packages:
   license_family: Apache
   size: 4519402
   timestamp: 1689195353551
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h13a7ad3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
-  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
-  md5: d84030d0863ffe7dea00b9a807fee961
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
+  sha256: f9007d5ca44741de72f9d7be03e74c911b61af062ed7a3761594675f30f5890c
+  md5: d42c670b0c96c1795fd859d5e0275a55
   depends:
-  - __osx >=11.0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 379948
-  timestamp: 1726660033582
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h1ee3ff0_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
-  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
-  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: curl
-  license_family: MIT
-  size: 342388
-  timestamp: 1726660508261
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h3ec0cbf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
-  sha256: 7c4983001c727f713b4448280ed4803d301087c184cd2819ba0b788ca62b73d1
-  md5: f43539295c4e0cd15202d41bc72b8a26
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 439171
-  timestamp: 1726659843118
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h58e7537_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
-  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
-  md5: 6c8669d8228a2bbd0283911cc6d6726e
-  depends:
-  - __osx >=10.13
-  - krb5 >=1.21.3,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 402588
-  timestamp: 1726660264675
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: hbbe4b11_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4551247
+  timestamp: 1689195336749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
   sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
   md5: 6e801c50a40301f6978c53976917b277
   depends:
@@ -6360,26 +4636,66 @@ packages:
   license_family: MIT
   size: 424900
   timestamp: 1726659794676
-- kind: conda
-  name: libcxx
-  version: 19.1.2
-  build: ha82da77_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.2-ha82da77_0.conda
-  sha256: 9c714110264f4fe824d40e11ad39b0eda65251f87826c81f4d67ccf8a3348d29
-  md5: ba89ad7c5477e6a9d020020fcdadd37d
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
+  sha256: 7c4983001c727f713b4448280ed4803d301087c184cd2819ba0b788ca62b73d1
+  md5: f43539295c4e0cd15202d41bc72b8a26
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 439171
+  timestamp: 1726659843118
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
   depends:
   - __osx >=11.0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 521199
-  timestamp: 1729038190391
-- kind: conda
-  name: libcxx
-  version: 19.1.2
-  build: hf95d169_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.2-hf95d169_0.conda
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.2-hf95d169_0.conda
   sha256: 04593566411ce8dc6400777c772c10a153ebf1082b104ee52a98562a24a50880
   md5: 8bdfb741a2cdbd0a4e7b7dc30fbc0d6c
   depends:
@@ -6388,28 +4704,16 @@ packages:
   license_family: Apache
   size: 526600
   timestamp: 1729038055775
-- kind: conda
-  name: libcxx-devel
-  version: 17.0.6
-  build: h86353a2_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
-  sha256: 914cc589f356dfc64ddc4f0dc305fce401356b688730b62e24b4f52358595a58
-  md5: 555639d6c7a4c6838cec6e50453fea43
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.2-ha82da77_0.conda
+  sha256: 9c714110264f4fe824d40e11ad39b0eda65251f87826c81f4d67ccf8a3348d29
+  md5: ba89ad7c5477e6a9d020020fcdadd37d
   depends:
-  - libcxx >=17.0.6
+  - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 820887
-  timestamp: 1725403726157
-- kind: conda
-  name: libcxx-devel
-  version: 17.0.6
-  build: h8f8a49f_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-17.0.6-h8f8a49f_6.conda
+  size: 521199
+  timestamp: 1729038190391
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-17.0.6-h8f8a49f_6.conda
   sha256: 3b23efafbf36b8d30bbd2f421e189ef4eb805ac29e65249c174391c23afd665b
   md5: faa013d493ffd2d5f2d2fc6df5f98f2e
   depends:
@@ -6418,12 +4722,35 @@ packages:
   license_family: Apache
   size: 822480
   timestamp: 1725403649896
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: h00291cd_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
+  sha256: 914cc589f356dfc64ddc4f0dc305fce401356b688730b62e24b4f52358595a58
+  md5: 555639d6c7a4c6838cec6e50453fea43
+  depends:
+  - libcxx >=17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 820887
+  timestamp: 1725403726157
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
+  sha256: 986207f130703897300ddc3637c52e86a5b21c735fe384bf48554d9a6d91c56d
+  md5: ff6a44e8b1707d02be2fe9a36ea88d4a
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 69601
+  timestamp: 1728177137503
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
   sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
   md5: a15785ccc62ae2a8febd299424081efb
   depends:
@@ -6432,12 +4759,16 @@ packages:
   license_family: MIT
   size: 70407
   timestamp: 1728177128525
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
   sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
   md5: a3439ce12d4e3cd887270d9436f9a4c8
   depends:
@@ -6448,70 +4779,7 @@ packages:
   license_family: MIT
   size: 155506
   timestamp: 1728177485361
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
-  sha256: 986207f130703897300ddc3637c52e86a5b21c735fe384bf48554d9a6d91c56d
-  md5: ff6a44e8b1707d02be2fe9a36ea88d4a
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 69601
-  timestamp: 1728177137503
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
-  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
-  md5: b422943d5d772b7cc858b36ad2a92db5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 72242
-  timestamp: 1728177071251
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
-  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
-  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 54089
-  timestamp: 1728177149927
-- kind: conda
-  name: libdrm
-  version: 2.4.123
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
-  sha256: 9a5dc3585a6468b266fc80e21fd2b6f3d8236818ee3fa853b6972ab0a44d7804
-  md5: 4e3c67f6999ea7ccac41611f930d19d4
-  depends:
-  - libgcc-ng >=13
-  - libpciaccess >=0.18,<0.19.0a0
-  license: MIT
-  license_family: MIT
-  size: 273843
-  timestamp: 1724719291504
-- kind: conda
-  name: libdrm
-  version: 2.4.123
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
   sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
   md5: ee605e794bdc14e2b7f84c4faa0d8c2c
   depends:
@@ -6522,43 +4790,17 @@ packages:
   license_family: MIT
   size: 303108
   timestamp: 1724719521496
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: h0678c8f_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
-  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
-  md5: 6016a8a1d0e63cac3de2c352cd40208b
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
+  sha256: 9a5dc3585a6468b266fc80e21fd2b6f3d8236818ee3fa853b6972ab0a44d7804
+  md5: 4e3c67f6999ea7ccac41611f930d19d4
   depends:
-  - ncurses >=6.2,<7.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 105382
-  timestamp: 1597616576726
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: hc8eb9b7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
-  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
-  md5: 30e4362988a2623e9eb34337b83e01f9
-  depends:
-  - ncurses >=6.2,<7.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 96607
-  timestamp: 1597616630749
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  - libgcc-ng >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  size: 273843
+  timestamp: 1724719291504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
   md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
   depends:
@@ -6568,13 +4810,7 @@ packages:
   license_family: BSD
   size: 123878
   timestamp: 1597616541093
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: debc31fb2f07ba2b0363f90e455873670734082822926ba4a9556431ec0bf36d
   md5: 29371161d77933a54fccf1bb66b96529
   depends:
@@ -6584,83 +4820,46 @@ packages:
   license_family: BSD
   size: 134104
   timestamp: 1597617110769
-- kind: conda
-  name: libegl
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
-  sha256: e64388e983cf14354b70fe908ca3943f2481ea63df8a4de5e4d418dc2addd38e
-  md5: 38a5cd3be5fb620b48069e27285f1a44
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
+  md5: c151d5eb730e9b7480e6d48c0fc44048
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_1
+  - libglvnd 1.7.0 ha4b6fd6_2
+  arch: x86_64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 44620
-  timestamp: 1727968589748
-- kind: conda
-  name: libegl
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_1.conda
-  sha256: 52cc18200fefa4a65852421c6fd1ccff57e598d2c331574b9093258a4ee774a2
-  md5: f82d2736a04324c05bdce1c39a57fee6
+  size: 44840
+  timestamp: 1731330973553
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
+  sha256: 8962abf38a58c235611ce356b9899f6caeb0352a8bce631b0bcc59352fda455e
+  md5: cf105bce884e4ef8c8ccdca9fe6695e7
   depends:
-  - libglvnd 1.7.0 hd24410f_1
+  - libglvnd 1.7.0 hd24410f_2
+  arch: aarch64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 53358
-  timestamp: 1727968557699
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h10d778d_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
-  md5: 899db79329439820b7e8f8de41bca902
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 106663
-  timestamp: 1702146352558
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h31becfc_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
-  md5: a9a13cb143bbaa477b1ebaefbe47a302
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 115123
-  timestamp: 1702146237623
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h93a5062_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
-  md5: 36d33e440c31857372a72137f78bacf5
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 107458
-  timestamp: 1702146414478
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  size: 53551
+  timestamp: 1731330990477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
   depends:
@@ -6669,29 +4868,30 @@ packages:
   license_family: BSD
   size: 112766
   timestamp: 1702146165126
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: h4ba1bb4_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
-  md5: 96ae6083cd1ac9f6bc81631ac835b317
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+  md5: a9a13cb143bbaa477b1ebaefbe47a302
   depends:
   - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  license: BSD-3-Clause
+  license: BSD-2-Clause
   license_family: BSD
-  size: 438992
-  timestamp: 1685726046519
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: hf998b51_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  size: 115123
+  timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
   sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
   md5: a1cfcc585f0c42bf8d5546bb1dfb668d
   depends:
@@ -6701,12 +4901,17 @@ packages:
   license_family: BSD
   size: 427426
   timestamp: 1685725977222
-- kind: conda
-  name: libexpat
-  version: 2.6.3
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
+  md5: 96ae6083cd1ac9f6bc81631ac835b317
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438992
+  timestamp: 1685726046519
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
   sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
   md5: 59f4c43bb1b5ef1c71946ff2cbf59524
   depends:
@@ -6718,12 +4923,7 @@ packages:
   license_family: MIT
   size: 73616
   timestamp: 1725568742634
-- kind: conda
-  name: libexpat
-  version: 2.6.3
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
   sha256: 02341c9c35128055fd404dfe675832b80f2bf9dbb99539457652c11c06e52757
   md5: 1d2b842bb76e268625e8ee8d0a9fe8c3
   depends:
@@ -6734,12 +4934,7 @@ packages:
   license_family: MIT
   size: 72342
   timestamp: 1725568840022
-- kind: conda
-  name: libexpat
-  version: 2.6.3
-  build: hac325c4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
   sha256: dd22dffad6731c352f4c14603868c9cce4d3b50ff5ff1e50f416a82dcb491947
   md5: c1db99b0a94a2f23bd6ce39e2d314e07
   depends:
@@ -6750,12 +4945,18 @@ packages:
   license_family: MIT
   size: 70517
   timestamp: 1725568864316
-- kind: conda
-  name: libexpat
-  version: 2.6.3
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
+  sha256: 5cbe5a199fba14ade55457a468ce663aac0b54832c39aa54470b3889b4c75c4a
+  md5: 5f22f07c2ab2dea8c66fe9585a062c96
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 63895
+  timestamp: 1725568783033
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
   sha256: 9543965d155b8da96fc67dd81705fe5c2571c7c00becc8de5534c850393d4e3c
   md5: 21415fbf4d0de6767a621160b43e5dea
   depends:
@@ -6768,70 +4969,7 @@ packages:
   license_family: MIT
   size: 138992
   timestamp: 1725569106114
-- kind: conda
-  name: libexpat
-  version: 2.6.3
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
-  sha256: 5cbe5a199fba14ade55457a468ce663aac0b54832c39aa54470b3889b4c75c4a
-  md5: 5f22f07c2ab2dea8c66fe9585a062c96
-  depends:
-  - __osx >=11.0
-  constrains:
-  - expat 2.6.3.*
-  license: MIT
-  license_family: MIT
-  size: 63895
-  timestamp: 1725568783033
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h0d85af4_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-  md5: ccb34fb14960ad8b125962d3d79b31a9
-  license: MIT
-  license_family: MIT
-  size: 51348
-  timestamp: 1636488394370
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3422bc3_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  md5: 086914b672be056eb70fd4285b6783b6
-  license: MIT
-  license_family: MIT
-  size: 39020
-  timestamp: 1636488587153
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3557bc0_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
-  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
-  md5: dddd85f4d52121fab0a8b099c5e06501
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  size: 59450
-  timestamp: 1636488255090
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h7f98852_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
@@ -6840,13 +4978,30 @@ packages:
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h8ffe710_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
+  md5: dddd85f4d52121fab0a8b099c5e06501
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 59450
+  timestamp: 1636488255090
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
   sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
   md5: 2c96d1b6915b408893f9472569dee135
   depends:
@@ -6856,30 +5011,7 @@ packages:
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- kind: conda
-  name: libflac
-  version: 1.4.3
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
-  sha256: b54935360349d3418b0663d787f20b3cba0b7ce3fcdf3ba5e7ef02b884759049
-  md5: 520b12eab32a92e19b1f239ac545ec03
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libogg 1.3.*
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 371550
-  timestamp: 1687765491794
-- kind: conda
-  name: libflac
-  version: 1.4.3
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
   sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
   md5: ee48bf17cc83a00f59ca1494d5646869
   depends:
@@ -6892,32 +5024,31 @@ packages:
   license_family: BSD
   size: 394383
   timestamp: 1687765514062
-- kind: conda
-  name: libflang
-  version: 5.0.0
-  build: h6538335_20180525
-  build_number: 20180525
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+  sha256: b54935360349d3418b0663d787f20b3cba0b7ce3fcdf3ba5e7ef02b884759049
+  md5: 520b12eab32a92e19b1f239ac545ec03
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371550
+  timestamp: 1687765491794
+- conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
   sha256: 0b893b511190332320f4a3e3d6424fbd350271ffbca34eb25b5cd8bc451f1a05
   md5: 9f473a344e18668e99a93f7e21a54b69
   depends:
   - openmp 5.0.0
   - vc >=14,<15.0a0
-  arch: x86_64
-  platform: win
   track_features:
   - flang
   license: Apache 2.0
   size: 531143
   timestamp: 1527899216421
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
   sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
   md5: 3cb76c3f10d3bc7f1105b2fc9db984df
   depends:
@@ -6930,13 +5061,7 @@ packages:
   license_family: GPL
   size: 848745
   timestamp: 1729027721139
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: he277a41_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
   sha256: 5d56757ccad208c79214395b00d006d8d18929a4ba49c47bd9460789a7620943
   md5: 511b511c5445e324066c3377481bcab8
   depends:
@@ -6948,14 +5073,7 @@ packages:
   license_family: GPL
   size: 535243
   timestamp: 1729089435134
-- kind: conda
-  name: libgcc-devel_linux-64
-  version: 13.3.0
-  build: h84ea5a7_101
-  build_number: 101
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
   sha256: 027cfb011328a108bc44f512a2dec6d954db85709e0b79b748c3392f85de0c64
   md5: 0ce69d40c142915ac9734bc6134e514a
   depends:
@@ -6964,14 +5082,7 @@ packages:
   license_family: GPL
   size: 2598313
   timestamp: 1724801050802
-- kind: conda
-  name: libgcc-devel_linux-aarch64
-  version: 13.3.0
-  build: h0c07274_101
-  build_number: 101
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_101.conda
   sha256: 2e4b691f811c1bddc72984e09d605c8b45532ec32307c3be007a84fac698bee2
   md5: 4729642346d35283ed198d32ecc41206
   depends:
@@ -6980,13 +5091,7 @@ packages:
   license_family: GPL
   size: 2063611
   timestamp: 1724801861173
-- kind: conda
-  name: libgcc-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
   sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
@@ -6995,13 +5100,7 @@ packages:
   license_family: GPL
   size: 54142
   timestamp: 1729027726517
-- kind: conda
-  name: libgcc-ng
-  version: 14.2.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
   sha256: 9b5cf168a6c7361cae869cb74b716766ee7c6d6b3f6172b32ba9bf91135efdc4
   md5: 0694c249c61469f2c0f7e2990782af21
   depends:
@@ -7010,13 +5109,7 @@ packages:
   license_family: GPL
   size: 54104
   timestamp: 1729089444587
-- kind: conda
-  name: libgcrypt
-  version: 1.11.0
-  build: h4ab18f5_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
   sha256: 9e97e4a753d2ee238cfc7375f0882830f0d8c1667431bc9d070a0f6718355570
   md5: 14858a47d4cc995892e79f2b340682d7
   depends:
@@ -7026,13 +5119,7 @@ packages:
   license_family: GPL
   size: 684307
   timestamp: 1721392291497
-- kind: conda
-  name: libgcrypt
-  version: 1.11.0
-  build: h68df207_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
   sha256: c0b09d4135a3d613c0ca6d52b5efa0c043bc497bcfe1c80d9b8385c40990f298
   md5: 75b5ba9d835a79c15a27cb7af804762f
   depends:
@@ -7042,13 +5129,17 @@ packages:
   license_family: GPL
   size: 736802
   timestamp: 1721392376840
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
+  md5: efab66b82ec976930b96d62a976de8e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 170646
+  timestamp: 1723626019265
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
   sha256: f816747b63432def4bfe2bfa517057149b2b94a48101fe13e7fcc2c223ec2042
   md5: 263a0b8af4b3fcdb35acc4038bb5bff5
   depends:
@@ -7057,46 +5148,7 @@ packages:
   license_family: GPL
   size: 199824
   timestamp: 1723626215655
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
-  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
-  md5: e46c142e2d2d9ccef31ad3d176b10fab
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_3
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 171120
-  timestamp: 1723629671164
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
-  sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
-  md5: c8cd7295cfb7bda5cbabea4fef904349
-  depends:
-  - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8414b35_3
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 159800
-  timestamp: 1723627007035
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: hdfe23c8_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
   sha256: 8f7631d03a093272a5a8423181ac2c66514503e082e5494a2e942737af8a34ad
   md5: ba6eeccaee150e24a544be8ae71aeca1
   depends:
@@ -7107,45 +5159,28 @@ packages:
   license_family: GPL
   size: 172305
   timestamp: 1723626852373
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
-  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
-  md5: efab66b82ec976930b96d62a976de8e7
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
+  sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
+  md5: c8cd7295cfb7bda5cbabea4fef904349
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8414b35_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 170646
-  timestamp: 1723626019265
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
-  sha256: 677df7af241b36c6b06dff52528c2a8e4f42f8cf40d962e693caa707b563c86c
-  md5: 5c1498c4da030824d57072f05220aad8
+  size: 159800
+  timestamp: 1723627007035
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
+  md5: e46c142e2d2d9ccef31ad3d176b10fab
   depends:
-  - libgcc-ng >=12
-  - libgettextpo 0.22.5 h0a1ffab_3
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 36989
-  timestamp: 1723626232155
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+  size: 171120
+  timestamp: 1723629671164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
   sha256: 0a66cdd46d1cd5201061252535cd91905b3222328a9294c1a5bcd32e85531545
   md5: 9aba7960731e6b4547b3a52f812ed801
   depends:
@@ -7156,43 +5191,17 @@ packages:
   license_family: GPL
   size: 36790
   timestamp: 1723626032786
-- kind: conda
-  name: libgfortran
-  version: 5.0.0
-  build: 13_2_0_h97931a8_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
-  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
-  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
+  sha256: 677df7af241b36c6b06dff52528c2a8e4f42f8cf40d962e693caa707b563c86c
+  md5: 5c1498c4da030824d57072f05220aad8
   depends:
-  - libgfortran5 13.2.0 h2873a65_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h0a1ffab_3
+  license: GPL-3.0-or-later
   license_family: GPL
-  size: 110106
-  timestamp: 1707328956438
-- kind: conda
-  name: libgfortran
-  version: 5.0.0
-  build: 13_2_0_hd922786_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
-  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
-  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
-  depends:
-  - libgfortran5 13.2.0 hf226fd6_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 110233
-  timestamp: 1707330749033
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  size: 36989
+  timestamp: 1723626232155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
   sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
   md5: f1fd30127802683586f768875127a987
   depends:
@@ -7203,13 +5212,7 @@ packages:
   license_family: GPL
   size: 53997
   timestamp: 1729027752995
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
   sha256: cb66e411fa32a5c6040f4e5e2a63c00897aae4c3133a9c004c2e929ccf19575b
   md5: 0294b92d2f47a240bebb1e3336b495f1
   depends:
@@ -7220,13 +5223,25 @@ packages:
   license_family: GPL
   size: 54105
   timestamp: 1729089471124
-- kind: conda
-  name: libgfortran-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
   sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
   md5: 0a7f4cd238267c88e5d69f7826a407eb
   depends:
@@ -7235,13 +5250,7 @@ packages:
   license_family: GPL
   size: 54106
   timestamp: 1729027945817
-- kind: conda
-  name: libgfortran-ng
-  version: 14.2.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
   sha256: cdd5bae1e33d6bdafe837c2e6ea594faf5bb7f880272ac1984468c7967adff41
   md5: 5e90005d310d69708ba0aa7f4fed1de6
   depends:
@@ -7250,64 +5259,7 @@ packages:
   license_family: GPL
   size: 54111
   timestamp: 1729089714658
-- kind: conda
-  name: libgfortran5
-  version: 13.2.0
-  build: h2873a65_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
-  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
-  md5: e4fb4d23ec2870ff3c40d10afe305aec
-  depends:
-  - llvm-openmp >=8.0.0
-  constrains:
-  - libgfortran 5.0.0 13_2_0_*_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1571379
-  timestamp: 1707328880361
-- kind: conda
-  name: libgfortran5
-  version: 13.2.0
-  build: hf226fd6_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
-  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
-  md5: 66ac81d54e95c534ae488726c1f698ea
-  depends:
-  - llvm-openmp >=8.0.0
-  constrains:
-  - libgfortran 5.0.0 13_2_0_*_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 997381
-  timestamp: 1707330687590
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hb6113d0_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
-  sha256: a87ff46d19916403cbf68cf1d785bf56b4d1ab7b2552468d2ea775d70782493f
-  md5: fc068e11b10e18f184e027782baa12b6
-  depends:
-  - libgcc >=14.2.0
-  constrains:
-  - libgfortran 14.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1102158
-  timestamp: 1729089452640
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hd5240d6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
   sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
   md5: 9822b874ea29af082e5d36098d25427d
   depends:
@@ -7318,63 +5270,86 @@ packages:
   license_family: GPL
   size: 1462645
   timestamp: 1729027735353
-- kind: conda
-  name: libgl
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
-  sha256: 2de573a2231d0ffa13242e274d33b7bae88fb0a178392fd4a03cf803a47e4051
-  md5: 204892bce2e44252b5cf272712f10bdd
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
+  sha256: a87ff46d19916403cbf68cf1d785bf56b4d1ab7b2552468d2ea775d70782493f
+  md5: fc068e11b10e18f184e027782baa12b6
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1102158
+  timestamp: 1729089452640
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
+  md5: 928b8be80851f5d8ffb016f9c81dae7a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_1
-  - libglx 1.7.0 ha4b6fd6_1
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - libglx 1.7.0 ha4b6fd6_2
+  arch: x86_64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 134476
-  timestamp: 1727968620103
-- kind: conda
-  name: libgl
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
-  sha256: 26e3570dcd72d95c4c5d007776fd0169028575140adef029a5b23729c4f164d6
-  md5: 06cf88e73c69957c56318c6a1ccc5306
+  size: 134712
+  timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+  sha256: 3e954380f16255d1c8ae5da3bd3044d3576a0e1ac2e3c3ff2fe8f2f1ad2e467a
+  md5: 0d00176464ebb25af83d40736a2cd3bb
   depends:
-  - libglvnd 1.7.0 hd24410f_1
-  - libglx 1.7.0 hd24410f_1
+  - libglvnd 1.7.0 hd24410f_2
+  - libglx 1.7.0 hd24410f_2
+  arch: aarch64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 146874
-  timestamp: 1727968574647
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h07bd6cf_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
-  sha256: 101fb31c509d6a69ac5d612b51d4088ddbc675fca18cf0c3589cfee26cd01ca0
-  md5: 890783f64502fa6bfcdc723cfbf581b4
+  size: 145442
+  timestamp: 1731331005019
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: e281356c0975751f478c53e14f3efea6cd1e23c3069406d10708d6c409525260
+  md5: 53e7cbb2beb03d69a478631e23e340e9
   depends:
-  - __osx >=11.0
-  - libffi >=3.4,<4.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.82.2 *_0
-  license: LGPL-2.1-or-later
-  size: 3635416
-  timestamp: 1729191799117
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h2ff4ddf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_2
+  - libglx-devel 1.7.0 ha4b6fd6_2
+  arch: x86_64
+  platform: linux
+  license: LicenseRef-libglvnd
+  size: 113911
+  timestamp: 1731331012126
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
+  sha256: ec5c3125b38295bad8acc80f793b8ee217ccb194338d73858be278db50ea82f1
+  md5: 5d8323dff6a93596fb6f985cf6e8521a
+  depends:
+  - libgl 1.7.0 hd24410f_2
+  - libglx-devel 1.7.0 hd24410f_2
+  arch: aarch64
+  platform: linux
+  license: LicenseRef-libglvnd
+  size: 113925
+  timestamp: 1731331014056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
   sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
   md5: 13e8e54035ddd2b91875ba399f0f7c04
   depends:
@@ -7389,12 +5364,51 @@ packages:
   license: LGPL-2.1-or-later
   size: 3931898
   timestamp: 1729191404130
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h7025463_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
+  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
+  md5: 47f6d85fe47b865e56c539f2ba5f4dad
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 4020802
+  timestamp: 1729191545578
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-hb6ef654_0.conda
+  sha256: d782be2d8d6784f0b8584ca3cfa93357cddc71b0975560a2bcabd174dac60fff
+  md5: 2e0511f82f1481210f148e1205fe2482
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3692367
+  timestamp: 1729191628049
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
+  sha256: 101fb31c509d6a69ac5d612b51d4088ddbc675fca18cf0c3589cfee26cd01ca0
+  md5: 890783f64502fa6bfcdc723cfbf581b4
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3635416
+  timestamp: 1729191799117
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
   sha256: 7dfbf492b736f8d379f8c3b32a823f0bf2167ff69963e4c940339b146a04c54a
   md5: 3e379c1b908a7101ecbc503def24613f
   depends:
@@ -7411,52 +5425,20 @@ packages:
   license: LGPL-2.1-or-later
   size: 3810166
   timestamp: 1729192227078
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: hb6ef654_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-hb6ef654_0.conda
-  sha256: d782be2d8d6784f0b8584ca3cfa93357cddc71b0975560a2bcabd174dac60fff
-  md5: 2e0511f82f1481210f148e1205fe2482
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
+  sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
+  md5: df069bea331c8486ac21814969301c1f
   depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.82.2 *_0
-  license: LGPL-2.1-or-later
-  size: 3692367
-  timestamp: 1729191628049
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: hc486b8e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
-  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
-  md5: 47f6d85fe47b865e56c539f2ba5f4dad
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.82.2 *_0
-  license: LGPL-2.1-or-later
-  size: 4020802
-  timestamp: 1729191545578
-- kind: conda
-  name: libglu
-  version: 9.0.0
-  build: h5eeb66e_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  license: SGI-2
+  size: 325824
+  timestamp: 1718880563533
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
   sha256: d4b60ab4337f7513c2c40419b04f3f8d71dc12bdf7e5baf0517d936296f11d78
   md5: 0554e8a9ccab69bc8033d0bebed1b933
   depends:
@@ -7470,89 +5452,73 @@ packages:
   license: SGI-2
   size: 317747
   timestamp: 1718880641384
-- kind: conda
-  name: libglu
-  version: 9.0.0
-  build: ha6d2627_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
-  sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
-  md5: df069bea331c8486ac21814969301c1f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  license: SGI-2
-  size: 325824
-  timestamp: 1718880563533
-- kind: conda
-  name: libglvnd
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
-  sha256: 67942c2b6e4ddb705640b5db962e678f17d8305df5c1633e939cef1158a95058
-  md5: 1ece2ccb1dc8c68639712b05e0fae070
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
+  md5: 434ca7e50e40f4918ab701e3facd59a0
   depends:
   - __glibc >=2.17,<3.0.a0
+  arch: x86_64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 132216
-  timestamp: 1727968577428
-- kind: conda
-  name: libglvnd
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
-  sha256: 281d2be6dbad9a7267ef2581bbaefb95f26be8d62c119e1a4efbc3c405d381b7
-  md5: 32763e24bc6e5ed4de4a4a1598448d5b
+  size: 132463
+  timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
+  sha256: 57ec3898a923d4bcc064669e90e8abfc4d1d945a13639470ba5f3748bd3090da
+  md5: 9e115653741810778c9a915a2f8439e7
+  arch: aarch64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 142605
-  timestamp: 1727968549960
-- kind: conda
-  name: libglx
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
-  sha256: facc239145719034f7b8815d9630032e701d26534dae28303cdbae8b19590a82
-  md5: 80a57756c545ad11f9847835aa21e6b2
+  size: 152135
+  timestamp: 1731330986070
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
+  md5: c8013e438185f33b13814c5c488acd5c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_1
+  - libglvnd 1.7.0 ha4b6fd6_2
   - xorg-libx11 >=1.8.10,<2.0a0
+  arch: x86_64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 77902
-  timestamp: 1727968607539
-- kind: conda
-  name: libglx
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
-  sha256: 822e2178395d18dc71d25dee255852b9eac0f6943bafa5be44cc2a12cf00e7e5
-  md5: b4e4c7703e944564b512dabbcc1130d0
+  size: 75504
+  timestamp: 1731330988898
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+  sha256: 6591af640cb05a399fab47646025f8b1e1a06a0d4bbb4d2e320d6629b47a1c61
+  md5: 1d4269e233636148696a67e2d30dad2a
   depends:
-  - libglvnd 1.7.0 hd24410f_1
+  - libglvnd 1.7.0 hd24410f_2
   - xorg-libx11 >=1.8.9,<2.0a0
+  arch: aarch64
+  platform: linux
   license: LicenseRef-libglvnd
-  size: 77728
-  timestamp: 1727968567627
-- kind: conda
-  name: libgomp
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  size: 77736
+  timestamp: 1731330998960
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: 0a930e0148ab6e61089bbcdba25a2e17ee383e7de82e7af10cc5c12c82c580f3
+  md5: 27ac5ae872a21375d980bd4a6f99edf3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xorgproto
+  arch: x86_64
+  platform: linux
+  license: LicenseRef-libglvnd
+  size: 26388
+  timestamp: 1731331003255
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
+  sha256: 4bc28ecc38f30ca1ac66a8fb6c5703f4d888381ec46d3938b7c3383210061ec5
+  md5: 1f9ddbb175a63401662d1c6222cef6ff
+  depends:
+  - libglx 1.7.0 hd24410f_2
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-xorgproto
+  arch: aarch64
+  platform: linux
+  license: LicenseRef-libglvnd
+  size: 26362
+  timestamp: 1731331008489
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
   sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
@@ -7561,25 +5527,14 @@ packages:
   license_family: GPL
   size: 460992
   timestamp: 1729027639220
-- kind: conda
-  name: libgomp
-  version: 14.2.0
-  build: he277a41_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
   sha256: 5aa53874a5e57a00f2e0c2e2910684eb674429cd5fcb803619b226a73e89aedf
   md5: 376f0e73abbda6d23c0cb749adc195ef
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 463521
   timestamp: 1729089357313
-- kind: conda
-  name: libgpg-error
-  version: '1.50'
-  build: h4f305b6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
   sha256: c60969d5c315f33fee90a1f2dd5d169e2834ace5a55f5a6f822aa7485a3a84cc
   md5: 0d7ff1a8e69565ca3add6925e18e708f
   depends:
@@ -7592,12 +5547,7 @@ packages:
   license_family: GPL
   size: 273774
   timestamp: 1719390736440
-- kind: conda
-  name: libgpg-error
-  version: '1.50'
-  build: hb13efb6_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
   sha256: 03742eddce9f264edfcf6a02a3c7bfef2b1d27e7d0c32b1598ebbcadab84cc65
   md5: 7c2cdd2e6915976622cfc519b76a3d56
   depends:
@@ -7610,13 +5560,19 @@ packages:
   license_family: GPL
   size: 283819
   timestamp: 1719390791757
-- kind: conda
-  name: libhwloc
-  version: 2.11.1
-  build: default_h3030c0e_1000
-  build_number: 1000
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.1-default_h3030c0e_1000.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
+  sha256: 8473a300e10b79557ce0ac81602506b47146aff3df4cc3568147a7dd07f480a2
+  md5: f54aeebefb5c5ff84eca4fb05ca8aa3a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2417964
+  timestamp: 1720460562447
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.1-default_h3030c0e_1000.conda
   sha256: 0e07bd9b8aedc12975d16c2d0b14879ce913859a3eefe95ce54b466c852c9e97
   md5: 5e9bea190b04e32a062fa34cda4223fa
   depends:
@@ -7627,13 +5583,7 @@ packages:
   license_family: BSD
   size: 2431447
   timestamp: 1720460748563
-- kind: conda
-  name: libhwloc
-  version: 2.11.1
-  build: default_h456cccd_1000
-  build_number: 1000
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.11.1-default_h456cccd_1000.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.11.1-default_h456cccd_1000.conda
   sha256: 0b5294c8e8fc5f9faab7e54786c5f3c4395ee64b5577a1f2ae687a960e089624
   md5: a14989f6bbea46e6ec4521a403f63ff2
   depends:
@@ -7644,13 +5594,7 @@ packages:
   license_family: BSD
   size: 2350774
   timestamp: 1720460664713
-- kind: conda
-  name: libhwloc
-  version: 2.11.1
-  build: default_h7685b71_1000
-  build_number: 1000
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.1-default_h7685b71_1000.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.1-default_h7685b71_1000.conda
   sha256: ffe883123f06a7398fdb5039a52f03e3e0ee2a55ed64133580446cda62d11d16
   md5: 4c4f204c15fdc91ee75cd0449a08b87a
   depends:
@@ -7661,13 +5605,7 @@ packages:
   license_family: BSD
   size: 2325644
   timestamp: 1720460737568
-- kind: conda
-  name: libhwloc
-  version: 2.11.1
-  build: default_h8125262_1000
-  build_number: 1000
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
   sha256: 92728e292640186759d6dddae3334a1bc0b139740b736ffaeccb825fb8c07a2e
   md5: 933bad6e4658157f1aec9b171374fde2
   depends:
@@ -7680,30 +5618,7 @@ packages:
   license_family: BSD
   size: 2379689
   timestamp: 1720461835526
-- kind: conda
-  name: libhwloc
-  version: 2.11.1
-  build: default_hecaa2ac_1000
-  build_number: 1000
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
-  sha256: 8473a300e10b79557ce0ac81602506b47146aff3df4cc3568147a7dd07f480a2
-  md5: f54aeebefb5c5ff84eca4fb05ca8aa3a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.7,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2417964
-  timestamp: 1720460562447
-- kind: conda
-  name: libi2c
-  version: '4.4'
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
   sha256: c6edef9b97719961a68aa631e4b0ed4dcd34254646e10b37555562c119ddefc5
   md5: 36c48b1a98b62f477ddb1185eecddbc5
   depends:
@@ -7713,12 +5628,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 18846
   timestamp: 1728589119656
-- kind: conda
-  name: libi2c
-  version: '4.4'
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.4-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.4-h5ad3122_0.conda
   sha256: 859343e7bfaf073235742905b529bc08fb2c1d47989117dc2cad208e747ba38e
   md5: a2cc659fbbcf1d4ca9aa6ae3d0d6651b
   depends:
@@ -7727,25 +5637,15 @@ packages:
   license: LGPL-2.1-or-later
   size: 19131
   timestamp: 1728589137907
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: h0d3ecfb_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
-  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
-  md5: 69bda57310071cf6d2b86caf11573d2d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
   license: LGPL-2.1-only
-  size: 676469
-  timestamp: 1702682458114
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: h31becfc_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
   sha256: a30e09d089cb75a0d5b8e5c354694c1317da98261185ed65aa3793e741060614
   md5: 9a8eb13f14de7d761555a98712e6df65
   depends:
@@ -7753,13 +5653,19 @@ packages:
   license: LGPL-2.1-only
   size: 705787
   timestamp: 1702684557134
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hcfcfb64_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
   sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
   md5: e1eb10b1cca179f2baa3601e4efc8712
   depends:
@@ -7769,68 +5675,7 @@ packages:
   license: LGPL-2.1-only
   size: 636146
   timestamp: 1702682547199
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
-  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  md5: d66573916ffcf376178462f1b61c941e
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  size: 705775
-  timestamp: 1702682170569
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hd75f5a5_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
-  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
-  md5: 6c3628d047e151efba7cf08c5e54d1ca
-  license: LGPL-2.1-only
-  size: 666538
-  timestamp: 1702682713201
-- kind: conda
-  name: libintl
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
-  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
-  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
-  depends:
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 95568
-  timestamp: 1723629479451
-- kind: conda
-  name: libintl
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
-  sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
-  md5: 3b98ec32e91b3b59ad53dbb9c96dd334
-  depends:
-  - __osx >=11.0
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 81171
-  timestamp: 1723626968270
-- kind: conda
-  name: libintl
-  version: 0.22.5
-  build: hdfe23c8_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
   sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
   md5: 52d4d643ed26c07599736326c46bf12f
   depends:
@@ -7839,44 +5684,24 @@ packages:
   license: LGPL-2.1-or-later
   size: 88086
   timestamp: 1723626826235
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
-  sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
-  md5: 7537784e9e35399234d4007f45cdb744
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_3
-  license: LGPL-2.1-or-later
-  size: 40746
-  timestamp: 1723629745649
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
-  sha256: c9d1d4fdfb5775828e54bc9fb443b1a6de9319a04b81d1bac52c26114a763154
-  md5: 271646de11b018c66e81eb4c4717b291
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+  sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
+  md5: 3b98ec32e91b3b59ad53dbb9c96dd334
   depends:
   - __osx >=11.0
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8414b35_3
   license: LGPL-2.1-or-later
-  size: 38584
-  timestamp: 1723627022409
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: hdfe23c8_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-hdfe23c8_3.conda
+  size: 81171
+  timestamp: 1723626968270
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 95568
+  timestamp: 1723629479451
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-hdfe23c8_3.conda
   sha256: 4913a20244520d6fae14452910613b652752982193a401482b7d699ee70bb13a
   md5: aeb045f400ec2b068c6c142b16f87c7e
   depends:
@@ -7886,27 +5711,36 @@ packages:
   license: LGPL-2.1-or-later
   size: 38249
   timestamp: 1723626863306
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: h0dc2134_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
-  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
-  md5: 72507f8e3961bc968af17435060b6dd6
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
+  sha256: c9d1d4fdfb5775828e54bc9fb443b1a6de9319a04b81d1bac52c26114a763154
+  md5: 271646de11b018c66e81eb4c4717b291
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8414b35_3
+  license: LGPL-2.1-or-later
+  size: 38584
+  timestamp: 1723627022409
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
+  sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
+  md5: 7537784e9e35399234d4007f45cdb744
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  license: LGPL-2.1-or-later
+  size: 40746
+  timestamp: 1723629745649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
-  size: 579748
-  timestamp: 1694475265912
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
   sha256: 675bc1f2a8581cd34a86c412663ec29c5f90c1d9f8d11866aa1ade5cdbdf8429
   md5: ed24e702928be089d9ba3f05618515c6
   depends:
@@ -7916,13 +5750,15 @@ packages:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 647126
   timestamp: 1694475003570
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hb547adb_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
   sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
   md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
   constrains:
@@ -7930,13 +5766,7 @@ packages:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 547541
   timestamp: 1694475104253
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
   sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
   md5: 3f1b948619c45b1ca714d60c7389092c
   depends:
@@ -7948,29 +5778,8 @@ packages:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 822966
   timestamp: 1694475223854
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
-  md5: ea25936bb4080d843790b586850f82b8
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  size: 618575
-  timestamp: 1694474974816
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
   md5: 4dc03a53fc69371a6158d0ed37214cd3
   depends:
@@ -7983,13 +5792,8 @@ packages:
   license_family: BSD
   size: 15608
   timestamp: 1729642910812
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
   sha256: 2b399e65e0338bf249657b98333e910cd7086ea1332d4d6f303735883ca49318
   md5: 0eb74e81de46454960bde9e44e7ee378
   depends:
@@ -8002,13 +5806,8 @@ packages:
   license_family: BSD
   size: 15711
   timestamp: 1729643010817
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_osx64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
   build_number: 25
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
   sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
   md5: dda0e24b4605ebbd381e48606a107bed
   depends:
@@ -8021,13 +5820,8 @@ packages:
   license_family: BSD
   size: 15852
   timestamp: 1729643174413
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
   sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
   md5: 19bbddfec972d401838330453186108d
   depends:
@@ -8040,13 +5834,8 @@ packages:
   license_family: BSD
   size: 15823
   timestamp: 1729643275943
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
   sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
   md5: f716ef84564c574e8e74ae725f5d5f93
   depends:
@@ -8059,13 +5848,8 @@ packages:
   license_family: BSD
   size: 3736560
   timestamp: 1729643588182
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_openblas.conda
   sha256: f8bc6fe22126ca0bf204c27f829d1e0006069cc98776a33122bf8d0548940b3c
   md5: 8f5ead31b3a168aedd488b8a87736c41
   depends:
@@ -8078,13 +5862,8 @@ packages:
   license_family: BSD
   size: 15609
   timestamp: 1729642916038
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-25_linuxaarch64_openblas.conda
   sha256: f0a591a2ac7e1259971124ddd466ce39da646699decda1a8ab45a2fabd257665
   md5: 1e68063075954830f707b41dab6c7fd8
   depends:
@@ -8097,13 +5876,8 @@ packages:
   license_family: BSD
   size: 15712
   timestamp: 1729643014949
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_osx64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-25_osx64_openblas.conda
   build_number: 25
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-25_osx64_openblas.conda
   sha256: 14e1ec71bd47d63ec32b95801b04d850f12fb8ece3b03483fd36f898336d987b
   md5: ddd746770d7811274ba38e0a832e3a50
   depends:
@@ -8116,13 +5890,8 @@ packages:
   license_family: BSD
   size: 15846
   timestamp: 1729643185849
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-25_osxarm64_openblas.conda
   sha256: 3db3a803a9295784c1fae97c1397b44f5c1c58472b7b06834d8387ed986778f9
   md5: fe649c1f453f9952a9048b80dc25f92f
   depends:
@@ -8135,13 +5904,8 @@ packages:
   license_family: BSD
   size: 15836
   timestamp: 1729643281243
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
   sha256: a7a6d417bf963659bdfa6ef6f5604696fb0717f7bed7f594ceb1ceedf7d93d16
   md5: d59fc46f1e1c2f3cf38a08a0a76ffee5
   depends:
@@ -8154,13 +5918,19 @@ packages:
   license_family: BSD
   size: 3736581
   timestamp: 1729643615092
-- kind: conda
-  name: libllvm17
-  version: 17.0.6
-  build: h5090b49_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
+  sha256: 605460ecc4ccc04163d0b06c99693864e5bcba7a9f014a5263c9856195282265
+  md5: fcd38f0553a99fa279fb66a5bfc2fb28
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26306756
+  timestamp: 1701378823527
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
   sha256: 5829e490e395d85442fb6c7edb0ec18d1a5bb1bc529919a89337d34235205064
   md5: 443b26505722696a9535732bc2a07576
   depends:
@@ -8173,66 +5943,7 @@ packages:
   license_family: Apache
   size: 24612870
   timestamp: 1718320971519
-- kind: conda
-  name: libllvm17
-  version: 17.0.6
-  build: hbedff68_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
-  sha256: 605460ecc4ccc04163d0b06c99693864e5bcba7a9f014a5263c9856195282265
-  md5: fcd38f0553a99fa279fb66a5bfc2fb28
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 26306756
-  timestamp: 1701378823527
-- kind: conda
-  name: libllvm19
-  version: 19.1.2
-  build: h1e63acb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm19-19.1.2-h1e63acb_0.conda
-  sha256: 31035f7aa439ca93645fb995a9b548f82f363068271cb4755fc5a3757d3af496
-  md5: f71d5443e58de8b821ba9fce74447b23
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 28702727
-  timestamp: 1729023904579
-- kind: conda
-  name: libllvm19
-  version: 19.1.2
-  build: h2edbd07_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.2-h2edbd07_0.conda
-  sha256: 4d3d0e704068fb6baa5d4be494122c6e894501797838aa821d26b7952b01027d
-  md5: e0c251e0b6815995e2f19532ab604f9b
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 39382849
-  timestamp: 1729030002029
-- kind: conda
-  name: libllvm19
-  version: 19.1.2
-  build: ha7bfdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.2-ha7bfdaf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.2-ha7bfdaf_0.conda
   sha256: 8c0eb8f753ef2a449acd846bc5853f7f11d319819bb5bbdf721c8ac0d8db875a
   md5: 128e74a4f8f4fef4dc5130a8bbccc15d
   depends:
@@ -8246,12 +5957,33 @@ packages:
   license_family: Apache
   size: 40136241
   timestamp: 1729031844469
-- kind: conda
-  name: libllvm19
-  version: 19.1.2
-  build: haf57ff0_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.2-haf57ff0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.2-h2edbd07_0.conda
+  sha256: 4d3d0e704068fb6baa5d4be494122c6e894501797838aa821d26b7952b01027d
+  md5: e0c251e0b6815995e2f19532ab604f9b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 39382849
+  timestamp: 1729030002029
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm19-19.1.2-h1e63acb_0.conda
+  sha256: 31035f7aa439ca93645fb995a9b548f82f363068271cb4755fc5a3757d3af496
+  md5: f71d5443e58de8b821ba9fce74447b23
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 28702727
+  timestamp: 1729023904579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.2-haf57ff0_0.conda
   sha256: 049b7dcb3bc43a1e496987b0d45ce9b9f894a88385744d5779027062e2cea6ae
   md5: 6038eda47f011c0f808d34accd8dacb6
   depends:
@@ -8264,12 +5996,7 @@ packages:
   license_family: Apache
   size: 26882925
   timestamp: 1729025168222
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h161d5f1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
   sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
   md5: 19e57602824042dfd0446292ef90488b
   depends:
@@ -8285,52 +6012,7 @@ packages:
   license_family: MIT
   size: 647599
   timestamp: 1729571887612
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h6d7220d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
-  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
-  md5: 3408c02539cee5f1141f9f11450b6a51
-  depends:
-  - __osx >=11.0
-  - c-ares >=1.34.2,<2.0a0
-  - libcxx >=17
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 566719
-  timestamp: 1729572385640
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: hc7306c3_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
-  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
-  md5: ab21007194b97beade22ceb7a3f6fee5
-  depends:
-  - __osx >=10.13
-  - c-ares >=1.34.2,<2.0a0
-  - libcxx >=17
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 606663
-  timestamp: 1729572019083
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: hc8609a4_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
   sha256: c093c6d370aadbf0409c20b6c54c488ee2f6fea976181919fcc63e87ee232673
   md5: f52c614fa214a8bedece9421c771670d
   depends:
@@ -8345,26 +6027,37 @@ packages:
   license_family: MIT
   size: 714610
   timestamp: 1729571912479
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
-  md5: c14f32510f694e3185704d89967ec422
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
   depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
-  size: 34501
-  timestamp: 1697358973269
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
@@ -8373,12 +6066,25 @@ packages:
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h0b9eccb_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
+  md5: c14f32510f694e3185704d89967ec422
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 34501
+  timestamp: 1697358973269
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+  sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
+  md5: 601bfb4b3c6f0b844443bb81a56651e0
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205914
+  timestamp: 1719301575771
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
   sha256: e65acc318b7535fb8f2b5e994fe6eac3ae0be3bdb2acbe6037841d033c51f290
   md5: 15cb67b1b9dd0d4b37c81daba785e6ad
   depends:
@@ -8387,12 +6093,25 @@ packages:
   license_family: BSD
   size: 208233
   timestamp: 1719301637185
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-hfdf4475_0.conda
+  sha256: bebf5797e2a278fd2094f2b0c29ccdfc51d400f4736701108a7e544a49705c64
+  md5: 7497372c91a31d3e8d64ce3f1a9632e8
+  depends:
+  - __osx >=10.13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203604
+  timestamp: 1719301669662
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
+  sha256: 685f73b7241978007dfe0cecb9cae46c6a26d87d192b6f85a09eb65023c0b99e
+  md5: 57b668b9b78dea2c08e44bb2385d57c0
+  depends:
+  - __osx >=11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205451
+  timestamp: 1719301708541
+- conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
   sha256: fcffdf32c620569738b85c98ddd25e1c84c8add80cd732743d90d469b7b532bb
   md5: 44a4d173e62c5ed6d715f18ae7c46b7a
   depends:
@@ -8403,115 +6122,7 @@ packages:
   license_family: BSD
   size: 35459
   timestamp: 1719302192495
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
-  sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
-  md5: 601bfb4b3c6f0b844443bb81a56651e0
-  depends:
-  - libgcc-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 205914
-  timestamp: 1719301575771
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h99b78c6_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
-  sha256: 685f73b7241978007dfe0cecb9cae46c6a26d87d192b6f85a09eb65023c0b99e
-  md5: 57b668b9b78dea2c08e44bb2385d57c0
-  depends:
-  - __osx >=11.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 205451
-  timestamp: 1719301708541
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: hfdf4475_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-hfdf4475_0.conda
-  sha256: bebf5797e2a278fd2094f2b0c29ccdfc51d400f4736701108a7e544a49705c64
-  md5: 7497372c91a31d3e8d64ce3f1a9632e8
-  depends:
-  - __osx >=10.13
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203604
-  timestamp: 1719301669662
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_h1a8b088_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-openmp_h1a8b088_0.conda
-  sha256: 83034982f733c5762e54cb046c1fbd44bc885466c58e3d251964e5ca5e3d6786
-  md5: eba54dbc44fbbd54751b5810b1126f4c
-  depends:
-  - _openmp_mutex * *_llvm
-  - _openmp_mutex >=4.5
-  - libgcc-ng >=14
-  - libgfortran-ng
-  - libgfortran5 >=14.1.0
-  - llvm-openmp >=18.1.8
-  constrains:
-  - openblas >=0.3.28,<0.3.29.0a0
-  track_features:
-  - openblas_threading_openmp
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4801515
-  timestamp: 1723932156159
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_h517c56d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_h517c56d_0.conda
-  sha256: 43d69d072f1a3774994d31f9d3241cfa0f1c5560b536989020d7cde30fbef956
-  md5: 9306fd5b6b39b2b7e13c1d50c3fee354
-  depends:
-  - __osx >=11.0
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=16.0.6
-  constrains:
-  - openblas >=0.3.28,<0.3.29.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2934061
-  timestamp: 1723931625423
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_h8869122_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_h8869122_0.conda
-  sha256: f86ff61991104bfa4fc7725c6d45c29516e7eb504a6d73ee23c50cd208900906
-  md5: 6bf3c78f6d014543765570c8e1c65642
-  depends:
-  - __osx >=10.13
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=16.0.6
-  constrains:
-  - openblas >=0.3.28,<0.3.29.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6052706
-  timestamp: 1723932292682
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_hd680484_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_0.conda
   sha256: 4412f2d82f343954f5d5ce0f479069d21770b488b8b49583f7b24f186a1e3e8f
   md5: f9d66b83195eb11c4a4a4413b30c13ff
   depends:
@@ -8530,209 +6141,53 @@ packages:
   license_family: BSD
   size: 5582186
   timestamp: 1723932272354
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: headless_py310hedf1e49_8
-  build_number: 8
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.10.0-headless_py310hedf1e49_8.conda
-  sha256: 9e393d7a436613a94debfb17dd9e2fd530e189c750fdda570b5c2fcdd6489ca7
-  md5: 387c2ab3a4cc701f153b73dd93e79f14
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-openmp_h1a8b088_0.conda
+  sha256: 83034982f733c5762e54cb046c1fbd44bc885466c58e3d251964e5ca5e3d6786
+  md5: eba54dbc44fbbd54751b5810b1126f4c
+  depends:
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=14
+  - libgfortran-ng
+  - libgfortran5 >=14.1.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  track_features:
+  - openblas_threading_openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4801515
+  timestamp: 1723932156159
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_h8869122_0.conda
+  sha256: f86ff61991104bfa4fc7725c6d45c29516e7eb504a6d73ee23c50cd208900906
+  md5: 6bf3c78f6d014543765570c8e1c65642
   depends:
   - __osx >=10.13
-  - ffmpeg >=6.1.2,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.1,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.2.2,<3.3.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 27549718
-  timestamp: 1728021103563
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: headless_py312h127a95d_8
-  build_number: 8
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312h127a95d_8.conda
-  sha256: f3cc44ab8ac58c07e90ee9e66fe5b7bec47baf633e5fd6534a0919f102bea3ab
-  md5: 71b194cbbd7c8d9599f31256355d3bc4
-  depends:
-  - _openmp_mutex >=4.5
-  - ffmpeg >=6.1.2,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc >=13
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.1,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.2.2,<3.3.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  license: Apache-2.0
-  license_family: Apache
-  size: 19960312
-  timestamp: 1728020811394
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: headless_py312he31edb6_8
-  build_number: 8
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312he31edb6_8.conda
-  sha256: 27683f7401cd176d7e368e297e6565ef733180b39c2f52f5d96eb665708c2b8d
-  md5: 05f0570253fe4ac7f40d5f46b258214e
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6052706
+  timestamp: 1723932292682
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_h517c56d_0.conda
+  sha256: 43d69d072f1a3774994d31f9d3241cfa0f1c5560b536989020d7cde30fbef956
+  md5: 9306fd5b6b39b2b7e13c1d50c3fee354
   depends:
   - __osx >=11.0
-  - ffmpeg >=6.1.2,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.1,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.2.2,<3.3.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  license: Apache-2.0
-  license_family: Apache
-  size: 21886575
-  timestamp: 1728020459453
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: qt6_py311h5a8f696_608
-  build_number: 608
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py311h5a8f696_608.conda
-  sha256: 0477cf06cd31ac79d08d1eb4e0c20fd321d372025a22dd7b727886065049091e
-  md5: 220a89c1f668b15090d52506aa941956
-  depends:
-  - ffmpeg >=6.1.2,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.1,<3.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.2.2,<3.3.0a0
-  - qt6-main >=6.7.3,<6.8.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 32987550
-  timestamp: 1728023066233
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: qt6_py39h5cac152_610
-  build_number: 610
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py39h5cac152_610.conda
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2934061
+  timestamp: 1723931625423
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py39h5cac152_610.conda
   sha256: 966c9c441f8a0005ebbe26d66cefccd08556faf4eaf6df2ee308c08ef0f50d91
   md5: 45d7118cbbbb6f4733a9b23d91989a3d
   depends:
@@ -8780,45 +6235,179 @@ packages:
   license_family: Apache
   size: 30891589
   timestamp: 1729610949785
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: h49f535f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-h49f535f_1.conda
-  sha256: 5e0c931478ed4113c9edb4ef0898c7f10f41b1af6bb580ae837b102fda887ca2
-  md5: 128013add92b7e579af3de6759bb8b46
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312h127a95d_8.conda
+  sha256: f3cc44ab8ac58c07e90ee9e66fe5b7bec47baf633e5fd6534a0919f102bea3ab
+  md5: 71b194cbbd7c8d9599f31256355d3bc4
+  depends:
+  - _openmp_mutex >=4.5
+  - ffmpeg >=6.1.2,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.2.2,<3.3.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  size: 19960312
+  timestamp: 1728020811394
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.10.0-headless_py310hedf1e49_8.conda
+  sha256: 9e393d7a436613a94debfb17dd9e2fd530e189c750fdda570b5c2fcdd6489ca7
+  md5: 387c2ab3a4cc701f153b73dd93e79f14
+  depends:
+  - __osx >=10.13
+  - ffmpeg >=6.1.2,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.2.2,<3.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27549718
+  timestamp: 1728021103563
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312he31edb6_8.conda
+  sha256: 27683f7401cd176d7e368e297e6565ef733180b39c2f52f5d96eb665708c2b8d
+  md5: 05f0570253fe4ac7f40d5f46b258214e
   depends:
   - __osx >=11.0
+  - ffmpeg >=6.1.2,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
   - libcxx >=17
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 3951327
-  timestamp: 1727734428093
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: h7bc525e_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.4.0-h7bc525e_1.conda
-  sha256: eb560161fd7a355c28988c8ca3a826f89aef41917617df427b56eb1922e22c95
-  md5: 41f83efe50e2140fe79e74f835e1d744
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.2.2,<3.3.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  size: 21886575
+  timestamp: 1728020459453
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py311h5a8f696_608.conda
+  sha256: 0477cf06cd31ac79d08d1eb4e0c20fd321d372025a22dd7b727886065049091e
+  md5: 220a89c1f668b15090d52506aa941956
   depends:
-  - __osx >=10.15
-  - libcxx >=17
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 4231912
-  timestamp: 1727735006500
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
+  - ffmpeg >=6.1.2,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.2.2,<3.3.0a0
+  - qt6-main >=6.7.3,<6.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 32987550
+  timestamp: 1728023066233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
   sha256: 1f804b6238951d59b3a431c2e01bd831d44e015ea6835809775bb60b6978e3b3
   md5: ba5ac0bb9ec5aec38dec37c230b12d64
   depends:
@@ -8829,13 +6418,7 @@ packages:
   - tbb >=2021.13.0
   size: 5362131
   timestamp: 1729594675874
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hd7d4d4f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_1.conda
   sha256: 781349dd5c10ef37bf7a0d7afb6d83c2c217bf798f4d79cc47ff339227cd7bf5
   md5: f4812fe0c0e4934ae2ec41b5371823ff
   depends:
@@ -8845,13 +6428,27 @@ packages:
   - tbb >=2021.13.0
   size: 4907367
   timestamp: 1727736165150
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hfe1841e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.4.0-h7bc525e_1.conda
+  sha256: eb560161fd7a355c28988c8ca3a826f89aef41917617df427b56eb1922e22c95
+  md5: 41f83efe50e2140fe79e74f835e1d744
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 4231912
+  timestamp: 1727735006500
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-h49f535f_1.conda
+  sha256: 5e0c931478ed4113c9edb4ef0898c7f10f41b1af6bb580ae837b102fda887ca2
+  md5: 128013add92b7e579af3de6759bb8b46
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 3951327
+  timestamp: 1727734428093
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_1.conda
   sha256: 9849d119e37f6c424ab04a8692d7cd37524d82eba8a0a2920a074bf3dbc1b44b
   md5: 8112a7a31fa5fa7adcd9f213db4545c2
   depends:
@@ -8862,30 +6459,7 @@ packages:
   - vc14_runtime >=14.29.30139
   size: 3323185
   timestamp: 1727742797259
-- kind: conda
-  name: libopenvino-arm-cpu-plugin
-  version: 2024.4.0
-  build: h49f535f_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-h49f535f_1.conda
-  sha256: 525dd6549178c4cb462a4c6d9941e2656092303875f20e756bc308d6666aa272
-  md5: e4fea763df742e2f2258fac928fcd735
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 7441642
-  timestamp: 1727734456011
-- kind: conda
-  name: libopenvino-arm-cpu-plugin
-  version: 2024.4.0
-  build: hd7d4d4f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_1.conda
   sha256: 8891f029fdb29bcd0da1dc2f60742700f94b6641df7726dae3188ee4fd95ca44
   md5: 3505d23e00013066cc80b544abcaf526
   depends:
@@ -8896,30 +6470,18 @@ packages:
   - tbb >=2021.13.0
   size: 8396025
   timestamp: 1727736188890
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h04f32e0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_1.conda
-  sha256: 78cb1c9dcab0a925a422a5a38d7a3e2127c91189b554eba5552d96db77e2d558
-  md5: 8bcf361232b712f26183ec1344b4b1c2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-h49f535f_1.conda
+  sha256: 525dd6549178c4cb462a4c6d9941e2656092303875f20e756bc308d6666aa272
+  md5: e4fea763df742e2f2258fac928fcd735
   depends:
-  - libopenvino 2024.4.0 hfe1841e_1
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 99710
-  timestamp: 1727742845056
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h4d9b6c2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
+  size: 7441642
+  timestamp: 1727734456011
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
   sha256: dc596ff555b7ae19a7cd62af8965445575e1441dd486b8aec6a647f9ecbada3a
   md5: 1d05a25da36ba5f98291d7237fc6b8ce
   depends:
@@ -8930,45 +6492,7 @@ packages:
   - tbb >=2021.13.0
   size: 111701
   timestamp: 1729594696807
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h8a2fcec_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-h8a2fcec_1.conda
-  sha256: e063af46407bce327fa2a5c346a15129268c0fb9968f23909b7661074138a204
-  md5: 69a92fdcb51c3f60c6b740e33aea1f2a
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  - tbb >=2021.13.0
-  size: 104178
-  timestamp: 1727734500385
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h904f6e8_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.4.0-h904f6e8_1.conda
-  sha256: 17b5dd31e9dd0e4029547d7b8e59be64eda5cc4bd49f472a60ba02225ed76089
-  md5: 040d99f3abf2f1954dc82f10943c3ad2
-  depends:
-  - __osx >=10.15
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
-  - tbb >=2021.13.0
-  size: 105675
-  timestamp: 1727735029695
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: hf15766e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_1.conda
   sha256: d8533e8f9fdcf6fb6ea44aba5007c8bb62b0da0ea28bc6b4b75bbcb3de4df8e5
   md5: c8168b9954a8e347d8a870a0bdba6cc2
   depends:
@@ -8978,30 +6502,38 @@ packages:
   - tbb >=2021.13.0
   size: 107990
   timestamp: 1727736222949
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h04f32e0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_1.conda
-  sha256: d874d48f60257e53b58d403a338159be0faaffac93f7d39e97c111c711554deb
-  md5: 9caed540cf3f82423b36fdd49ade48ea
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.4.0-h904f6e8_1.conda
+  sha256: 17b5dd31e9dd0e4029547d7b8e59be64eda5cc4bd49f472a60ba02225ed76089
+  md5: 040d99f3abf2f1954dc82f10943c3ad2
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - tbb >=2021.13.0
+  size: 105675
+  timestamp: 1727735029695
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-h8a2fcec_1.conda
+  sha256: e063af46407bce327fa2a5c346a15129268c0fb9968f23909b7661074138a204
+  md5: 69a92fdcb51c3f60c6b740e33aea1f2a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - tbb >=2021.13.0
+  size: 104178
+  timestamp: 1727734500385
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_1.conda
+  sha256: 78cb1c9dcab0a925a422a5a38d7a3e2127c91189b554eba5552d96db77e2d558
+  md5: 8bcf361232b712f26183ec1344b4b1c2
   depends:
   - libopenvino 2024.4.0 hfe1841e_1
   - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 194349
-  timestamp: 1727742884368
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h4d9b6c2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
+  size: 99710
+  timestamp: 1727742845056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
   sha256: 27b732f1ba3ae7dc8263f59e69447eebabcc76de86e2ec4c9722842a1d2f4aa8
   md5: 838b2db868f9ab69a7bad9c065a3362d
   depends:
@@ -9012,45 +6544,7 @@ packages:
   - tbb >=2021.13.0
   size: 237694
   timestamp: 1729594707449
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h8a2fcec_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-h8a2fcec_1.conda
-  sha256: 3fa11fc10209a97dc06064a27a5ef4ca6ec619ccc6c26b3fc9c2618c2d338d1f
-  md5: e8a4b17000d53f2535ac2aa9d83d5ba4
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  - tbb >=2021.13.0
-  size: 211529
-  timestamp: 1727734517574
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h904f6e8_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.4.0-h904f6e8_1.conda
-  sha256: ccdaf62023d0625a03eba83396379e3a4683075d0ff33ed375d857642ab1d9cc
-  md5: 3e58791c03a55e0f2cd7f937078b2336
-  depends:
-  - __osx >=10.15
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
-  - tbb >=2021.13.0
-  size: 217416
-  timestamp: 1727735046115
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: hf15766e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_1.conda
   sha256: d9c2b766b1d491efdad4987d74287cea0945bb279c0666b2aba1091c7a9cb1b4
   md5: 4a85f812507f352c3dd162255ca92054
   depends:
@@ -9060,46 +6554,38 @@ packages:
   - tbb >=2021.13.0
   size: 224280
   timestamp: 1727736262029
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h364e3e2_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.4.0-h364e3e2_1.conda
-  sha256: 18d02087eb6bc2020438197e4c4d769e8da0275e70c029dcae211dc28bb16527
-  md5: d88d2184086ea72c6d82a914b3206c33
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.4.0-h904f6e8_1.conda
+  sha256: ccdaf62023d0625a03eba83396379e3a4683075d0ff33ed375d857642ab1d9cc
+  md5: 3e58791c03a55e0f2cd7f937078b2336
   depends:
   - __osx >=10.15
   - libcxx >=17
   - libopenvino 2024.4.0 h7bc525e_1
-  - pugixml >=1.14,<1.15.0a0
-  size: 181128
-  timestamp: 1727735062714
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h372dad0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_1.conda
-  sha256: 4255d0ae5ee122a47e0a77418f951d57f35c6b363a173c4583c907637ac9699e
-  md5: 3dc40fff10eab0d7a8f719756a7e30f7
+  - tbb >=2021.13.0
+  size: 217416
+  timestamp: 1727735046115
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-h8a2fcec_1.conda
+  sha256: 3fa11fc10209a97dc06064a27a5ef4ca6ec619ccc6c26b3fc9c2618c2d338d1f
+  md5: e8a4b17000d53f2535ac2aa9d83d5ba4
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - tbb >=2021.13.0
+  size: 211529
+  timestamp: 1727734517574
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_1.conda
+  sha256: d874d48f60257e53b58d403a338159be0faaffac93f7d39e97c111c711554deb
+  md5: 9caed540cf3f82423b36fdd49ade48ea
   depends:
   - libopenvino 2024.4.0 hfe1841e_1
-  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 159985
-  timestamp: 1727742935549
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h3f63f65_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
+  size: 194349
+  timestamp: 1727742884368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
   sha256: 0c7cd10c9e3d99d6f23e4d7b48cd8e72aeb4a1c7acb801b6ca9add0f87f238d3
   md5: 00a6127960a3f41d4bfcabd35d5fbeec
   depends:
@@ -9110,13 +6596,7 @@ packages:
   - pugixml >=1.14,<1.15.0a0
   size: 197567
   timestamp: 1729594718187
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h6ef32b0_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_1.conda
   sha256: 6ba3e169093cc4937baa1366552f8bdd1133bb4851ea6eda2c20897ffe76bc25
   md5: 3bb4e66afee69752d0254f399454a015
   depends:
@@ -9126,13 +6606,17 @@ packages:
   - pugixml >=1.14,<1.15.0a0
   size: 184604
   timestamp: 1727736275255
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h868cbb4_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h868cbb4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.4.0-h364e3e2_1.conda
+  sha256: 18d02087eb6bc2020438197e4c4d769e8da0275e70c029dcae211dc28bb16527
+  md5: d88d2184086ea72c6d82a914b3206c33
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - pugixml >=1.14,<1.15.0a0
+  size: 181128
+  timestamp: 1727735062714
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h868cbb4_1.conda
   sha256: c31517fc4ff50d95cf3c8888307019e6424d685e2d9da9843ab83295c3b4de6a
   md5: 78c2f1ec1ec18e20b19e20fe8a30db8e
   depends:
@@ -9142,30 +6626,18 @@ packages:
   - pugixml >=1.14,<1.15.0a0
   size: 173970
   timestamp: 1727734536231
-- kind: conda
-  name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
-  build: h7bc525e_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.4.0-h7bc525e_1.conda
-  sha256: 6e949602df71436eeeb251d3341068e0de28dd3acf4aa6ea0956d1ab2a785bda
-  md5: bf19aff20ed3c8146703f0d225628a25
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_1.conda
+  sha256: 4255d0ae5ee122a47e0a77418f951d57f35c6b363a173c4583c907637ac9699e
+  md5: 3dc40fff10eab0d7a8f719756a7e30f7
   depends:
-  - __osx >=10.15
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
+  - libopenvino 2024.4.0 hfe1841e_1
   - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  size: 11144640
-  timestamp: 1727735085846
-- kind: conda
-  name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 159985
+  timestamp: 1727742935549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
   sha256: 5642443645408f030e9dfbe20dbe2c2ab6d852daf02c9a36eac123b44bf2980f
   md5: 6cfc840bc39c17d92fb25e5a35789e5b
   depends:
@@ -9177,13 +6649,18 @@ packages:
   - tbb >=2021.13.0
   size: 12101994
   timestamp: 1729594729554
-- kind: conda
-  name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
-  build: hfe1841e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.4.0-h7bc525e_1.conda
+  sha256: 6e949602df71436eeeb251d3341068e0de28dd3acf4aa6ea0956d1ab2a785bda
+  md5: bf19aff20ed3c8146703f0d225628a25
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 11144640
+  timestamp: 1727735085846
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_1.conda
   sha256: 0e25e7c5fc374c49b795ce4546e49a6b181b36029a2fbfa43ea289e268022685
   md5: fb644753d714acace1f62f180252aaf2
   depends:
@@ -9195,13 +6672,7 @@ packages:
   - vc14_runtime >=14.29.30139
   size: 8038586
   timestamp: 1727742976578
-- kind: conda
-  name: libopenvino-intel-gpu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
   sha256: 508d0e36febebfb66628d8cb0312b4133c212eac1e8d891fc8977e0d85b23741
   md5: 9e9814b40d8fdfd8485451e3fa2f1719
   depends:
@@ -9214,13 +6685,7 @@ packages:
   - tbb >=2021.13.0
   size: 8885078
   timestamp: 1729594772427
-- kind: conda
-  name: libopenvino-intel-gpu-plugin
-  version: 2024.4.0
-  build: hfe1841e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_1.conda
   sha256: 807d69917f8924519423e3f6b64f32345551c5f1a08c0dead4ddcf71bdbd1b36
   md5: 3425d54332ca5792678c189e7eb2cc4a
   depends:
@@ -9233,13 +6698,7 @@ packages:
   - vc14_runtime >=14.29.30139
   size: 7182614
   timestamp: 1727743041822
-- kind: conda
-  name: libopenvino-intel-npu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
   sha256: a07bdb55c3214cd5b27736ee6d06abe55782ddf1cfaeb9fffee96179bf12390b
   md5: 724719ce97feb6f310f88ae8dbb40afd
   depends:
@@ -9251,46 +6710,7 @@ packages:
   - tbb >=2021.13.0
   size: 799335
   timestamp: 1729594804720
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h364e3e2_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.4.0-h364e3e2_1.conda
-  sha256: f2ff5a5da8f2adf6bcfca080d920066f24a7d10a0c237ae1343722056d31b204
-  md5: 65d5c0d7deb8d568d363fc90bba668d9
-  depends:
-  - __osx >=10.15
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
-  - pugixml >=1.14,<1.15.0a0
-  size: 182957
-  timestamp: 1727735135816
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h372dad0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_1.conda
-  sha256: dd777e23535b70e4071baa44258648c95baf6d79f43e9bc8cd27faa810df0f68
-  md5: a597057c32cd79d96403bd4a5ac6d38c
-  depends:
-  - libopenvino 2024.4.0 hfe1841e_1
-  - pugixml >=1.14,<1.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 158232
-  timestamp: 1727743098747
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h3f63f65_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
   sha256: 6038aefea84aeb9534aaf6963d2b266eb757fa36c1a7a9f5e29d6d813bd85a2c
   md5: 8908f31eab30f65636eb61ab9cb1f3ad
   depends:
@@ -9301,13 +6721,7 @@ packages:
   - pugixml >=1.14,<1.15.0a0
   size: 204163
   timestamp: 1729594816408
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h6ef32b0_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_1.conda
   sha256: 30f4825789b3a82d51bf80eeb2baeba8f2c15eb1c58296a61b5d0dfde10ad191
   md5: 5f8c79d05bec97d469a3174c8328f61a
   depends:
@@ -9317,13 +6731,17 @@ packages:
   - pugixml >=1.14,<1.15.0a0
   size: 192039
   timestamp: 1727736288484
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h868cbb4_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h868cbb4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.4.0-h364e3e2_1.conda
+  sha256: f2ff5a5da8f2adf6bcfca080d920066f24a7d10a0c237ae1343722056d31b204
+  md5: 65d5c0d7deb8d568d363fc90bba668d9
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - pugixml >=1.14,<1.15.0a0
+  size: 182957
+  timestamp: 1727735135816
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h868cbb4_1.conda
   sha256: 8d21c0ca0b76258cee94473cd914b9bf057218bd6e36bd8d8e78abf0530b8a5b
   md5: c203b54e1edf2a5ea2c76d297e097159
   depends:
@@ -9333,50 +6751,18 @@ packages:
   - pugixml >=1.14,<1.15.0a0
   size: 173568
   timestamp: 1727734556587
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h56b1c3c_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-h56b1c3c_1.conda
-  sha256: f189bcd7aa68b2e61dbb334757f14133c5d1da6cb07679c226ebe0fa83892ce3
-  md5: 031735d911b8f46c7ba3cacb0565c860
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_1.conda
+  sha256: dd777e23535b70e4071baa44258648c95baf6d79f43e9bc8cd27faa810df0f68
+  md5: a597057c32cd79d96403bd4a5ac6d38c
   depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  size: 1228021
-  timestamp: 1727734590200
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h5707d70_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-h5707d70_1.conda
-  sha256: 39b66fbf88884fe093a2b1c87b432851afbf15e57ef9b18800634619aceb559b
-  md5: 52d26dbc42460ba541e234626fea1011
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
   - libopenvino 2024.4.0 hfe1841e_1
-  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - pugixml >=1.14,<1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 991756
-  timestamp: 1727743145820
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h5c8f2c3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
+  size: 158232
+  timestamp: 1727743098747
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
   sha256: b68c2ee5fd08c0974ad9395ea0de809b306c261485114cbcbbc0f55c1e0285b3
   md5: e098caa87868e8dcc7ed5d011981207d
   depends:
@@ -9389,31 +6775,7 @@ packages:
   - libstdcxx >=13
   size: 1559399
   timestamp: 1729594827815
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h9381666_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.4.0-h9381666_1.conda
-  sha256: 7fab7fadd14918bbc41375422279b6d9d63459e22e8e3f689cc8cbf612cc7c64
-  md5: ef81e0bd029cd0ed174bf967589f6628
-  depends:
-  - __osx >=10.15
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  size: 1281366
-  timestamp: 1727735162793
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: he59a552_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-he59a552_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-he59a552_1.conda
   sha256: 0c86cce07d20a3b2d0db14b349096ad197b42113eb854c64242b748b3cae5d84
   md5: 8ce3f67a3d4b070b6493c88b0afe400f
   depends:
@@ -9425,15 +6787,21 @@ packages:
   - libstdcxx >=13
   size: 1404754
   timestamp: 1727736302649
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h56b1c3c_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-h56b1c3c_1.conda
-  sha256: 802622fc93ece7ddae63461fe1212677d606e2f273217c8bdcce30eb734f241f
-  md5: 2774e2b992650f812668f1417d254e9d
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.4.0-h9381666_1.conda
+  sha256: 7fab7fadd14918bbc41375422279b6d9d63459e22e8e3f689cc8cbf612cc7c64
+  md5: ef81e0bd029cd0ed174bf967589f6628
+  depends:
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 1281366
+  timestamp: 1727735162793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-h56b1c3c_1.conda
+  sha256: f189bcd7aa68b2e61dbb334757f14133c5d1da6cb07679c226ebe0fa83892ce3
+  md5: 031735d911b8f46c7ba3cacb0565c860
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
@@ -9441,17 +6809,11 @@ packages:
   - libcxx >=17
   - libopenvino 2024.4.0 h49f535f_1
   - libprotobuf >=5.27.5,<5.27.6.0a0
-  size: 419159
-  timestamp: 1727734612023
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h5707d70_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-h5707d70_1.conda
-  sha256: 3bfdfaca70c91af517fe7ee5897164611676e91d68b639717b7da3b6db037b85
-  md5: 27b80a14e7f69e8facc6d021692b9543
+  size: 1228021
+  timestamp: 1727734590200
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-h5707d70_1.conda
+  sha256: 39b66fbf88884fe093a2b1c87b432851afbf15e57ef9b18800634619aceb559b
+  md5: 52d26dbc42460ba541e234626fea1011
   depends:
   - libabseil * cxx17*
   - libabseil >=20240722.0,<20240723.0a0
@@ -9460,15 +6822,9 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 419305
-  timestamp: 1727743190562
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h5c8f2c3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
+  size: 991756
+  timestamp: 1727743145820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
   sha256: fa57b201fb92af0adc2118de8e92648959b98c0dc1a60b278ba2b79c5601eea6
   md5: 59bb8c3502cb9d35f1fb26691730288c
   depends:
@@ -9481,31 +6837,7 @@ packages:
   - libstdcxx >=13
   size: 653105
   timestamp: 1729594841297
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h9381666_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.4.0-h9381666_1.conda
-  sha256: 02a79422eb03e329dc2daa60242a299ba0b5ad6c7d2fbe16690ae9b6b0d09d11
-  md5: 733d3c5fe554e675fe279308f28dbd0c
-  depends:
-  - __osx >=10.15
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  size: 427045
-  timestamp: 1727735182582
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: he59a552_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-he59a552_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-he59a552_1.conda
   sha256: e38bd130841f9ac7ff73befcb1f241a17efd0568678a994c2e3f64b11009da79
   md5: 03a42996356af6a472c6b29bfaab8275
   depends:
@@ -9517,28 +6849,44 @@ packages:
   - libstdcxx >=13
   size: 605738
   timestamp: 1727736320540
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h4398f7a_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.4.0-h4398f7a_1.conda
-  sha256: e04195e7ce2fb0709b3fc22d53f2560046ad7ac956c334ed3af1a30363afde5a
-  md5: 8834ede936d55c678b2e4fe07c2a8575
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.4.0-h9381666_1.conda
+  sha256: 02a79422eb03e329dc2daa60242a299ba0b5ad6c7d2fbe16690ae9b6b0d09d11
+  md5: 733d3c5fe554e675fe279308f28dbd0c
   depends:
   - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
   - libcxx >=17
   - libopenvino 2024.4.0 h7bc525e_1
-  size: 788511
-  timestamp: 1727735199787
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5888daf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 427045
+  timestamp: 1727735182582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-h56b1c3c_1.conda
+  sha256: 802622fc93ece7ddae63461fe1212677d606e2f273217c8bdcce30eb734f241f
+  md5: 2774e2b992650f812668f1417d254e9d
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  size: 419159
+  timestamp: 1727734612023
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-h5707d70_1.conda
+  sha256: 3bfdfaca70c91af517fe7ee5897164611676e91d68b639717b7da3b6db037b85
+  md5: 27b80a14e7f69e8facc6d021692b9543
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libopenvino 2024.4.0 hfe1841e_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 419305
+  timestamp: 1727743190562
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
   sha256: a029b3ebff1e8d1d2736a548a616c20066ed6508f238782afbf3a77a4f57c6cd
   md5: e0b88fd64dc95f715ef52e607a9af89b
   depends:
@@ -9548,13 +6896,7 @@ packages:
   - libstdcxx >=13
   size: 1075090
   timestamp: 1729594854413
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_1.conda
   sha256: 19458d2980e8f69af5528ebbc6e1c8a70ba940b54122ccd4e4b75669f8c183fe
   md5: 19f5a7e35f6208f892455941e0aa29a0
   depends:
@@ -9563,13 +6905,25 @@ packages:
   - libstdcxx >=13
   size: 996782
   timestamp: 1727736334613
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.4.0-h4398f7a_1.conda
+  sha256: e04195e7ce2fb0709b3fc22d53f2560046ad7ac956c334ed3af1a30363afde5a
+  md5: 8834ede936d55c678b2e4fe07c2a8575
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  size: 788511
+  timestamp: 1727735199787
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-hf9b8971_1.conda
+  sha256: c4dee1ecc31696bf5ac52e8af88305a814ca6068ec128517af6c6979c9dbc732
+  md5: 2820ed3662ff9ac7ac61a717049d08c2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  size: 767608
+  timestamp: 1727734631665
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_1.conda
   sha256: 38e25f599eb022e3c655541ecd33547f7111058b520373a785fd16463caeabd9
   md5: 1607477ea0676f98505df042a9ec6672
   depends:
@@ -9579,47 +6933,7 @@ packages:
   - vc14_runtime >=14.29.30139
   size: 677864
   timestamp: 1727743230045
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-hf9b8971_1.conda
-  sha256: c4dee1ecc31696bf5ac52e8af88305a814ca6068ec128517af6c6979c9dbc732
-  md5: 2820ed3662ff9ac7ac61a717049d08c2
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  size: 767608
-  timestamp: 1727734631665
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h0b17760_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h0b17760_1.conda
-  sha256: b7330f292ab20b3175c2daaa5adb3d0ece25c529523a013492899296e4872338
-  md5: 90c4254246b927db47137bd7bd5ffeda
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  - libprotobuf >=5.27.5,<5.27.6.0a0
-  - snappy >=1.2.1,<1.3.0a0
-  size: 932670
-  timestamp: 1727734671391
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h6481b9d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
   sha256: fdc4871a05bbb61cfe6db1e60018d74cbd6d65d82f03b9be515c3ad41bb7ca04
   md5: 12bf831b85f17368bc71a26ac93a8493
   depends:
@@ -9633,13 +6947,7 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   size: 1282840
   timestamp: 1729594867098
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h7d3acce_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-h7d3acce_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-h7d3acce_1.conda
   sha256: 5d72bff273fb65e4ac21b7970eaab49c539d3603a81d706aa806f8535bda9301
   md5: c606736dd480b09d24251123f8108f3c
   depends:
@@ -9652,13 +6960,7 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   size: 1192551
   timestamp: 1727736349937
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: hd55e6c5_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.4.0-hd55e6c5_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.4.0-hd55e6c5_1.conda
   sha256: 57a21aeaeaf0a8b811f545ad8eb3c6e1dd74848e5a67ce8d84a82b21834c63ce
   md5: 7c270faed41a76fc45b4a1641154b51f
   depends:
@@ -9671,13 +6973,20 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   size: 975929
   timestamp: 1727735239249
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: hf4e5e90_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-hf4e5e90_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h0b17760_1.conda
+  sha256: b7330f292ab20b3175c2daaa5adb3d0ece25c529523a013492899296e4872338
+  md5: 90c4254246b927db47137bd7bd5ffeda
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  size: 932670
+  timestamp: 1727734671391
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-hf4e5e90_1.conda
   sha256: 0dc25c998ce231e6bc33183e6013e96db013ca07fffb45ad140c3ad59c60b86e
   md5: a82ca6e666d027e8fd369a14a51c97fc
   depends:
@@ -9691,28 +7000,7 @@ packages:
   - vc14_runtime >=14.29.30139
   size: 880412
   timestamp: 1727743277470
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h4398f7a_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h4398f7a_1.conda
-  sha256: 4affc1a6d186f05be71b953d23e29cd7ea73bcb045b1db7e284de8a7f0c63fc3
-  md5: 74e6f266e094ba1014bc133b4583c8d7
-  depends:
-  - __osx >=10.15
-  - libcxx >=17
-  - libopenvino 2024.4.0 h7bc525e_1
-  size: 369174
-  timestamp: 1727735257807
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5888daf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
   sha256: a8f26058cf57159492c63fb0622ea2858763ea22338c507ff40a6e9bb792295e
   md5: d48c774c40ea2047adbff043e9076e7a
   depends:
@@ -9722,13 +7010,7 @@ packages:
   - libstdcxx >=13
   size: 466563
   timestamp: 1729594879557
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_1.conda
   sha256: 6a6f7d6cdf0295befe14169c088466b4acb3b5c4327c5beac2bef1c2c5e57f85
   md5: 4ab346a3b72352d33efbded20fe30dd4
   depends:
@@ -9737,13 +7019,25 @@ packages:
   - libstdcxx >=13
   size: 429769
   timestamp: 1727736364966
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h4398f7a_1.conda
+  sha256: 4affc1a6d186f05be71b953d23e29cd7ea73bcb045b1db7e284de8a7f0c63fc3
+  md5: 74e6f266e094ba1014bc133b4583c8d7
+  depends:
+  - __osx >=10.15
+  - libcxx >=17
+  - libopenvino 2024.4.0 h7bc525e_1
+  size: 369174
+  timestamp: 1727735257807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-hf9b8971_1.conda
+  sha256: 1abe1c27fb21b6afcc5b3ecc575ebf73fa0cd4a4bbede804b950ac3e611eaa83
+  md5: b8162158a8e105632fc89cc05ed4d9d4
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 h49f535f_1
+  size: 370223
+  timestamp: 1727734689422
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_1.conda
   sha256: 4d06a6d430f2c58793dd2c8ccd45641c57a7b1fbe130540ce9ed83f4e6809241
   md5: a7e771ba26beb25c785a6d34f8b54aed
   depends:
@@ -9753,41 +7047,7 @@ packages:
   - vc14_runtime >=14.29.30139
   size: 324141
   timestamp: 1727743317824
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-hf9b8971_1.conda
-  sha256: 1abe1c27fb21b6afcc5b3ecc575ebf73fa0cd4a4bbede804b950ac3e611eaa83
-  md5: b8162158a8e105632fc89cc05ed4d9d4
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 h49f535f_1
-  size: 370223
-  timestamp: 1727734689422
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: h27ca646_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
-  sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
-  md5: 3d0dbee0ccd2f6d6781d270313627b62
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 252854
-  timestamp: 1606823635137
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: h7f98852_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
   sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
   md5: 15345e56d527b330e1cacbdf58676e8f
   depends:
@@ -9796,13 +7056,30 @@ packages:
   license_family: BSD
   size: 260658
   timestamp: 1606823578035
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: h8ffe710_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
+  sha256: 92a87ade11af2cff41c35cf941f1a79390fde1f113f8e51e1cce30d31b7c8305
+  md5: ac7534c50934ed25e4749d74b04c667a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328825
+  timestamp: 1606823775764
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
+  sha256: c126fc225bece591a8f010e95ca7d010ea2d02df9251830bec24a19bf823fc31
+  md5: 380b9ea5f6a7a277e6c1ac27d034369b
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279983
+  timestamp: 1606823633642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+  sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
+  md5: 3d0dbee0ccd2f6d6781d270313627b62
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 252854
+  timestamp: 1606823635137
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
   sha256: b2e5ec193762a5b4f905f8100437370e164df3db0ea5c18b4ce09390f5d3d525
   md5: e35a6bcfeb20ea83aab21dfc50ae62a4
   depends:
@@ -9812,58 +7089,7 @@ packages:
   license_family: BSD
   size: 260615
   timestamp: 1606824019288
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: hc929b4f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
-  sha256: c126fc225bece591a8f010e95ca7d010ea2d02df9251830bec24a19bf823fc31
-  md5: 380b9ea5f6a7a277e6c1ac27d034369b
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 279983
-  timestamp: 1606823633642
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: hf897c2e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
-  sha256: 92a87ade11af2cff41c35cf941f1a79390fde1f113f8e51e1cce30d31b7c8305
-  md5: ac7534c50934ed25e4749d74b04c667a
-  depends:
-  - libgcc-ng >=9.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328825
-  timestamp: 1606823775764
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h5833ebf_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h5833ebf_1.conda
-  sha256: 05740cc58df7a9c966a277331dea1987db485508c0a35d2ac9ef562f8061df06
-  md5: 7b4c6d7f35e9fe945e810e213d21b942
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libqdldl >=0.1.7,<0.1.8.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 360361
-  timestamp: 1729342406705
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h5888daf_1.conda
   sha256: 7c083bdff58df5cc3aed647020fef2a708d2fb57c8a504866db6a1e5e2f12b94
   md5: 2a6b1aade375d6d404a0838c95793f6a
   depends:
@@ -9875,13 +7101,7 @@ packages:
   license_family: APACHE
   size: 432789
   timestamp: 1729342281763
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h5ad3122_1.conda
   sha256: 005a3ff75e883f480f5b25644addcef31d8213106229b6d42b665f7fbdff0a2f
   md5: 2620cfedf3f3d4722f4508cca423ecac
   depends:
@@ -9892,13 +7112,7 @@ packages:
   license_family: APACHE
   size: 414572
   timestamp: 1729342273243
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h97d8b74_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-h97d8b74_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-h97d8b74_1.conda
   sha256: 96118e576c6efd4c1e26ea8809f50c75f52acc95251b71b6d9bcfd51eba0d67c
   md5: a1b3121f636d0b0d68a78717d839dff0
   depends:
@@ -9909,13 +7123,18 @@ packages:
   license_family: APACHE
   size: 382479
   timestamp: 1729342338177
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h5833ebf_1.conda
+  sha256: 05740cc58df7a9c966a277331dea1987db485508c0a35d2ac9ef562f8061df06
+  md5: 7b4c6d7f35e9fe945e810e213d21b942
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libqdldl >=0.1.7,<0.1.8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 360361
+  timestamp: 1729342406705
+- conda: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-he0c23c2_1.conda
   sha256: 4960d81fe9251fa0dd11b171716a1e5b76ea10f583c82766b27b219f739b97ec
   md5: 3cb8c763b4cc0d0d99931fe296cb9df2
   depends:
@@ -9927,26 +7146,7 @@ packages:
   license_family: APACHE
   size: 268107
   timestamp: 1729342615595
-- kind: conda
-  name: libpciaccess
-  version: '0.18'
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
-  sha256: 0c6806dcd53da457c472cf22ad7793aef074cb198a10677a91b02c7dceeee770
-  md5: 6d48179630f00e8c9ad9e30879ce1e54
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 29211
-  timestamp: 1707101477910
-- kind: conda
-  name: libpciaccess
-  version: '0.18'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
   sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
   md5: 48f4330bfcd959c3cfb704d424903c82
   depends:
@@ -9955,12 +7155,53 @@ packages:
   license_family: MIT
   size: 28361
   timestamp: 1707101388552
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: h3ca93ac_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
+  sha256: 0c6806dcd53da457c472cf22ad7793aef074cb198a10677a91b02c7dceeee770
+  md5: 6d48179630f00e8c9ad9e30879ce1e54
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 29211
+  timestamp: 1707101477910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
+  sha256: 23b5ce15cf9c6017641a8396bab00ae807dd9f662718cfa7f61de114d0c97647
+  md5: 5d25802b25fcc7419fa13e21affaeb3a
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 294907
+  timestamp: 1726236639270
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
   sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
   md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
   depends:
@@ -9971,70 +7212,7 @@ packages:
   license: zlib-acknowledgement
   size: 348933
   timestamp: 1726235196095
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: h4b8f8c9_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
-  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
-  md5: f32ac2c8dd390dbf169f550887ed09d9
-  depends:
-  - __osx >=10.13
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 268073
-  timestamp: 1726234803010
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hadc24fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
-  md5: f4cc49d7aa68316213e4b12be35308d1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 290661
-  timestamp: 1726234747153
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hc14010f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
-  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
-  md5: fb36e93f0ea6a6f5d2b99984f34b049e
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 263385
-  timestamp: 1726234714421
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hc4a20ef_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
-  sha256: 23b5ce15cf9c6017641a8396bab00ae807dd9f662718cfa7f61de114d0c97647
-  md5: 5d25802b25fcc7419fa13e21affaeb3a
-  depends:
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 294907
-  timestamp: 1726236639270
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: h2d7952a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
   sha256: 51dddb6e5879960a1b9b3c5de0eb970373903977c0fa68a42f86bb7197c695cf
   md5: 50e2dddb3417a419cbc2388d0b1c06f7
   depends:
@@ -10045,29 +7223,7 @@ packages:
   license: PostgreSQL
   size: 2530022
   timestamp: 1729085009049
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: h365486b_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.4-h365486b_3.conda
-  sha256: 1a019cc7ccac5d7019d773f3e5b5054da858f35a1044cbde04765362412bdd31
-  md5: fe4f02d31e7679f2331ad9c640233e86
-  depends:
-  - __osx >=10.13
-  - krb5 >=1.21.3,<1.22.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: PostgreSQL
-  size: 2383857
-  timestamp: 1729085339189
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: hb7c570e_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
   sha256: cd17b7b1fa11907c28319a80c18cd025ec8344be630a2b3f7dfe97b3ef682000
   md5: 49e510416b386a1ea805edf38ce09956
   depends:
@@ -10077,13 +7233,17 @@ packages:
   license: PostgreSQL
   size: 2661524
   timestamp: 1729085053843
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: hfb0b52a_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-hfb0b52a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.4-h365486b_3.conda
+  sha256: 1a019cc7ccac5d7019d773f3e5b5054da858f35a1044cbde04765362412bdd31
+  md5: fe4f02d31e7679f2331ad9c640233e86
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: PostgreSQL
+  size: 2383857
+  timestamp: 1729085339189
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-hfb0b52a_3.conda
   sha256: 7c9766926fa1bfad284d27dc252eeddb189126ea5694da8f8045f1fb55c8f8d3
   md5: ce76e2611f75bfe95efb239bd69be770
   depends:
@@ -10093,89 +7253,7 @@ packages:
   license: PostgreSQL
   size: 2411968
   timestamp: 1729085615848
-- kind: conda
-  name: libprotobuf
-  version: 5.27.5
-  build: h029595c_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.27.5-h029595c_2.conda
-  sha256: 347a1fe304526efe23929c357c145c4917549ba1edd9da432e92a54f4ad4082d
-  md5: f789a1fe2a1f45e325a784b34c3c4baa
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2879939
-  timestamp: 1727423311791
-- kind: conda
-  name: libprotobuf
-  version: 5.27.5
-  build: h53f8970_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.27.5-h53f8970_2.conda
-  sha256: 787d86c041c03d33b24e28df5f881f47c74c3fe9053b791f14616dc51f32a687
-  md5: e9d021f82c48bb08b0b2c321b2f7778c
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2375066
-  timestamp: 1727423411355
-- kind: conda
-  name: libprotobuf
-  version: 5.27.5
-  build: h62b0dff_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.27.5-h62b0dff_2.conda
-  sha256: ac77bce3b9a58e6fa72bed339af0d47faf1dec3bc717e4e05e2e729dc42bd2b3
-  md5: e3b68d9a164d807f70df49e17bc54931
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2332719
-  timestamp: 1727424047974
-- kind: conda
-  name: libprotobuf
-  version: 5.27.5
-  build: hcaed137_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.27.5-hcaed137_2.conda
-  sha256: f039a07e6a52542e298ad0cf39d95d261f02c62256c82a60e246f291b2535e1b
-  md5: 0155746155856bc39091b5242c9b52d7
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6090012
-  timestamp: 1727424307861
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h5b01275_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
   sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
   md5: ab0bff36363bec94720275a681af8b83
   depends:
@@ -10189,12 +7267,98 @@ packages:
   license_family: BSD
   size: 2945348
   timestamp: 1728565355702
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.7-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.27.5-h029595c_2.conda
+  sha256: 347a1fe304526efe23929c357c145c4917549ba1edd9da432e92a54f4ad4082d
+  md5: f789a1fe2a1f45e325a784b34c3c4baa
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2879939
+  timestamp: 1727423311791
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.27.5-h62b0dff_2.conda
+  sha256: ac77bce3b9a58e6fa72bed339af0d47faf1dec3bc717e4e05e2e729dc42bd2b3
+  md5: e3b68d9a164d807f70df49e17bc54931
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2332719
+  timestamp: 1727424047974
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.27.5-h53f8970_2.conda
+  sha256: 787d86c041c03d33b24e28df5f881f47c74c3fe9053b791f14616dc51f32a687
+  md5: e9d021f82c48bb08b0b2c321b2f7778c
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2375066
+  timestamp: 1727423411355
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.27.5-hcaed137_2.conda
+  sha256: f039a07e6a52542e298ad0cf39d95d261f02c62256c82a60e246f291b2535e1b
+  md5: 0155746155856bc39091b5242c9b52d7
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6090012
+  timestamp: 1727424307861
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.7-hcb278e6_0.conda
+  sha256: 62230c93e8f7508a97e5b3a439b2b981eda9aa192cbc08497cbcca220ebf3acc
+  md5: 9221c4cca4d44cf4103fbdd47595e3dd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18277
+  timestamp: 1680741612751
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.7-hd600fc2_0.conda
+  sha256: 231a460dd87408d1d07150ffd53c29a8d8aaa494f111c83a369d85b53bf4015d
+  md5: 07140396b010c957bf75471ea7fcb858
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18380
+  timestamp: 1680741551284
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.7-hf0c8a7f_0.conda
+  sha256: 3af1a36d6770737103c97926b1d3ca432f638e3692850355add84062adcabf5f
+  md5: dfa2f71b0d4132cf202d707aee23dfb5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17698
+  timestamp: 1680741819397
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.7-hb7217d7_0.conda
+  sha256: 39bb718bca8ce87afdc592d857944ba39bfac54c31a1de4d669597b52bc668ea
+  md5: b4df6812b4ab33c1a520287f46d91220
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17189
+  timestamp: 1680741853527
+- conda: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.7-h63175ca_0.conda
   sha256: 706c0405c5d01e58d08dfc26a9b49b7121e25f4913f594692f05afe45dacca6f
   md5: 0f2bbabcd06bfd6015a783a788f88b0f
   depends:
@@ -10205,70 +7369,7 @@ packages:
   license_family: APACHE
   size: 21662
   timestamp: 1680741889208
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hb7217d7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.7-hb7217d7_0.conda
-  sha256: 39bb718bca8ce87afdc592d857944ba39bfac54c31a1de4d669597b52bc668ea
-  md5: b4df6812b4ab33c1a520287f46d91220
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: APACHE
-  size: 17189
-  timestamp: 1680741853527
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hcb278e6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.7-hcb278e6_0.conda
-  sha256: 62230c93e8f7508a97e5b3a439b2b981eda9aa192cbc08497cbcca220ebf3acc
-  md5: 9221c4cca4d44cf4103fbdd47595e3dd
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 18277
-  timestamp: 1680741612751
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hd600fc2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.7-hd600fc2_0.conda
-  sha256: 231a460dd87408d1d07150ffd53c29a8d8aaa494f111c83a369d85b53bf4015d
-  md5: 07140396b010c957bf75471ea7fcb858
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 18380
-  timestamp: 1680741551284
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hf0c8a7f_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.7-hf0c8a7f_0.conda
-  sha256: 3af1a36d6770737103c97926b1d3ca432f638e3692850355add84062adcabf5f
-  md5: dfa2f71b0d4132cf202d707aee23dfb5
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: APACHE
-  size: 17698
-  timestamp: 1680741819397
-- kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: hc0ffecb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
   sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
   md5: 83f045969988f5c7a65f3950b95a8b35
   depends:
@@ -10287,29 +7388,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 6390511
   timestamp: 1726227212382
-- kind: conda
-  name: libsanitizer
-  version: 13.3.0
-  build: ha58e236_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_1.conda
-  sha256: 6892c7e723dbfb3a7e65c9c21ad7396dee5c73fd988e039045ca96145632ee71
-  md5: ed8a2074f0afb09450a009e02de65e3c
-  depends:
-  - libgcc >=13.3.0
-  - libstdcxx >=13.3.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 4105930
-  timestamp: 1724802022367
-- kind: conda
-  name: libsanitizer
-  version: 13.3.0
-  build: heb74ff8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
   sha256: c86d130f0a3099e46ff51aa7ffaab73cb44fc420d27a96076aab3b9a326fc137
   md5: c4cb22f270f501f5c59a122dc2adf20a
   depends:
@@ -10319,13 +7398,17 @@ packages:
   license_family: GPL
   size: 4133922
   timestamp: 1724801171589
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h3428b0d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_1.conda
+  sha256: 6892c7e723dbfb3a7e65c9c21ad7396dee5c73fd988e039045ca96145632ee71
+  md5: ed8a2074f0afb09450a009e02de65e3c
+  depends:
+  - libgcc >=13.3.0
+  - libstdcxx >=13.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 4105930
+  timestamp: 1724802022367
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_2.conda
   sha256: 18d517b71e832698477ce58be8a77dd83326c1b82745e61dc6be25c68f319cbd
   md5: f32423a30fe0f5634ce1a16916d3bc76
   depends:
@@ -10340,13 +7423,7 @@ packages:
   license: CECILL-C
   size: 343836
   timestamp: 1728823102739
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h57f7dbb_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_2.conda
   sha256: f7981a98752f5115049c41922bff8f84b4beae663bb5e036c395f96b01b11d00
   md5: 537c6cc6087ef85bc75e323508bb43c6
   depends:
@@ -10360,13 +7437,7 @@ packages:
   license: CECILL-C
   size: 358635
   timestamp: 1728825149231
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h8e19eb7_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.5-h8e19eb7_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.5-h8e19eb7_2.conda
   sha256: 51ffb52fd3b15e90cf26b7f2163684f119ef84752c727c378493db81e9b264fc
   md5: 9478f4c127e455d0c155a82d4d48fdb1
   depends:
@@ -10380,13 +7451,7 @@ packages:
   license: CECILL-C
   size: 288602
   timestamp: 1728823135377
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h9f781f6_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
   sha256: 589231872f000f96c4f27ee8fadd388631a7edd2c68b06c4987d77981681bb95
   md5: 588d606a602d0058bd6c63a81fc4cfc8
   depends:
@@ -10400,35 +7465,7 @@ packages:
   license: CECILL-C
   size: 270272
   timestamp: 1728823368136
-- kind: conda
-  name: libsndfile
-  version: 1.2.2
-  build: h79657aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
-  sha256: 8fcd5e45d6fb071e8baf492ebb8710203fd5eedf0cb791e007265db373c89942
-  md5: ad8e62c0faec46b1442f960489c80b49
-  depends:
-  - lame >=3.100,<3.101.0a0
-  - libflac >=1.4.3,<1.5.0a0
-  - libgcc-ng >=12
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libvorbis >=1.3.7,<1.4.0a0
-  - mpg123 >=1.32.1,<1.33.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 396501
-  timestamp: 1695747749825
-- kind: conda
-  name: libsndfile
-  version: 1.2.2
-  build: hc60ed4a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
   sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
   md5: ef1910918dd895516a769ed36b5b3a4e
   depends:
@@ -10444,38 +7481,23 @@ packages:
   license_family: LGPL
   size: 354372
   timestamp: 1695747735668
-- kind: conda
-  name: libspral
-  version: 2024.05.08
-  build: h2fd7c63_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-h2fd7c63_3.conda
-  sha256: 6f8c85252ede9e4b5809663e64992a95687fab8818dffeaab40f4baf69d0a706
-  md5: 876ad3096aa012894dda4f4c6419e3f3
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+  sha256: 8fcd5e45d6fb071e8baf492ebb8710203fd5eedf0cb791e007265db373c89942
+  md5: ad8e62c0faec46b1442f960489c80b49
   depends:
-  - _openmp_mutex >=4.5
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
   - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.4.0
-  - libhwloc >=2.11.1,<2.11.2.0a0
-  - liblapack >=3.9.0,<4.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - metis >=5.1.0,<5.1.1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 341454
-  timestamp: 1722957510875
-- kind: conda
-  name: libspral
-  version: 2024.05.08
-  build: h831f25b_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h831f25b_3.conda
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 396501
+  timestamp: 1695747749825
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h831f25b_3.conda
   sha256: aa46c3372d9ab0bfa27bda084a6b550b06d63f5cc8fa23bd314cb9dba11cf650
   md5: ece7dcd9811f9f5c49852da2a14928ab
   depends:
@@ -10495,41 +7517,26 @@ packages:
   license_family: BSD
   size: 355926
   timestamp: 1722955364533
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_0.conda
-  sha256: 4f3cd0477c831eab48fb7fa3ed91d918aeb644fad9b4014726d445339750cdcc
-  md5: 964bef59135d876c596ae67b3315e812
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-h2fd7c63_3.conda
+  sha256: 6f8c85252ede9e4b5809663e64992a95687fab8818dffeaab40f4baf69d0a706
+  md5: 876ad3096aa012894dda4f4c6419e3f3
   depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
-  size: 884970
-  timestamp: 1729592254351
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: h2f8c449_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_0.conda
-  sha256: 6bae3280dc402c9d306275363f3a88f6a667b8e3bfa68859b7928d42f0f1495a
-  md5: 9dbe833ae53f6756fd87e32bd5fa508e
-  depends:
-  - __osx >=10.13
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.4.0
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
   - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 915473
-  timestamp: 1729591970061
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hadc24fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_0.conda
+  - metis >=5.1.0,<5.1.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341454
+  timestamp: 1722957510875
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_0.conda
   sha256: 76ffc7a5823b51735c11d535f3666b3c9c7d1519f9fbb6fa9cdff79db01960b9
   md5: 540296f0ce9d3352188c15a89b30b9ac
   depends:
@@ -10539,26 +7546,7 @@ packages:
   license: Unlicense
   size: 874704
   timestamp: 1729591931557
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hbaaea75_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_0.conda
-  sha256: 76aa4bbbaa2334689b16048f04ac4c7406e9bfb1f225ac7107fd2a73f85329cf
-  md5: 5bbe4802d5460b80620411fe1da8fec3
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 837789
-  timestamp: 1729592072314
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hc4a20ef_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_0.conda
   sha256: 469ed05e9a1622b0204a2b6cf620c9054bf6904e2ed818a1f91ee96a7bc64517
   md5: ccbe261fb8c1f1cd1a3122592247d3c4
   depends:
@@ -10567,12 +7555,35 @@ packages:
   license: Unlicense
   size: 1042108
   timestamp: 1729592001716
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h0841786_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_0.conda
+  sha256: 6bae3280dc402c9d306275363f3a88f6a667b8e3bfa68859b7928d42f0f1495a
+  md5: 9dbe833ae53f6756fd87e32bd5fa508e
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915473
+  timestamp: 1729591970061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_0.conda
+  sha256: 76aa4bbbaa2334689b16048f04ac4c7406e9bfb1f225ac7107fd2a73f85329cf
+  md5: 5bbe4802d5460b80620411fe1da8fec3
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837789
+  timestamp: 1729592072314
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_0.conda
+  sha256: 4f3cd0477c831eab48fb7fa3ed91d918aeb644fad9b4014726d445339750cdcc
+  md5: 964bef59135d876c596ae67b3315e812
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 884970
+  timestamp: 1729592254351
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
   md5: 1f5a58e686b13bcfde88b93f547d23fe
   depends:
@@ -10583,12 +7594,7 @@ packages:
   license_family: BSD
   size: 271133
   timestamp: 1685837707056
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h492db2e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
   sha256: 409163dd4a888b9266369f1bce57b5ca56c216e34249637c3e10eb404e356171
   md5: 45532845e121677ad328c9af9953f161
   depends:
@@ -10599,12 +7605,17 @@ packages:
   license_family: BSD
   size: 284335
   timestamp: 1685837600415
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h7a5bd25_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
   sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
   md5: 029f7dc931a3b626b94823bc77830b01
   depends:
@@ -10614,12 +7625,7 @@ packages:
   license_family: BSD
   size: 255610
   timestamp: 1685837894256
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h7dfc565_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
   sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
   md5: dc262d03aae04fe26825062879141a41
   depends:
@@ -10632,43 +7638,7 @@ packages:
   license_family: BSD
   size: 266806
   timestamp: 1685838242099
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: hd019ec5_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
-  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
-  md5: ca3a72efba692c59a90d4b9fc0dfe774
-  depends:
-  - libzlib >=1.2.13,<2.0.0a0
-  - openssl >=3.1.1,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 259556
-  timestamp: 1685837820566
-- kind: conda
-  name: libstdcxx
-  version: 14.2.0
-  build: h3f4de04_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
-  sha256: 519556d2c93f1b487091ce046d62e762286177f4a670ec10e16005177d0bcab3
-  md5: 37f489acd39e22b623d2d1e5ac6d195c
-  depends:
-  - libgcc 14.2.0 he277a41_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3816794
-  timestamp: 1729089463404
-- kind: conda
-  name: libstdcxx
-  version: 14.2.0
-  build: hc0a3c3a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
   sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
   md5: 234a5554c53625688d51062645337328
   depends:
@@ -10677,14 +7647,16 @@ packages:
   license_family: GPL
   size: 3893695
   timestamp: 1729027746910
-- kind: conda
-  name: libstdcxx-devel_linux-64
-  version: 13.3.0
-  build: h84ea5a7_101
-  build_number: 101
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+  sha256: 519556d2c93f1b487091ce046d62e762286177f4a670ec10e16005177d0bcab3
+  md5: 37f489acd39e22b623d2d1e5ac6d195c
+  depends:
+  - libgcc 14.2.0 he277a41_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3816794
+  timestamp: 1729089463404
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
   sha256: 0a9226c1b994f996229ffb54fa40d608cd4e4b48e8dc73a66134bea8ce949412
   md5: 29b5a4ed4613fa81a07c21045e3f5bf6
   depends:
@@ -10693,14 +7665,7 @@ packages:
   license_family: GPL
   size: 14074676
   timestamp: 1724801075448
-- kind: conda
-  name: libstdcxx-devel_linux-aarch64
-  version: 13.3.0
-  build: h0c07274_101
-  build_number: 101
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_101.conda
   sha256: a2cc4cc3ef5d470c25a872a05485cf322a525950f9e1472e22cc97030d0858b1
   md5: a7fdc5d75d643dd46f4e3d6092a13036
   depends:
@@ -10709,13 +7674,7 @@ packages:
   license_family: GPL
   size: 12182186
   timestamp: 1724801911954
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.2.0
-  build: h4852527_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
   sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   md5: 8371ac6457591af2cf6159439c1fd051
   depends:
@@ -10724,13 +7683,7 @@ packages:
   license_family: GPL
   size: 54105
   timestamp: 1729027780628
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.2.0
-  build: hf1166c9_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
   sha256: 9f97461bd55a2745a7a0941f3502a047f15bfe7bb2952dc7fb204b3202f866fd
   md5: 0e75771b8a03afae5a2c6ce71bc733f5
   depends:
@@ -10739,13 +7692,7 @@ packages:
   license_family: GPL
   size: 54133
   timestamp: 1729089498541
-- kind: conda
-  name: libsystemd0
-  version: '256.7'
-  build: h2774228_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
   sha256: fa9cfbacaa2f14072b07ff9c832a8750627755346a1472f116a94aecea28f08e
   md5: ad328c530a12a8798776e5f03942090f
   depends:
@@ -10759,13 +7706,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 411535
   timestamp: 1729786797378
-- kind: conda
-  name: libsystemd0
-  version: '256.7'
-  build: hd54d049_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
   sha256: 6deceabf4a4109293aacba77a61a83d5bdef028b879b29d3b819937c80de8909
   md5: c44e82f6be3d65cf0589f1182e162ce8
   depends:
@@ -10778,35 +7719,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 430774
   timestamp: 1729786916983
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: h583c2ba_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
-  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
-  md5: 4b78bcdcc8780cede8b3d090deba874d
-  depends:
-  - __osx >=10.13
-  - lerc >=4.0.0,<5.0a0
-  - libcxx >=17
-  - libdeflate >=1.22,<1.23.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: HPND
-  size: 395980
-  timestamp: 1728232302162
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: he137b08_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
   sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
   md5: 63872517c98aa305da58a757c443698e
   depends:
@@ -10823,13 +7736,7 @@ packages:
   license: HPND
   size: 428156
   timestamp: 1728232228989
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hec21d91_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
   sha256: 14ecb9e129b1b5ffd6d4bee48de95cd2cd0973c712e1b965d3ef977cca23936d
   md5: 1f80061f5ba6956fcdc381f34618cd8d
   depends:
@@ -10845,35 +7752,23 @@ packages:
   license: HPND
   size: 464938
   timestamp: 1728232266969
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hfc51747_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
-  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
-  md5: eac317ed1cc6b9c0af0c27297e364665
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
+  md5: 4b78bcdcc8780cede8b3d090deba874d
   depends:
+  - __osx >=10.13
   - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
   - libdeflate >=1.22,<1.23.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
-  size: 978865
-  timestamp: 1728232594877
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hfce79cd_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+  size: 395980
+  timestamp: 1728232302162
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
   sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
   md5: b9abf45f7c64caf3303725f1aa0e9a4d
   depends:
@@ -10889,12 +7784,23 @@ packages:
   license: HPND
   size: 366323
   timestamp: 1728232400072
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
@@ -10903,12 +7809,7 @@ packages:
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: hb4cce97_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
   sha256: 616277b0c5f7616c2cdf36f6c316ea3f9aa5bb35f2d4476a349ab58b9b91675f
   md5: 000e30b09db0b7c775b21695dff30969
   depends:
@@ -10917,12 +7818,44 @@ packages:
   license_family: BSD
   size: 35720
   timestamp: 1680113474501
-- kind: conda
-  name: libuv
-  version: 1.49.2
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.49.2-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.49.2-hb9d3cd8_0.conda
+  sha256: a35cd81cd1a9add11024097da83cc06b0aae83186fe4124b77710876f37d8f31
+  md5: 070e3c9ddab77e38799d5c30b109c633
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 884647
+  timestamp: 1729322566955
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.49.2-h86ecc28_0.conda
+  sha256: adf4eca89339ac7780f2394e7e6699be81259eb91f79f9d9fdf2c1bc6b26f210
+  md5: 1899e1ec2be63386c41c4db31d3056af
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 627484
+  timestamp: 1729322575379
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.49.2-hd79239c_0.conda
+  sha256: a2083200357513f932b44e88858a50a638d1a751a050bc62b2cbee2ac54f102c
+  md5: ec36c2438046ca8d2b4368d62dd5c38c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 413607
+  timestamp: 1729322686826
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.49.2-h7ab814d_0.conda
+  sha256: 0e5176af1e788ad5006cf261c4ea5a288a935fda48993b0240ddd2e562dc3d02
+  md5: 4bc348e3a1a74d20a3f9beb866d75e0a
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 410500
+  timestamp: 1729322654121
+- conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.49.2-h2466b09_0.conda
   sha256: d598c536f0e432901ba8b489564799f6f570471b2a3ce9b76e152ee0a961a380
   md5: 30ebb43533efcdc8c357ef409bad86b6
   depends:
@@ -10933,70 +7866,7 @@ packages:
   license_family: MIT
   size: 290376
   timestamp: 1729322844056
-- kind: conda
-  name: libuv
-  version: 1.49.2
-  build: h7ab814d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.49.2-h7ab814d_0.conda
-  sha256: 0e5176af1e788ad5006cf261c4ea5a288a935fda48993b0240ddd2e562dc3d02
-  md5: 4bc348e3a1a74d20a3f9beb866d75e0a
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 410500
-  timestamp: 1729322654121
-- kind: conda
-  name: libuv
-  version: 1.49.2
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.49.2-h86ecc28_0.conda
-  sha256: adf4eca89339ac7780f2394e7e6699be81259eb91f79f9d9fdf2c1bc6b26f210
-  md5: 1899e1ec2be63386c41c4db31d3056af
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 627484
-  timestamp: 1729322575379
-- kind: conda
-  name: libuv
-  version: 1.49.2
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.49.2-hb9d3cd8_0.conda
-  sha256: a35cd81cd1a9add11024097da83cc06b0aae83186fe4124b77710876f37d8f31
-  md5: 070e3c9ddab77e38799d5c30b109c633
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 884647
-  timestamp: 1729322566955
-- kind: conda
-  name: libuv
-  version: 1.49.2
-  build: hd79239c_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.49.2-hd79239c_0.conda
-  sha256: a2083200357513f932b44e88858a50a638d1a751a050bc62b2cbee2ac54f102c
-  md5: ec36c2438046ca8d2b4368d62dd5c38c
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 413607
-  timestamp: 1729322686826
-- kind: conda
-  name: libva
-  version: 2.22.0
-  build: h8a09558_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
   sha256: 0bd81019e02cce8d9d4077c96b82ca03c9b0ece67831c7437f977ca1f5a924a3
   md5: 139262125a3eac8ff6eef898598745a3
   depends:
@@ -11016,59 +7886,7 @@ packages:
   license_family: MIT
   size: 217708
   timestamp: 1726828458441
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h01db608_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
-  sha256: 1ade4727be5c52b287001b8094d02af66342dfe0ba13ef69222aaaf2e9be4342
-  md5: c2863ff72c6d8a59054f8b9102c206e9
-  depends:
-  - libgcc-ng >=9.3.0
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=9.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 292082
-  timestamp: 1610616294416
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h046ec9c_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
-  sha256: fbcce1005efcd616e452dea07fe34893d8dd13c65628e74920eeb68ac549faf7
-  md5: fbbda1fede0aadaa252f6919148c4ce1
-  depends:
-  - libcxx >=11.0.0
-  - libogg >=1.3.4,<1.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 254208
-  timestamp: 1610609857389
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h0e60522_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
-  sha256: 6cdc018a024908270205d8512d92f92cf0adaaa5401c2b403757189b138bf56a
-  md5: e1a22282de0169c93e4ffe6ce6acc212
-  depends:
-  - libogg >=1.3.4,<1.4.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 273721
-  timestamp: 1610610022421
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h9c3ff4c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
   sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
   md5: 309dec04b70a3cc0f1e84a4013683bc0
   depends:
@@ -11079,12 +7897,28 @@ packages:
   license_family: BSD
   size: 286280
   timestamp: 1610609811627
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h9f76cd9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+  sha256: 1ade4727be5c52b287001b8094d02af66342dfe0ba13ef69222aaaf2e9be4342
+  md5: c2863ff72c6d8a59054f8b9102c206e9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292082
+  timestamp: 1610616294416
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
+  sha256: fbcce1005efcd616e452dea07fe34893d8dd13c65628e74920eeb68ac549faf7
+  md5: fbbda1fede0aadaa252f6919148c4ce1
+  depends:
+  - libcxx >=11.0.0
+  - libogg >=1.3.4,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 254208
+  timestamp: 1610609857389
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
   sha256: 60457217e20d8b24a8390c81338a8fa69c8656b440c067cd82f802a09da93cb9
   md5: 92a1a88d1a1d468c19d9e1659ac8d3df
   depends:
@@ -11094,42 +7928,18 @@ packages:
   license_family: BSD
   size: 254839
   timestamp: 1610609991029
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: h0a1ffab_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
-  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
-  md5: 3cb63f822a49e4c406639ebf8b5d87d7
+- conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
+  sha256: 6cdc018a024908270205d8512d92f92cf0adaaa5401c2b403757189b138bf56a
+  md5: e1a22282de0169c93e4ffe6ce6acc212
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   license: BSD-3-Clause
   license_family: BSD
-  size: 1211700
-  timestamp: 1717859955539
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: h7bae524_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
-  sha256: 5d6458b5395cba0804846f156574aa8a34eef6d5f05d39e9932ddbb4215f8bd0
-  md5: 95bee48afff34f203e4828444c2b2ae9
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1178981
-  timestamp: 1717860096742
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+  size: 273721
+  timestamp: 1610610022421
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
   sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
   md5: cde393f461e0c169d9ffb2fc70f81c33
   depends:
@@ -11139,12 +7949,17 @@ packages:
   license_family: BSD
   size: 1022466
   timestamp: 1717859935011
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: hf036a51_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
+  md5: 3cb63f822a49e4c406639ebf8b5d87d7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1211700
+  timestamp: 1717859955539
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.1-hf036a51_0.conda
   sha256: 47e70e76988c11de97d539794fd4b03db69b75289ac02cdc35ae5a595ffcd973
   md5: 9b8744a702ffb1738191e094e6eb67dc
   depends:
@@ -11154,26 +7969,28 @@ packages:
   license_family: BSD
   size: 1297054
   timestamp: 1717860051058
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
-  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
-  md5: b2c0047ea73819d992484faacbbe1c24
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
+  sha256: 5d6458b5395cba0804846f156574aa8a34eef6d5f05d39e9932ddbb4215f8bd0
+  md5: 95bee48afff34f203e4828444c2b2ae9
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1178981
+  timestamp: 1717860096742
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
   constrains:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 355099
-  timestamp: 1713200298965
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
   sha256: 10dded60f274e29c573cfacf6e96f5d0fc374ee431250374a44cbd773916ab9d
   md5: 5fd7ab3e5f382c70607fbac6335e6e19
   depends:
@@ -11184,12 +8001,16 @@ packages:
   license_family: BSD
   size: 363577
   timestamp: 1713201785160
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
   sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
   md5: c0af0edfebe780b19940e94871f1a765
   constrains:
@@ -11198,12 +8019,7 @@ packages:
   license_family: BSD
   size: 287750
   timestamp: 1713200194013
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
   sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
   md5: abd61d0ab127ec5cd68f62c2969e6f34
   depends:
@@ -11216,45 +8032,7 @@ packages:
   license_family: BSD
   size: 274359
   timestamp: 1713200524021
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
-  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
-  md5: b26e8aa824079e1be0294e7152ca4559
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - libwebp 1.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 438953
-  timestamp: 1713199854503
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: h262b8f6_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
-  md5: cd14ee5cca2464a425b1dbfc24d90db2
-  depends:
-  - libgcc >=13
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 397493
-  timestamp: 1727280745441
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: h8a09558_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
   sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
   md5: 92ed62436b625154323d40d5f2f11dd7
   depends:
@@ -11267,29 +8045,19 @@ packages:
   license_family: MIT
   size: 395888
   timestamp: 1727278577118
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: hdb1d25a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
-  md5: af523aae2eca6dfa1c8eec693f5b9a79
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+  md5: cd14ee5cca2464a425b1dbfc24d90db2
   depends:
-  - __osx >=11.0
+  - libgcc >=13
   - pthread-stubs
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 323658
-  timestamp: 1727278733917
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: hf1f96e2_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  size: 397493
+  timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
   sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
   md5: bbeca862892e2898bdb45792a61c4afc
   depends:
@@ -11301,27 +8069,19 @@ packages:
   license_family: MIT
   size: 323770
   timestamp: 1727278927545
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
-  md5: b4df5d7d4b63579d081fd3a4cf99740e
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
   depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  size: 114269
-  timestamp: 1702724369203
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
@@ -11329,13 +8089,15 @@ packages:
   license: LGPL-2.1-or-later
   size: 100393
   timestamp: 1702724383534
-- kind: conda
-  name: libxkbcommon
-  version: 1.7.0
-  build: h2c5496b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
+  md5: b4df5d7d4b63579d081fd3a4cf99740e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 114269
+  timestamp: 1702724369203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
   sha256: 6804c2a7062d10de6f159f7106dc45ebccc8d42bfb925f7919e26e567fa6da6b
   md5: e2eaefa4de2b7237af7c907b8bbc760a
   depends:
@@ -11349,13 +8111,7 @@ packages:
   license_family: MIT
   size: 593336
   timestamp: 1718819935698
-- kind: conda
-  name: libxkbcommon
-  version: 1.7.0
-  build: h46f2afe_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
   sha256: 8ed470f72c733aea32bb5d272bf458041add7923d7716d5046bd40edf7ddd67c
   md5: 78a24e611ab9c09c518f519be49c2e46
   depends:
@@ -11369,70 +8125,7 @@ packages:
   license_family: MIT
   size: 596053
   timestamp: 1718819931537
-- kind: conda
-  name: libxml2
-  version: 2.12.7
-  build: h00a45b3_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h00a45b3_4.conda
-  sha256: 1ce32ab0ffbc8938f0820949ea733eb11f2f05355034af12fc6fe708f184fac1
-  md5: d25c3e16ee77cd25342e4e235424c758
-  depends:
-  - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 753275
-  timestamp: 1721031124841
-- kind: conda
-  name: libxml2
-  version: 2.12.7
-  build: h01dff8b_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h01dff8b_4.conda
-  sha256: a9a76cdc6e93c0182bc2ac58b1ea0152be1a16a5d23f4dc7b8df282a7aef8d20
-  md5: 1265488dc5035457b729583119ad4a1b
-  depends:
-  - __osx >=11.0
-  - icu >=75.1,<76.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 588990
-  timestamp: 1721031045514
-- kind: conda
-  name: libxml2
-  version: 2.12.7
-  build: h0f24e4e_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
-  sha256: ae78197961b09b0eef4ee194a44e4adc4555c0f2f20c348086b0cd8aaf2f7731
-  md5: ed4d301f0d2149b34deb9c4fecafd836
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 1682090
-  timestamp: 1721031296951
-- kind: conda
-  name: libxml2
-  version: 2.12.7
-  build: he7c6b58_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
   sha256: 10e9e0ac52b9a516a17edbc07f8d559e23778e54f1a7721b2e0e8219284fed3b
   md5: 08a9265c637230c37cb1be4a6cad4536
   depends:
@@ -11446,13 +8139,20 @@ packages:
   license_family: MIT
   size: 707169
   timestamp: 1721031016143
-- kind: conda
-  name: libxml2
-  version: 2.12.7
-  build: heaf3512_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h00a45b3_4.conda
+  sha256: 1ce32ab0ffbc8938f0820949ea733eb11f2f05355034af12fc6fe708f184fac1
+  md5: d25c3e16ee77cd25342e4e235424c758
+  depends:
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 753275
+  timestamp: 1721031124841
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
   sha256: ed18a2d8d428c0b88d47751ebcc7cc4e6202f99c3948fffd776cba83c4f0dad3
   md5: ea1be6ecfe814da889e882c8b6ead79d
   depends:
@@ -11465,109 +8165,33 @@ packages:
   license_family: MIT
   size: 619901
   timestamp: 1721031175411
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h0ed339e_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h0ed339e_6.conda
-  sha256: e3a7f487ab6c095d2a38360928291cb07da52eecd3ae07a4852a173ceb800aa5
-  md5: 9e128dd2c202031e51a8c09ed872e2bb
-  depends:
-  - __osx >=10.13
-  - ace >=8.0.1,<8.0.2.0a0
-  - eigen
-  - ffmpeg >=6.1.2,<7.0a0
-  - libcxx >=17
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.10.0,<4.10.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - portaudio >=19.6.0,<19.7.0a0
-  - qt-main >=5.15.8,<5.16.0a0
-  - robot-testing-framework >=2.0.1,<2.0.2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - soxr >=0.1.3,<0.1.4.0a0
-  - tinyxml
-  - ycm-cmake-modules
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 7569001
-  timestamp: 1727889180670
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h31b8c72_6
-  build_number: 6
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h31b8c72_6.conda
-  sha256: 0844802b019fdac7c21ea2a58270925fe8a8edc08b24d93a850980ad9e7021e3
-  md5: 95e4c446bc9d4ad75f17f20eaa4c7c9b
-  depends:
-  - ace >=8.0.1,<8.0.2.0a0
-  - eigen
-  - ffmpeg >=6.1.2,<7.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libi2c >=4.3,<5.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.10.0,<4.10.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - portaudio >=19.6.0,<19.7.0a0
-  - qt-main >=5.15.8,<5.16.0a0
-  - robot-testing-framework >=2.0.1,<2.0.2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - soxr >=0.1.3,<0.1.4.0a0
-  - tinyxml
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  - ycm-cmake-modules
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 10727534
-  timestamp: 1727889622110
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h35b7655_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h35b7655_6.conda
-  sha256: 4972e3ec65c1006de02330a790c2e6ee16cc19fab3ecf5ee53db84a333789b1b
-  md5: 0ae95375f9fd510e1c682d3d4bf296ab
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h01dff8b_4.conda
+  sha256: a9a76cdc6e93c0182bc2ac58b1ea0152be1a16a5d23f4dc7b8df282a7aef8d20
+  md5: 1265488dc5035457b729583119ad4a1b
   depends:
   - __osx >=11.0
-  - ace >=8.0.1,<8.0.2.0a0
-  - eigen
-  - ffmpeg >=6.1.2,<7.0a0
-  - libcxx >=17
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.10.0,<4.10.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.46.1,<4.0a0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - portaudio >=19.6.0,<19.7.0a0
-  - qt-main >=5.15.8,<5.16.0a0
-  - robot-testing-framework >=2.0.1,<2.0.2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - soxr >=0.1.3,<0.1.4.0a0
-  - tinyxml
-  - ycm-cmake-modules
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 7498450
-  timestamp: 1727889164876
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h564f6a6_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-h564f6a6_6.conda
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 588990
+  timestamp: 1721031045514
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+  sha256: ae78197961b09b0eef4ee194a44e4adc4555c0f2f20c348086b0cd8aaf2f7731
+  md5: ed4d301f0d2149b34deb9c4fecafd836
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1682090
+  timestamp: 1721031296951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-h564f6a6_6.conda
   sha256: c169f24238eeb50bb5aa3eb58c8afb3f11ebe8cddc7098a113e56e601cf25c89
   md5: 0e085c829f738f08547fe5e8958e6649
   depends:
@@ -11595,13 +8219,85 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 10594881
   timestamp: 1727889822933
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h71b8b94_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-h71b8b94_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h31b8c72_6.conda
+  sha256: 0844802b019fdac7c21ea2a58270925fe8a8edc08b24d93a850980ad9e7021e3
+  md5: 95e4c446bc9d4ad75f17f20eaa4c7c9b
+  depends:
+  - ace >=8.0.1,<8.0.2.0a0
+  - eigen
+  - ffmpeg >=6.1.2,<7.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libi2c >=4.3,<5.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 10727534
+  timestamp: 1727889622110
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h0ed339e_6.conda
+  sha256: e3a7f487ab6c095d2a38360928291cb07da52eecd3ae07a4852a173ceb800aa5
+  md5: 9e128dd2c202031e51a8c09ed872e2bb
+  depends:
+  - __osx >=10.13
+  - ace >=8.0.1,<8.0.2.0a0
+  - eigen
+  - ffmpeg >=6.1.2,<7.0a0
+  - libcxx >=17
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 7569001
+  timestamp: 1727889180670
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h35b7655_6.conda
+  sha256: 4972e3ec65c1006de02330a790c2e6ee16cc19fab3ecf5ee53db84a333789b1b
+  md5: 0ae95375f9fd510e1c682d3d4bf296ab
+  depends:
+  - __osx >=11.0
+  - ace >=8.0.1,<8.0.2.0a0
+  - eigen
+  - ffmpeg >=6.1.2,<7.0a0
+  - libcxx >=17
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 7498450
+  timestamp: 1727889164876
+- conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-h71b8b94_6.conda
   sha256: f2837483c62ed450419570cf1a04165433769709e329924f0ce257bfafeb1636
   md5: 324f1b2f7947dfedc4d45680b7517c7c
   depends:
@@ -11626,13 +8322,52 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 9322634
   timestamp: 1727890415974
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
+  md5: 08aad7cbe9f5a6b460d0976076b6ae64
+  depends:
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 66657
+  timestamp: 1727963199518
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
   sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
   md5: 41fbfac52c601159df6c01f875de31b9
   depends:
@@ -11645,107 +8380,13 @@ packages:
   license_family: Other
   size: 55476
   timestamp: 1727963768015
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h8359307_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 46438
-  timestamp: 1727963202283
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h86ecc28_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
-  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
-  md5: 08aad7cbe9f5a6b460d0976076b6ae64
-  depends:
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 66657
-  timestamp: 1727963199518
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 60963
-  timestamp: 1727963148474
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hd23fc13_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
-  md5: 003a54a4e32b02f7355b50a837e699da
-  depends:
-  - __osx >=10.13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 57133
-  timestamp: 1727963183990
-- kind: conda
-  name: llvm-meta
-  version: 5.0.0
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
   sha256: 090bbeacc3297ff579b53f55ad184f05c30e316fe9d5d7df63df1d2ad4578b79
   md5: 213b5b5ad34008147a824460e50a691c
   license: BSD-3-Clause
   license_family: BSD
   size: 2667
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.2
-  build: h013ceaa_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-19.1.2-h013ceaa_0.conda
-  sha256: e1c8265187d98cb486b946ec89effdff88494ae1560cc83b1410961c7c9d5121
-  md5: d51a2e037784c2604ba616b4fd9508e3
-  constrains:
-  - openmp 19.1.2|19.1.2.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  size: 3088536
-  timestamp: 1729145272074
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.2
-  build: h024ca30_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.2-h024ca30_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.2-h024ca30_0.conda
   sha256: 77ef4713b1762ec2c0326400e5009e15595d3c27a10e5bbe91a29d63c99ee9b9
   md5: 51ee2f29348ec593205c30ebc52aa0c0
   depends:
@@ -11756,28 +8397,16 @@ packages:
   license_family: APACHE
   size: 3189011
   timestamp: 1729145283078
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.2
-  build: hb52a8e5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
-  sha256: a1836fa9eddf8b3fa2209db4a3423b13fdff93a8eacc9fe8360a6867e7f440d0
-  md5: 7ad59f95f091ed6a99a7cbcd6f201be0
-  depends:
-  - __osx >=11.0
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-19.1.2-h013ceaa_0.conda
+  sha256: e1c8265187d98cb486b946ec89effdff88494ae1560cc83b1410961c7c9d5121
+  md5: d51a2e037784c2604ba616b4fd9508e3
   constrains:
   - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 280737
-  timestamp: 1729145191646
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.2
-  build: hf78d878_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
+  size: 3088536
+  timestamp: 1729145272074
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
   sha256: 92231d391886bca0c0dabb42f02a37e7acb8ea84399843173fe8c294814735dd
   md5: ca5f963676a9ad5383b7441368e1d107
   depends:
@@ -11788,13 +8417,35 @@ packages:
   license_family: APACHE
   size: 305589
   timestamp: 1729145249496
-- kind: conda
-  name: llvm-tools
-  version: 17.0.6
-  build: h5090b49_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
+  sha256: a1836fa9eddf8b3fa2209db4a3423b13fdff93a8eacc9fe8360a6867e7f440d0
+  md5: 7ad59f95f091ed6a99a7cbcd6f201be0
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.2|19.1.2.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 280737
+  timestamp: 1729145191646
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
+  sha256: 2380e9ac72aba8ef351ec13c9d5b1b233057c70bf4b9b3cea0b3f5bfb5a4e211
+  md5: 4260f86b3dd201ad7ea758d783cd5613
+  depends:
+  - libllvm17 17.0.6 hbedff68_1
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - llvm        17.0.6
+  - clang       17.0.6
+  - clang-tools 17.0.6
+  - llvmdev     17.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23219165
+  timestamp: 1701378990823
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
   sha256: a8011fffc1ab3b49f2027fbdba0887e90a2d288240484a4ba4c1b80617522541
   md5: df635fb4c27fc012c0caf53adf61f043
   depends:
@@ -11812,35 +8463,7 @@ packages:
   license_family: Apache
   size: 21864486
   timestamp: 1718321368877
-- kind: conda
-  name: llvm-tools
-  version: 17.0.6
-  build: hbedff68_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
-  sha256: 2380e9ac72aba8ef351ec13c9d5b1b233057c70bf4b9b3cea0b3f5bfb5a4e211
-  md5: 4260f86b3dd201ad7ea758d783cd5613
-  depends:
-  - libllvm17 17.0.6 hbedff68_1
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - llvm        17.0.6
-  - clang       17.0.6
-  - clang-tools 17.0.6
-  - llvmdev     17.0.6
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 23219165
-  timestamp: 1701378990823
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hcb278e6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
   sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
   md5: 318b08df404f9c9be5712aaa5a6f0bb0
   depends:
@@ -11850,12 +8473,7 @@ packages:
   license_family: BSD
   size: 143402
   timestamp: 1674727076728
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hd600fc2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
   sha256: 076870eb72411f41c46598c7582a2f3f42ba94c526a2d60a0c8f70a0a7a64429
   md5: 500145a83ed07ce79c8cef24252f366b
   depends:
@@ -11865,59 +8483,7 @@ packages:
   license_family: BSD
   size: 163770
   timestamp: 1674727020254
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h15f6cfe_1007
-  build_number: 1007
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h15f6cfe_1007.conda
-  sha256: f54ad3e5d47a0235ba2830848fee590faad550639336fe1e2413ab16fee7ac39
-  md5: 7687ec5796288536947bf616179726d8
-  depends:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3898314
-  timestamp: 1728064659078
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h3023b02_1007
-  build_number: 1007
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-h3023b02_1007.conda
-  sha256: 9443014f00a78a216c59f17a1309e49beb24b96082d198b4ab1626522fc7da40
-  md5: 4e4566c484361d6a92478f57db53fb08
-  depends:
-  - __osx >=10.13
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3949838
-  timestamp: 1728064564171
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h670dfbf_1007
-  build_number: 1007
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h670dfbf_1007.conda
-  sha256: 453f4733b1803452b8169c31749d92d46bf6fe7e467897d89535d3fcb6f16b6f
-  md5: e6672417b63f335358d90f5ba939c4ab
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3844618
-  timestamp: 1728064627281
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: hd0bcaf9_1007
-  build_number: 1007
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
   sha256: e8a00971e6d00bd49f375c5d8d005b37a9abba0b1768533aed0f90a422bf5cc7
   md5: 28eb714416de4eb83e2cbc47e99a1b45
   depends:
@@ -11928,13 +8494,35 @@ packages:
   license_family: APACHE
   size: 3923560
   timestamp: 1728064567817
-- kind: conda
-  name: mkl
-  version: 2024.2.2
-  build: h66d3029_14
-  build_number: 14
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h670dfbf_1007.conda
+  sha256: 453f4733b1803452b8169c31749d92d46bf6fe7e467897d89535d3fcb6f16b6f
+  md5: e6672417b63f335358d90f5ba939c4ab
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3844618
+  timestamp: 1728064627281
+- conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-h3023b02_1007.conda
+  sha256: 9443014f00a78a216c59f17a1309e49beb24b96082d198b4ab1626522fc7da40
+  md5: 4e4566c484361d6a92478f57db53fb08
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3949838
+  timestamp: 1728064564171
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h15f6cfe_1007.conda
+  sha256: f54ad3e5d47a0235ba2830848fee590faad550639336fe1e2413ab16fee7ac39
+  md5: 7687ec5796288536947bf616179726d8
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3898314
+  timestamp: 1728064659078
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
   sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
   md5: f011e7cc21918dc9d1efe0209e27fa16
   depends:
@@ -11944,27 +8532,7 @@ packages:
   license_family: Proprietary
   size: 103019089
   timestamp: 1727378392081
-- kind: conda
-  name: mpg123
-  version: 1.32.8
-  build: h65af167_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.8-h65af167_0.conda
-  sha256: e76f42e9156b5c0b5f92b5291b3a49dbb57cfa59fe47ae63277636a663457389
-  md5: 954ee7649e85e975a6d0b2c1bacb96d6
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 559226
-  timestamp: 1729968939562
-- kind: conda
-  name: mpg123
-  version: 1.32.8
-  build: hc50e24c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.8-hc50e24c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.8-hc50e24c_0.conda
   sha256: 5b3e9fe0ce303429f82def3a37d9f3227c69cd6a45a26753351c3c86d2454c75
   md5: 7a7229e20b7b4c6840d6fe2378646a77
   depends:
@@ -11975,131 +8543,41 @@ packages:
   license_family: LGPL
   size: 492429
   timestamp: 1729968968920
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: h694c41f_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.7.3-h694c41f_5.conda
-  sha256: 41649e1cfdfae5530a76949616a4ecaf862748d6048e49bac2991920e868bdab
-  md5: 235cf2d095ba79dac99a25a3abdeeae6
-  license: CECILL-C
-  size: 23156
-  timestamp: 1727303586187
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: h8af1aa0_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
-  sha256: 29a9527b286203881328f5057b4e75953884ae1a75d01a5119bf10776a150c61
-  md5: 2b8630bd5e0b25e53ee5fbe4844c3b4c
-  license: CECILL-C
-  size: 23025
-  timestamp: 1727303578959
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: ha770c72_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.8-h65af167_0.conda
+  sha256: e76f42e9156b5c0b5f92b5291b3a49dbb57cfa59fe47ae63277636a663457389
+  md5: 954ee7649e85e975a6d0b2c1bacb96d6
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 559226
+  timestamp: 1729968939562
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
   sha256: 23749d8c3695d95255c21fa4ebf73c70a07b098262c052a854d1504416e69478
   md5: 1f49bbeab690751b93f54cb61b0722aa
   license: CECILL-C
   size: 22999
   timestamp: 1727303528508
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: hce30654_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
+  sha256: 29a9527b286203881328f5057b4e75953884ae1a75d01a5119bf10776a150c61
+  md5: 2b8630bd5e0b25e53ee5fbe4844c3b4c
+  license: CECILL-C
+  size: 23025
+  timestamp: 1727303578959
+- conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.7.3-h694c41f_5.conda
+  sha256: 41649e1cfdfae5530a76949616a4ecaf862748d6048e49bac2991920e868bdab
+  md5: 235cf2d095ba79dac99a25a3abdeeae6
+  license: CECILL-C
+  size: 23156
+  timestamp: 1727303586187
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
   sha256: 957568ea03765a383d1f2413f701bb4179705f879f4028dfa2653c723f8ec038
   md5: 1a1380f7da054ed3327d40b3abe732f3
   license: CECILL-C
   size: 23186
   timestamp: 1727303612860
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: h3416ed2_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.7.3-h3416ed2_5.conda
-  sha256: 4a6cfb691beca7d108b534e08dee86a3b2e8523e8ece183189995e30d3ff82c7
-  md5: 87efba371ce4e0058862983c1f1faf84
-  depends:
-  - __osx >=10.13
-  - libblas >=3.9.0,<4.0a0
-  - libgfortran 5.*
-  - libgfortran5 >=13.2.0
-  - liblapack >=3.9.0,<4.0a0
-  - libscotch >=7.0.5,<7.0.6.0a0
-  - llvm-openmp >=17.0.6
-  - llvm-openmp >=18.1.8
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include 5.7.3 h694c41f_5
-  constrains:
-  - libopenblas * *openmp*
-  license: CECILL-C
-  size: 2278066
-  timestamp: 1727303832161
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: h505cb68_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
-  sha256: 27d4b8d78cb662e0406e42f34474f18565b3c46e893f9e938edf1dbafab30547
-  md5: 2ac9aea3b26d7de591223671b3fe0de2
-  depends:
-  - _openmp_mutex >=4.5
-  - libblas >=3.9.0,<4.0a0
-  - libgcc >=13
-  - libgfortran
-  - libgfortran5 >=13.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libscotch >=7.0.5,<7.0.6.0a0
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include 5.7.3 h8af1aa0_5
-  constrains:
-  - libopenblas * *openmp*
-  license: CECILL-C
-  size: 2363904
-  timestamp: 1727303927035
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: h7c2359a_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
-  sha256: 00e65d0dff5d773612c742d2ad48e041fbeb0bd779cf7a3fa85ed91b479254e4
-  md5: 943cbd250d41f9c1f3ac2004deea7a31
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libflang >=5.0.0,<6.0.0.a0
-  - liblapack >=3.9.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libopenblas * *openmp*
-  license: CECILL-C
-  size: 3074465
-  timestamp: 1727304479582
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: hcd84eb1_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
   sha256: 94da4438e92a53bb8670971cb1247787e8f4d91ce06f28e9d31fdb3f6afa33e2
   md5: 46d52291d856e44ff8b81bc3b480b228
   depends:
@@ -12118,13 +8596,44 @@ packages:
   license: CECILL-C
   size: 2440160
   timestamp: 1727303788976
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: he17653c_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
+  sha256: 27d4b8d78cb662e0406e42f34474f18565b3c46e893f9e938edf1dbafab30547
+  md5: 2ac9aea3b26d7de591223671b3fe0de2
+  depends:
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch >=7.0.5,<7.0.6.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include 5.7.3 h8af1aa0_5
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  size: 2363904
+  timestamp: 1727303927035
+- conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.7.3-h3416ed2_5.conda
+  sha256: 4a6cfb691beca7d108b534e08dee86a3b2e8523e8ece183189995e30d3ff82c7
+  md5: 87efba371ce4e0058862983c1f1faf84
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch >=7.0.5,<7.0.6.0a0
+  - llvm-openmp >=17.0.6
+  - llvm-openmp >=18.1.8
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include 5.7.3 h694c41f_5
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  size: 2278066
+  timestamp: 1727303832161
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
   sha256: fa605c3028d958cbe670620ee583ef8f0551d79fdc0d41a61e43478c9c42b3ee
   md5: 364d512567d810c33ed77207f898129e
   depends:
@@ -12143,30 +8652,22 @@ packages:
   license: CECILL-C
   size: 2178444
   timestamp: 1727304238416
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h0887d5e_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h0887d5e_2.conda
-  sha256: 7769d67c3b9463e45ec8e57ea3e0adfdd2f17c0c2b32226e1e88ed669baf14fe
-  md5: 7643ebb29dae0a548c356c5c4d44b79e
+- conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
+  sha256: 00e65d0dff5d773612c742d2ad48e041fbeb0bd779cf7a3fa85ed91b479254e4
+  md5: 943cbd250d41f9c1f3ac2004deea7a31
   depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - openssl >=3.3.2,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 630582
-  timestamp: 1729802112289
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h266115a_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
+  - libblas >=3.9.0,<4.0a0
+  - libflang >=5.0.0,<6.0.0.a0
+  - liblapack >=3.9.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  size: 3074465
+  timestamp: 1727304479582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
   sha256: bf0c230c35ca70e2c98530eb064a99f0c4d4596793a0be3ca8a3cbd92094ef82
   md5: 85c0dc0bcd110c998b01856975486ee7
   depends:
@@ -12178,13 +8679,7 @@ packages:
   license_family: GPL
   size: 649443
   timestamp: 1729804130603
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h3f5c77f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
   sha256: 27cb52f00b2fedb89ed4e7ed2527caf7c5b245dac76a809d0aed58514e08d325
   md5: cc7bc11893dd1aee492dae85f317769e
   depends:
@@ -12195,13 +8690,7 @@ packages:
   license_family: GPL
   size: 636837
   timestamp: 1729806881403
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h918ca22_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-9.0.1-h918ca22_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-9.0.1-h918ca22_2.conda
   sha256: d46a234777afaa7f7c4aa1898067a89f43d86db348909fee1b418713809e8836
   md5: 6adefe5eada0fb37f098288127961ac9
   depends:
@@ -12212,53 +8701,18 @@ packages:
   license_family: GPL
   size: 644932
   timestamp: 1729801807155
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: h11569fd_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
-  sha256: 0c014ecbb449cd10bab96bf036cae646068ce42827f582244117adc805850d04
-  md5: 94c70f21e0a1f8558941d901027215a4
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h0887d5e_2.conda
+  sha256: 7769d67c3b9463e45ec8e57ea3e0adfdd2f17c0c2b32226e1e88ed669baf14fe
+  md5: 7643ebb29dae0a548c356c5c4d44b79e
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-common 9.0.1 h3f5c77f_2
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1408789
-  timestamp: 1729806960210
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: h502887b_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-9.0.1-h502887b_2.conda
-  sha256: df608e92b025d8f83c10a5a932d2b3c16b983571016a04fc21d3660d04e820fe
-  md5: 901d570614d2c0c58a6e3800d9261cf4
-  depends:
-  - __osx >=10.13
+  - __osx >=11.0
   - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-common 9.0.1 h918ca22_2
   - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 1329554
-  timestamp: 1729802009317
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: he0572af_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+  size: 630582
+  timestamp: 1729802112289
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
   sha256: e376189cd11304f4089971b372dac8a1cbbab6eacda8ca978ead2c220d16b8a4
   md5: 57a9e7ee3c0840d3c8c9012473978629
   depends:
@@ -12273,13 +8727,35 @@ packages:
   license_family: GPL
   size: 1372671
   timestamp: 1729804203990
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: he9bc4e1_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-he9bc4e1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
+  sha256: 0c014ecbb449cd10bab96bf036cae646068ce42827f582244117adc805850d04
+  md5: 94c70f21e0a1f8558941d901027215a4
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h3f5c77f_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1408789
+  timestamp: 1729806960210
+- conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-9.0.1-h502887b_2.conda
+  sha256: df608e92b025d8f83c10a5a932d2b3c16b983571016a04fc21d3660d04e820fe
+  md5: 901d570614d2c0c58a6e3800d9261cf4
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h918ca22_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1329554
+  timestamp: 1729802009317
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-he9bc4e1_2.conda
   sha256: ca89f4accacfc2297b5036aa847c2387c53aa937c8f9050ceec275c1be32eec1
   md5: f36d1cf1ffeb604bac5870c04cb4ee8f
   depends:
@@ -12293,41 +8769,7 @@ packages:
   license_family: GPL
   size: 1346928
   timestamp: 1729802330351
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h7bae524_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
-  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
-  md5: cb2b0ea909b97b3d70cd3921d1445e1a
-  depends:
-  - __osx >=11.0
-  license: X11 AND BSD-3-Clause
-  size: 802321
-  timestamp: 1724658775723
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: hcccb83c_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
-  sha256: acad4cf1f57b12ee1e42995e6fac646fa06aa026529f05eb8c07eb0a84a47a84
-  md5: 91d49c85cacd92caa40cf375ef72a25d
-  depends:
-  - libgcc-ng >=12
-  license: X11 AND BSD-3-Clause
-  size: 924472
-  timestamp: 1724658573518
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: he02047a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
   sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
   md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
   depends:
@@ -12336,13 +8778,15 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 889086
   timestamp: 1724658547447
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: hf036a51_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
+  sha256: acad4cf1f57b12ee1e42995e6fac646fa06aa026529f05eb8c07eb0a84a47a84
+  md5: 91d49c85cacd92caa40cf375ef72a25d
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 924472
+  timestamp: 1724658573518
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
   sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
   md5: e102bbf8a6ceeaf429deab8032fc8977
   depends:
@@ -12350,12 +8794,15 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 822066
   timestamp: 1724658603042
-- kind: conda
-  name: ninja
-  version: 1.12.1
-  build: h297d8ca_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
   sha256: 40f7b76b07067935f8a5886aab0164067b7aa71eb5ad20b7278618c0c2c98e06
   md5: 3aa1c7e292afeff25a0091ddd7c69b72
   depends:
@@ -12365,42 +8812,7 @@ packages:
   license_family: Apache
   size: 2198858
   timestamp: 1715440571685
-- kind: conda
-  name: ninja
-  version: 1.12.1
-  build: h3c5361c_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.12.1-h3c5361c_0.conda
-  sha256: 230f11a2f73955b67550be09a0c1fd053772f5e01e98d5873547d63ebea73229
-  md5: a0ebabd021c8191aeb82793fe43cfdcb
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  size: 124942
-  timestamp: 1715440780183
-- kind: conda
-  name: ninja
-  version: 1.12.1
-  build: h420ef59_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
-  sha256: 11528acfa0f05d0c51639f6b09b51dc6611b801668449bb36c206c4b055be4f4
-  md5: 9166c10405d41c95ffde8fcb8e5c3d51
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  size: 112576
-  timestamp: 1715440927034
-- kind: conda
-  name: ninja
-  version: 1.12.1
-  build: h70be974_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.12.1-h70be974_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.12.1-h70be974_0.conda
   sha256: a42f12c03a69cdcd2e7d5f95fd4e0f1e5fc43ef482aff2b8ee16a3730cc642de
   md5: 216635cea46498d8045c7cf0f03eaf72
   depends:
@@ -12410,12 +8822,27 @@ packages:
   license_family: Apache
   size: 2329583
   timestamp: 1715442512963
-- kind: conda
-  name: ninja
-  version: 1.12.1
-  build: hc790b64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.12.1-h3c5361c_0.conda
+  sha256: 230f11a2f73955b67550be09a0c1fd053772f5e01e98d5873547d63ebea73229
+  md5: a0ebabd021c8191aeb82793fe43cfdcb
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 124942
+  timestamp: 1715440780183
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
+  sha256: 11528acfa0f05d0c51639f6b09b51dc6611b801668449bb36c206c4b055be4f4
+  md5: 9166c10405d41c95ffde8fcb8e5c3d51
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 112576
+  timestamp: 1715440927034
+- conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
   sha256: b821cb72cb3ef08fab90a9bae899510e6cf3c23b5da6070d1ec30099dfe6a5be
   md5: a557dde55343e03c68cd7e29e7f87279
   depends:
@@ -12426,27 +8853,7 @@ packages:
   license_family: Apache
   size: 285150
   timestamp: 1715441052517
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h5833ebf_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
-  sha256: 71f790d3dafe309e46c2214a6354d8d1818d646d637b2f5f9f84c5aa5c315a42
-  md5: 026a08bd5b6a2a2f240c00c32446156d
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 202873
-  timestamp: 1729545964601
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
   sha256: a87471d9265a7c02a98c20debac8b13afd80963968ed7b1c1c2ac7b80955ce31
   md5: de9cd5bca9e4918527b9b72b6e2e1409
   depends:
@@ -12457,12 +8864,7 @@ packages:
   license_family: MOZILLA
   size: 230204
   timestamp: 1729545773406
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
   sha256: 404a4ec0430fbdce53fee00d9acf9f307aa9b3a6d06b5696c38ca3f92195a490
   md5: 6170d131ea39ca6e8f6695507c9d3388
   depends:
@@ -12472,12 +8874,7 @@ packages:
   license_family: MOZILLA
   size: 235389
   timestamp: 1729545760194
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h97d8b74_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.36-h97d8b74_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.36-h97d8b74_0.conda
   sha256: c98566d1280b73d8660f9e9db5a735afb2512a93e04dff0de1e51b2af9133d21
   md5: 9367273bb726a8991cd9bf9b1a022f57
   depends:
@@ -12487,66 +8884,17 @@ packages:
   license_family: MOZILLA
   size: 208747
   timestamp: 1729546041279
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: h6f44f80_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.106-h6f44f80_0.conda
-  sha256: de7cc89e24b7e72c9f842534af205b566d7bceb95307aad0434a40e2ec13e73e
-  md5: 243f6ae13f81edd8e82f0baddab0aaf2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
+  sha256: 71f790d3dafe309e46c2214a6354d8d1818d646d637b2f5f9f84c5aa5c315a42
+  md5: 026a08bd5b6a2a2f240c00c32446156d
   depends:
   - __osx >=11.0
   - libcxx >=17
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 1814292
-  timestamp: 1729811695707
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: hbde9d96_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.106-hbde9d96_0.conda
-  sha256: 3d1fbe1972d2106d06d211d95857d1836608fa1d27f5d4ab14b8788205bf59df
-  md5: daf45dad51ce90d321897cca2d1036da
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 1902087
-  timestamp: 1729811793532
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: hcffee33_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
-  sha256: 76115ba1a5b5fbb7e3b471c84e983b514394c800adee30b158799ecdc15ded66
-  md5: e132b0f4cec9a1476c5c4da3722fc124
-  depends:
-  - libgcc >=13
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 1990164
-  timestamp: 1729814601835
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: hdf54f9c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
+  size: 202873
+  timestamp: 1729545964601
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
   sha256: e5dd3e57498decdef87ff641fa6b7bd5484fce3f2783811ee5ec278bc9e71281
   md5: efe735c7dc47dddbb14b3433d11c6feb
   depends:
@@ -12560,34 +8908,46 @@ packages:
   license_family: MOZILLA
   size: 2001391
   timestamp: 1729811441549
-- kind: conda
-  name: numpy
-  version: 2.1.2
-  build: py311h394b0bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.2-py311h394b0bb_0.conda
-  sha256: 70bbd9d0d8b71230fbcd15b70abd2fc25296bf9f5d0998cb4505becee72021fc
-  md5: 530bb67b583c4411577ae86f601cc91f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
+  sha256: 76115ba1a5b5fbb7e3b471c84e983b514394c800adee30b158799ecdc15ded66
+  md5: e132b0f4cec9a1476c5c4da3722fc124
+  depends:
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1990164
+  timestamp: 1729814601835
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.106-hbde9d96_0.conda
+  sha256: 3d1fbe1972d2106d06d211d95857d1836608fa1d27f5d4ab14b8788205bf59df
+  md5: daf45dad51ce90d321897cca2d1036da
   depends:
   - __osx >=10.13
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
   - libcxx >=17
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8099526
-  timestamp: 1728240345835
-- kind: conda
-  name: numpy
-  version: 2.1.2
-  build: py311h71ddf71_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.2-py311h71ddf71_0.conda
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1902087
+  timestamp: 1729811793532
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.106-h6f44f80_0.conda
+  sha256: de7cc89e24b7e72c9f842534af205b566d7bceb95307aad0434a40e2ec13e73e
+  md5: 243f6ae13f81edd8e82f0baddab0aaf2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1814292
+  timestamp: 1729811695707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.2-py311h71ddf71_0.conda
   sha256: da4c6cf1a51afc95aeeecf403cd1efbaed0ab19567d59a3e2e316313073476e4
   md5: 4e72b55892331ada8fbcf5954df582f2
   depends:
@@ -12605,12 +8965,7 @@ packages:
   license_family: BSD
   size: 9099547
   timestamp: 1728240501130
-- kind: conda
-  name: numpy
-  version: 2.1.2
-  build: py312h2eb110b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.2-py312h2eb110b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.2-py312h2eb110b_0.conda
   sha256: eba7ea647685325e7c09d4c4445047d36e754e2444389c8b6aa41e8a4171216c
   md5: 548aab48a0d2bf1a2a6a6542b4fd3c7c
   depends:
@@ -12628,12 +8983,24 @@ packages:
   license_family: BSD
   size: 7129746
   timestamp: 1728240412984
-- kind: conda
-  name: numpy
-  version: 2.1.2
-  build: py312h801f5e3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.2-py312h801f5e3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.2-py311h394b0bb_0.conda
+  sha256: 70bbd9d0d8b71230fbcd15b70abd2fc25296bf9f5d0998cb4505becee72021fc
+  md5: 530bb67b583c4411577ae86f601cc91f
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8099526
+  timestamp: 1728240345835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.2-py312h801f5e3_0.conda
   sha256: 7e6840963d5395a59cb0aca32d43fd4e539c00a0677fcad16e4a3ab1f5c7aab7
   md5: 3f9101c02190f155b6525490238fc794
   depends:
@@ -12651,12 +9018,7 @@ packages:
   license_family: BSD
   size: 6436873
   timestamp: 1728240394809
-- kind: conda
-  name: numpy
-  version: 2.1.2
-  build: py312hf10105a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.2-py312hf10105a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.2-py312hf10105a_0.conda
   sha256: 81aadbcee02b5cbf74b543c29b0bbb7917431ee07d83351267f1fcad35d787c8
   md5: ff10ff589eedbf2006ccda86d11150a2
   depends:
@@ -12674,13 +9036,7 @@ packages:
   license_family: BSD
   size: 7048272
   timestamp: 1728665362128
-- kind: conda
-  name: ocl-icd
-  version: 2.3.2
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
   sha256: 0e01384423e48e5011eb6b224da8dc5e3567c87dbcefbe60cd9d5cead276cdcd
   md5: c66f837ac65e4d1cdeb80e2a1d5fcc3d
   depends:
@@ -12689,86 +9045,7 @@ packages:
   license_family: BSD
   size: 135681
   timestamp: 1710946531879
-- kind: conda
-  name: openexr
-  version: 3.2.2
-  build: h2627bef_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h2627bef_2.conda
-  sha256: a0eef2672e778c22416dbbedd0be47fb32d745c402f8a250f3015e0cacbe1d9a
-  md5: e54052079776261c205927064e54b921
-  depends:
-  - __osx >=10.13
-  - imath >=3.1.12,<3.1.13.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1287176
-  timestamp: 1726024906174
-- kind: conda
-  name: openexr
-  version: 3.2.2
-  build: h78594a9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-h78594a9_2.conda
-  sha256: 031f9b050ab64367a7da975e8165fa6ff8ad1324b07876debbbeddee81f1c8be
-  md5: 274ed28a7ca293e2a38fa599555ebcaa
-  depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1394661
-  timestamp: 1726024774994
-- kind: conda
-  name: openexr
-  version: 3.2.2
-  build: h9aba623_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h9aba623_2.conda
-  sha256: e4807540184853f758386c62656bd5f9c7d93470b3fb43a6b33de21076dd87d6
-  md5: 742b266c64e3ed5d170d5972eed9bfd5
-  depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1201419
-  timestamp: 1726025286785
-- kind: conda
-  name: openexr
-  version: 3.2.2
-  build: hab01212_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-hab01212_2.conda
-  sha256: 5317b63c63fb57f0de109dcecb38ffb8ff05747eaee90b6771697dec198f5c8d
-  md5: 104fb7fbb910fe9d66fe81d1611baf2c
-  depends:
-  - __osx >=11.0
-  - imath >=3.1.12,<3.1.13.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1248482
-  timestamp: 1726024848729
-- kind: conda
-  name: openexr
-  version: 3.3.1
-  build: hccdc605_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
   sha256: de1abf7be0caca0cd83174ea77a9dbfeb1d36d748508e524cd2b9253ec3d86f6
   md5: 907ffbb8a276c12c5a8a8aed2c5a10f9
   depends:
@@ -12782,27 +9059,56 @@ packages:
   license_family: BSD
   size: 1405340
   timestamp: 1729546542495
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
-  sha256: fbd43d4ab82fd6dfd1502a55ccade4aabae4a85fa2353396078da8d5c10941db
-  md5: 97fc3bbca08e95e1d7af8366d5a4ece6
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-h78594a9_2.conda
+  sha256: 031f9b050ab64367a7da975e8165fa6ff8ad1324b07876debbbeddee81f1c8be
+  md5: 274ed28a7ca293e2a38fa599555ebcaa
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
+  - imath >=3.1.12,<3.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
   license_family: BSD
-  size: 770201
-  timestamp: 1706873872574
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+  size: 1394661
+  timestamp: 1726024774994
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h2627bef_2.conda
+  sha256: a0eef2672e778c22416dbbedd0be47fb32d745c402f8a250f3015e0cacbe1d9a
+  md5: e54052079776261c205927064e54b921
+  depends:
+  - __osx >=10.13
+  - imath >=3.1.12,<3.1.13.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1287176
+  timestamp: 1726024906174
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-hab01212_2.conda
+  sha256: 5317b63c63fb57f0de109dcecb38ffb8ff05747eaee90b6771697dec198f5c8d
+  md5: 104fb7fbb910fe9d66fe81d1611baf2c
+  depends:
+  - __osx >=11.0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1248482
+  timestamp: 1726024848729
+- conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h9aba623_2.conda
+  sha256: e4807540184853f758386c62656bd5f9c7d93470b3fb43a6b33de21076dd87d6
+  md5: 742b266c64e3ed5d170d5972eed9bfd5
+  depends:
+  - imath >=3.1.12,<3.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1201419
+  timestamp: 1726025286785
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
   sha256: 0d4eaf15fb771f25c924aef831d76eea11d90c824778fc1e7666346e93475f42
   md5: 3dfcf61b8e78af08110f5229f79580af
   depends:
@@ -12812,12 +9118,35 @@ packages:
   license_family: BSD
   size: 735244
   timestamp: 1706873814072
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
+  sha256: fbd43d4ab82fd6dfd1502a55ccade4aabae4a85fa2353396078da8d5c10941db
+  md5: 97fc3bbca08e95e1d7af8366d5a4ece6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 770201
+  timestamp: 1706873872574
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.1-h73e2aa4_0.conda
+  sha256: 4e660e62225815dd996788ed08dc50870e387c159f31d65cd8b677988dfb387b
+  md5: 877f116d9a4f8b826b0e1d427ac00871
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 660428
+  timestamp: 1706874091051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
+  sha256: ecadea5985082105b102f86ff8289128fb247c183b36355d867eb6fc6996df29
+  md5: 25a7835e284a4d947fe9a70efa97e019
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 598764
+  timestamp: 1706874342701
+- conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
   sha256: 37c954a1235531499c45439c602dda6f788e3683795e12fb6e1e4c86074386c7
   md5: 01d1a98fd9ac45d49040ad8cdd62083a
   depends:
@@ -12828,56 +9157,56 @@ packages:
   license_family: BSD
   size: 409185
   timestamp: 1706874444698
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.1-h73e2aa4_0.conda
-  sha256: 4e660e62225815dd996788ed08dc50870e387c159f31d65cd8b677988dfb387b
-  md5: 877f116d9a4f8b826b0e1d427ac00871
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 660428
-  timestamp: 1706874091051
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
-  sha256: ecadea5985082105b102f86ff8289128fb247c183b36355d867eb6fc6996df29
-  md5: 25a7835e284a4d947fe9a70efa97e019
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 598764
-  timestamp: 1706874342701
-- kind: conda
-  name: openmp
-  version: 5.0.0
-  build: vc14_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
   sha256: 05c19170938b589f59049679d4e0679c98160fecc6fd1bf721b0f4980bd235dd
   md5: 8284c925330fa53668ade00db3c9e787
   depends:
   - llvm-meta 5.0.0|5.0.0.*
   - vc 14.*
-  arch: x86_64
-  platform: win
   license: NCSA
   size: 590466
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
+  md5: 4d638782050ab6faa27275bed57e9b4e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2891789
+  timestamp: 1725410790053
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
+  sha256: 4669d26dbf81e4d72093d8260f55d19d57204d82b1d9440be83d11d313b5990c
+  md5: 9e1e477b3f8ee3789297883faffa708b
+  depends:
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 3428083
+  timestamp: 1725412266679
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
+  sha256: 2b75d4b56e45992adf172b158143742daeb316c35274b36f385ccb6644e93268
+  md5: 2ff47134c8e292868a4609519b1ea3b6
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2544654
+  timestamp: 1725410973572
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
+  sha256: 940fa01c4dc6152158fe8943e05e55a1544cab639df0994e3b35937839e4f4d1
+  md5: 1773ebccdc13ec603356e8ff1db9e958
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2882450
+  timestamp: 1725410638874
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
   sha256: a45c42f3577294e22ac39ddb6ef5a64fd5322e8a6725afefbf4f2b4109340bf9
   md5: 1dc86753693df5e3326bb8a85b74c589
   depends:
@@ -12889,91 +9218,19 @@ packages:
   license_family: Apache
   size: 8396053
   timestamp: 1725412961673
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: h8359307_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
-  sha256: 940fa01c4dc6152158fe8943e05e55a1544cab639df0994e3b35937839e4f4d1
-  md5: 1773ebccdc13ec603356e8ff1db9e958
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 2882450
-  timestamp: 1725410638874
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
-  sha256: 4669d26dbf81e4d72093d8260f55d19d57204d82b1d9440be83d11d313b5990c
-  md5: 9e1e477b3f8ee3789297883faffa708b
-  depends:
-  - ca-certificates
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  size: 3428083
-  timestamp: 1725412266679
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
-  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
-  md5: 4d638782050ab6faa27275bed57e9b4e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  size: 2891789
-  timestamp: 1725410790053
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: hd23fc13_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
-  sha256: 2b75d4b56e45992adf172b158143742daeb316c35274b36f385ccb6644e93268
-  md5: 2ff47134c8e292868a4609519b1ea3b6
-  depends:
-  - __osx >=10.13
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 2544654
-  timestamp: 1725410973572
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: h136a8c3_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
-  sha256: 75ee7b242b62f43f31f3caa5f85a56130dc3efeb09222ab21e041093eb364711
-  md5: 26c46a328a1a81dbd5f5d8b75a90d131
+- conda: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
+  sha256: 4fdea6a623b8c2ca45ef6576cbe287b54b129ebf4467631b7d6bcc6a940bad21
+  md5: b36c121074bec51888739cfb2762d460
   depends:
   - eigen
-  - libcxx >=16
+  - libgcc-ng >=12
   - libosqp >=0.6.3,<0.6.4.0a0
+  - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 33987
-  timestamp: 1709559705042
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: h63a7d18_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
+  size: 35336
+  timestamp: 1709559434463
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
   sha256: a8db1a2cd767bc172bd51351719712820dab440c30f74f1b5afeaca26db4f40f
   md5: ffc5561a5a697954fdde3289e245e2c9
   depends:
@@ -12985,13 +9242,29 @@ packages:
   license_family: BSD
   size: 34800
   timestamp: 1709559465740
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: h6d7489e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hb7bbaee_1.conda
+  sha256: 4d0f259f3de97e9d397aa48fd51c47b75234a0a550014e198167cf199a091fb6
+  md5: 5d38b4edc2643631aa61e07c6b6ed3ae
+  depends:
+  - eigen
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34303
+  timestamp: 1709559740511
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
+  sha256: 75ee7b242b62f43f31f3caa5f85a56130dc3efeb09222ab21e041093eb364711
+  md5: 26c46a328a1a81dbd5f5d8b75a90d131
+  depends:
+  - eigen
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33987
+  timestamp: 1709559705042
+- conda: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
   sha256: 24bd9f72d13d4451d9e7099bfaef9eddb53c95f2310acd598b536b05c31d7d38
   md5: 623017d0d46414e5eacc08e42a7042c0
   depends:
@@ -13004,48 +9277,7 @@ packages:
   license_family: BSD
   size: 63988
   timestamp: 1709560102716
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: hb7bbaee_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hb7bbaee_1.conda
-  sha256: 4d0f259f3de97e9d397aa48fd51c47b75234a0a550014e198167cf199a091fb6
-  md5: 5d38b4edc2643631aa61e07c6b6ed3ae
-  depends:
-  - eigen
-  - libcxx >=16
-  - libosqp >=0.6.3,<0.6.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 34303
-  timestamp: 1709559740511
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: hdd734ac_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
-  sha256: 4fdea6a623b8c2ca45ef6576cbe287b54b129ebf4467631b7d6bcc6a940bad21
-  md5: b36c121074bec51888739cfb2762d460
-  depends:
-  - eigen
-  - libgcc-ng >=12
-  - libosqp >=0.6.3,<0.6.4.0a0
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 35336
-  timestamp: 1709559434463
-- kind: conda
-  name: packaging
-  version: '24.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
   sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
   md5: cbe1bb1f21567018ce595d9c2be0f0db
   depends:
@@ -13054,13 +9286,7 @@ packages:
   license_family: APACHE
   size: 50290
   timestamp: 1718189540074
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: h4c5309f_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
   sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
   md5: 7df02e445367703cd87a574046e3a6f0
   depends:
@@ -13076,13 +9302,19 @@ packages:
   license: LGPL-2.1-or-later
   size: 447117
   timestamp: 1719839527713
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h070dd5b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
   sha256: e9f4b912e48514771d477f2ee955f59d4ff4ef799c3d4d16e4d0f335ce91df67
   md5: 94022de9682cb1a0bb18a99cbc3541b3
   depends:
@@ -13093,13 +9325,18 @@ packages:
   license_family: BSD
   size: 884590
   timestamp: 1723488793100
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h297a79d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+  sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
+  md5: 58cde0663f487778bcd7a0c8daf50293
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 854306
+  timestamp: 1723488807216
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
   sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
   md5: 147c83e5e44780c7492998acbacddf52
   depends:
@@ -13110,13 +9347,7 @@ packages:
   license_family: BSD
   size: 618973
   timestamp: 1723488853807
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h3d7b363_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
   sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
   md5: a3a3baddcfb8c80db84bec3cb7746fb8
   depends:
@@ -13129,47 +9360,7 @@ packages:
   license_family: BSD
   size: 820831
   timestamp: 1723489427046
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h7634a1b_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
-  sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
-  md5: 58cde0663f487778bcd7a0c8daf50293
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 854306
-  timestamp: 1723488807216
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: hba22ea6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
-  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
-  md5: df359c09c41cd186fffb93a2d87aa6f5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 952308
-  timestamp: 1723488734144
-- kind: conda
-  name: pixman
-  version: 0.43.2
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
   sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
   md5: 71004cbf7924e19c02746ccde9fd7123
   depends:
@@ -13179,12 +9370,7 @@ packages:
   license_family: MIT
   size: 386826
   timestamp: 1706549500138
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
   sha256: e145b0d89c800326a20d1afd86c74f9422b81549b17fe53add46c2fa43a4c93e
   md5: 81b2ddea4b0eca188da9c5a7aa4b0cff
   depends:
@@ -13194,12 +9380,25 @@ packages:
   license_family: MIT
   size: 295064
   timestamp: 1709240909660
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+  sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
+  md5: cb134c1e03fd32f4e6bea3f6de2614fd
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 323904
+  timestamp: 1709239931160
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  md5: 0308c68e711cd295aaa026a4f8c4b1e5
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 198755
+  timestamp: 1709239846651
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
   sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
   md5: b98135614135d5f458b75ab9ebb9558c
   depends:
@@ -13210,41 +9409,7 @@ packages:
   license_family: MIT
   size: 461854
   timestamp: 1709239971654
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
-  sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
-  md5: cb134c1e03fd32f4e6bea3f6de2614fd
-  depends:
-  - libcxx >=16
-  license: MIT
-  license_family: MIT
-  size: 323904
-  timestamp: 1709239931160
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
-  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
-  md5: 0308c68e711cd295aaa026a4f8c4b1e5
-  depends:
-  - libcxx >=16
-  license: MIT
-  license_family: MIT
-  size: 198755
-  timestamp: 1709239846651
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: h4bc722e_1009
-  build_number: 1009
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
   sha256: c9601efb1af5391317e04eca77c6fe4d716bf1ca1ad8da2a05d15cb7c28d7d4e
   md5: 1bee70681f504ea424fb07cdb090c001
   depends:
@@ -13254,13 +9419,38 @@ packages:
   license_family: GPL
   size: 115175
   timestamp: 1720805894943
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: h88c491f_1009
-  build_number: 1009
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
+  md5: 05eda637f6465f7e8c5ab7e341341ea9
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 54834
+  timestamp: 1720806008171
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
+  sha256: 636122606556b651ad4d0ac60c7ab6b379e98f390359a1f0c05ad6ba6fb3837f
+  md5: 0b1b9f9e420e4a0e40879b61f94ae646
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 239818
+  timestamp: 1720806136579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
+  sha256: d82f4655b2d67fe12eefe1a3eea4cd27d33fa41dbc5e9aeab5fd6d3d2c26f18a
+  md5: b4f41e19a8c20184eec3aaf0f0953293
+  depends:
+  - __osx >=11.0
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 49724
+  timestamp: 1720806128118
+- conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
   sha256: 86b0c40c8b569dbc164cb1de098ddabf4c240a5e8f38547aab00493891fa67f3
   md5: 122d6514d415fbe02c9b58aee9f6b53e
   depends:
@@ -13272,111 +9462,7 @@ packages:
   license_family: GPL
   size: 36118
   timestamp: 1720806338740
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: hce167ba_1009
-  build_number: 1009
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
-  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
-  md5: 05eda637f6465f7e8c5ab7e341341ea9
-  depends:
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 54834
-  timestamp: 1720806008171
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: hde07d2e_1009
-  build_number: 1009
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
-  sha256: d82f4655b2d67fe12eefe1a3eea4cd27d33fa41dbc5e9aeab5fd6d3d2c26f18a
-  md5: b4f41e19a8c20184eec3aaf0f0953293
-  depends:
-  - __osx >=11.0
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 49724
-  timestamp: 1720806128118
-- kind: conda
-  name: pkg-config
-  version: 0.29.2
-  build: hf7e621a_1009
-  build_number: 1009
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
-  sha256: 636122606556b651ad4d0ac60c7ab6b379e98f390359a1f0c05ad6ba6fb3837f
-  md5: 0b1b9f9e420e4a0e40879b61f94ae646
-  depends:
-  - __osx >=10.13
-  - libiconv >=1.17,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 239818
-  timestamp: 1720806136579
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h13dd4ca_9
-  build_number: 9
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
-  sha256: 5ff2b55d685c29dfe632ef856796a4b862305088543d4982f0b807e8d9bb756e
-  md5: d325d46394b6c46d15718c855fb20b4a
-  depends:
-  - libcxx >=15.0.7
-  license: MIT
-  license_family: MIT
-  size: 78863
-  timestamp: 1693868663440
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h5c6c0ed_9
-  build_number: 9
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
-  sha256: a73e31c5fe9d717cd42470b394018f4e48eed4a439b9371d2c6d380c86aed591
-  md5: ab049f8223bccc6f621975beaa75c624
-  depends:
-  - alsa-lib >=1.2.10,<1.3.0.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 118203
-  timestamp: 1693868376750
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h63175ca_9
-  build_number: 9
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
-  sha256: 5f5cf0c24075e9006c96537c885342f24a8c4f4408e994bfe1a63a2ae2528f13
-  md5: 62046084688064857ae9152cefd10abf
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 152179
-  timestamp: 1693868652380
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h7c63dc7_9
-  build_number: 9
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
   sha256: c09ae032d0303abfea34c0957834538b48133b0431283852741ed3e0f66fdb36
   md5: 893f2c33af6b03cfd04820a8c31f5798
   depends:
@@ -13387,13 +9473,18 @@ packages:
   license_family: MIT
   size: 115512
   timestamp: 1693868383
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: he965462_9
-  build_number: 9
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/portaudio-19.6.0-he965462_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
+  sha256: a73e31c5fe9d717cd42470b394018f4e48eed4a439b9371d2c6d380c86aed591
+  md5: ab049f8223bccc6f621975beaa75c624
+  depends:
+  - alsa-lib >=1.2.10,<1.3.0.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 118203
+  timestamp: 1693868376750
+- conda: https://conda.anaconda.org/conda-forge/osx-64/portaudio-19.6.0-he965462_9.conda
   sha256: fa568ca8f85dc081f8ef5d84b44ca42b9886327d9c2090d46a4aabaf5a29ccb3
   md5: 433d8393c9d8aa95f38f520416c4eb27
   depends:
@@ -13402,43 +9493,27 @@ packages:
   license_family: MIT
   size: 77178
   timestamp: 1693868569418
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h00291cd_1002
-  build_number: 1002
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
-  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
-  md5: 8bcf980d2c6b17094961198284b8e862
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
+  sha256: 5ff2b55d685c29dfe632ef856796a4b862305088543d4982f0b807e8d9bb756e
+  md5: d325d46394b6c46d15718c855fb20b4a
   depends:
-  - __osx >=10.13
+  - libcxx >=15.0.7
   license: MIT
   license_family: MIT
-  size: 8364
-  timestamp: 1726802331537
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h86ecc28_1002
-  build_number: 1002
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
-  sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
-  md5: bb5a90c93e3bac3d5690acf76b4a6386
+  size: 78863
+  timestamp: 1693868663440
+- conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
+  sha256: 5f5cf0c24075e9006c96537c885342f24a8c4f4408e994bfe1a63a2ae2528f13
+  md5: 62046084688064857ae9152cefd10abf
   depends:
-  - libgcc >=13
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 8342
-  timestamp: 1726803319942
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hb9d3cd8_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  size: 152179
+  timestamp: 1693868652380
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
   depends:
@@ -13448,13 +9523,25 @@ packages:
   license_family: MIT
   size: 8252
   timestamp: 1726802366959
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hd74edd7_1002
-  build_number: 1002
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+  sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+  md5: bb5a90c93e3bac3d5690acf76b4a6386
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8342
+  timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
   sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
   md5: 415816daf82e0b23a736a069a75e9da7
   depends:
@@ -13463,13 +9550,7 @@ packages:
   license_family: MIT
   size: 8381
   timestamp: 1726802424786
-- kind: conda
-  name: pthreads-win32
-  version: 2.9.1
-  build: h2466b09_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
   sha256: b989bdcf0a22ba05a238adac1ad3452c11871681f565e509f629e225a26b7d45
   md5: cf98a67a1ec8040b42455002a24f0b0b
   depends:
@@ -13479,41 +9560,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 265827
   timestamp: 1728400965968
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h13dd4ca_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
-  sha256: 0bfeac4f1a374da9ff0a322344cdab577d397d6a0a0e5591f08cb7b491926825
-  md5: 4de774bb04e03af9704ec1a2618c636c
-  depends:
-  - libcxx >=15.0.7
-  license: MIT
-  license_family: MIT
-  size: 92472
-  timestamp: 1696182843052
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
-  sha256: 4f37f0a94bb465157e66f1a38ac1843f223db72b80c5e6a87ff354219ee86037
-  md5: 9af93a191056b12e841b7d32f1b01b1c
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 110831
-  timestamp: 1696182637281
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
   sha256: ea5f2d593177318f6b19af05018c953f41124cbb3bf21f9fdedfdb6ac42913ae
   md5: 2c97dd90633508b422c11bd3018206ab
   depends:
@@ -13523,12 +9570,35 @@ packages:
   license_family: MIT
   size: 114871
   timestamp: 1696182708943
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+  sha256: 4f37f0a94bb465157e66f1a38ac1843f223db72b80c5e6a87ff354219ee86037
+  md5: 9af93a191056b12e841b7d32f1b01b1c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 110831
+  timestamp: 1696182637281
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
+  sha256: 8ba30eb9ead058a19a472bb8e795ab408c629b0b84fc5bb7b6899e7429d5e625
+  md5: 92f9416f48c010bf04c34c9841c84b09
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 94175
+  timestamp: 1696182807580
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
+  sha256: 0bfeac4f1a374da9ff0a322344cdab577d397d6a0a0e5591f08cb7b491926825
+  md5: 4de774bb04e03af9704ec1a2618c636c
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 92472
+  timestamp: 1696182843052
+- conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
   sha256: 68a5cb9a7560b2ce0d72ccebc7f6623e13ca66a67f80feb1094a75199bd1a50c
   md5: 6794ab7a1f26ebfe0452297eba029d4f
   depends:
@@ -13539,46 +9609,7 @@ packages:
   license_family: MIT
   size: 111324
   timestamp: 1696182979614
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: he965462_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
-  sha256: 8ba30eb9ead058a19a472bb8e795ab408c629b0b84fc5bb7b6899e7429d5e625
-  md5: 92f9416f48c010bf04c34c9841c84b09
-  depends:
-  - libcxx >=15.0.7
-  license: MIT
-  license_family: MIT
-  size: 94175
-  timestamp: 1696182807580
-- kind: conda
-  name: pulseaudio-client
-  version: '17.0'
-  build: h729494f_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
-  sha256: 209eac3123ee2c84a35401626941c4aa64e04e2c9854084ddeba6432c6078a41
-  md5: f35f57712d5c2abca98c85a51a408bc1
-  depends:
-  - dbus >=1.13.6,<2.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.3,<3.0a0
-  - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=255
-  constrains:
-  - pulseaudio 17.0 *_0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 766184
-  timestamp: 1705690164726
-- kind: conda
-  name: pulseaudio-client
-  version: '17.0'
-  build: hb77b528_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
   sha256: b27c0c8671bd95c205a61aeeac807c095b60bc76eb5021863f919036d7a964fc
   md5: 07f45f1be1c25345faddb8db0de8039b
   depends:
@@ -13593,14 +9624,22 @@ packages:
   license_family: LGPL
   size: 757633
   timestamp: 1705690081905
-- kind: conda
-  name: pybind11
-  version: 2.13.6
-  build: pyh085cc03_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
+  sha256: 209eac3123ee2c84a35401626941c4aa64e04e2c9854084ddeba6432c6078a41
+  md5: f35f57712d5c2abca98c85a51a408bc1
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=255
+  constrains:
+  - pulseaudio 17.0 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 766184
+  timestamp: 1705690164726
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyh085cc03_1.conda
   sha256: fbcf9f6dfaf4877afe64f3b8a3eb848bfe896ef98b4b3761542cd08095f3d0a0
   md5: 7b029bb9de2902139df04ddb0477713b
   depends:
@@ -13612,14 +9651,7 @@ packages:
   license_family: BSD
   size: 185569
   timestamp: 1729256651326
-- kind: conda
-  name: pybind11-global
-  version: 2.13.6
-  build: pyh085cc03_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh085cc03_1.conda
   sha256: 4ba255f3aa2d72fcc992d1a8939a758d045f4d2ac946feabc6ce85fb6b2507aa
   md5: 9092fb5f6e54792440ced2323da305e7
   depends:
@@ -13630,40 +9662,8 @@ packages:
   license_family: BSD
   size: 181129
   timestamp: 1729256629202
-- kind: conda
-  name: python
-  version: 3.11.10
-  build: ha513fb2_3_cpython
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
   build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
-  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
-  md5: 1a88c32ab9e997380ba1f9306624f805
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 15442415
-  timestamp: 1729043110107
-- kind: conda
-  name: python
-  version: 3.11.10
-  build: hc5c86c4_3_cpython
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
   sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
   md5: 9e1ad55c87368e662177661a998feed5
   depends:
@@ -13689,12 +9689,7 @@ packages:
   license: Python-2.0
   size: 30543977
   timestamp: 1729043512711
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: h5d932e8_0_cpython
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.7-h5d932e8_0_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.7-h5d932e8_0_cpython.conda
   sha256: 25570873d92d4d9490c6db780cc85e6c28bd3ff61dc1ece79f602cf82bc73bc1
   md5: e6cab21bb5787270388939cf41cc5f43
   depends:
@@ -13719,12 +9714,29 @@ packages:
   license: Python-2.0
   size: 13762126
   timestamp: 1728057461028
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: h739c21a_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+  build_number: 3
+  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
+  md5: 1a88c32ab9e997380ba1f9306624f805
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15442415
+  timestamp: 1729043110107
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
   sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
   md5: e0d82e57ebb456077565e6d82cd4a323
   depends:
@@ -13745,12 +9757,7 @@ packages:
   license: Python-2.0
   size: 12975439
   timestamp: 1728057819519
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: hce54a09_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
   sha256: 2308cfa9ec563360d29ced7fd13a6b60b9a7b3cf8961a95c78c69f486211d018
   md5: 21f1f7c6ccf6b747c5086d2422c230e1
   depends:
@@ -13771,13 +9778,8 @@ packages:
   license: Python-2.0
   size: 15987537
   timestamp: 1728057382072
-- kind: conda
-  name: python_abi
-  version: '3.11'
-  build: 5_cp311
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
   md5: 139a8d40c8a2f430df31048949e450de
   constrains:
@@ -13786,28 +9788,8 @@ packages:
   license_family: BSD
   size: 6211
   timestamp: 1723823324668
-- kind: conda
-  name: python_abi
-  version: '3.11'
-  build: 5_cp311
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
-  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
-  md5: e6d62858c06df0be0e6255c753d74787
-  constrains:
-  - python 3.11.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6303
-  timestamp: 1723823062672
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
   sha256: 5ccdad9981753cc4a2d126e356673a21c0cd5b34e209cb8d476a3947d4ad9b39
   md5: 62b20f305498284a07dc6c45fd0e5c87
   constrains:
@@ -13816,13 +9798,18 @@ packages:
   license_family: BSD
   size: 6329
   timestamp: 1723823366253
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
   build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+  build_number: 5
   sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
   md5: b76f9b1c862128e56ac7aa8cd2333de9
   constrains:
@@ -13831,13 +9818,8 @@ packages:
   license_family: BSD
   size: 6278
   timestamp: 1723823099686
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
   sha256: 9486662af81a219e96d343449eff242f38d7c5128ced5ce5acf85857265058d6
   md5: e8681f534453af7afab4cd2bc1423eec
   constrains:
@@ -13846,76 +9828,7 @@ packages:
   license_family: BSD
   size: 6730
   timestamp: 1723823139725
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h07d6d3d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.15-h07d6d3d_0.conda
-  sha256: 1776e3acf620e01c15164d02816ff7fba2332b1d3155921345186790d669c54e
-  md5: 525048cba1b5aa9c88c56e093b743ac9
-  depends:
-  - __osx >=10.13
-  - gst-plugins-base >=1.24.7,<1.25.0a0
-  - gstreamer >=1.24.7,<1.25.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp17 >=17.0.6,<17.1.0a0
-  - libclang13 >=17.0.6
-  - libcxx >=17
-  - libglib >=2.82.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm17 >=17.0.6,<17.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libpq >=16.4,<17.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-libs >=9.0.1,<9.1.0a0
-  - nspr >=4.36,<5.0a0
-  - nss >=3.106,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - qt 5.15.15
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 46035885
-  timestamp: 1729903901466
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h264fbc2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
-  sha256: 77c78ce62e5c53ed529f035535283b96ee617ffd64ae1ea6a2dfdea186e39608
-  md5: e6e473c620bc0c3772dbed14f9eb4ab2
-  depends:
-  - gst-plugins-base >=1.24.7,<1.25.0a0
-  - gstreamer >=1.24.7,<1.25.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang13 >=19.1.2
-  - libglib >=2.82.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - qt 5.15.15
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 60059195
-  timestamp: 1729904868434
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h374914d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
   sha256: 333be9817b492b7303d3a01073d3cff71719e72ba11507141ddfdd89732dc7a8
   md5: 26e8b00e73c114c9b787d36edcbf4424
   depends:
@@ -13974,12 +9887,7 @@ packages:
   license_family: LGPL
   size: 52549288
   timestamp: 1729904847636
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h3c8598d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
   sha256: efe565fbe7f0b0c39f3c179d383a8a3f39582934e225775927b9c05c9b9792ea
   md5: 2b6e3e9f306565824c25f64df8953f39
   depends:
@@ -14036,12 +9944,36 @@ packages:
   license: LGPL-3.0-only
   size: 51848391
   timestamp: 1729887971802
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h7d33341_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h7d33341_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.15-h07d6d3d_0.conda
+  sha256: 1776e3acf620e01c15164d02816ff7fba2332b1d3155921345186790d669c54e
+  md5: 525048cba1b5aa9c88c56e093b743ac9
+  depends:
+  - __osx >=10.13
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp17 >=17.0.6,<17.1.0a0
+  - libclang13 >=17.0.6
+  - libcxx >=17
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libllvm17 >=17.0.6,<17.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=16.4,<17.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.106,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 46035885
+  timestamp: 1729903901466
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h7d33341_0.conda
   sha256: 995563c7c2ae112179cb1cec67837af1624234a1e39e1ca86f6b5de44cbc6af8
   md5: 065abdbfa76bdb7b89cee314a594055e
   depends:
@@ -14070,12 +10002,32 @@ packages:
   license_family: LGPL
   size: 50010318
   timestamp: 1729905112196
-- kind: conda
-  name: qt6-main
-  version: 6.7.3
-  build: h20baabe_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
+  sha256: 77c78ce62e5c53ed529f035535283b96ee617ffd64ae1ea6a2dfdea186e39608
+  md5: e6e473c620bc0c3772dbed14f9eb4ab2
+  depends:
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=19.1.2
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 60059195
+  timestamp: 1729904868434
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
   sha256: ea392f29b89505f878f4654f297674cd18a068abba764fd9b84802804ba97d23
   md5: 1b22804cf94e520ff2bafc0a908dd6a4
   depends:
@@ -14132,13 +10084,7 @@ packages:
   license_family: LGPL
   size: 47296097
   timestamp: 1727454717035
-- kind: conda
-  name: qt6-main
-  version: 6.7.3
-  build: hfb098fa_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_1.conda
   sha256: c10933396b409f74f05fe7036ddf2b129e219dd3939170c3ebb0fd0790cd14ac
   md5: 3dd4b78a610e48def640c3c9acd0c7e7
   depends:
@@ -14166,13 +10112,7 @@ packages:
   license_family: LGPL
   size: 88587578
   timestamp: 1727941590323
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8228510_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4
   depends:
@@ -14182,13 +10122,7 @@ packages:
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8fc344f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
   sha256: 4c99f7417419734e3797d45bc355e61c26520e111893b0d7087a01a7fbfbe3dd
   md5: 105eb1e16bf83bfb2eb380a48032b655
   depends:
@@ -14198,28 +10132,7 @@ packages:
   license_family: GPL
   size: 294092
   timestamp: 1679532238805
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h92ec313_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
-  md5: 8cbb776a2f641b943d413b3e19df71f4
-  depends:
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 250351
-  timestamp: 1679532511311
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h9e318b2_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
   sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
   md5: f17f77f2acf4d344734bda76829ce14e
   depends:
@@ -14228,54 +10141,16 @@ packages:
   license_family: GPL
   size: 255870
   timestamp: 1679532707590
-- kind: conda
-  name: rhash
-  version: 1.4.5
-  build: h7ab814d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.5-h7ab814d_0.conda
-  sha256: e6a3e9dbfcb5ad5d69a20c8ac237d37a282a95983314a28912fc54208c5db391
-  md5: 352b210f81798ae1e2f25a98ef4b3b54
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
   depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 177240
-  timestamp: 1728886815751
-- kind: conda
-  name: rhash
-  version: 1.4.5
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.5-h86ecc28_0.conda
-  sha256: 82f3555c8f4fa76faf111622766457a8d17755bf493c0ac72ee59f4dad71d994
-  md5: 93bac703d92dafc337db454e6e93a520
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 201958
-  timestamp: 1728886717057
-- kind: conda
-  name: rhash
-  version: 1.4.5
-  build: ha44c9a9_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.5-ha44c9a9_0.conda
-  sha256: 8680069a88f33e96046cf09c3c973074976064c5f13c282bf0e6d6a798f4f7ab
-  md5: a7a3324229bba7fd1c06bcbbb26a420a
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 178400
-  timestamp: 1728886821902
-- kind: conda
-  name: rhash
-  version: 1.4.5
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.5-hb9d3cd8_0.conda
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.5-hb9d3cd8_0.conda
   sha256: 04677caac29ec64a5d41d0cca8dbec5f60fa166d5458ff5a4393e4dc08a4799e
   md5: 9af0e7981755f09c81421946c4bcea04
   depends:
@@ -14285,13 +10160,72 @@ packages:
   license_family: MIT
   size: 186921
   timestamp: 1728886721623
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.5-h86ecc28_0.conda
+  sha256: 82f3555c8f4fa76faf111622766457a8d17755bf493c0ac72ee59f4dad71d994
+  md5: 93bac703d92dafc337db454e6e93a520
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 201958
+  timestamp: 1728886717057
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.5-ha44c9a9_0.conda
+  sha256: 8680069a88f33e96046cf09c3c973074976064c5f13c282bf0e6d6a798f4f7ab
+  md5: a7a3324229bba7fd1c06bcbbb26a420a
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 178400
+  timestamp: 1728886821902
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.5-h7ab814d_0.conda
+  sha256: e6a3e9dbfcb5ad5d69a20c8ac237d37a282a95983314a28912fc54208c5db391
+  md5: 352b210f81798ae1e2f25a98ef4b3b54
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 177240
+  timestamp: 1728886815751
+- conda: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
+  sha256: 242a98d006cb6056ada72553b856d89c3965f1f76ee96aaeac1020922ae5fffb
+  md5: 3e26d7c5a6e543cd83264ac70df92b6b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 185412
+  timestamp: 1674116888665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
+  sha256: 326bdaab98b2f68f0b5b83e5b022fff50fa49ded1e959a1c9b00e378aa6ff2e2
+  md5: d186a8ab75c012d89f274cc903b17182
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 181367
+  timestamp: 1674116967037
+- conda: https://conda.anaconda.org/conda-forge/osx-64/robot-testing-framework-2.0.1-hf0c8a7f_1.conda
+  sha256: abf91531f35526083b3d3656f56b38084be5069eb53a2431be70632c915b4b29
+  md5: 4b729ac0107d659584848764ab16ad2b
+  depends:
+  - libcxx >=14.0.6
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 186609
+  timestamp: 1674117260864
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
+  sha256: b9e1e7c27b0c3559691921d07a6cdb1b57d2bea575cce2939401f3c643a2a1cc
+  md5: f94db447c6bd18a0a22087dd897e400c
+  depends:
+  - libcxx >=14.0.6
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 181170
+  timestamp: 1674117151771
+- conda: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
   sha256: 5552242dd9b16126fb19bbece630d1a7184e44ab5a9b40f2fb6d11472006ccce
   md5: fc8684b4e2e739e6dc3d33b5863c64a5
   depends:
@@ -14302,74 +10236,49 @@ packages:
   license: LGPL-2.1-or-later
   size: 229485
   timestamp: 1674117166712
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
-  sha256: b9e1e7c27b0c3559691921d07a6cdb1b57d2bea575cce2939401f3c643a2a1cc
-  md5: f94db447c6bd18a0a22087dd897e400c
-  depends:
-  - libcxx >=14.0.6
-  - tinyxml
-  license: LGPL-2.1-or-later
-  size: 181170
-  timestamp: 1674117151771
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
-  sha256: 242a98d006cb6056ada72553b856d89c3965f1f76ee96aaeac1020922ae5fffb
-  md5: 3e26d7c5a6e543cd83264ac70df92b6b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
+  sha256: 794978a95605128144fc14c193eae1abf79524dafe34d9ef36aa5d6ba40ff7bb
+  md5: 53326ff6864578787913ba15616ad2f9
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - tinyxml
-  license: LGPL-2.1-or-later
-  size: 185412
-  timestamp: 1674116888665
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hd600fc2_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
-  sha256: 326bdaab98b2f68f0b5b83e5b022fff50fa49ded1e959a1c9b00e378aa6ff2e2
-  md5: d186a8ab75c012d89f274cc903b17182
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156115
+  timestamp: 1695759535287
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
+  sha256: 7c6efceabfb742aa84cd745dd5e3cf24d9ee7167ee3851c99b29425faf21fd1c
+  md5: 2beaa8269df50204969ed14432cec69e
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - tinyxml
-  license: LGPL-2.1-or-later
-  size: 181367
-  timestamp: 1674116967037
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hf0c8a7f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/robot-testing-framework-2.0.1-hf0c8a7f_1.conda
-  sha256: abf91531f35526083b3d3656f56b38084be5069eb53a2431be70632c915b4b29
-  md5: 4b729ac0107d659584848764ab16ad2b
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 159244
+  timestamp: 1695759461200
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
+  sha256: ae5d633048e1f8e77a3e57153f7a97982045cf6961e03e301d324797aefeb6d3
+  md5: 4c5c936fe91d3302ff62f99fee1057f3
   depends:
-  - libcxx >=14.0.6
-  - tinyxml
-  license: LGPL-2.1-or-later
-  size: 186609
-  timestamp: 1674117260864
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: h21dd15a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
+  - libcxx >=15.0.7
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 157071
+  timestamp: 1695759772225
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
+  sha256: 7f1e0d3e765a629852f00aef8a66a23ac98d2251efdb18073239d8e76493e14a
+  md5: 3f2b68e7acdffc200fea7b801be0ed36
+  depends:
+  - libcxx >=15.0.7
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156067
+  timestamp: 1695759902673
+- conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
   sha256: 6db7e8853bf7b2ed45c987c927ee4190d0255f914c9cd135693a169416bef727
   md5: 695be37cf7e9d14a14ec5f79ef1ffc6b
   depends:
@@ -14381,91 +10290,7 @@ packages:
   license_family: BSD
   size: 151281
   timestamp: 1695760016129
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: h293081c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
-  sha256: 794978a95605128144fc14c193eae1abf79524dafe34d9ef36aa5d6ba40ff7bb
-  md5: 53326ff6864578787913ba15616ad2f9
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 156115
-  timestamp: 1695759535287
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: h32cd00b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
-  sha256: 7c6efceabfb742aa84cd745dd5e3cf24d9ee7167ee3851c99b29425faf21fd1c
-  md5: 2beaa8269df50204969ed14432cec69e
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 159244
-  timestamp: 1695759461200
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: hce1cd6f_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
-  sha256: ae5d633048e1f8e77a3e57153f7a97982045cf6961e03e301d324797aefeb6d3
-  md5: 4c5c936fe91d3302ff62f99fee1057f3
-  depends:
-  - libcxx >=15.0.7
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 157071
-  timestamp: 1695759772225
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: hfc12253_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
-  sha256: 7f1e0d3e765a629852f00aef8a66a23ac98d2251efdb18073239d8e76493e14a
-  md5: 3f2b68e7acdffc200fea7b801be0ed36
-  depends:
-  - libcxx >=15.0.7
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 156067
-  timestamp: 1695759902673
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: h2a74887_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
-  sha256: 6c21954d98a915d7617c0944440167e5ac695117ca7410f37eea4af0a9f0821c
-  md5: 719245709dd47dbc3f93ce85fa544f43
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1317383
-  timestamp: 1725255076176
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: h3ed165c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
   sha256: 80691a3ce313f0f7908480c0af216520d655e9480e036feb489c2095ad37950a
   md5: be75875082c99c7a9f9fe930a1bd2bb1
   depends:
@@ -14478,12 +10303,19 @@ packages:
   license: Zlib
   size: 1391142
   timestamp: 1725255009793
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: hac325c4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.7-hac325c4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
+  sha256: 6c21954d98a915d7617c0944440167e5ac695117ca7410f37eea4af0a9f0821c
+  md5: 719245709dd47dbc3f93ce85fa544f43
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1317383
+  timestamp: 1725255076176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.7-hac325c4_0.conda
   sha256: b2785777b22ff8a883210f81c4e6a14f0c4f4ab83595ddef6f0d8560fa4ecc0a
   md5: 9e4fe70a7b62b7c82a06bfd5b5af48e1
   depends:
@@ -14492,12 +10324,16 @@ packages:
   license: Zlib
   size: 1232457
   timestamp: 1725255027620
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
+  sha256: d86b4f39c09efb6febd5e2e5a2c0894c82f7ac4b8b4aebb24e4fbd9acf797d60
+  md5: 33f5451441cbc0ce083b3d37c181519e
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: Zlib
+  size: 1256184
+  timestamp: 1725254933792
+- conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
   sha256: bf850eba90ff5103c2a92d3ab0395edd078b7c95cbabc4254462d9bea7850c48
   md5: e452497e0b9824c0be7f6670adbabc63
   depends:
@@ -14507,40 +10343,7 @@ packages:
   license: Zlib
   size: 2243873
   timestamp: 1725255268158
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
-  sha256: d86b4f39c09efb6febd5e2e5a2c0894c82f7ac4b8b4aebb24e4fbd9acf797d60
-  md5: 33f5451441cbc0ce083b3d37c181519e
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: Zlib
-  size: 1256184
-  timestamp: 1725254933792
-- kind: conda
-  name: sigtool
-  version: 0.1.3
-  build: h44b9a77_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
-  sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
-  md5: 4a2cac04f86a4540b8c9b8d8f597848f
-  depends:
-  - openssl >=3.0.0,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 210264
-  timestamp: 1643442231687
-- kind: conda
-  name: sigtool
-  version: 0.1.3
-  build: h88f4db0_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
   sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
   md5: fbfb84b9de9a6939cb165c02c69b1865
   depends:
@@ -14549,12 +10352,26 @@ packages:
   license_family: MIT
   size: 213817
   timestamp: 1643442169866
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: h1088aeb_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+  sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
+  md5: 4a2cac04f86a4540b8c9b8d8f597848f
+  depends:
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 210264
+  timestamp: 1643442231687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
   sha256: 79f5d0a9098acf2ed16e6ecc4c11472b50ccf59feea37a7d585fd43888d7e41f
   md5: e4ed5b015f525b56f95c26d85a4ea208
   depends:
@@ -14564,12 +10381,27 @@ packages:
   license_family: BSD
   size: 42888
   timestamp: 1720003817527
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: h23299a8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
   sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
   md5: 7635a408509e20dcfc7653ca305ad799
   depends:
@@ -14580,58 +10412,7 @@ packages:
   license_family: BSD
   size: 59350
   timestamp: 1720004197144
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: ha2e4443_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
-  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
-  md5: 6b7dcc7349efd123d493d2dbe85a045f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 42465
-  timestamp: 1720003704360
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: hd02b534_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
-  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
-  md5: 69d0f9694f3294418ee935da3d5f7272
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 35708
-  timestamp: 1720003794374
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: he1e6707_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
-  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
-  md5: ddceef5df973c8ff7d6b32353c0cb358
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 37036
-  timestamp: 1720003862906
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: h0b41bf4_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
   sha256: 141e3364d26f162bfeae8491787c0d8796ada6c29a8cd567c1cd17c3c6b418f9
   md5: e8d261785be19b1575d23ccbbeae4ddd
   depends:
@@ -14640,27 +10421,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 131370
   timestamp: 1674059502792
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: h5008568_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
-  sha256: b3028eab2df50ebfbfbf7e21074d4862a8aa12867272ae363c0b415c6119ebe7
-  md5: 02fbc2cdd53ed18f8a4dbf36125d8b7d
-  depends:
-  - llvm-openmp >=14.0.6
-  license: LGPL-2.1-or-later
-  size: 90088
-  timestamp: 1674122598089
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: hb4cce97_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
   sha256: 58b006195863f200efdb5785a4a954f8d0284b5984703d4d74ec4c09343e58e2
   md5: 13e1d5bd316dec4077351f4246b9b2a8
   depends:
@@ -14669,13 +10430,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 111209
   timestamp: 1674059588618
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: hbf74d83_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/soxr-0.1.3-hbf74d83_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/soxr-0.1.3-hbf74d83_3.conda
   sha256: d274add245e2f9f1b8963533d08ce0761baa78c7923d0c8450ad54d7b2885e77
   md5: 27b06405f0b654997e5bda2b33e5e2e7
   depends:
@@ -14683,13 +10438,15 @@ packages:
   license: LGPL-2.1-or-later
   size: 127934
   timestamp: 1674059732818
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: hcfcfb64_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
+  sha256: b3028eab2df50ebfbfbf7e21074d4862a8aa12867272ae363c0b415c6119ebe7
+  md5: 02fbc2cdd53ed18f8a4dbf36125d8b7d
+  depends:
+  - llvm-openmp >=14.0.6
+  license: LGPL-2.1-or-later
+  size: 90088
+  timestamp: 1674122598089
+- conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
   sha256: 167201931c6be6355fa79e22fe5b8993f67a2efd0fc94acbb15393918d9a7578
   md5: 8112bd0d3eb530551b2adebda0ea4c0c
   depends:
@@ -14699,12 +10456,7 @@ packages:
   license: LGPL-2.1-or-later
   size: 112328
   timestamp: 1674059996047
-- kind: conda
-  name: svt-av1
-  version: 2.2.1
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.2.1-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.2.1-h5888daf_0.conda
   sha256: a1c197ea17dac43ad6c223e42d78726b9f37f31f63d65e0c062e418cb98c7a8f
   md5: 0d9c441855be3d8dfdb2e800fe755059
   depends:
@@ -14715,12 +10467,7 @@ packages:
   license_family: BSD
   size: 2404332
   timestamp: 1724459503486
-- kind: conda
-  name: svt-av1
-  version: 2.2.1
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.2.1-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.2.1-h5ad3122_0.conda
   sha256: f8b36c7a715b5069a802502e3cae788dd2ef2ec29d09dfa28a5c81265d7649d7
   md5: 8c8509c168215d15d790fb5ad5c2e69a
   depends:
@@ -14730,27 +10477,7 @@ packages:
   license_family: BSD
   size: 1769578
   timestamp: 1724459367826
-- kind: conda
-  name: svt-av1
-  version: 2.2.1
-  build: ha39b806_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.2.1-ha39b806_0.conda
-  sha256: 4199d3344d4f305e2d9c5f2fd58d4ac744b08565ee0ea8c08944e3fc9129ad76
-  md5: b2761a20146810d3c03380576ae5c4fb
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1326484
-  timestamp: 1724459521607
-- kind: conda
-  name: svt-av1
-  version: 2.2.1
-  build: hac325c4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.2.1-hac325c4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.2.1-hac325c4_0.conda
   sha256: 9e229a7e34d0526c9e52bac85e3aa4c3d8c25df4f8618274bc135f9c19140a5d
   md5: 07799aecfd86318fa5b4c5202b7acdce
   depends:
@@ -14760,12 +10487,17 @@ packages:
   license_family: BSD
   size: 2153628
   timestamp: 1724459465920
-- kind: conda
-  name: svt-av1
-  version: 2.2.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.2.1-ha39b806_0.conda
+  sha256: 4199d3344d4f305e2d9c5f2fd58d4ac744b08565ee0ea8c08944e3fc9129ad76
+  md5: b2761a20146810d3c03380576ae5c4fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1326484
+  timestamp: 1724459521607
+- conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
   sha256: 79985e6ea3e93f8e6a71f06dbe7ca1f5f61c1948b7a45d1d5ac7e71f46461cad
   md5: c34bbf7ec0696702f361d1c791ed3246
   depends:
@@ -14776,77 +10508,7 @@ packages:
   license_family: BSD
   size: 1704957
   timestamp: 1724459941490
-- kind: conda
-  name: swig
-  version: 4.3.0
-  build: h051d1ac_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.3.0-h051d1ac_0.conda
-  sha256: 40093468f8983fe331d8a4e8e631a8dbcee0167edcbb2f68aef6db2ab68aa816
-  md5: 2a8e52dc5014460dc890041d31f79f93
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - pcre2 >=10.44,<10.45.0a0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1113443
-  timestamp: 1729589137221
-- kind: conda
-  name: swig
-  version: 4.3.0
-  build: h05d4bff_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/swig-4.3.0-h05d4bff_0.conda
-  sha256: 5d1accf5609d7152c8ee0961b7a83aa73519866f549e4e75aa0b8e2fe365db65
-  md5: e977150e8f2dd12aa3fa3c94c87e5b8f
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - pcre2 >=10.44,<10.45.0a0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1160596
-  timestamp: 1729589065015
-- kind: conda
-  name: swig
-  version: 4.3.0
-  build: h2f4baa9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.3.0-h2f4baa9_0.conda
-  sha256: 50b8b93bd1cef4451c6a659f59ad48ca886990f1123a71dbe54c49562f64ac30
-  md5: 3004200698c3e9599b255fb357628f48
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - pcre2 >=10.44,<10.45.0a0
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1299652
-  timestamp: 1729589010660
-- kind: conda
-  name: swig
-  version: 4.3.0
-  build: h51fbe9b_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.0-h51fbe9b_0.conda
-  sha256: b6f66e27dac7799a844e530f2b946713223106b8df66c809a6dda4a96ae68ba3
-  md5: f076cd8282f1c164e57990a1daf70fd1
-  depends:
-  - pcre2 >=10.44,<10.45.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1079944
-  timestamp: 1729589112085
-- kind: conda
-  name: swig
-  version: 4.3.0
-  build: heed6a68_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/swig-4.3.0-heed6a68_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.3.0-heed6a68_0.conda
   sha256: 4771f7a2323d7f3c4d42b1c8ed670335ede7e78b80d8ba17d3c40b781dedcbdc
   md5: 0e4da15e507b716140699aca1a279a88
   depends:
@@ -14858,14 +10520,52 @@ packages:
   license_family: GPL
   size: 1248414
   timestamp: 1729588950292
-- kind: conda
-  name: sysroot_linux-64
-  version: '2.17'
-  build: h4a8ded7_18
-  build_number: 18
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.3.0-h2f4baa9_0.conda
+  sha256: 50b8b93bd1cef4451c6a659f59ad48ca886990f1123a71dbe54c49562f64ac30
+  md5: 3004200698c3e9599b255fb357628f48
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - pcre2 >=10.44,<10.45.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 1299652
+  timestamp: 1729589010660
+- conda: https://conda.anaconda.org/conda-forge/osx-64/swig-4.3.0-h05d4bff_0.conda
+  sha256: 5d1accf5609d7152c8ee0961b7a83aa73519866f549e4e75aa0b8e2fe365db65
+  md5: e977150e8f2dd12aa3fa3c94c87e5b8f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - pcre2 >=10.44,<10.45.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 1160596
+  timestamp: 1729589065015
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.3.0-h051d1ac_0.conda
+  sha256: 40093468f8983fe331d8a4e8e631a8dbcee0167edcbb2f68aef6db2ab68aa816
+  md5: 2a8e52dc5014460dc890041d31f79f93
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - pcre2 >=10.44,<10.45.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 1113443
+  timestamp: 1729589137221
+- conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.0-h51fbe9b_0.conda
+  sha256: b6f66e27dac7799a844e530f2b946713223106b8df66c809a6dda4a96ae68ba3
+  md5: f076cd8282f1c164e57990a1daf70fd1
+  depends:
+  - pcre2 >=10.44,<10.45.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 1079944
+  timestamp: 1729589112085
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
   sha256: 23c7ab371c1b74d01a187e05aa7240e3f5654599e364a9adff7f0b02e26f471f
   md5: 0ea96f90a10838f58412aa84fdd9df09
   depends:
@@ -14875,14 +10575,7 @@ packages:
   license_family: GPL
   size: 15500960
   timestamp: 1729794510631
-- kind: conda
-  name: sysroot_linux-aarch64
-  version: '2.17'
-  build: h5b4a56d_18
-  build_number: 18
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_18.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_18.conda
   sha256: 769a720e0066e3b5c4168d6de455dbde12c2ee11ee3a19fc614659d04f726370
   md5: d42f4bece921c5e59f56a36414106dc1
   depends:
@@ -14892,28 +10585,7 @@ packages:
   license_family: GPL
   size: 15669544
   timestamp: 1729794509305
-- kind: conda
-  name: tapi
-  version: 1300.6.5
-  build: h03f4b80_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
-  sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
-  md5: b703bc3e6cba5943acf0e5f987b5d0e2
-  depends:
-  - __osx >=11.0
-  - libcxx >=17.0.0.a0
-  - ncurses >=6.5,<7.0a0
-  license: NCSA
-  license_family: MIT
-  size: 207679
-  timestamp: 1725491499758
-- kind: conda
-  name: tapi
-  version: 1300.6.5
-  build: h390ca13_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
   sha256: f97372a1c75b749298cb990405a690527e8004ff97e452ed2c59e4bc6a35d132
   md5: c6ee25eb54accb3f1c8fc39203acfaf1
   depends:
@@ -14924,60 +10596,18 @@ packages:
   license_family: MIT
   size: 221236
   timestamp: 1725491044729
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: h17cf362_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.13.0-h17cf362_0.conda
-  sha256: 7961f725106210e904741a5668cb2f4ad975d337c4dad1810bf7adee299a6a78
-  md5: dc63ae8c472c97bccc9607ece78116db
-  depends:
-  - libgcc >=13
-  - libhwloc >=2.11.1,<2.11.2.0a0
-  - libstdcxx >=13
-  license: Apache-2.0
-  license_family: APACHE
-  size: 143697
-  timestamp: 1725533999201
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: h37c8870_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-h37c8870_0.conda
-  sha256: 9a20a60ebf743f99e38a7be049f8ca90f264851c13dc8cb41eb09d854a631e31
-  md5: 89742f5ac7aeb5c44ec2b4c3c6692c3c
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - libhwloc >=2.11.1,<2.11.2.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 159453
-  timestamp: 1725532728568
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: h7b3277c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
-  sha256: 4a16118d5f71da9e8177921be996da87112a55fe53a700ab5dffe14ae2b6ecba
-  md5: a8a0feb11d51d4a0a2e56fbd53c628cf
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+  sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
+  md5: b703bc3e6cba5943acf0e5f987b5d0e2
   depends:
   - __osx >=11.0
-  - libcxx >=17
-  - libhwloc >=2.11.1,<2.11.2.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 115213
-  timestamp: 1725532720037
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: h84d6215_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
+  license: NCSA
+  license_family: MIT
+  size: 207679
+  timestamp: 1725491499758
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
   sha256: 7d4d3ad608dc6ae5a7e0f431f784985398a18bcde2ba3ce19cc32f61e2defd98
   md5: ee6f7fd1e76061ef1fa307d41fa86a96
   depends:
@@ -14989,12 +10619,40 @@ packages:
   license_family: APACHE
   size: 175779
   timestamp: 1725532539822
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: hc790b64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.13.0-h17cf362_0.conda
+  sha256: 7961f725106210e904741a5668cb2f4ad975d337c4dad1810bf7adee299a6a78
+  md5: dc63ae8c472c97bccc9607ece78116db
+  depends:
+  - libgcc >=13
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 143697
+  timestamp: 1725533999201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-h37c8870_0.conda
+  sha256: 9a20a60ebf743f99e38a7be049f8ca90f264851c13dc8cb41eb09d854a631e31
+  md5: 89742f5ac7aeb5c44ec2b4c3c6692c3c
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 159453
+  timestamp: 1725532728568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
+  sha256: 4a16118d5f71da9e8177921be996da87112a55fe53a700ab5dffe14ae2b6ecba
+  md5: a8a0feb11d51d4a0a2e56fbd53c628cf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 115213
+  timestamp: 1725532720037
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
   sha256: 990dbe4fb42f14700c22bd434d8312607bf8d0bd9f922b054e51fda14c41994c
   md5: 28496a1e6af43c63927da4f80260348d
   depends:
@@ -15006,42 +10664,7 @@ packages:
   license_family: APACHE
   size: 151494
   timestamp: 1725532984828
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h260d524_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
-  sha256: ffed96f7167394be9007c1b4e2b28cf690388f9aaef0b57f0d44ad44bb247f94
-  md5: 514f487df6232e8dd819faf3c5915e58
-  depends:
-  - libcxx >=11.0.1
-  license: Zlib
-  size: 52319
-  timestamp: 1613627858183
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h2d74725_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
-  sha256: 92b01cf22522c6da6e56825692c2ae2c0dd1a1bc7251a86cdf47d5ab451cb31c
-  md5: a5c2010323ceaa8faec6697921b23928
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: Zlib
-  size: 71271
-  timestamp: 1611562303689
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h4bd325d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
   sha256: d9e3c192c535c06ec139ada7bcd1f12313ebd377208fc8149348e8534229f39e
   md5: 39dd0757ee71ccd5b120440dce126c37
   depends:
@@ -15050,27 +10673,7 @@ packages:
   license: Zlib
   size: 56535
   timestamp: 1611562094388
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h65a07b1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tinyxml-2.6.2-h65a07b1_2.tar.bz2
-  sha256: 46ab86c00bd3da363965ed7ce70568c034161bcff00b60c7b214bfc5863598c7
-  md5: f68a89c60bb5823762f1b15a2cd6ff0b
-  depends:
-  - libcxx >=11.0.1
-  license: Zlib
-  size: 52047
-  timestamp: 1613627913149
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: hd62202e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
   sha256: d7f66bd0ddfbe1b8f2638678d962140e8ab8a63d779b9366247e1f7daabeb575
   md5: 454eb4b31a1f4313c72ef7f536cae5d9
   depends:
@@ -15079,12 +10682,42 @@ packages:
   license: Zlib
   size: 56283
   timestamp: 1611562275383
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml-2.6.2-h65a07b1_2.tar.bz2
+  sha256: 46ab86c00bd3da363965ed7ce70568c034161bcff00b60c7b214bfc5863598c7
+  md5: f68a89c60bb5823762f1b15a2cd6ff0b
+  depends:
+  - libcxx >=11.0.1
+  license: Zlib
+  size: 52047
+  timestamp: 1613627913149
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
+  sha256: ffed96f7167394be9007c1b4e2b28cf690388f9aaef0b57f0d44ad44bb247f94
+  md5: 514f487df6232e8dd819faf3c5915e58
+  depends:
+  - libcxx >=11.0.1
+  license: Zlib
+  size: 52319
+  timestamp: 1613627858183
+- conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
+  sha256: 92b01cf22522c6da6e56825692c2ae2c0dd1a1bc7251a86cdf47d5ab451cb31c
+  md5: a5c2010323ceaa8faec6697921b23928
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Zlib
+  size: 71271
+  timestamp: 1611562303689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
   sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
   md5: f75105e0585851f818e0009dd1dde4dc
   depends:
@@ -15094,13 +10727,7 @@ packages:
   license_family: BSD
   size: 3351802
   timestamp: 1695506242997
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h1abcd95_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
   sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
   md5: bf830ba5afc507c6232d4ef0fb1a882d
   depends:
@@ -15109,13 +10736,7 @@ packages:
   license_family: BSD
   size: 3270220
   timestamp: 1699202389792
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5083fa2_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
   sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
   md5: b50a57ba89c32b62428b71a875291c9b
   depends:
@@ -15124,13 +10745,7 @@ packages:
   license_family: BSD
   size: 3145523
   timestamp: 1699202432999
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5226925_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
   sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
   md5: fc048363eb8f03cd1737600a5d08aafe
   depends:
@@ -15141,41 +10756,13 @@ packages:
   license_family: BSD
   size: 3503410
   timestamp: 1699202577803
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: noxft_h4845f30_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  md5: d453b98d9c83e71da0741bb0ff4d76bc
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
-- kind: conda
-  name: tzdata
-  version: 2024b
-  build: hc8b5060_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
   sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
   md5: 8ac3367aafb1cc0a068483c580af8015
   license: LicenseRef-Public-Domain
   size: 122354
   timestamp: 1728047496079
-- kind: conda
-  name: ucrt
-  version: 10.0.22621.0
-  build: h57928b3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
   sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
   md5: 6797b005cd0f439c4c5c9ac565783700
   constrains:
@@ -15183,27 +10770,7 @@ packages:
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 559710
   timestamp: 1728377334097
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: h0e2417a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
-  sha256: c23df29cd90c80f1bd599909cb8fb0281058d372324afde481687f240a7e77c7
-  md5: 466dfbfb384f10c790f48c9b4316ffb1
-  depends:
-  - libcxx >=15.0.7
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1
-  size: 253937
-  timestamp: 1691504579753
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: h661eb56_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
   sha256: 718eb807a5e6e6993ee06745cb2a25a6b353427485a6e50df01db99c6016a53f
   md5: a737e5c549c13fbb5590c581848b0446
   depends:
@@ -15214,12 +10781,7 @@ packages:
   license: LGPL-2.1
   size: 281830
   timestamp: 1691504075258
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: h7b6a552_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
   sha256: 09156b060dbfba9480bbd782ee57e4e6b324365385fb75e1ddaffb25cb79e218
   md5: 7da048d2fb224953a804da9e8026197f
   depends:
@@ -15230,12 +10792,7 @@ packages:
   license: LGPL-2.1
   size: 319756
   timestamp: 1691504019265
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: he8a5cf4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/unixodbc-2.3.12-he8a5cf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unixodbc-2.3.12-he8a5cf4_0.conda
   sha256: 048b6e6911905c413176601c6ea8ca519f57f5c12eeff297623dfcadd4012c68
   md5: ab0e676e1de2d40a2816aeda4d4edcab
   depends:
@@ -15245,13 +10802,17 @@ packages:
   license: LGPL-2.1
   size: 259234
   timestamp: 1691504490810
-- kind: conda
-  name: vc
-  version: '14.3'
-  build: ha32ba9b_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
+  sha256: c23df29cd90c80f1bd599909cb8fb0281058d372324afde481687f240a7e77c7
+  md5: 466dfbfb384f10c790f48c9b4316ffb1
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1
+  size: 253937
+  timestamp: 1691504579753
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
   sha256: 2a47c5bd8bec045959afada7063feacd074ad66b170c1ea92dd139b389fcf8fd
   md5: 311c9ba1dfdd2895a8cb08346ff26259
   depends:
@@ -15262,13 +10823,7 @@ packages:
   license_family: BSD
   size: 17447
   timestamp: 1728400826998
-- kind: conda
-  name: vc14_runtime
-  version: 14.40.33810
-  build: hcc2c482_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
   sha256: 4c669c65007f88a7cdd560192f7e6d5679d191ac71610db724e18b2410964d64
   md5: ce23a4b980ee0556a118ed96550ff3f3
   depends:
@@ -15279,13 +10834,7 @@ packages:
   license_family: Proprietary
   size: 750719
   timestamp: 1728401055788
-- kind: conda
-  name: vs2015_runtime
-  version: 14.40.33810
-  build: h3bf8584_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
   sha256: 80aa9932203d65a96f817b8be4fafc176fb2b3fe6cf6899ede678b8f0317fbff
   md5: 8c6b061d44cafdfc8e8c6eb5f100caf0
   depends:
@@ -15294,13 +10843,7 @@ packages:
   license_family: BSD
   size: 17453
   timestamp: 1728400827536
-- kind: conda
-  name: vs2019_win-64
-  version: 19.29.30139
-  build: he1865b1_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_22.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_22.conda
   sha256: d22e90a4012dae3e67c912c80ab9876eff2ba58c5735e47442ab8bcf3df8525d
   md5: 8bcfb79dfd0ca4e9bc3a645c6bd9f16a
   depends:
@@ -15313,24 +10856,14 @@ packages:
   license_family: BSD
   size: 19994
   timestamp: 1728401194337
-- kind: conda
-  name: vswhere
-  version: 3.1.7
-  build: h57928b3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
   sha256: 8caeda9c0898cb8ee2cf4f45640dbbbdf772ddc01345cfb0f7b352c58b4d8025
   md5: ba83df93b48acfc528f5464c9a882baa
   license: MIT
   license_family: MIT
   size: 219013
   timestamp: 1719460515960
-- kind: conda
-  name: wayland
-  version: 1.23.1
-  build: h3e06ad9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
   sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
   md5: 0a732427643ae5e0486a727927791da1
   depends:
@@ -15343,12 +10876,7 @@ packages:
   license_family: MIT
   size: 321561
   timestamp: 1724530461598
-- kind: conda
-  name: wayland
-  version: 1.23.1
-  build: h698ed42_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
   sha256: 71c591803459e1f68f9ad206a4f2fa3971147502bad8791e94fd18d8362f8ce6
   md5: 2661f9252065051914f1cdf5835e7430
   depends:
@@ -15360,13 +10888,7 @@ packages:
   license_family: MIT
   size: 324815
   timestamp: 1724530528414
-- kind: conda
-  name: wayland-protocols
-  version: '1.37'
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
   sha256: f6cac1efd4d2a6e30c1671f0566d4e6ac3fe2dc34c9ff7f309bbbc916520ebcf
   md5: 73ec79a77d31eb7e4a3276cd246b776c
   depends:
@@ -15375,13 +10897,7 @@ packages:
   license_family: MIT
   size: 95953
   timestamp: 1725657284103
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h166bdaf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
   md5: 6c99772d483f566d59e25037fea2c4b1
   depends:
@@ -15390,13 +10906,7 @@ packages:
   license_family: GPL
   size: 897548
   timestamp: 1660323080555
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h4e544f5_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
   sha256: b48f150db8c052c197691c9d76f59e252d3a7f01de123753d51ebf2eed1cf057
   md5: 0efaf807a0b5844ce5f605bd9b668281
   depends:
@@ -15405,39 +10915,21 @@ packages:
   license_family: GPL
   size: 1000661
   timestamp: 1660324722559
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h57fd34a_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
-  sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
-  md5: b1f6dccde5d3a1f911960b6e567113ff
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 717038
-  timestamp: 1660323292329
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h775f41a_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
   sha256: de611da29f4ed0733a330402e163f9260218e6ba6eae593a5f945827d0ee1069
   md5: 23e9c3180e2c0f9449bb042914ec2200
   license: GPL-2.0-or-later
   license_family: GPL
   size: 937077
   timestamp: 1660323305349
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h8ffe710_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+  sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
+  md5: b1f6dccde5d3a1f911960b6e567113ff
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 717038
+  timestamp: 1660323292329
+- conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
   sha256: 97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249
   md5: 19e39905184459760ccb8cf5c75f148b
   depends:
@@ -15447,29 +10939,7 @@ packages:
   license_family: GPL
   size: 1041889
   timestamp: 1660323726084
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: h2d74725_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
-  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
-  md5: ca7129a334198f08347fb19ac98a2de9
-  depends:
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 5517425
-  timestamp: 1646611941216
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: h924138e_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
   sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
   md5: e7f6ed84d4623d52ee581325c1587a6b
   depends:
@@ -15479,43 +10949,7 @@ packages:
   license_family: GPL
   size: 3357188
   timestamp: 1646609687141
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: hbb4e6a2_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
-  sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
-  md5: a3bf3e95b7795871a6734a784400fcea
-  depends:
-  - libcxx >=12.0.1
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 3433205
-  timestamp: 1646610148268
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: hbc6ce65_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
-  md5: b1f7f2780feffe310b068c021e8ff9b2
-  depends:
-  - libcxx >=12.0.1
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1832744
-  timestamp: 1646609481185
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: hdd96247_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
   sha256: cb2227f2441499900bdc0168eb423d7b2056c8fd5a3541df4e2d05509a88c668
   md5: 786853760099c74a1d4f0da98dd67aea
   depends:
@@ -15525,29 +10959,35 @@ packages:
   license_family: GPL
   size: 1018181
   timestamp: 1646610147365
-- kind: conda
-  name: xcb-util
-  version: 0.4.1
-  build: h5c728e9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
-  sha256: 59f586defd3c1295a32d8eb587036302ab254300d88e605354e8eaa4a27563ec
-  md5: b4cf8ba6cff9cdf1249bcfe1314222b0
+- conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+  sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
+  md5: a3bf3e95b7795871a6734a784400fcea
   depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 20597
-  timestamp: 1718844955591
-- kind: conda
-  name: xcb-util
-  version: 0.4.1
-  build: hb711507_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3433205
+  timestamp: 1646610148268
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
+  md5: b1f7f2780feffe310b068c021e8ff9b2
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1832744
+  timestamp: 1646609481185
+- conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 5517425
+  timestamp: 1646611941216
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
   sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
   md5: 8637c3e5821654d0edf97e2b0404b443
   depends:
@@ -15557,12 +10997,17 @@ packages:
   license_family: MIT
   size: 19965
   timestamp: 1718843348208
-- kind: conda
-  name: xcb-util-cursor
-  version: 0.1.5
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
+  sha256: 59f586defd3c1295a32d8eb587036302ab254300d88e605354e8eaa4a27563ec
+  md5: b4cf8ba6cff9cdf1249bcfe1314222b0
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 20597
+  timestamp: 1718844955591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
   sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
   md5: eb44b3b6deb1cab08d72cb61686fe64c
   depends:
@@ -15576,30 +11021,7 @@ packages:
   license_family: MIT
   size: 20296
   timestamp: 1726125844850
-- kind: conda
-  name: xcb-util-image
-  version: 0.4.0
-  build: h5c728e9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
-  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
-  md5: b82e5c78dbbfa931980e8bfe83bce913
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  license: MIT
-  license_family: MIT
-  size: 24910
-  timestamp: 1718880504308
-- kind: conda
-  name: xcb-util-image
-  version: 0.4.0
-  build: hb711507_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
   sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
   md5: a0901183f08b6c7107aab109733a3c91
   depends:
@@ -15610,27 +11032,18 @@ packages:
   license_family: MIT
   size: 24551
   timestamp: 1718880534789
-- kind: conda
-  name: xcb-util-keysyms
-  version: 0.4.1
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
-  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
-  md5: 57ca8564599ddf8b633c4ea6afee6f3a
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
+  md5: b82e5c78dbbfa931980e8bfe83bce913
   depends:
   - libgcc-ng >=12
   - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
   license: MIT
   license_family: MIT
-  size: 14343
-  timestamp: 1718846624153
-- kind: conda
-  name: xcb-util-keysyms
-  version: 0.4.1
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  size: 24910
+  timestamp: 1718880504308
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
   sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
   md5: ad748ccca349aec3e91743e08b5e2b50
   depends:
@@ -15640,27 +11053,17 @@ packages:
   license_family: MIT
   size: 14314
   timestamp: 1718846569232
-- kind: conda
-  name: xcb-util-renderutil
-  version: 0.3.10
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
-  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
-  md5: 7beeda4223c5484ef72d89fb66b7e8c1
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
+  md5: 57ca8564599ddf8b633c4ea6afee6f3a
   depends:
   - libgcc-ng >=12
   - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 18139
-  timestamp: 1718849914457
-- kind: conda
-  name: xcb-util-renderutil
-  version: 0.3.10
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  size: 14343
+  timestamp: 1718846624153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
   sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
   md5: 0e0cbe0564d03a99afd5fd7b362feecd
   depends:
@@ -15670,27 +11073,17 @@ packages:
   license_family: MIT
   size: 16978
   timestamp: 1718848865819
-- kind: conda
-  name: xcb-util-wm
-  version: 0.4.2
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
-  md5: f14dcda6894722e421da2b7dcffb0b78
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
+  md5: 7beeda4223c5484ef72d89fb66b7e8c1
   depends:
   - libgcc-ng >=12
   - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 50772
-  timestamp: 1718845072660
-- kind: conda
-  name: xcb-util-wm
-  version: 0.4.2
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  size: 18139
+  timestamp: 1718849914457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
   sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
   md5: 608e0ef8256b81d04456e8d211eee3e8
   depends:
@@ -15700,27 +11093,17 @@ packages:
   license_family: MIT
   size: 51689
   timestamp: 1718844051451
-- kind: conda
-  name: xkeyboard-config
-  version: '2.43'
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
-  sha256: b3f09cc99b6b7707aa8812bbc7556fd431999ad3a48292e4ff82335b5fda976c
-  md5: a809b8e3776fbc05696c82f8cf6f5a92
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
+  md5: f14dcda6894722e421da2b7dcffb0b78
   depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
-  size: 391011
-  timestamp: 1727840308426
-- kind: conda
-  name: xkeyboard-config
-  version: '2.43'
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+  size: 50772
+  timestamp: 1718845072660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
   sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
   md5: f725c7425d6d7c15e31f3b99a88ea02f
   depends:
@@ -15731,28 +11114,17 @@ packages:
   license_family: MIT
   size: 389475
   timestamp: 1727840188958
-- kind: conda
-  name: xorg-libice
-  version: 1.1.1
-  build: h57736b2_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
-  sha256: 525f197136d0c136dcba68b16d8f3636f27be111d677b2a06d8b99cf3f45ba4a
-  md5: 99a9c8245a1cc6dacd292ffeca39425f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+  sha256: b3f09cc99b6b7707aa8812bbc7556fd431999ad3a48292e4ff82335b5fda976c
+  md5: a809b8e3776fbc05696c82f8cf6f5a92
   depends:
   - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
-  size: 60151
-  timestamp: 1727533134400
-- kind: conda
-  name: xorg-libice
-  version: 1.1.1
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+  size: 391011
+  timestamp: 1727840308426
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
   sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
   md5: 19608a9656912805b2b9a2f6bd257b04
   depends:
@@ -15762,30 +11134,16 @@ packages:
   license_family: MIT
   size: 58159
   timestamp: 1727531850109
-- kind: conda
-  name: xorg-libsm
-  version: 1.2.4
-  build: hbac51e1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
-  sha256: 3d3c78a2e2a915d96b8bf8a670ba91e5abba50f55dc3ff699d345c958118e94c
-  md5: 18655ac9fc6624db89b33a89fed51c5f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
+  sha256: 525f197136d0c136dcba68b16d8f3636f27be111d677b2a06d8b99cf3f45ba4a
+  md5: 99a9c8245a1cc6dacd292ffeca39425f
   depends:
   - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 28357
-  timestamp: 1727635998392
-- kind: conda
-  name: xorg-libsm
-  version: 1.2.4
-  build: he73a12e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+  size: 60151
+  timestamp: 1727533134400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
   sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
   md5: 05a8ea5f446de33006171a7afe6ae857
   depends:
@@ -15797,45 +11155,18 @@ packages:
   license_family: MIT
   size: 27516
   timestamp: 1727634669421
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.9
-  build: he755bbd_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
-  sha256: bcd9ebdd7ca25d8ab1eb4f3f919113e264a8ad84fa713c48e737e9167a82fb4b
-  md5: 7acc45f80415e6ec352b729105dc0375
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
+  sha256: 3d3c78a2e2a915d96b8bf8a670ba91e5abba50f55dc3ff699d345c958118e94c
+  md5: 18655ac9fc6624db89b33a89fed51c5f
   depends:
   - libgcc >=13
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
-  size: 863528
-  timestamp: 1727352755656
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.10
-  build: h2321a68_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
-  sha256: d7b68c1a67cc074b14cda8ccc90d52291ee78607fb2294fdf84cfe49eecaeea8
-  md5: 8daa358aecb1dbba214ea468a17f934c
-  depends:
-  - __osx >=11.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto
-  license: MIT
-  license_family: MIT
-  size: 753888
-  timestamp: 1727356859339
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.10
-  build: h4f16b4b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+  size: 28357
+  timestamp: 1727635998392
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
   sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
   md5: 0b666058a179b744a622d0a4a0c56353
   depends:
@@ -15847,12 +11178,18 @@ packages:
   license_family: MIT
   size: 838308
   timestamp: 1727356837875
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.10
-  build: ha6c16c8_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.10-ha6c16c8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
+  sha256: bcd9ebdd7ca25d8ab1eb4f3f919113e264a8ad84fa713c48e737e9167a82fb4b
+  md5: 7acc45f80415e6ec352b729105dc0375
+  depends:
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 863528
+  timestamp: 1727352755656
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.10-ha6c16c8_0.conda
   sha256: 228b538e083a61c546f0252ed3195b57ab7c7d37a8bdc701224f9569c3db76de
   md5: e0b36043f72afb8e46b71f31e8cc143d
   depends:
@@ -15863,43 +11200,18 @@ packages:
   license_family: MIT
   size: 780923
   timestamp: 1727356879017
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: h00291cd_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
-  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
-  md5: c6cc91149a08402bbb313c5dc0142567
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
+  sha256: d7b68c1a67cc074b14cda8ccc90d52291ee78607fb2294fdf84cfe49eecaeea8
+  md5: 8daa358aecb1dbba214ea468a17f934c
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
   license: MIT
   license_family: MIT
-  size: 13176
-  timestamp: 1727034772877
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: h86ecc28_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
-  sha256: a00c4c6054209c84fb460c5e4ae7193c335a9ee1851645c9ad59312438e853f7
-  md5: c5f72a733c461aa7785518d29b997cc8
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 15690
-  timestamp: 1727036097294
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  size: 753888
+  timestamp: 1727356859339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
   sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
   md5: 77cbc488235ebbaab2b6e912d3934bae
   depends:
@@ -15909,13 +11221,25 @@ packages:
   license_family: MIT
   size: 14679
   timestamp: 1727034741045
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hd74edd7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
+  sha256: a00c4c6054209c84fb460c5e4ae7193c335a9ee1851645c9ad59312438e853f7
+  md5: c5f72a733c461aa7785518d29b997cc8
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 15690
+  timestamp: 1727036097294
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
   sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
   md5: 7e0125f8fb619620a0011dc9297e2493
   depends:
@@ -15924,29 +11248,7 @@ packages:
   license_family: MIT
   size: 13515
   timestamp: 1727034783560
-- kind: conda
-  name: xorg-libxdamage
-  version: 1.1.6
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
-  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
-  md5: d5773c4e4d64428d7ddaa01f6f845dc7
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 13794
-  timestamp: 1727891406431
-- kind: conda
-  name: xorg-libxdamage
-  version: 1.1.6
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
   sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
   md5: b5fcc7172d22516e1f965490e65e33a4
   depends:
@@ -15959,40 +11261,19 @@ packages:
   license_family: MIT
   size: 13217
   timestamp: 1727891438799
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: h00291cd_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
-  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
-  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 18465
-  timestamp: 1727794980957
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
-  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
-  md5: 25a5a7b797fe6e084e04ffe2db02fc62
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
+  md5: d5773c4e4d64428d7ddaa01f6f845dc7
   depends:
   - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 20615
-  timestamp: 1727796660574
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  size: 13794
+  timestamp: 1727891406431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
   sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
   md5: 8035c64cb77ed555e3f150b7b3972480
   depends:
@@ -16002,12 +11283,25 @@ packages:
   license_family: MIT
   size: 19901
   timestamp: 1727794976192
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
+  md5: 25a5a7b797fe6e084e04ffe2db02fc62
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 20615
+  timestamp: 1727796660574
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
   sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
   md5: 77c447f48cab5d3a15ac224edb86a968
   depends:
@@ -16016,42 +11310,7 @@ packages:
   license_family: MIT
   size: 18487
   timestamp: 1727795205022
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: h00291cd_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.6-h00291cd_0.conda
-  sha256: 26c88c5629895d7df5722320931377aa1ba3dea3950faa77e0c9fe5af29f78e5
-  md5: 62f4f9d7a6c176be164329b4a1fc2616
-  depends:
-  - __osx >=10.13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 42572
-  timestamp: 1727752240262
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
-  sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
-  md5: bd1e86dd8aa3afd78a4bfdb4ef918165
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 50746
-  timestamp: 1727754268156
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
   sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
   md5: febbab7d15033c913d53c7a2c102309d
   depends:
@@ -16062,12 +11321,27 @@ packages:
   license_family: MIT
   size: 50060
   timestamp: 1727752228921
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+  sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
+  md5: bd1e86dd8aa3afd78a4bfdb4ef918165
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50746
+  timestamp: 1727754268156
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.6-h00291cd_0.conda
+  sha256: 26c88c5629895d7df5722320931377aa1ba3dea3950faa77e0c9fe5af29f78e5
+  md5: 62f4f9d7a6c176be164329b4a1fc2616
+  depends:
+  - __osx >=10.13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 42572
+  timestamp: 1727752240262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
   sha256: 4526fcd879b74400e66cc2a041ca00c0ecd210486459cc65610b135be7c6a2d2
   md5: acf6c394865f1b7a51c8e57fec6fcde3
   depends:
@@ -16077,27 +11351,7 @@ packages:
   license_family: MIT
   size: 41870
   timestamp: 1727752280756
-- kind: conda
-  name: xorg-libxfixes
-  version: 6.0.1
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
-  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
-  md5: 78f8715c002cc66991d7c11e3cf66039
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 20289
-  timestamp: 1727796500830
-- kind: conda
-  name: xorg-libxfixes
-  version: 6.0.1
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
   sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
   md5: 4bdb303603e9821baf5fe5fdff1dc8f8
   depends:
@@ -16108,29 +11362,17 @@ packages:
   license_family: MIT
   size: 19575
   timestamp: 1727794961233
-- kind: conda
-  name: xorg-libxi
-  version: 1.8.2
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
-  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
-  md5: eeee3bdb31c6acde2b81ad1b8c287087
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
+  md5: 78f8715c002cc66991d7c11e3cf66039
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 48197
-  timestamp: 1727801059062
-- kind: conda
-  name: xorg-libxi
-  version: 1.8.2
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  size: 20289
+  timestamp: 1727796500830
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
   sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
   md5: 17dcc85db3c7886650b8908b183d6876
   depends:
@@ -16143,13 +11385,19 @@ packages:
   license_family: MIT
   size: 47179
   timestamp: 1727799254088
-- kind: conda
-  name: xorg-libxinerama
-  version: 1.1.5
-  build: h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
+  md5: eeee3bdb31c6acde2b81ad1b8c287087
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 48197
+  timestamp: 1727801059062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
   sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
   md5: 5e2eb9bf77394fc2e5918beefec9f9ab
   depends:
@@ -16162,13 +11410,7 @@ packages:
   license_family: MIT
   size: 13891
   timestamp: 1727908521531
-- kind: conda
-  name: xorg-libxinerama
-  version: 1.1.5
-  build: h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
   sha256: 5f84f820397db504e187754665d48d385e0a2a49f07ffc2372c7f42fa36dd972
   md5: a7b99f104e14b99ca773d2fe2d195585
   depends:
@@ -16180,30 +11422,36 @@ packages:
   license_family: MIT
   size: 14388
   timestamp: 1727908606602
-- kind: conda
-  name: xorg-libxrender
-  version: 0.9.11
-  build: h57736b2_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
-  sha256: 50c000a26e828313b668902c2ae5ff7956d9d34418b4fc6fc15f73cba31b45e0
-  md5: 19fb476dc5cdd51b67719a6342fab237
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+  sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
+  md5: 2de7f99d6581a4a7adbff607b5c278ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 29599
+  timestamp: 1727794874300
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
+  sha256: b2588a2b101d1b0a4e852532c8b9c92c59ef584fc762dd700567bdbf8cd00650
+  md5: dd3e74283a082381aa3860312e3c721e
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-xorgproto
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  arch: aarch64
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 38052
-  timestamp: 1727530023529
-- kind: conda
-  name: xorg-libxrender
-  version: 0.9.11
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+  size: 30197
+  timestamp: 1727794957221
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
   sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
   md5: a7a49a8b85122b49214798321e2e96b4
   depends:
@@ -16215,13 +11463,18 @@ packages:
   license_family: MIT
   size: 37780
   timestamp: 1727529943015
-- kind: conda
-  name: xorg-libxtst
-  version: 1.2.5
-  build: hb9d3cd8_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+  sha256: 50c000a26e828313b668902c2ae5ff7956d9d34418b4fc6fc15f73cba31b45e0
+  md5: 19fb476dc5cdd51b67719a6342fab237
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 38052
+  timestamp: 1727530023529
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
   md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
   depends:
@@ -16234,30 +11487,7 @@ packages:
   license_family: MIT
   size: 32808
   timestamp: 1727964811275
-- kind: conda
-  name: xorg-libxxf86vm
-  version: 1.1.5
-  build: h57736b2_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
-  sha256: db7455e84e3427e800e4830296247e8a465a13f2cd0b389415a5aec989f5fab0
-  md5: 82fa1f5642ef7ac7172e295327ce20e2
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 18392
-  timestamp: 1728920054223
-- kind: conda
-  name: xorg-libxxf86vm
-  version: 1.1.5
-  build: hb9d3cd8_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
   sha256: 0b8f062a5b4a2c3833267285b7d41b3542f54d2c935c86ca98504c3e5296354c
   md5: 7da9007c0582712c4bad4131f89c8372
   depends:
@@ -16269,28 +11499,18 @@ packages:
   license_family: MIT
   size: 18072
   timestamp: 1728920051869
-- kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: h57736b2_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
-  sha256: 00e2bb1f05e7737002165a4523300c1c28dda127de099288c38ce4a62789183e
-  md5: 4589bf66785ace0f78e8d59d403aad98
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
+  sha256: db7455e84e3427e800e4830296247e8a465a13f2cd0b389415a5aec989f5fab0
+  md5: 82fa1f5642ef7ac7172e295327ce20e2
   depends:
   - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
-  size: 30717
-  timestamp: 1726847443586
-- kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: hb9d3cd8_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+  size: 18392
+  timestamp: 1728920054223
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
   sha256: f302a3f6284ee9ad3b39e45251d7ed15167896564dc33e006077a896fd3458a6
   md5: bc4cd53a083b6720d61a1519a1900878
   depends:
@@ -16300,28 +11520,16 @@ packages:
   license_family: MIT
   size: 30549
   timestamp: 1726846235301
-- kind: conda
-  name: xorg-xf86vidmodeproto
-  version: 2.3.1
-  build: h57736b2_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1004.conda
-  sha256: db4373a3c910ceaf821ecf0e79c0263d727813c21b94995c3b5629955cf934ef
-  md5: c63c8de70afa2fd9848375d27ef92a66
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+  sha256: 00e2bb1f05e7737002165a4523300c1c28dda127de099288c38ce4a62789183e
+  md5: 4589bf66785ace0f78e8d59d403aad98
   depends:
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 26277
-  timestamp: 1728918984977
-- kind: conda
-  name: xorg-xf86vidmodeproto
-  version: 2.3.1
-  build: hb9d3cd8_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1004.conda
+  size: 30717
+  timestamp: 1726847443586
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1004.conda
   sha256: f649e15e53d82fe5cece0b1fcc82deea3cd71a01ea4b3ebdc2cef1cdfeaf19b3
   md5: 24831329718daa6cbe35fcd071b778d4
   depends:
@@ -16331,43 +11539,16 @@ packages:
   license_family: MIT
   size: 26209
   timestamp: 1728918994652
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: h00291cd_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-xorgproto-2024.1-h00291cd_1.conda
-  sha256: 34049565572408df1417c16d234841d00cdd8c7ddad632f372c28bdffddb3c65
-  md5: 8d29dcaff88cd231bb16ca7ec4819701
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 567510
-  timestamp: 1726846480273
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: h86ecc28_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
-  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
-  md5: 91cef7867bf2b47f614597b59705ff56
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1004.conda
+  sha256: db4373a3c910ceaf821ecf0e79c0263d727813c21b94995c3b5629955cf934ef
+  md5: c63c8de70afa2fd9848375d27ef92a66
   depends:
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 566948
-  timestamp: 1726847598167
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  size: 26277
+  timestamp: 1728918984977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
   sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
   md5: 7c21106b851ec72c037b162c216d8f05
   depends:
@@ -16377,13 +11558,25 @@ packages:
   license_family: MIT
   size: 565425
   timestamp: 1726846388217
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: hd74edd7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
+  md5: 91cef7867bf2b47f614597b59705ff56
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 566948
+  timestamp: 1726847598167
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xorgproto-2024.1-h00291cd_1.conda
+  sha256: 34049565572408df1417c16d234841d00cdd8c7ddad632f372c28bdffddb3c65
+  md5: 8d29dcaff88cd231bb16ca7ec4819701
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 567510
+  timestamp: 1726846480273
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
   sha256: f76eb03c674719ccaf599c7f5e50a02747382928bdc0927509ef946d450edfa6
   md5: 1b974e05b976e33edb29a0475013ac60
   depends:
@@ -16392,12 +11585,7 @@ packages:
   license_family: MIT
   size: 567698
   timestamp: 1726846426361
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   md5: 2161070d867d1b1204ea749c8eec4ef0
   depends:
@@ -16405,34 +11593,27 @@ packages:
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h57fd34a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-  md5: 39c6b54e94014701dd157f4f576ed211
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+  sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
+  md5: 83baad393a31d59c20b63ba4da6592df
+  depends:
+  - libgcc-ng >=12
   license: LGPL-2.1 and GPL-2.0
-  size: 235693
-  timestamp: 1660346961024
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h775f41a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  size: 440555
+  timestamp: 1660348056328
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
   sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
   md5: a72f9d4ea13d55d745ff1ed594747f10
   license: LGPL-2.1 and GPL-2.0
   size: 238119
   timestamp: 1660346964847
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h8d14728_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
   sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
   md5: 515d77642eaa3639413c6b1bc3f94219
   depends:
@@ -16441,56 +11622,7 @@ packages:
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h9cdd2b7_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
-  sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
-  md5: 83baad393a31d59c20b63ba4da6592df
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1 and GPL-2.0
-  size: 440555
-  timestamp: 1660348056328
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: h7013b1f_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h7013b1f_6.conda
-  sha256: 7901cf3a8e252b59d69515e0305b4a2f423ef834e92be7b36e325143fcbf4bcc
-  md5: e6b4679b73ad73edad1a930f903c96b8
-  depends:
-  - libyarp 3.9.0 h0ed339e_6
-  - yarp-python >=3.9.0,<3.9.1.0a0
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 25204
-  timestamp: 1727889672135
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: h7176fba_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-h7176fba_6.conda
-  sha256: 5a5635f3cff9221b6b9185c8cb0d54e0eca992df91ce511ed64dd7288bf58eee
-  md5: 3d64fa11c16123162380e06bfc636991
-  depends:
-  - libyarp 3.9.0 h35b7655_6
-  - yarp-python >=3.9.0,<3.9.1.0a0
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 25148
-  timestamp: 1727889519799
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: hca90a2c_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-hca90a2c_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-hca90a2c_6.conda
   sha256: 8b4acd77ec8b8850a8558b15bf3114e9f2d4145603a7db8d398fd518fc864f3d
   md5: 1cf6806c64fbe61292d15777e1b9ed34
   depends:
@@ -16499,28 +11631,7 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 25051
   timestamp: 1727890037319
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: hcac4619_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-hcac4619_6.conda
-  sha256: 577079221982011d2403c46ced359e9b5d1c9902f7acac8c099ee66a19cf8fbe
-  md5: 897e1ed084e69ddb3edea1277c26fc99
-  depends:
-  - libyarp 3.9.0 h71b8b94_6
-  - yarp-python >=3.9.0,<3.9.1.0a0
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 25687
-  timestamp: 1727890748773
-- kind: conda
-  name: yarp
-  version: 3.9.0
-  build: hded75bf_6
-  build_number: 6
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-hded75bf_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-hded75bf_6.conda
   sha256: 15b4fb29a0a3fc2e39e6677e21d24472f31a04784f55b309173afc371b0827f4
   md5: 78ff0ce4c7a150eba280db71f00ec4ee
   depends:
@@ -16529,13 +11640,34 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 25150
   timestamp: 1727890244738
-- kind: conda
-  name: yarp-python
-  version: 3.9.0
-  build: py311h328aa9c_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h328aa9c_6.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h7013b1f_6.conda
+  sha256: 7901cf3a8e252b59d69515e0305b4a2f423ef834e92be7b36e325143fcbf4bcc
+  md5: e6b4679b73ad73edad1a930f903c96b8
+  depends:
+  - libyarp 3.9.0 h0ed339e_6
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 25204
+  timestamp: 1727889672135
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-h7176fba_6.conda
+  sha256: 5a5635f3cff9221b6b9185c8cb0d54e0eca992df91ce511ed64dd7288bf58eee
+  md5: 3d64fa11c16123162380e06bfc636991
+  depends:
+  - libyarp 3.9.0 h35b7655_6
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 25148
+  timestamp: 1727889519799
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-hcac4619_6.conda
+  sha256: 577079221982011d2403c46ced359e9b5d1c9902f7acac8c099ee66a19cf8fbe
+  md5: 897e1ed084e69ddb3edea1277c26fc99
+  depends:
+  - libyarp 3.9.0 h71b8b94_6
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 25687
+  timestamp: 1727890748773
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h328aa9c_6.conda
   sha256: 426a4a0f5ac6d2d528254006d8d1e0eed84678d0de7d12c8a994286e3844c02e
   md5: 00f4cca64ceda79c9134de21f6bf56b1
   depends:
@@ -16550,54 +11682,7 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 1169183
   timestamp: 1727889982400
-- kind: conda
-  name: yarp-python
-  version: 3.9.0
-  build: py311h7a96f56_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h7a96f56_6.conda
-  sha256: c7912ce32b23c769f9c6165e005347a3531909d434f169a65c06e243262e8dd4
-  md5: 2a67e22b73fada071124fcadae48d952
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - libyarp 3.9.0 h0ed339e_6
-  - numpy
-  - openssl >=3.3.2,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1028144
-  timestamp: 1727889661962
-- kind: conda
-  name: yarp-python
-  version: 3.9.0
-  build: py312h3ccbe7c_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h3ccbe7c_6.conda
-  sha256: e3d35a596fc30a13e4523032fce9d68b6414c7d433245c6ab0edf855874f5375
-  md5: b282a343f62e0f361fec6425eafb583b
-  depends:
-  - libyarp 3.9.0 h71b8b94_6
-  - numpy
-  - openssl >=3.3.2,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 900108
-  timestamp: 1727890740953
-- kind: conda
-  name: yarp-python
-  version: 3.9.0
-  build: py312h53f4ca0_6
-  build_number: 6
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h53f4ca0_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h53f4ca0_6.conda
   sha256: 81144f88f478d1507cd5c0904d72928d9505c6aa6ee14abb7f2e4f809d140b98
   md5: e55980b5418af34efb05b00c6e2128e9
   depends:
@@ -16612,13 +11697,21 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 1027832
   timestamp: 1727889802708
-- kind: conda
-  name: yarp-python
-  version: 3.9.0
-  build: py312hd1b4365_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312hd1b4365_6.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h7a96f56_6.conda
+  sha256: c7912ce32b23c769f9c6165e005347a3531909d434f169a65c06e243262e8dd4
+  md5: 2a67e22b73fada071124fcadae48d952
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libyarp 3.9.0 h0ed339e_6
+  - numpy
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 1028144
+  timestamp: 1727889661962
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312hd1b4365_6.conda
   sha256: 5cdcfbb569771e90a3a7cc5a9e62b7fede16728545582ac0fc0af99a45509959
   md5: 87280f87fdcb238bd619231a5c01e083
   depends:
@@ -16633,12 +11726,22 @@ packages:
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
   size: 985449
   timestamp: 1727889336370
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h3ccbe7c_6.conda
+  sha256: e3d35a596fc30a13e4523032fce9d68b6414c7d433245c6ab0edf855874f5375
+  md5: b282a343f62e0f361fec6425eafb583b
+  depends:
+  - libyarp 3.9.0 h71b8b94_6
+  - numpy
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 900108
+  timestamp: 1727890740953
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
   sha256: 6769b34a14f710a93d16f620d49f41941ca3ba1e2d4dc632e3b337560646c7f1
   md5: 26683374f411369c90da91947a126287
   depends:
@@ -16649,12 +11752,7 @@ packages:
   license_family: BSD
   size: 143998
   timestamp: 1725628711468
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
   sha256: e561dfc7b3ff30940424359b06efdd1ac74abcf0331433dc787c417bcb794787
   md5: ac96ccc881727dafb5a5418487255769
   depends:
@@ -16664,12 +11762,7 @@ packages:
   license_family: BSD
   size: 143813
   timestamp: 1725628825447
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: hac325c4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.9-hac325c4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.9-hac325c4_0.conda
   sha256: 9e4c9097be9c097cc2d3673c54b32f4866d71a9b17f3d9f3fdd64b9eddf6dae2
   md5: d94d8d85229f42f27f7aca74f15ba635
   depends:
@@ -16679,12 +11772,17 @@ packages:
   license_family: BSD
   size: 143537
   timestamp: 1725628779879
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
+  sha256: 094b959a13f5c90407dd84c82221a8187b787cf571a6ed70110f8d13c4e6027b
+  md5: 53e254d12b23ee5c301e625932a6aa77
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143788
+  timestamp: 1725628834144
+- conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
   sha256: 25e574e6e8588830e2e5d8227f12c5d61043b9111bc8bf826588355a4fe74246
   md5: 68ae20bf2e6f6787994c17789885cdf0
   depends:
@@ -16695,28 +11793,48 @@ packages:
   license_family: BSD
   size: 144067
   timestamp: 1725628982924
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
-  sha256: 094b959a13f5c90407dd84c82221a8187b787cf571a6ed70110f8d13c4e6027b
-  md5: 53e254d12b23ee5c301e625932a6aa77
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
+  md5: bc230abb5d21b63ff4799b0e75204783
+  depends:
+  - libgcc >=13
+  - libzlib 1.3.1 h86ecc28_2
+  license: Zlib
+  license_family: Other
+  size: 95582
+  timestamp: 1727963203597
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
   depends:
   - __osx >=11.0
-  - libcxx >=17
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 143788
-  timestamp: 1725628834144
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
   sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
   md5: be60c4e8efa55fddc17b4131aa47acbd
   depends:
@@ -16728,77 +11846,18 @@ packages:
   license_family: Other
   size: 107439
   timestamp: 1727963788936
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h8359307_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
-  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
-  md5: e3170d898ca6cb48f1bb567afb92f775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
   depends:
-  - __osx >=11.0
-  - libzlib 1.3.1 h8359307_2
-  license: Zlib
-  license_family: Other
-  size: 77606
-  timestamp: 1727963209370
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h86ecc28_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
-  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
-  md5: bc230abb5d21b63ff4799b0e75204783
-  depends:
-  - libgcc >=13
-  - libzlib 1.3.1 h86ecc28_2
-  license: Zlib
-  license_family: Other
-  size: 95582
-  timestamp: 1727963203597
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
-  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib 1.3.1 hb9d3cd8_2
-  license: Zlib
-  license_family: Other
-  size: 92286
-  timestamp: 1727963153079
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: hd23fc13_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
-  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
-  md5: c989e0295dcbdc08106fe5d9e935f0b9
-  depends:
-  - __osx >=10.13
-  - libzlib 1.3.1 hd23fc13_2
-  license: Zlib
-  license_family: Other
-  size: 88544
-  timestamp: 1727963189976
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h02f22dd_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
   sha256: 484f9d0722c77685ae379fbff3ccd662af9ead7e59eb39cd6d0c677cdf25ff6c
   md5: be8d5f8cf21aed237b8b182ea86b3dd6
   depends:
@@ -16809,12 +11868,27 @@ packages:
   license_family: BSD
   size: 539937
   timestamp: 1714723130243
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h0ea2cb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
   sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
   md5: 9a17230f95733c04dc40a2b1e5491d74
   depends:
@@ -16826,49 +11900,3 @@ packages:
   license_family: BSD
   size: 349143
   timestamp: 1714723445995
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h915ae27_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
-  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
-  md5: 4cb2cd56f039b129bb0e491c1164167e
-  depends:
-  - __osx >=10.9
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 498900
-  timestamp: 1714723303098
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: ha6fb4c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
-  md5: 4d056880988120e29d75bfff282e0f45
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 554846
-  timestamp: 1714722996770
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: hb46c0d2_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
-  md5: d96942c06c3e84bfcc5efb038724a7fd
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 405089
-  timestamp: 1714723101397

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,5 +61,7 @@ python = "*"
 numpy = "*"
 yarp = "*"
 osqp-eigen = "*"
+# Transitive Irrlicht/SDL dependency
+xorg-libxrandr = "*"
 # Find a way to add this only for supported envs
 # icub-main = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,7 +61,12 @@ python = "*"
 numpy = "*"
 yarp = "*"
 osqp-eigen = "*"
-# Transitive Irrlicht/SDL dependency
-xorg-libxrandr = "*"
 # Find a way to add this only for supported envs
 # icub-main = "*"
+
+[target.linux.dependencies]
+# Transitive Irrlicht/SDL dependency
+xorg-xorgproto = "*"
+libgl-devel = "*"
+xorg-libxrandr = "*"
+wayland = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,9 +38,9 @@ configure = { cmd = [
     ".build",
 ]}
 
-build = { cmd = "cmake --build .build --config Release", depends_on = ["configure"] }
-test = { cmd = "ctest --test-dir .build --build-config Release", depends_on = ["build"] }
-install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends_on = ["build"] }
+build = { cmd = "cmake --build .build --config Release", depends-on = ["configure"] }
+test = { cmd = "ctest --test-dir .build --build-config Release", depends-on = ["build"] }
+install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends-on = ["build"] }
 uninstall = { cmd = ["cmake", "--build", ".build", "--target", "uninstall"]}
 
 


### PR DESCRIPTION
There are transitive dependencies of glfw3, and glfw3 does not provide any glfw3-devel output to depend on.