### PR TITLE
 Drop ubuntu-20.04 GitHub Action image 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2019]
 
     steps:
     - uses: actions/checkout@v3
@@ -163,8 +163,8 @@ jobs:
         os:
           - ubuntu-latest
         docker_image:
-          - "ubuntu:20.04"
           - "ubuntu:22.04"
+          - "ubuntu:24.04"
 
     container:
       image: ${{ matrix.docker_image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,6 @@ jobs:
           - ubuntu-latest
         docker_image:
           - "ubuntu:22.04"
-          - "ubuntu:24.04"
 
     container:
       image: ${{ matrix.docker_image }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
 
@@ -54,7 +54,7 @@ jobs:
           path: docs/site
 
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build]
     if: github.ref == 'refs/heads/master'
     steps:

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-22.04, windows-2019, macos-13]
         matlab_version: [R2022a, R2022b, R2023a]
 
     steps:

--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     regenerate-matlab-bindings:
         name: "Regenerate MATLAB bindings"
-        runs-on: [ubuntu-20.04]
+        runs-on: [ubuntu-22.04]
         steps:
         - uses: actions/checkout@v2
 


### PR DESCRIPTION
The `ubuntu-20.04` image of GitHub Action was deprecated for a long time, and is currently being removed. This PR migrates all its uses to `ubuntu-22.04`.