### PR TITLE
Add first version of SphericalJoint

### DIFF
--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -23,6 +23,7 @@ set(IDYNTREE_MODEL_HEADERS include/iDynTree/ContactWrench.h
                            include/iDynTree/MovableJointImpl.h
                            include/iDynTree/RevoluteJoint.h
                            include/iDynTree/PrismaticJoint.h
+                           include/iDynTree/SphericalJoint.h
                            include/iDynTree/SolidShapes.h
                            include/iDynTree/SubModel.h
                            include/iDynTree/Traversal.h
@@ -57,6 +58,7 @@ set(IDYNTREE_MODEL_SOURCES src/ContactWrench.cpp
                            src/ModelInterfaceDestructors.cpp
                            src/RevoluteJoint.cpp
                            src/PrismaticJoint.cpp
+                           src/SphericalJoint.cpp
                            src/SolidShapes.cpp
                            src/SubModel.cpp
                            src/Traversal.cpp

--- a/src/model/include/iDynTree/ModelTestUtils.h
+++ b/src/model/include/iDynTree/ModelTestUtils.h
@@ -9,6 +9,7 @@
 #include <iDynTree/FixedJoint.h>
 #include <iDynTree/RevoluteJoint.h>
 #include <iDynTree/PrismaticJoint.h>
+#include <iDynTree/SphericalJoint.h>
 #include <iDynTree/FreeFloatingState.h>
 #include <iDynTree/LinkState.h>
 
@@ -45,7 +46,7 @@ inline Link getRandomLink()
 /**
  * Add a random link with random model.
  */
-inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, bool onlyRevoluteJoints=false)
+inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, bool onlyRevoluteJoints=false, bool includeSphericalJoints=false)
 {
     // Add Link
     LinkIndex newLinkIndex = model.addLink(newLinkName,getRandomLink());
@@ -53,7 +54,12 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
     // Now add joint
     LinkIndex parentLinkIndex = model.getLinkIndex(parentLink);
 
-    int nrOfJointTypes = 3;
+    int nrOfJointTypes = 3; // 0=Fixed, 1=Revolute, 2=Prismatic,
+
+    if (includeSphericalJoints)
+    {
+        nrOfJointTypes = nrOfJointTypes + 1;  // 3=Spherical
+    }
 
     int jointType = rand() % nrOfJointTypes;
 
@@ -82,6 +88,12 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
         prismJoint.setRestTransform(getRandomTransform());
         prismJoint.setAxis(getRandomAxis(),newLinkIndex);
         model.addJoint(newLinkName+"joint",&prismJoint);
+    } else if( jointType == 3 )
+    {
+        SphericalJoint spherJoint;
+        spherJoint.setAttachedLinks(parentLinkIndex,newLinkIndex);
+        spherJoint.setRestTransform(getRandomTransform());
+        model.addJoint(newLinkName+"joint",&spherJoint);
     }
     else
     {
@@ -120,7 +132,7 @@ inline std::string int2string(int i)
     return ss.str();
 }
 
-inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false)
+inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false, bool includeSphericalJoints=false)
 {
     Model model;
 
@@ -130,7 +142,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     {
         std::string parentLink = getRandomLinkOfModel(model);
         std::string linkName = "link" + int2string(i);
-        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints);
+        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints,includeSphericalJoints);
     }
 
     for(unsigned int i=0; i < nrOfAdditionalFrames; i++)
@@ -143,7 +155,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     return model;
 }
 
-inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false)
+inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false, bool includeSphericalJoints=false)
 {
     Model model;
 
@@ -154,7 +166,7 @@ inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     {
         std::string parentLink = linkName;
         linkName = "link" + int2string(i);
-        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints);
+        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints,includeSphericalJoints);
     }
 
     for(unsigned int i=0; i < nrOfAdditionalFrames; i++)

--- a/src/model/include/iDynTree/SphericalJoint.h
+++ b/src/model/include/iDynTree/SphericalJoint.h
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef IDYNTREE_SPHERICAL_JOINT_H
+#define IDYNTREE_SPHERICAL_JOINT_H
+
+#include <iDynTree/Transform.h>
+#include <iDynTree/SpatialMotionVector.h>
+
+#include <iDynTree/Indices.h>
+#include <iDynTree/MovableJointImpl.h>
+#include <iDynTree/VectorFixSize.h>
+
+namespace iDynTree
+{
+    /**
+     * Class representing a spherical joint, i.e. a joint that
+     * constrains two links to have the same position but allows
+     * any relative orientation (3 rotational degrees of freedom).
+     *
+     * The joint state is parameterized using a unit quaternion
+     * q = [qw, qx, qy, qz] (4 position coordinates), and the
+     * angular velocity ω expressed in the first link frame
+     * (3 velocity coordinates).
+     *
+     * Note: The quaternion follows the real/imaginary (w,x,y,z) convention
+     * used by iDynTree, where w is the real part and (x,y,z) is the imaginary part.
+     *
+     * The 6D spatial vectors (velocity, acceleration, forces) follow the
+     * linear/angular (linear first, angular second) convention used by iDynTree.
+     *
+     * \ingroup iDynTreeModel
+     */
+    class SphericalJoint : public MovableJointImpl<4,3>
+    {
+    private:
+        // Structure attributes
+        LinkIndex link1;
+        LinkIndex link2;
+        Transform link1_X_link2_at_rest;
+
+        // Cache attributes
+        mutable Vector4 q_previous;
+        mutable Transform link1_X_link2;
+        mutable Transform link2_X_link1;
+        mutable SpatialMotionVector S_link1_link2[3];
+        mutable SpatialMotionVector S_link2_link1[3];
+
+        void updateBuffers(const Vector4& new_q) const;
+        void resetBuffers(const Vector4& new_q) const;
+        void resetAxisBuffers() const;
+
+        // Helper methods
+        void normalizeQuaternion(Vector4& q) const;
+        Transform quaternionToTransform(const Vector4& q) const;
+
+    public:
+        /**
+         * Constructor
+         */
+        SphericalJoint();
+
+        /**
+         * Constructor in which the LinkIndex to which the joint is attached are not specified.
+         * This constructor is typically used together with the Model::addJoint or
+         * Model::addJointAndLink methods, in which the links to which the joint is attached are
+         * specified by the other arguments of the method.
+         */
+        SphericalJoint(const Transform& link1_X_link2);
+
+        /**
+         * Copy constructor
+         */
+        SphericalJoint(const SphericalJoint& other);
+
+        /**
+         * Destructor
+         */
+        virtual ~SphericalJoint();
+
+        // Documentation inherited
+        virtual IJoint * clone() const;
+
+        // Documentation inherited
+        virtual void setAttachedLinks(const LinkIndex link1, const LinkIndex link2);
+
+        // Documentation inherited
+        virtual void setRestTransform(const Transform& link1_X_link2);
+
+        // Documentation inherited
+        virtual LinkIndex getFirstAttachedLink() const;
+
+        // Documentation inherited
+        virtual LinkIndex getSecondAttachedLink() const;
+
+        // Documentation inherited
+        virtual Transform getRestTransform(const LinkIndex child,
+                                           const LinkIndex parent) const;
+
+
+        // Documentation inherited
+        virtual const Transform & getTransform(const VectorDynSize & jntPos,
+                                               const LinkIndex child,
+                                               const LinkIndex parent) const;
+
+        // Documentation inherited
+        TransformDerivative getTransformDerivative(const VectorDynSize & jntPos,
+                                                   const LinkIndex child,
+                                                   const LinkIndex parent,
+                                                   const int posCoord_i) const;
+
+        // Documentation inherited
+        virtual SpatialMotionVector getMotionSubspaceVector(int dof_i,
+                                                            const LinkIndex child,
+                                                            const LinkIndex parent=LINK_INVALID_INDEX) const;
+
+         // Documentation inherited
+        virtual void computeChildPosVelAcc(const VectorDynSize & jntPos,
+                                           const VectorDynSize & jntVel,
+                                           const VectorDynSize & jntAcc,
+                                           LinkPositions & linkPositions,
+                                           LinkVelArray & linkVels,
+                                           LinkAccArray & linkAccs,
+                                           const LinkIndex child, const LinkIndex parent) const;
+
+        // Documentation inherited
+        virtual void computeChildVel(const VectorDynSize & jntPos,
+                                     const VectorDynSize & jntVel,
+                                     LinkVelArray & linkVels,
+                                     const LinkIndex child, const LinkIndex parent) const;
+
+        // Documentation inherited
+        virtual void computeChildVelAcc(const VectorDynSize & jntPos,
+                                        const VectorDynSize & jntVel,
+                                        const VectorDynSize & jntAcc,
+                                        LinkVelArray & linkVels,
+                                        LinkAccArray & linkAccs,
+                                        const LinkIndex child, const LinkIndex parent) const;
+
+        // Documentation inherited
+        virtual void computeChildAcc(const VectorDynSize & jntPos,
+                                     const VectorDynSize & jntVel,
+                                     const LinkVelArray & linkVels,
+                                     const VectorDynSize & jntAcc,
+                                     LinkAccArray & linkAccs,
+                                     const LinkIndex child, const LinkIndex parent) const;
+
+        // Documentation inherited
+        virtual void computeChildBiasAcc(const VectorDynSize & jntPos,
+                                         const VectorDynSize & jntVel,
+                                         const LinkVelArray & linkVels,
+                                         LinkAccArray & linkBiasAccs,
+                                         const LinkIndex child, const LinkIndex parent) const;
+
+        // Documentation inherited
+        virtual void computeJointTorque(const VectorDynSize & jntPos,
+                                        const Wrench & internalWrench,
+                                        const LinkIndex linkThatAppliesWrench,
+                                        const LinkIndex linkOnWhichWrenchIsApplied,
+                                        VectorDynSize & jntTorques) const;
+
+        // Documentation inherited
+        virtual bool hasPosLimits() const;
+
+        // Documentation inherited
+        virtual bool enablePosLimits(const bool enable);
+
+        // Documentation inherited
+        virtual bool getPosLimits(const size_t _index, double & min, double & max) const;
+
+        // Documentation inherited
+        virtual double getMinPosLimit(const size_t _index) const;
+
+        // Documentation inherited
+        virtual double getMaxPosLimit(const size_t _index) const;
+
+        // Documentation inherited
+        virtual bool setPosLimits(const size_t _index, double min, double max);
+
+        // Documentation inherited
+        virtual JointDynamicsType getJointDynamicsType() const;
+
+        // Documentation inherited
+        virtual bool setJointDynamicsType(const JointDynamicsType enable);
+
+        // Documentation inherited
+        virtual bool setDamping(const size_t _index, double damping);
+
+        // Documentation inherited
+        virtual bool setStaticFriction(const size_t _index, double staticFriction);
+
+        // Documentation inherited
+        virtual double getDamping(const size_t _index) const;
+
+        // Documentation inherited
+        virtual double getStaticFriction(const size_t _index) const;
+    };
+}
+
+#endif

--- a/src/model/src/SphericalJoint.cpp
+++ b/src/model/src/SphericalJoint.cpp
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <iDynTree/SphericalJoint.h>
+
+#include <iDynTree/VectorDynSize.h>
+#include <iDynTree/TransformDerivative.h>
+#include <iDynTree/LinkState.h>
+#include <iDynTree/Wrench.h>
+#include <iDynTree/Twist.h>
+#include <iDynTree/Rotation.h>
+#include <iDynTree/GeomVector3.h>
+
+#include <cassert>
+#include <cmath>
+
+namespace iDynTree
+{
+
+SphericalJoint::SphericalJoint():
+        link1(LINK_INVALID_INDEX), link2(LINK_INVALID_INDEX),
+        link1_X_link2_at_rest(Transform::Identity())
+{
+    this->setPosCoordsOffset(0);
+    this->setDOFsOffset(0);
+
+    // Initialize with identity quaternion (w,x,y,z) = (1,0,0,0)
+    Vector4 identityQuat;
+    identityQuat(0) = 1.0; identityQuat(1) = 0.0; identityQuat(2) = 0.0; identityQuat(3) = 0.0;
+    this->resetAxisBuffers();
+    this->resetBuffers(identityQuat);
+}
+
+SphericalJoint::SphericalJoint(const Transform& _link1_X_link2):
+                             link1(LINK_INVALID_INDEX), link2(LINK_INVALID_INDEX),
+                             link1_X_link2_at_rest(_link1_X_link2)
+{
+    this->setPosCoordsOffset(0);
+    this->setDOFsOffset(0);
+
+    // Initialize with identity quaternion (w,x,y,z) = (1,0,0,0)
+    Vector4 identityQuat;
+    identityQuat(0) = 1.0; identityQuat(1) = 0.0; identityQuat(2) = 0.0; identityQuat(3) = 0.0;
+    this->resetAxisBuffers();
+    this->resetBuffers(identityQuat);
+}
+
+SphericalJoint::SphericalJoint(const SphericalJoint& other):
+                             link1(other.link1), link2(other.link2),
+                             link1_X_link2_at_rest(other.link1_X_link2_at_rest)
+{
+    this->setPosCoordsOffset(other.getPosCoordsOffset());
+    this->setDOFsOffset(other.getDOFsOffset());
+
+    this->resetAxisBuffers();
+    this->resetBuffers(other.q_previous);
+}
+
+SphericalJoint::~SphericalJoint()
+{
+}
+
+IJoint* SphericalJoint::clone() const
+{
+    return (IJoint *) new SphericalJoint(*this);
+}
+
+void SphericalJoint::setAttachedLinks(const LinkIndex _link1, const LinkIndex _link2)
+{
+    this->link1 = _link1;
+    this->link2 = _link2;
+}
+
+void SphericalJoint::setRestTransform(const Transform& _link1_X_link2)
+{
+    this->link1_X_link2_at_rest = _link1_X_link2;
+    this->resetAxisBuffers();
+}
+
+LinkIndex SphericalJoint::getFirstAttachedLink() const
+{
+    return link1;
+}
+
+LinkIndex SphericalJoint::getSecondAttachedLink() const
+{
+    return link2;
+}
+
+void SphericalJoint::normalizeQuaternion(Vector4& q) const
+{
+    // Normalize quaternion (w,x,y,z) where w is real part, (x,y,z) is imaginary part
+    double norm = std::sqrt(q(0)*q(0) + q(1)*q(1) + q(2)*q(2) + q(3)*q(3));
+    if (norm > 1e-12)
+    {
+        q(0) /= norm;
+        q(1) /= norm;
+        q(2) /= norm;
+        q(3) /= norm;
+    }
+    else
+    {
+        // Fallback to identity quaternion if norm is too small
+        q(0) = 1.0; q(1) = 0.0; q(2) = 0.0; q(3) = 0.0;
+    }
+}
+
+Transform SphericalJoint::quaternionToTransform(const Vector4& q) const
+{
+    Transform result;
+
+    // Set translation to zero (spherical joint doesn't allow translation)
+    result.setPosition(Position::Zero());
+
+    // Convert quaternion (w,x,y,z) to rotation matrix using iDynTree's convention
+    Rotation rot;
+    rot.fromQuaternion(q);
+    result.setRotation(rot);
+
+    return result;
+}
+
+void SphericalJoint::resetBuffers(const Vector4& new_q) const
+{
+    this->q_previous = new_q;
+
+    // Create transform from quaternion
+    Transform quat_transform = quaternionToTransform(new_q);
+
+    this->link1_X_link2 = this->link1_X_link2_at_rest * quat_transform;
+    this->link2_X_link1 = this->link1_X_link2.inverse();
+}
+
+void SphericalJoint::updateBuffers(const Vector4& new_q) const
+{
+    // Check if quaternion has changed
+    bool quaternion_changed = false;
+    for (int i = 0; i < 4; i++)
+    {
+        if (std::abs(new_q(i) - this->q_previous(i)) > 1e-12)
+        {
+            quaternion_changed = true;
+            break;
+        }
+    }
+
+    if (quaternion_changed)
+    {
+        this->resetBuffers(new_q);
+    }
+}
+
+void SphericalJoint::resetAxisBuffers() const
+{
+    // Motion subspace vectors for spherical joint (3 DOFs)
+    // These represent rotation about x, y, z axes in link1 frame
+    // SpatialMotionVector follows [linear; angular] convention in iDynTree
+
+    // Create zero linear motion and unit angular motions for each axis
+    LinearMotionVector3 zeroLinear;
+    zeroLinear.zero();
+    AngularMotionVector3 xAngular, yAngular, zAngular;
+    xAngular(0) = 1.0; xAngular(1) = 0.0; xAngular(2) = 0.0;
+    yAngular(0) = 0.0; yAngular(1) = 1.0; yAngular(2) = 0.0;
+    zAngular(0) = 0.0; zAngular(1) = 0.0; zAngular(2) = 1.0;
+
+    // X-axis rotation: SpatialMotionVector(linear, angular)
+    this->S_link1_link2[0] = SpatialMotionVector(zeroLinear, xAngular);
+    this->S_link2_link1[0] = -this->S_link1_link2[0];
+
+    // Y-axis rotation: SpatialMotionVector(linear, angular)
+    this->S_link1_link2[1] = SpatialMotionVector(zeroLinear, yAngular);
+    this->S_link2_link1[1] = -this->S_link1_link2[1];
+
+    // Z-axis rotation: SpatialMotionVector(linear, angular)
+    this->S_link1_link2[2] = SpatialMotionVector(zeroLinear, zAngular);
+    this->S_link2_link1[2] = -this->S_link1_link2[2];
+}
+
+Transform SphericalJoint::getRestTransform(const LinkIndex child, const LinkIndex parent) const
+{
+    if( child == this->link1 )
+    {
+        assert( parent == this->link2 );
+        return this->link1_X_link2_at_rest.inverse();
+    }
+    else
+    {
+        assert( child == this->link2 );
+        assert( parent == this->link1 );
+        return this->link1_X_link2_at_rest;
+    }
+}
+
+const Transform & SphericalJoint::getTransform(const VectorDynSize & jntPos, const LinkIndex child, const LinkIndex parent) const
+{
+    // Extract quaternion from joint position vector
+    Vector4 q;
+    for (int i = 0; i < 4; i++)
+    {
+        q(i) = jntPos(this->getPosCoordsOffset() + i);
+    }
+
+    // Normalize quaternion
+    normalizeQuaternion(q);
+
+    // Update internal buffers
+    this->updateBuffers(q);
+
+    if( child == this->link1 )
+    {
+        assert( parent == this->link2 );
+        return this->link2_X_link1;
+    }
+    else
+    {
+        assert( child == this->link2 );
+        assert( parent == this->link1 );
+        return this->link1_X_link2;
+    }
+}
+
+TransformDerivative SphericalJoint::getTransformDerivative(const VectorDynSize & jntPos,
+                                                          const LinkIndex child,
+                                                          const LinkIndex parent,
+                                                          const int posCoord_i) const
+{
+    // For spherical joint, this is complex due to quaternion parameterization
+    // For now, return zero - this would need proper implementation for advanced features
+    return TransformDerivative::Zero();
+}
+
+SpatialMotionVector SphericalJoint::getMotionSubspaceVector(int dof_i,
+                                                           const LinkIndex child,
+                                                           const LinkIndex parent) const
+{
+    if( child == this->link1 )
+    {
+        assert( parent == this->link2 );
+        return this->S_link2_link1[dof_i];
+    }
+    else
+    {
+        assert( child == this->link2 );
+        assert( parent == this->link1 );
+        return this->S_link1_link2[dof_i];
+    }
+}
+
+void SphericalJoint::computeChildPosVelAcc(const VectorDynSize & jntPos,
+                                          const VectorDynSize & jntVel,
+                                          const VectorDynSize & jntAcc,
+                                          LinkPositions & linkPositions,
+                                          LinkVelArray & linkVels,
+                                          LinkAccArray & linkAccs,
+                                          const LinkIndex child,
+                                          const LinkIndex parent) const
+{
+    const Transform & child_X_parent = this->getTransform(jntPos, child, parent);
+    const Transform & parent_X_child = this->getTransform(jntPos, parent, child);
+
+    // Propagate position
+    linkPositions(child) = linkPositions(parent) * parent_X_child;
+
+    // Propagate velocity: for spherical joint we need to add joint velocity contribution
+    Twist joint_twist = Twist::Zero();
+    for (int dof = 0; dof < 3; dof++)
+    {
+        joint_twist = joint_twist + this->getMotionSubspaceVector(dof, child, parent) * jntVel(this->getDOFsOffset() + dof);
+    }
+    linkVels(child) = child_X_parent * linkVels(parent) + joint_twist;
+
+    // Propagate acceleration: similar to velocity but also including joint acceleration
+    SpatialAcc joint_acc = SpatialAcc::Zero();
+    for (int dof = 0; dof < 3; dof++)
+    {
+        joint_acc = joint_acc + this->getMotionSubspaceVector(dof, child, parent) * jntAcc(this->getDOFsOffset() + dof);
+    }
+
+    // Add bias acceleration due to joint velocity (Coriolis terms)
+    SpatialAcc bias_acc = SpatialAcc::Zero();
+    // For spherical joint, bias acceleration comes from cross products of angular velocities
+    // This is a simplified implementation - full implementation would need proper Coriolis terms
+
+    linkAccs(child) = child_X_parent * linkAccs(parent) + joint_acc + bias_acc;
+}
+
+void SphericalJoint::computeChildVel(const VectorDynSize & jntPos,
+                                    const VectorDynSize & jntVel,
+                                    LinkVelArray & linkVels,
+                                    const LinkIndex child, const LinkIndex parent) const
+{
+    const Transform & child_X_parent = this->getTransform(jntPos, child, parent);
+
+    // Propagate velocity with joint velocity contribution
+    Twist joint_twist = Twist::Zero();
+    for (int dof = 0; dof < 3; dof++)
+    {
+        joint_twist = joint_twist + this->getMotionSubspaceVector(dof, child, parent) * jntVel(this->getDOFsOffset() + dof);
+    }
+    linkVels(child) = child_X_parent * linkVels(parent) + joint_twist;
+}
+
+void SphericalJoint::computeChildVelAcc(const VectorDynSize & jntPos,
+                                       const VectorDynSize & jntVel,
+                                       const VectorDynSize & jntAcc,
+                                       LinkVelArray & linkVels,
+                                       LinkAccArray & linkAccs,
+                                       const LinkIndex child, const LinkIndex parent) const
+{
+    // Compute velocity first
+    this->computeChildVel(jntPos, jntVel, linkVels, child, parent);
+
+    // Then compute acceleration
+    const Transform & child_X_parent = this->getTransform(jntPos, child, parent);
+
+    SpatialAcc joint_acc = SpatialAcc::Zero();
+    for (int dof = 0; dof < 3; dof++)
+    {
+        joint_acc = joint_acc + this->getMotionSubspaceVector(dof, child, parent) * jntAcc(this->getDOFsOffset() + dof);
+    }
+
+    // Add bias acceleration
+    SpatialAcc bias_acc = SpatialAcc::Zero();
+
+    linkAccs(child) = child_X_parent * linkAccs(parent) + joint_acc + bias_acc;
+}
+
+void SphericalJoint::computeChildAcc(const VectorDynSize & jntPos,
+                                    const VectorDynSize & jntVel,
+                                    const LinkVelArray & linkVels,
+                                    const VectorDynSize & jntAcc,
+                                    LinkAccArray & linkAccs,
+                                    const LinkIndex child, const LinkIndex parent) const
+{
+    const Transform & child_X_parent = this->getTransform(jntPos, child, parent);
+
+    SpatialAcc joint_acc = SpatialAcc::Zero();
+    for (int dof = 0; dof < 3; dof++)
+    {
+        joint_acc = joint_acc + this->getMotionSubspaceVector(dof, child, parent) * jntAcc(this->getDOFsOffset() + dof);
+    }
+
+    linkAccs(child) = child_X_parent * linkAccs(parent) + joint_acc;
+}
+
+void SphericalJoint::computeChildBiasAcc(const VectorDynSize & jntPos,
+                                        const VectorDynSize & jntVel,
+                                        const LinkVelArray & linkVels,
+                                        LinkAccArray & linkBiasAccs,
+                                        const LinkIndex child, const LinkIndex parent) const
+{
+    const Transform & child_X_parent = this->getTransform(jntPos, child, parent);
+
+    // For spherical joint, bias acceleration includes Coriolis terms
+    // This is a simplified implementation
+    SpatialAcc bias_acc = SpatialAcc::Zero();
+
+    linkBiasAccs(child) = child_X_parent * linkBiasAccs(parent) + bias_acc;
+}
+
+void SphericalJoint::computeJointTorque(const VectorDynSize & jntPos,
+                                       const Wrench & internalWrench,
+                                       const LinkIndex linkThatAppliesWrench,
+                                       const LinkIndex linkOnWhichWrenchIsApplied,
+                                       VectorDynSize & jntTorques) const
+{
+    // Project the wrench onto the motion subspace vectors
+    for (int dof = 0; dof < 3; dof++)
+    {
+        SpatialMotionVector S = this->getMotionSubspaceVector(dof, linkOnWhichWrenchIsApplied, linkThatAppliesWrench);
+        jntTorques(this->getDOFsOffset() + dof) = internalWrench.dot(S);
+    }
+}
+
+// Joint limits and dynamics are not supported for spherical joints
+bool SphericalJoint::hasPosLimits() const
+{
+    return false;
+}
+
+bool SphericalJoint::enablePosLimits(const bool enable)
+{
+    // Position limits are not supported for spherical joints
+    return false;
+}
+
+bool SphericalJoint::getPosLimits(const size_t _index, double & min, double & max) const
+{
+    return false;
+}
+
+double SphericalJoint::getMinPosLimit(const size_t _index) const
+{
+    return 0.0;
+}
+
+double SphericalJoint::getMaxPosLimit(const size_t _index) const
+{
+    return 0.0;
+}
+
+bool SphericalJoint::setPosLimits(const size_t _index, double min, double max)
+{
+    return false;
+}
+
+JointDynamicsType SphericalJoint::getJointDynamicsType() const
+{
+    return NoJointDynamics;
+}
+
+bool SphericalJoint::setJointDynamicsType(const JointDynamicsType enable)
+{
+    // Joint dynamics are not supported for spherical joints
+    return false;
+}
+
+bool SphericalJoint::setDamping(const size_t _index, double damping)
+{
+    return false;
+}
+
+bool SphericalJoint::setStaticFriction(const size_t _index, double staticFriction)
+{
+    return false;
+}
+
+double SphericalJoint::getDamping(const size_t _index) const
+{
+    return 0.0;
+}
+
+double SphericalJoint::getStaticFriction(const size_t _index) const
+{
+    return 0.0;
+}
+
+}

--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -448,7 +448,7 @@ void checkRandomModels()
 
     for(int i=2; i <= 100; i += 30 )
     {
-        Model randomModel = getRandomModel(i);
+        Model randomModel = getRandomModel(i,/*nrOfAdditionalFrames =*/10, /*onlyRevoluteJoints=*/false, /*includeSphericalJoints=*/true);
 
         std::cout << "Checking reduced model for random model of size: " << i << std::endl;
         checkAll(randomModel);


### PR DESCRIPTION
This is the first PR required to implement https://github.com/icub-tech-iit/creo2urdf/issues/136 .

This PR adds a `SphericalJoint` class that implements a spherical joint that is implemented using a `quaternion` as position variable, while angular velocity for velocity.

The basic structure of the `SphericalJoint` was generated via CoPilot Agentic mode with Claude, and that is probably the reason why the math implementation of the methods need to be double checked.

Note that this is the first joint with a number of DOF different from 0 or 1, so its use may expose bugs in user code. For example, a classical bug is confusions between `IJoint::getJointIndex`, `IJoint::getPosCoordsOffset` and `IJoint:: getDOFsOffset`, as these methods all return the same values for model with just 1-dof and 0-dof joints, but will return different values for models with spherical joints.

A first test was added by modifying the `getRandomModel` to optionally also generate models with SphericalJoint, and this optional support is enabled in the `ModelUnitTest`, that indeed is now segfaulting, so for sure we need to fix something. To simplify debugging, probably it make sense to develop a joint generic unit test that just checks the consistency of getTransform, getMotionSubspace and all the `computeChild**`methods based on the mathematical definitions of these methods, that mostly mirror the content of https://traversaro.github.io/traversaro-phd-thesis/traversaro-phd-thesis.pdf .