### PR TITLE
Add option for generating random models with RevoluteSO2 and fix code and tests that assumed 0-dof or 1-dof joints

### DIFF
--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -23,6 +23,9 @@
 // Wrap the std::unordered_map<std::string, double>
 %template(StringToDoubleUnorderedMap) std::unordered_map<std::string, double>;
 
+// Wrap the std::unordered_map<std::string, std::vector<double>>
+%template(StringToDoubleVectorUnorderedMap) std::unordered_map<std::string, std::vector<double>>;
+
 // Ignore some methods to avoid warnings
 %include "./ignore.i"
 

--- a/bindings/pybind11/idyntree_model.cpp
+++ b/bindings/pybind11/idyntree_model.cpp
@@ -71,7 +71,7 @@ void modelClassDefinition(py::class_<Model>& model) {
         m.computeFullTreeTraversal(*traversal);
         return traversal;
       })
-      .def_property_readonly("visual_solid_shapes", 
+      .def_property_readonly("visual_solid_shapes",
                              py::overload_cast<>(&Model::visualSolidShapes))
       .def_property_readonly("collision_solid_shapes",
                              py::overload_cast<>(&Model::collisionSolidShapes))
@@ -118,13 +118,14 @@ void traversalClassDefinition(py::class_<Traversal>& traversal) {
 }
 
     void utilityFunctionsDefinition(pybind11::module& module) {
+        // Expose the deprecated interface for backward compatibility
         module
             .def("get_random_model",
-                 iDynTree::getRandomModel,
+                 static_cast<Model(*)(unsigned int, size_t, bool)>(&iDynTree::getRandomModel),
                  py::arg("nr_of_joints"), py::arg("nr_of_additional_frames") = 10,
                  py::arg("only_revolute_joints") = false)
             .def("get_random_chain",
-                 iDynTree::getRandomChain,
+                 static_cast<Model(*)(unsigned int, size_t, bool)>(&iDynTree::getRandomChain),
                  py::arg("nr_of_joints"), py::arg("nr_of_additional_frames") = 10,
                  py::arg("only_revolute_joints") = false);
     }

--- a/src/estimation/tests/BerdyHelperUnitTest.cpp
+++ b/src/estimation/tests/BerdyHelperUnitTest.cpp
@@ -31,7 +31,7 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     FreeFloatingAcc generalizedProperAccs(berdy.model());
     LinkNetExternalWrenches extWrenches(berdy.model());
 
-    getRandomInverseDynamicsInputs(pos,vel,generalizedProperAccs,extWrenches);
+    getRandomInverseDynamicsInputs(berdy.model(),pos,vel,generalizedProperAccs,extWrenches);
 
     // Force the base linear velocity to be zero for ensure consistency with the compute buffers
     vel.baseVel().setLinearVec3(LinVelocity(0.0, 0.0, 0.0));
@@ -106,7 +106,7 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
     */
 
     ASSERT_EQUAL_VECTOR(dynamicsResidual, zeroRes);
-    
+
     if( berdy.getNrOfSensorsMeasurements() > 0 )
     {
         std::cout << "BerdyHelperUnitTest, testing sensors matrix for model " << filename <<  std::endl;
@@ -117,14 +117,14 @@ void testBerdySensorMatrices(BerdyHelper & berdy, std::string filename)
         SensorsMeasurements sensMeas(berdy.sensors());
         bool ok = predictSensorsMeasurementsFromRawBuffers(berdy.model(),berdy.sensors(),berdy.dynamicTraversal(),
                                                            linkVels,linkProperAccs,intWrenches,sensMeas);
- 
+
 	    // Handle rate of change of momentum in base
         SpatialForceVector rcm;
         rcm.zero();
         for(int linkIdx = 0; linkIdx<extWrenches.getNrOfLinks(); linkIdx++)
         {
             // compute {}^{B}H_{L}
-            Transform base_H_link = linkPos(baseIdx).inverse() * linkPos(linkIdx); 
+            Transform base_H_link = linkPos(baseIdx).inverse() * linkPos(linkIdx);
             rcm = rcm + (base_H_link * extWrenches(linkIdx));
         }
 
@@ -184,7 +184,7 @@ void testBerdyOriginalFixedBase(BerdyHelper & berdy, std::string filename)
     FreeFloatingAcc generalizedProperAccs(berdy.model());
     LinkNetExternalWrenches extWrenches(berdy.model());
 
-    getRandomInverseDynamicsInputs(pos,vel,generalizedProperAccs,extWrenches);
+    getRandomInverseDynamicsInputs(berdy.model(),pos,vel,generalizedProperAccs,extWrenches);
 
     Vector3 grav;
     grav.zero();
@@ -358,8 +358,8 @@ void testBerdyHelpers(std::string fileName)
     ok = berdyHelper.init(estimator.model(), estimator.sensors(), options);
     ASSERT_IS_TRUE(ok);
     testBerdySensorMatrices(berdyHelper, fileName);
-    
-    // Test includeAllJointTorqueAsSensors option 
+
+    // Test includeAllJointTorqueAsSensors option
     options.berdyVariant = iDynTree::BERDY_FLOATING_BASE;
     // For now floating berdy needs all the ext wrenches as dynamic variables
     options.includeAllNetExternalWrenchesAsDynamicVariables = true;

--- a/src/estimation/tests/ExternalWrenchesEstimationUnitTest.cpp
+++ b/src/estimation/tests/ExternalWrenchesEstimationUnitTest.cpp
@@ -70,7 +70,7 @@ void checkSimpleModelExternalWrenchEstimation(size_t nrOfJoints)
     FreeFloatingAcc robotAcc(model);
 
     robotPos.worldBasePos() = getRandomTransform();
-    getRandomVector(robotPos.jointPos());
+    getRandomJointPositions(robotPos.jointPos(), model);
 
     robotVel.baseVel() = getRandomTwist();
     getRandomVector(robotVel.jointVel());
@@ -131,7 +131,7 @@ void checkRandomModelExternalWrenchEstimation(size_t nrOfJoints)
     FreeFloatingAcc robotAcc(model);
 
     robotPos.worldBasePos() = getRandomTransform();
-    getRandomVector(robotPos.jointPos());
+    getRandomJointPositions(robotPos.jointPos(), model);
 
     robotVel.baseVel() = getRandomTwist();
     getRandomVector(robotVel.jointVel());
@@ -268,7 +268,7 @@ void checkSimpleModelExternalWrenchEstimationWithFTSensors()
     FreeFloatingAcc robotAcc(model);
 
     robotPos.worldBasePos() = getRandomTransform();
-    getRandomVector(robotPos.jointPos());
+    getRandomJointPositions(robotPos.jointPos(), model);
 
     robotVel.baseVel() = getRandomTwist();
     getRandomVector(robotVel.jointVel());

--- a/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
@@ -67,7 +67,6 @@ void setRandomState(iDynTree::KinDynComputations & dynComp)
     Vector3 gravityVec;
     getRandomVector(gravityVec);
     gravity = toEigen(gravityVec);
-    gravity(2) = 0.0;  // Keep the original constraint
 
     // Use model-aware joint position generation for proper handling of all joint types
     VectorDynSize qj_idyn(posCoords);

--- a/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsMatrixViewAndSpanUnitTest.cpp
@@ -18,6 +18,8 @@
 #include <iDynTree/JointState.h>
 #include <iDynTree/FreeFloatingState.h>
 
+#include <iDynTree/ModelTestUtils.h>
+
 #include <iDynTree/ModelLoader.h>
 
 
@@ -47,37 +49,39 @@ int real_random_int(int initialValue, int finalValue)
 void setRandomState(iDynTree::KinDynComputations & dynComp)
 {
     size_t dofs = dynComp.getNrOfDegreesOfFreedom();
+    size_t posCoords = dynComp.model().getNrOfPosCoords();
     Transform    worldTbase;
     Eigen::Vector6d baseVel;
     Eigen::Vector3d gravity;
 
-    Eigen::VectorXd qj(dofs), dqj(dofs), ddqj(dofs);
+    Eigen::VectorXd qj(posCoords), dqj(dofs), ddqj(dofs);
 
-    worldTbase = iDynTree::Transform(Rotation::RPY(random_double(),random_double(),random_double()),
-                                     Position(random_double(),random_double(),random_double()));
+    // Use utility functions for generating random state
+    worldTbase = getRandomTransform();
 
+    // Generate random base velocity using iDynTree utility and convert to Eigen
+    Twist baseTwist = getRandomTwist();
+    baseVel = toEigen(baseTwist);
+
+    // Generate random gravity vector
+    Vector3 gravityVec;
+    getRandomVector(gravityVec);
+    gravity = toEigen(gravityVec);
+    gravity(2) = 0.0;  // Keep the original constraint
+
+    // Use model-aware joint position generation for proper handling of all joint types
+    VectorDynSize qj_idyn(posCoords);
+    getRandomJointPositions(qj_idyn, dynComp.model());
+    qj = toEigen(qj_idyn);
+
+    // Generate random joint velocities and accelerations
+    VectorDynSize dqj_idyn(dofs), ddqj_idyn(dofs);
+    getRandomVector(dqj_idyn);
+    getRandomVector(ddqj_idyn);
+    dqj = toEigen(dqj_idyn);
+    ddqj = toEigen(ddqj_idyn);
 
     Eigen::Matrix4d transform = toEigen(worldTbase.asHomogeneousTransform());
-
-    for(int i=0; i < 3; i++)
-    {
-        gravity(i) = random_double();
-    }
-
-    gravity(2) = 0.0;
-
-    for(int i=0; i < 6; i++)
-    {
-        baseVel(i) = real_random_double();
-    }
-
-    for(size_t dof=0; dof < dofs; dof++)
-
-    {
-        qj(dof) = random_double();
-        dqj(dof) = random_double();
-        ddqj(dof) = random_double();
-    }
 
     bool ok = dynComp.setRobotState(transform,
                                     make_span(qj.data(), qj.size()),
@@ -88,7 +92,7 @@ void setRandomState(iDynTree::KinDynComputations & dynComp)
 
     ASSERT_IS_TRUE(ok);
 
-    Eigen::VectorXd qj_read(dofs), dqj_read(dofs);
+    Eigen::VectorXd qj_read(posCoords), dqj_read(dofs);
     Eigen::Vector3d gravity_read;
     Eigen::Matrix4d transform_read;
     Eigen::Vector6d baseVel_read;

--- a/src/high-level/tests/KinDynComputationsUnitTest.cpp
+++ b/src/high-level/tests/KinDynComputationsUnitTest.cpp
@@ -21,6 +21,8 @@
 #include <iDynTree/SubModel.h>
 #include <iDynTree/ModelTransformers.h>
 
+#include <iDynTree/ModelTestUtils.h>
+
 #include <iDynTree/ModelLoader.h>
 
 
@@ -45,36 +47,26 @@ int real_random_int(int initialValue, int finalValue)
 void setRandomState(iDynTree::KinDynComputations & dynComp)
 {
     size_t dofs = dynComp.getNrOfDegreesOfFreedom();
+    size_t posCoords = dynComp.model().getNrOfPosCoords();
     Transform    worldTbase;
     Twist        baseVel;
     Vector3 gravity;
 
-    iDynTree::VectorDynSize qj(dofs), dqj(dofs), ddqj(dofs);
+    iDynTree::VectorDynSize qj(posCoords), dqj(dofs), ddqj(dofs);
 
-    worldTbase = iDynTree::Transform(Rotation::RPY(random_double(),random_double(),random_double()),
-            Position(random_double(),random_double(),random_double()));
+    // Use utility functions for generating random state
+    worldTbase = getRandomTransform();
+    baseVel = getRandomTwist();
+    getRandomVector(gravity);
 
-    for(int i=0; i < 3; i++)
-    {
-        gravity(i) = random_double();
-    }
-
-    for(int i=0; i < 6; i++)
-    {
-        baseVel(i) = real_random_double();
-    }
-
-    for(size_t dof=0; dof < dofs; dof++)
-
-    {
-        qj(dof) = random_double();
-        dqj(dof) = random_double();
-        ddqj(dof) = random_double();
-    }
+    // Use model-aware joint position generation for proper handling of all joint types
+    getRandomJointPositions(qj, dynComp.model());
+    getRandomVector(dqj);
+    getRandomVector(ddqj);
 
     bool ok = dynComp.setRobotState(worldTbase,qj,baseVel,dqj,gravity);
 
-    iDynTree::VectorDynSize qj_read(dofs), dqj_read(dofs);
+    iDynTree::VectorDynSize qj_read(posCoords), dqj_read(dofs);
     Vector3 gravity_read;
     Transform    worldTbase_read;
     Twist        baseVel_read;

--- a/src/model/include/iDynTree/ModelTestUtils.h
+++ b/src/model/include/iDynTree/ModelTestUtils.h
@@ -19,10 +19,6 @@
 #include <cmath>
 #include "IJoint.h"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 namespace iDynTree
 {
 
@@ -205,22 +201,16 @@ inline void getRandomJointPositions(VectorDynSize& vec, const Model& model)
         }
         else
         {
-            // Special handling for RevoluteSO2Joint (2 pos coords, 1 DOF)
-            if (jntPtr->getNrOfPosCoords() == 2 && jntPtr->getNrOfDOFs() == 1)
+            // Set random values for all position coordinates
+            for(int i=0; i < jntPtr->getNrOfPosCoords(); i++)
             {
-                // Generate random angle and set complex representation
-                double angle = getRandomDouble(-M_PI, M_PI);
-                vec(jntPtr->getPosCoordsOffset()) = std::cos(angle);
-                vec(jntPtr->getPosCoordsOffset() + 1) = std::sin(angle);
-            }
-            else
-            {
-                for(int i=0; i < jntPtr->getNrOfPosCoords(); i++)
-                {
-                    vec(jntPtr->getPosCoordsOffset()+i) = getRandomDouble();
-                }
+                vec(jntPtr->getPosCoordsOffset()+i) = getRandomDouble();
             }
         }
+
+        // Use normalizeJointPosCoords to make the code more general
+        // This handles different joint types (RevoluteSO2, Revolute, Prismatic, etc.) appropriately
+        jntPtr->normalizeJointPosCoords(vec);
     }
 
     return;

--- a/src/model/include/iDynTree/ModelTestUtils.h
+++ b/src/model/include/iDynTree/ModelTestUtils.h
@@ -300,7 +300,8 @@ inline void getRandomJointPositions(VectorDynSize& vec, const Model& model)
  * Get random robot positions, velocities and accelerations
  * and external wrenches to be given as an input to InverseDynamics.
  */
-inline bool getRandomInverseDynamicsInputs(FreeFloatingPos& pos,
+inline bool getRandomInverseDynamicsInputs(const Model& model,
+                                           FreeFloatingPos& pos,
                                            FreeFloatingVel& vel,
                                            FreeFloatingAcc& acc,
                                            LinkNetExternalWrenches& extWrenches)
@@ -309,14 +310,8 @@ inline bool getRandomInverseDynamicsInputs(FreeFloatingPos& pos,
     vel.baseVel() =  getRandomTwist();
     acc.baseAcc() =  getRandomTwist();
 
-    // Use model-aware joint position generation instead of naive random vector
-    // This is needed for proper handling of RevoluteSO2Joint and other special joints
-    // However, we don't have access to the model here, so we can't use getRandomJointPositions
-    // This function is not used in the failing test anyway, but should be addressed separately
-    for(unsigned int jnt=0; jnt < pos.getNrOfPosCoords(); jnt++)
-    {
-        pos.jointPos()(jnt) = getRandomDouble();
-    }
+    // Use model-aware joint position generation for proper handling of all joint types
+    getRandomJointPositions(pos.jointPos(), model);
 
     for(unsigned int jnt=0; jnt < vel.getNrOfDOFs(); jnt++)
     {

--- a/src/model/include/iDynTree/ModelTestUtils.h
+++ b/src/model/include/iDynTree/ModelTestUtils.h
@@ -33,8 +33,11 @@ enum JointTypes : unsigned int
     JOINT_REVOLUTE_SO2 = 1 << 3  // 1000 - RevoluteSO2Joint
 };
 
-// Default joint types: Fixed, Revolute, and Prismatic
-const unsigned int DEFAULT_JOINT_TYPES = JOINT_FIXED | JOINT_REVOLUTE | JOINT_PRISMATIC;
+// Simple joint types: Fixed, Revolute, and Prismatic
+const unsigned int SIMPLE_JOINT_TYPES = JOINT_FIXED | JOINT_REVOLUTE | JOINT_PRISMATIC;
+
+// All available joint types: Fixed, Revolute, Prismatic, and RevoluteSO2
+const unsigned int ALL_JOINT_TYPES = JOINT_FIXED | JOINT_REVOLUTE | JOINT_PRISMATIC | JOINT_REVOLUTE_SO2;
 
 inline Link getRandomLink()
 {
@@ -61,7 +64,7 @@ inline Link getRandomLink()
 /**
  * Add a random link with random model.
  */
-inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES)
+inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, unsigned int allowedJointTypes = SIMPLE_JOINT_TYPES)
 {
     // Add Link
     LinkIndex newLinkIndex = model.addLink(newLinkName,getRandomLink());
@@ -86,7 +89,7 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
 
     // If no joint types are allowed, use default
     if (availableJointTypes.empty()) {
-        allowedJointTypes = DEFAULT_JOINT_TYPES;
+        allowedJointTypes = SIMPLE_JOINT_TYPES;
         if (allowedJointTypes & JOINT_FIXED) {
             availableJointTypes.push_back(0);
         }
@@ -179,9 +182,9 @@ inline std::string int2string(int i)
  * - getRandomModel(5) // Uses default joint types (Fixed, Revolute, Prismatic)
  * - getRandomModel(5, 10, JOINT_REVOLUTE | JOINT_PRISMATIC) // Only revolute and prismatic joints
  * - getRandomModel(5, 10, JOINT_REVOLUTE) // Only revolute joints
- * - getRandomModel(5, 10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2) // All joint types including SO2
+ * - getRandomModel(5, 10, SIMPLE_JOINT_TYPES | JOINT_REVOLUTE_SO2) // All joint types including SO2
  */
-inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES)
+inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, unsigned int allowedJointTypes = SIMPLE_JOINT_TYPES)
 {
     Model model;
 
@@ -211,7 +214,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
  * @param nrOfAdditionalFrames Number of additional frames to add (default: 10)
  * @param allowedJointTypes Bitfield specifying which joint types to include (default: Fixed, Revolute, Prismatic)
  */
-inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES)
+inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, unsigned int allowedJointTypes = SIMPLE_JOINT_TYPES)
 {
     Model model;
 
@@ -239,7 +242,7 @@ inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
 IDYNTREE_DEPRECATED_WITH_MSG("Use getRandomModel variant that takes in input the allowedJointTypes as bitset.")
 inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames, bool onlyRevoluteJoints)
 {
-    unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES;
+    unsigned int allowedJointTypes = SIMPLE_JOINT_TYPES;
     if (onlyRevoluteJoints) {
         allowedJointTypes = JOINT_REVOLUTE;
     }
@@ -249,7 +252,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
 IDYNTREE_DEPRECATED_WITH_MSG("Use getRandomChain variant that takes in input the allowedJointTypes as bitset.")
 inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames, bool onlyRevoluteJoints)
 {
-    unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES;
+    unsigned int allowedJointTypes = SIMPLE_JOINT_TYPES;
     if (onlyRevoluteJoints) {
         allowedJointTypes = JOINT_REVOLUTE;
     }

--- a/src/model/include/iDynTree/ModelTestUtils.h
+++ b/src/model/include/iDynTree/ModelTestUtils.h
@@ -236,26 +236,22 @@ inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
 }
 
 // Backward compatibility overloads
-inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames, bool onlyRevoluteJoints, bool includeRevoluteJointsSO2 = false)
+IDYNTREE_DEPRECATED_WITH_MSG("Use getRandomModel variant that takes in input the allowedJointTypes as bitset.")
+inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames, bool onlyRevoluteJoints)
 {
     unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES;
     if (onlyRevoluteJoints) {
         allowedJointTypes = JOINT_REVOLUTE;
-    }
-    if (includeRevoluteJointsSO2) {
-        allowedJointTypes |= JOINT_REVOLUTE_SO2;
     }
     return getRandomModel(nrOfJoints, nrOfAdditionalFrames, allowedJointTypes);
 }
 
-inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames, bool onlyRevoluteJoints, bool includeRevoluteJointsSO2 = false)
+IDYNTREE_DEPRECATED_WITH_MSG("Use getRandomChain variant that takes in input the allowedJointTypes as bitset.")
+inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames, bool onlyRevoluteJoints)
 {
     unsigned int allowedJointTypes = DEFAULT_JOINT_TYPES;
     if (onlyRevoluteJoints) {
         allowedJointTypes = JOINT_REVOLUTE;
-    }
-    if (includeRevoluteJointsSO2) {
-        allowedJointTypes |= JOINT_REVOLUTE_SO2;
     }
     return getRandomChain(nrOfJoints, nrOfAdditionalFrames, allowedJointTypes);
 }
@@ -294,6 +290,43 @@ inline void getRandomJointPositions(VectorDynSize& vec, const Model& model)
     }
 
     return;
+}
+
+/**
+ * Get random robot positions, velocities and accelerations
+ * and external wrenches to be given as an input to InverseDynamics.
+ *
+ * @deprecated This function does not work properly with RevoluteSO2Joint joints.
+ * Use the version that takes a Model parameter instead.
+ */
+IDYNTREE_DEPRECATED_WITH_MSG("This function does not work properly with RevoluteSO2Joint joints. Use the version that takes a Model parameter instead.")
+inline bool getRandomInverseDynamicsInputs(FreeFloatingPos& pos,
+                                           FreeFloatingVel& vel,
+                                           FreeFloatingAcc& acc,
+                                           LinkNetExternalWrenches& extWrenches)
+{
+    pos.worldBasePos() = getRandomTransform();
+    vel.baseVel() =  getRandomTwist();
+    acc.baseAcc() =  getRandomTwist();
+
+    // Simple random generation - does not work properly with RevoluteSO2Joint
+    for(unsigned int jnt=0; jnt < pos.getNrOfPosCoords(); jnt++)
+    {
+        pos.jointPos()(jnt) = getRandomDouble();
+    }
+
+    for(unsigned int jnt=0; jnt < vel.getNrOfDOFs(); jnt++)
+    {
+        vel.jointVel()(jnt) = getRandomDouble();
+        acc.jointAcc()(jnt) = getRandomDouble();
+    }
+
+    for(unsigned int link=0; link < extWrenches.getNrOfLinks(); link++ )
+    {
+        extWrenches(link) = getRandomWrench();
+    }
+
+    return true;
 }
 
 /**

--- a/src/model/include/iDynTree/ModelTestUtils.h
+++ b/src/model/include/iDynTree/ModelTestUtils.h
@@ -8,6 +8,7 @@
 #include <iDynTree/Model.h>
 #include <iDynTree/FixedJoint.h>
 #include <iDynTree/RevoluteJoint.h>
+#include <iDynTree/RevoluteSO2Joint.h>
 #include <iDynTree/PrismaticJoint.h>
 #include <iDynTree/FreeFloatingState.h>
 #include <iDynTree/LinkState.h>
@@ -45,7 +46,7 @@ inline Link getRandomLink()
 /**
  * Add a random link with random model.
  */
-inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, bool onlyRevoluteJoints=false)
+inline void addRandomLinkToModel(Model & model, std::string parentLink, std::string newLinkName, bool onlyRevoluteJoints=false, bool includeRevoluteJointsSO2=false)
 {
     // Add Link
     LinkIndex newLinkIndex = model.addLink(newLinkName,getRandomLink());
@@ -54,6 +55,9 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
     LinkIndex parentLinkIndex = model.getLinkIndex(parentLink);
 
     int nrOfJointTypes = 3;
+    if (includeRevoluteJointsSO2) {
+        nrOfJointTypes = 4;
+    }
 
     int jointType = rand() % nrOfJointTypes;
 
@@ -82,6 +86,14 @@ inline void addRandomLinkToModel(Model & model, std::string parentLink, std::str
         prismJoint.setRestTransform(getRandomTransform());
         prismJoint.setAxis(getRandomAxis(),newLinkIndex);
         model.addJoint(newLinkName+"joint",&prismJoint);
+    }
+    else if( jointType == 3 )
+    {
+        RevoluteSO2Joint revSO2Joint;
+        revSO2Joint.setAttachedLinks(parentLinkIndex,newLinkIndex);
+        revSO2Joint.setRestTransform(getRandomTransform());
+        revSO2Joint.setAxis(getRandomAxis(),newLinkIndex);
+        model.addJoint(newLinkName+"joint",&revSO2Joint);
     }
     else
     {
@@ -120,7 +132,7 @@ inline std::string int2string(int i)
     return ss.str();
 }
 
-inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false)
+inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false, bool includeRevoluteJointsSO2=false)
 {
     Model model;
 
@@ -130,7 +142,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     {
         std::string parentLink = getRandomLinkOfModel(model);
         std::string linkName = "link" + int2string(i);
-        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints);
+        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints,includeRevoluteJointsSO2);
     }
 
     for(unsigned int i=0; i < nrOfAdditionalFrames; i++)
@@ -143,7 +155,7 @@ inline Model getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     return model;
 }
 
-inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false)
+inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10, bool onlyRevoluteJoints=false, bool includeRevoluteJointsSO2=false)
 {
     Model model;
 
@@ -154,7 +166,7 @@ inline Model getRandomChain(unsigned int nrOfJoints, size_t nrOfAdditionalFrames
     {
         std::string parentLink = linkName;
         linkName = "link" + int2string(i);
-        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints);
+        addRandomLinkToModel(model,parentLink,linkName,onlyRevoluteJoints,includeRevoluteJointsSO2);
     }
 
     for(unsigned int i=0; i < nrOfAdditionalFrames; i++)

--- a/src/model/include/iDynTree/ModelTransformers.h
+++ b/src/model/include/iDynTree/ModelTransformers.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include <iDynTree/Utils.h>
+
 namespace iDynTree
 {
 class Model;
@@ -76,11 +78,34 @@ bool createReducedModel(const Model& fullModel,
  * to be in "rest" position (i.e. zero for revolute or prismatic joints), or the position
  * specified in the removedJointPositions if a given joint is specified in removedJointPositions
  *
+ * @note This function signature with std::unordered_map<std::string, double>
+ *             only supports joints with 1 position coordinate (revolute, prismatic).
+ *             For joints with higher dimensionality (e.g., RevoluteSO2 with 2 position coordinates),
+ *             use the overload with std::unordered_map<std::string, std::vector<double>>.
  */
 bool createReducedModel(const Model& fullModel,
                         const std::vector<std::string>& jointsInReducedModel,
                         Model& reducedModel,
                         const std::unordered_map<std::string, double>& removedJointPositions);
+
+/**
+ * This function takes in input a iDynTree::Model and
+ * an ordered list of joints and returns a model with
+ * just the joint specified in the list, with that exact order.
+ *
+ * All other joints are be removed by lumping (i.e. fusing together)
+ * the inertia of the links that are connected by that joint, assuming the joint
+ * to be in "rest" position (i.e. zero for revolute or prismatic joints), or the position
+ * specified in the removedJointPositions if a given joint is specified in removedJointPositions
+ *
+ * This version supports joints with multiple position coordinates (e.g., RevoluteSO2).
+ * For joints with n position coordinates, the vector should contain exactly n values.
+ * For example, RevoluteSO2 joints expect 2 values: [cos(θ), sin(θ)].
+ */
+bool createReducedModel(const Model& fullModel,
+                        const std::vector<std::string>& jointsInReducedModel,
+                        Model& reducedModel,
+                        const std::unordered_map<std::string, std::vector<double>>& removedJointPositions);
 
 /**
  * @brief Given a specified base, return a model with a "normalized" joint numbering for that base.
@@ -169,11 +194,11 @@ bool moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(const iDynTree::Model
 /**
  * \function Remove all additional frames from the model, except a specified allowlist.
  *
- * This function takes in input a model, and return a model with all the additional 
+ * This function takes in input a model, and return a model with all the additional
  * frame list removed, except for the additional frames whose name is specified in
  * the specified allowlist.
  *
- * @note The main use of this function is for processing models that need to be 
+ * @note The main use of this function is for processing models that need to be
  *       passed to other libraries or physics engines, where the additional frames
  *       may create problems or create performance problem. As long as you are using
  *       iDynTree, the presence of additional frames does not impact the performance

--- a/src/model/src/Model.cpp
+++ b/src/model/src/Model.cpp
@@ -567,7 +567,7 @@ JointIndex Model::insertLinkToExistingJointAndAddJointForDisplacedLink(const std
 
 size_t Model::getNrOfPosCoords() const
 {
-    return nrOfDOFs;
+    return nrOfPosCoords;
 }
 
 size_t Model::getNrOfDOFs() const

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -9,6 +9,7 @@
 #include <iDynTree/FixedJoint.h>
 #include <iDynTree/RevoluteJoint.h>
 #include <iDynTree/PrismaticJoint.h>
+#include <iDynTree/RevoluteSO2Joint.h>
 
 #include <iDynTree/Sensors.h>
 #include <iDynTree/SixAxisForceTorqueSensor.h>
@@ -638,6 +639,23 @@ bool createReducedModelAndChangeLinkFrames(const Model& fullModel,
             newJointPrismatic->setAxis(prismaticAxis_wrt_newLink2, newLink2);
 
             newJoint = (IJointPtr) newJointPrismatic;
+        }
+        else if (dynamic_cast<const RevoluteSO2Joint*>(oldJoint))
+        {
+            const RevoluteSO2Joint* oldJointRevoluteSO2 = dynamic_cast<const RevoluteSO2Joint*>(oldJoint);
+
+            Transform oldLink1_X_oldLink2 = oldJointRevoluteSO2->getRestTransform(oldLink1, oldLink2);
+            Transform newLink1_X_newLink2 = newLink1_X_oldLink1 * oldLink1_X_oldLink2 * newLink2_X_oldLink2.inverse();
+
+            Axis rotationAxis_wrt_newLink2 = newLink2_X_oldLink2 * oldJointRevoluteSO2->getAxis(oldLink2);
+
+            RevoluteSO2Joint* newJointRevoluteSO2 = new RevoluteSO2Joint(*oldJointRevoluteSO2);
+
+            newJointRevoluteSO2->setAttachedLinks(newLink1, newLink2);
+            newJointRevoluteSO2->setRestTransform(newLink1_X_newLink2);
+            newJointRevoluteSO2->setAxis(rotationAxis_wrt_newLink2, newLink2);
+
+            newJoint = (IJointPtr)newJointRevoluteSO2;
         }
         else
         {

--- a/src/model/src/ModelTransformers.cpp
+++ b/src/model/src/ModelTransformers.cpp
@@ -416,6 +416,7 @@ void reducedModelAddSolidShapes(const Model& fullModel,
 
 }
 
+
 // This function is a private function that is not exposed in the headers, but it used as a backend
 // of both:
 //  * createReducedModel : function to create a reduced model given the specified joints
@@ -431,7 +432,7 @@ void reducedModelAddSolidShapes(const Model& fullModel,
 bool createReducedModelAndChangeLinkFrames(const Model& fullModel,
                                            const std::vector< std::string >& jointsInReducedModel,
                                            Model& reducedModel,
-                                           const std::unordered_map<std::string, double>& removedJointPositions,
+                                           const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                            const std::unordered_map<std::string, iDynTree::Transform>& newLink_H_oldLink,
                                            bool addOriginalLinkFrameWith_original_frame_suffix,
                                            bool includeAllAdditionalFrames,
@@ -467,40 +468,44 @@ bool createReducedModelAndChangeLinkFrames(const Model& fullModel,
     // The position for the joint removed from the model is supposed to be 0
     FreeFloatingPos jointPos(fullModel);
 
-    // \todo used an appropriate method here
+    // Set joint positions using the new vector-based interface
     for(JointIndex jntIdx=0; jntIdx < fullModel.getNrOfJoints(); jntIdx++)
     {
-        // Get nr of DOFs for joint
-        size_t nrOfDofs = fullModel.getJoint(jntIdx)->getNrOfDOFs();
+        // Get nr of position coordinates for joint
+        size_t nrOfPosCoords = fullModel.getJoint(jntIdx)->getNrOfPosCoords();
 
         // Nothing to do if the joint is fixed
-        if (nrOfDofs == 0)
+        if (nrOfPosCoords == 0)
         {
             continue;
         }
 
-        // If the joint has 1 DOF, either use the value specified in removedJointPositions
-        // or if no value is found in removedJointPositions, use 0
-        if (nrOfDofs == 1)
+        std::string jointName = fullModel.getJointName(jntIdx);
+        auto it = removedJointPositions.find(jointName);
+
+        if (it != removedJointPositions.end())
         {
-            auto it = removedJointPositions.find(fullModel.getJointName(jntIdx));
-
-            if (it != removedJointPositions.end())
+            // Check if the provided vector has the correct size
+            if (it->second.size() != nrOfPosCoords)
             {
-                jointPos.jointPos()(fullModel.getJoint(jntIdx)->getPosCoordsOffset()) = it->second;
-            }
-            else
-            {
-                fullModel.getJoint(jntIdx)->setJointPosCoordsToRest(jointPos.jointPos());
+                std::cerr << "[ERROR] createReducedModel error : "
+                            << " joint " << jointName << " expects " << nrOfPosCoords
+                            << " position coordinates, but " << it->second.size()
+                            << " were provided in removedJointPositions."
+                            << std::endl;
+                return false;
             }
 
-            continue;
+            // Set the joint position coordinates from the provided vector
+            size_t posOffset = fullModel.getJoint(jntIdx)->getPosCoordsOffset();
+            for (size_t i = 0; i < nrOfPosCoords; i++)
+            {
+                jointPos.jointPos()(posOffset + i) = it->second[i];
+            }
         }
-
-        // If the joint has nrOfDofs > 1, we do not support specifying it in removedJointPositions
-        // and we always set it to the rest position
-        if (nrOfDofs > 1)
+        else
         {
+            // If no values provided, set to rest position
             fullModel.getJoint(jntIdx)->setJointPosCoordsToRest(jointPos.jointPos());
         }
     }
@@ -741,7 +746,7 @@ bool createReducedModelAndChangeLinkFrames(const Model& fullModel,
 
                     // Update the appliedWrenchLink
                     if (fullModel.getLinkName(sensorCopy->getAppliedWrenchLink()) == oldSecondLinkName) {
-                        sensorCopy->setAppliedWrenchLink(reducedModel.getLinkIndex(newSecondLinkName));
+                        sensorCopy->setAppliedWrenchLink(newSecondLinkIndex);
                     }
 
                     // Add the sensor to the reduced model
@@ -776,7 +781,7 @@ bool createReducedModelAndChangeLinkFrames(const Model& fullModel,
 
                     // Update the appliedWrenchLink
                     if (fullModel.getLinkName(sensorCopy->getAppliedWrenchLink()) == oldFirstLinkName) {
-                        sensorCopy->setAppliedWrenchLink(reducedModel.getLinkIndex(newFirstLinkName));
+                        sensorCopy->setAppliedWrenchLink(newFirstLinkIndex);
                     }
 
                     // Add the sensor to the reduced model
@@ -869,9 +874,9 @@ bool createReducedModelAndChangeLinkFrames(const Model& fullModel,
 }
 
 bool createReducedModel(const Model& fullModel,
-                        const std::vector< std::string >& jointsInReducedModel,
+                        const std::vector<std::string>& jointsInReducedModel,
                         Model& reducedModel,
-                        const std::unordered_map<std::string, double>& removedJointPositions)
+                        const std::unordered_map<std::string, std::vector<double>>& removedJointPositions)
 {
     // We do not want to move the link frames in createReducedModel
     std::unordered_map<std::string, iDynTree::Transform> newLink_H_oldLink;
@@ -882,9 +887,24 @@ bool createReducedModel(const Model& fullModel,
 
 bool createReducedModel(const Model& fullModel,
                         const std::vector< std::string >& jointsInReducedModel,
+                        Model& reducedModel,
+                        const std::unordered_map<std::string, double>& removedJointPositions)
+{
+    // Convert the double-based map to vector-based map
+    std::unordered_map<std::string, std::vector<double>> removedJointPositionsVector;
+    for (const auto& pair : removedJointPositions)
+    {
+        removedJointPositionsVector[pair.first] = {pair.second};
+    }
+
+    return createReducedModel(fullModel, jointsInReducedModel, reducedModel, removedJointPositionsVector);
+}
+
+bool createReducedModel(const Model& fullModel,
+                        const std::vector< std::string >& jointsInReducedModel,
                         Model& reducedModel)
 {
-    std::unordered_map<std::string, double> emptyRemovedJointPositions;
+    std::unordered_map<std::string, std::vector<double>> emptyRemovedJointPositions;
     return createReducedModel(fullModel, jointsInReducedModel, reducedModel, emptyRemovedJointPositions);
 }
 
@@ -1078,7 +1098,7 @@ bool moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(const iDynTree::Model
     }
 
     // As we do not remove any joint, this map is empty
-    std::unordered_map<std::string, double> removedJointPositions;
+    std::unordered_map<std::string, std::vector<double>> removedJointPositions;
 
     // We now need to compute the newLink_H_oldLink transform for each link we need to transform
     std::unordered_map<std::string, iDynTree::Transform> newLink_H_oldLink;
@@ -1168,7 +1188,7 @@ bool removeAdditionalFramesFromModel(const Model& modelWithAllAdditionalFrames,
     return createReducedModelAndChangeLinkFrames(modelWithAllAdditionalFrames,
                                                  consideredJoints,
                                                  modelWithOnlyAllowedAdditionalFrames,
-                                                 std::unordered_map<std::string, double>(),
+                                                 std::unordered_map<std::string, std::vector<double>>(),
                                                  std::unordered_map<std::string, iDynTree::Transform>(),
                                                  false,
                                                  includeAllAdditionalFrames,

--- a/src/model/tests/ModelTransformersUnitTest.cpp
+++ b/src/model/tests/ModelTransformersUnitTest.cpp
@@ -47,7 +47,7 @@ void checkThatOneSphereGetsAName()
 void checkRemoveAdditionalFramesFromModel()
 {
     // Create random model with 10 links and 10 additional frames
-    iDynTree::Model modelWithAllAdditionalFrames = getRandomModel(10, 10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
+    iDynTree::Model modelWithAllAdditionalFrames = getRandomModel(10, 10, SIMPLE_JOINT_TYPES | JOINT_REVOLUTE_SO2);
 
     // Create an allow list of three additional frames
     std::vector<std::string> allowedAdditionalFrames;

--- a/src/model/tests/ModelTransformersUnitTest.cpp
+++ b/src/model/tests/ModelTransformersUnitTest.cpp
@@ -47,7 +47,7 @@ void checkThatOneSphereGetsAName()
 void checkRemoveAdditionalFramesFromModel()
 {
     // Create random model with 10 links and 10 additional frames
-    iDynTree::Model modelWithAllAdditionalFrames = getRandomModel(10, 10);
+    iDynTree::Model modelWithAllAdditionalFrames = getRandomModel(10, 10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
 
     // Create an allow list of three additional frames
     std::vector<std::string> allowedAdditionalFrames;

--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -93,7 +93,7 @@ void getRandomSubsetOfJoints(const Model & model,
     }
 }
 
-void getRandomJointPositonsForJointsNotInReducedModels(const Model & fullModel,
+void getRandomJointPositionsForJointsNotInReducedModels(const Model & fullModel,
                                                        const std::vector<std::string>& subsetOfJointsInReducedModel,
                                                        std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                                        FreeFloatingPos& fullModelPos)
@@ -318,7 +318,7 @@ void checkReducedModel(const Model & model)
 
         // Get random positions for reduced models
         std::unordered_map<std::string, std::vector<double>> removedJointPositions;
-        getRandomJointPositonsForJointsNotInReducedModels(model, jointInReducedModel, removedJointPositions, fullPos);
+        getRandomJointPositionsForJointsNotInReducedModels(model, jointInReducedModel, removedJointPositions, fullPos);
 
         Model reducedModel;
         bool ok = createReducedModel(model, jointInReducedModel, reducedModel, removedJointPositions);

--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -265,7 +265,7 @@ void checkReducedModel(const Model & model)
         FreeFloatingGeneralizedTorques reducedTrqsCheck(reducedModel);
 
         reducedPos.worldBasePos() = getRandomTransform();
-        getRandomVector(reducedPos.jointPos());
+        getRandomJointPositions(reducedPos.jointPos(), reducedModel);
 
         reducedVel.baseVel() = getRandomTwist();
         getRandomVector(reducedVel.jointVel());

--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -528,7 +528,7 @@ void checkRandomModels()
 
     for(int i=2; i <= 100; i += 30 )
     {
-        Model randomModel = getRandomModel(i,/*nrOfAdditionalFrames =*/10, /*onlyRevoluteJoints=*/false, /*includeRevoluteJointsSO2=*/true);
+        Model randomModel = getRandomModel(i,/*nrOfAdditionalFrames =*/10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
 
         std::cout << "Checking reduced model for random model of size: " << i << std::endl;
         checkAll(randomModel);

--- a/src/model/tests/ModelUnitTest.cpp
+++ b/src/model/tests/ModelUnitTest.cpp
@@ -542,7 +542,7 @@ void checkRandomModels()
 
     for(int i=2; i <= 100; i += 30 )
     {
-        Model randomModel = getRandomModel(i,/*nrOfAdditionalFrames =*/10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
+        Model randomModel = getRandomModel(i,/*nrOfAdditionalFrames =*/10, SIMPLE_JOINT_TYPES | JOINT_REVOLUTE_SO2);
 
         std::cout << "Checking reduced model for random model of size: " << i << std::endl;
         checkAll(randomModel);

--- a/src/model_io/codecs/include/iDynTree/ModelLoader.h
+++ b/src/model_io/codecs/include/iDynTree/ModelLoader.h
@@ -222,7 +222,7 @@ public:
      */
     bool loadReducedModelFromFullModel(const Model& fullModel,
                                        const std::vector<std::string> & consideredJoints,
-                                       const std::unordered_map<std::string, double>& removedJointPositions,
+                                       const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                        const std::string filetype="");
 
     /**
@@ -249,7 +249,7 @@ public:
      */
     bool loadReducedModelFromString(const std::string modelString,
                                     const std::vector<std::string> & consideredJoints,
-                                    const std::unordered_map<std::string, double>& removedJointPositions,
+                                    const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                     const std::string filetype="",
                                     const std::vector<std::string>& packageDirs = {});
 
@@ -276,7 +276,7 @@ public:
      */
     bool loadReducedModelFromFile(const std::string filename,
                                   const std::vector<std::string> & consideredJoints,
-                                  const std::unordered_map<std::string, double>& removedJointPositions,
+                                  const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                   const std::string filetype="",
                                   const std::vector<std::string>& packageDirs = {});
 

--- a/src/model_io/codecs/src/ModelLoader.cpp
+++ b/src/model_io/codecs/src/ModelLoader.cpp
@@ -134,7 +134,7 @@ namespace iDynTree
                                                     const std::vector< std::string >& consideredJoints,
                                                     const std::string filetype)
     {
-        std::unordered_map<std::string, double> emptyRemovedJointPositions;
+        std::unordered_map<std::string, std::vector<double>> emptyRemovedJointPositions;
         return this->loadReducedModelFromFullModel(fullModel, consideredJoints, emptyRemovedJointPositions, filetype);
     }
 
@@ -143,7 +143,7 @@ namespace iDynTree
                                                  const std::string filetype,
                                                  const std::vector<std::string>& packageDirs /*= {}*/)
     {
-        std::unordered_map<std::string, double> emptyRemovedJointPositions;
+        std::unordered_map<std::string, std::vector<double>> emptyRemovedJointPositions;
         return this->loadReducedModelFromString(modelString, consideredJoints, emptyRemovedJointPositions, filetype, packageDirs);
     }
 
@@ -152,13 +152,13 @@ namespace iDynTree
                                                const std::string filetype,
                                                const std::vector<std::string>& packageDirs /*= {}*/)
     {
-        std::unordered_map<std::string, double> emptyRemovedJointPositions;
+        std::unordered_map<std::string, std::vector<double>> emptyRemovedJointPositions;
         return this->loadReducedModelFromFile(filename, consideredJoints, emptyRemovedJointPositions, filetype, packageDirs);
     }
 
     bool ModelLoader::loadReducedModelFromFullModel(const Model& fullModel,
                                                     const std::vector< std::string >& consideredJoints,
-                                                    const std::unordered_map<std::string, double>& removedJointPositions,
+                                                    const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                                     const std::string /*filetype*/)
     {
         Model _modelReduced;
@@ -175,7 +175,7 @@ namespace iDynTree
 
     bool ModelLoader::loadReducedModelFromString(const std::string modelString,
                                                  const std::vector< std::string >& consideredJoints,
-                                                 const std::unordered_map<std::string, double>& removedJointPositions,
+                                                 const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                                  const std::string filetype,
                                                  const std::vector<std::string>& packageDirs /*= {}*/)
     {
@@ -197,7 +197,7 @@ namespace iDynTree
 
     bool ModelLoader::loadReducedModelFromFile(const std::string filename,
                                                const std::vector< std::string >& consideredJoints,
-                                               const std::unordered_map<std::string, double>& removedJointPositions,
+                                               const std::unordered_map<std::string, std::vector<double>>& removedJointPositions,
                                                const std::string filetype,
                                                const std::vector<std::string>& packageDirs /*= {}*/)
     {

--- a/src/tests/integration/DynamicsIntegrationTest.cpp
+++ b/src/tests/integration/DynamicsIntegrationTest.cpp
@@ -4,6 +4,7 @@
 
 #include <iDynTree/EigenHelpers.h>
 #include <iDynTree/TestUtils.h>
+#include <iDynTree/ModelTestUtils.h>
 
 #include <iDynTree/Model.h>
 #include <iDynTree/Traversal.h>
@@ -42,7 +43,7 @@ void checkInverseAndForwardDynamicsAreIdempotent(const Model & model,
     // Fill the input to forward dynamics with random data
     robotPos.worldBasePos() = getRandomTransform();
     robotVel.baseVel() = getRandomTwist();
-    getRandomVector(robotPos.jointPos());
+    getRandomJointPositions(robotPos.jointPos(), model);
     getRandomVector(robotVel.jointVel());
     for(unsigned int link=0; link < model.getNrOfLinks(); link++ )
     {

--- a/src/tests/integration/DynamicsIntegrationTest.cpp
+++ b/src/tests/integration/DynamicsIntegrationTest.cpp
@@ -157,7 +157,7 @@ void checkInverseAndForwardDynamicsAreIdempotent(const Model & model,
     toEigen(REGR_baseWrench) = toEigen(invDynResults).segment<6>(0) + toEigen(RNEA_EXT_baseForceAndJointTorques.baseWrench());
     toEigen(REGR_jointTorques) = toEigen(invDynResults).segment(6, model.getNrOfDOFs()) + toEigen(RNEA_EXT_baseForceAndJointTorques.jointTorques());
 
-    double tolRegr = 1e-6;
+    double tolRegr = 2e-6;
     ASSERT_EQUAL_VECTOR_TOL(REGR_baseWrench, RNEA_baseForceAndJointTorques.baseWrench().asVector(), tolRegr);
     ASSERT_EQUAL_VECTOR_TOL(REGR_jointTorques, RNEA_baseForceAndJointTorques.jointTorques(), tolRegr);
 }

--- a/src/tests/integration/DynamicsLinearizationIntegrationTest.cpp
+++ b/src/tests/integration/DynamicsLinearizationIntegrationTest.cpp
@@ -517,7 +517,7 @@ int main()
     for(unsigned int joints =0; joints < 20; joints++)
     {
         std::cerr << "Checking DynamicsLinearization test on on random tree with " << joints  << "joints " << std::endl;
-        Model model = getRandomModel(joints);
+        Model model = getRandomModel(joints, 10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
         checkABAandABALinearizationAreConsistent(model);
     }
 

--- a/src/tests/integration/DynamicsLinearizationIntegrationTest.cpp
+++ b/src/tests/integration/DynamicsLinearizationIntegrationTest.cpp
@@ -517,7 +517,7 @@ int main()
     for(unsigned int joints =0; joints < 20; joints++)
     {
         std::cerr << "Checking DynamicsLinearization test on on random tree with " << joints  << "joints " << std::endl;
-        Model model = getRandomModel(joints, 10, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
+        Model model = getRandomModel(joints, 10, SIMPLE_JOINT_TYPES | JOINT_REVOLUTE_SO2);
         checkABAandABALinearizationAreConsistent(model);
     }
 

--- a/src/tests/integration/ModelTransformersIntegrationTest.cpp
+++ b/src/tests/integration/ModelTransformersIntegrationTest.cpp
@@ -39,32 +39,22 @@ int real_random_int(int initialValue, int finalValue)
 void setRandomState(iDynTree::KinDynComputations & originalKinDyn, iDynTree::KinDynComputations & transformedKinDyn)
 {
     size_t dofs = originalKinDyn.getNrOfDegreesOfFreedom();
+    size_t posCoords = originalKinDyn.model().getNrOfPosCoords();
     Transform    worldTbase;
     Twist        baseVel;
     Vector3 gravity;
 
-    iDynTree::VectorDynSize qj(dofs), dqj(dofs), ddqj(dofs);
+    iDynTree::VectorDynSize qj(posCoords), dqj(dofs), ddqj(dofs);
 
-    worldTbase = iDynTree::Transform(Rotation::RPY(random_double(),random_double(),random_double()),
-            Position(random_double(),random_double(),random_double()));
+    // Use utility functions for generating random state
+    worldTbase = getRandomTransform();
+    baseVel = getRandomTwist();
+    getRandomVector(gravity);
 
-    for(int i=0; i < 3; i++)
-    {
-        gravity(i) = random_double();
-    }
-
-    for(int i=0; i < 6; i++)
-    {
-        baseVel(i) = real_random_double();
-    }
-
-    for(size_t dof=0; dof < dofs; dof++)
-
-    {
-        qj(dof) = random_double();
-        dqj(dof) = random_double();
-        ddqj(dof) = random_double();
-    }
+    // Use model-aware joint position generation for proper handling of all joint types
+    getRandomJointPositions(qj, originalKinDyn.model());
+    getRandomVector(dqj);
+    getRandomVector(ddqj);
 
     ASSERT_IS_TRUE(originalKinDyn.setRobotState(worldTbase,qj,baseVel,dqj,gravity));
     ASSERT_IS_TRUE(transformedKinDyn.setRobotState(worldTbase,qj,baseVel,dqj,gravity));

--- a/src/tests/integration/ModelTransformersIntegrationTest.cpp
+++ b/src/tests/integration/ModelTransformersIntegrationTest.cpp
@@ -72,7 +72,7 @@ void checkThatMoveLinkFramesToBeCompatibleWithURDFWithGivenBaseLinkIsConsistent(
         size_t nrOfJoints = 20;
         size_t nrOFAdditionalFrames = 10;
 
-        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
+        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames, SIMPLE_JOINT_TYPES | JOINT_REVOLUTE_SO2);
 
         // Get random base link
         iDynTree::LinkIndex originalBaseLinkIndex = static_cast<iDynTree::LinkIndex>(rand() % originalModel.getNrOfLinks());

--- a/src/tests/integration/ModelTransformersIntegrationTest.cpp
+++ b/src/tests/integration/ModelTransformersIntegrationTest.cpp
@@ -72,7 +72,7 @@ void checkThatMoveLinkFramesToBeCompatibleWithURDFWithGivenBaseLinkIsConsistent(
         size_t nrOfJoints = 20;
         size_t nrOFAdditionalFrames = 10;
 
-        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames, SIMPLE_JOINT_TYPES | JOINT_REVOLUTE_SO2);
+        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames, SIMPLE_JOINT_TYPES);
 
         // Get random base link
         iDynTree::LinkIndex originalBaseLinkIndex = static_cast<iDynTree::LinkIndex>(rand() % originalModel.getNrOfLinks());

--- a/src/tests/integration/ModelTransformersIntegrationTest.cpp
+++ b/src/tests/integration/ModelTransformersIntegrationTest.cpp
@@ -72,7 +72,7 @@ void checkThatMoveLinkFramesToBeCompatibleWithURDFWithGivenBaseLinkIsConsistent(
         size_t nrOfJoints = 20;
         size_t nrOFAdditionalFrames = 10;
 
-        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames);
+        iDynTree::Model originalModel = iDynTree::getRandomModel(nrOfJoints, nrOFAdditionalFrames, DEFAULT_JOINT_TYPES | JOINT_REVOLUTE_SO2);
 
         // Get random base link
         iDynTree::LinkIndex originalBaseLinkIndex = static_cast<iDynTree::LinkIndex>(rand() % originalModel.getNrOfLinks());

--- a/src/tests/integration/iCubTorqueEstimationIntegrationTest.cpp
+++ b/src/tests/integration/iCubTorqueEstimationIntegrationTest.cpp
@@ -166,7 +166,7 @@ void compareEstimators(const std::string& urdfFileName,
     iDynTree::Vector3 imuAngularVel;
     iDynTree::SensorsMeasurements sensMeas(usedSensors);
 
-    iDynTree::getRandomVector(jointPos);
+    iDynTree::getRandomJointPositions(jointPos, model);
     iDynTree::getRandomVector(jointVel);
     iDynTree::getRandomVector(jointAcc);
 


### PR DESCRIPTION
The RevoluteJointSO2 has been added in:
- #1254 

Fixed the `getRandomJointPositions` that was using DOFOffset instead of CoordPosOffset

This PR adds an option for generating models that includes that joints (false by default)