### PR TITLE
Temporary disable MATLAB Windows tests

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-13]
+        # Skip Windows tests for now, see https://github.com/robotology/idyntree/issues/1251
+        os: [ubuntu-22.04, macos-13]
         matlab_version: [R2022a, R2022b, R2023a]
 
     steps:


### PR DESCRIPTION
Temporary workaround to https://github.com/robotology/idyntree/issues/1251 to have a green CI .