### PR TITLE
Migrate windows-2019 jobs to windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, windows-2019, macos-13]
+        os: [ubuntu-22.04, windows-latest, macos-13]
         matlab_version: [R2022a, R2022b, R2023a]
 
     steps:


### PR DESCRIPTION
Related issue: https://github.com/robotology/robotology-superbuild/issues/1858 .