### PR TITLE
Add typemaps for ContactWrench attributes in Python bindings

### DIFF
--- a/bindings/python/python.i
+++ b/bindings/python/python.i
@@ -18,6 +18,9 @@
 // Include attributes
 %include <attribute.i>
 
+// include typemaps
+%include "typemaps.i"
+
 // Initialize NumPy
 %init %{
 import_array();
@@ -449,3 +452,5 @@ SPAN_TYPEMAP(double,         iDynTree::Span<double>)
 %attributeref(iDynTree::FreeFloatingVel, iDynTree::JointDOFsDoubleArray&, jointVel)
 %attributeref(iDynTree::FreeFloatingAcc, iDynTree::SpatialAcc&, baseAcc)
 %attributeref(iDynTree::FreeFloatingAcc, iDynTree::JointDOFsDoubleArray&, jointAcc)
+%attributeref(iDynTree::ContactWrench, iDynTree::Wrench&, contactWrench);
+%attributeref(iDynTree::ContactWrench, iDynTree::Position&, contactPoint);


### PR DESCRIPTION
Introduce typemaps for ContactWrench attributes,