### PR TITLE
Fix UnitTestModelExporter

### DIFF
--- a/src/model_io/codecs/tests/ModelExporterUnitTest.cpp
+++ b/src/model_io/codecs/tests/ModelExporterUnitTest.cpp
@@ -242,6 +242,9 @@ void testJointAxisWithNonZeroOriginButPassingThroughChildLinkFrameOrigin() {
     link1_X_link2.setPosition(iDynTree::Position(1.0, 0.0, 0.0));
     joint->setRestTransform(link1_X_link2);
 
+    // Set the attached links first before setting the axis
+    joint->setAttachedLinks(model.getLinkIndex(link1Name), model.getLinkIndex(link2Name));
+
     // Mark the rotation of the joint along z, and add a offset of the axis along z
     iDynTree::Axis axis;
     axis.setDirection(iDynTree::Direction(0.0, 0.0, 1.0));
@@ -289,7 +292,10 @@ void testJointAxisWithNonZeroOriginButPassingThroughChildLinkFrameOrigin() {
     // Add a offset in the x direction between link_1 and link_2
     iDynTree::Transform link1_X_link2New = iDynTree::Transform::Identity();
     link1_X_link2New.setPosition(iDynTree::Position(1.0, 0.0, 0.0));
-    jointNew->setRestTransform(link1_X_link2);
+    jointNew->setRestTransform(link1_X_link2New);
+
+    // Set the attached links first before setting the axis
+    jointNew->setAttachedLinks(modelThatCantBeExportedToUrdf.getLinkIndex(link1Name), modelThatCantBeExportedToUrdf.getLinkIndex(link2Name));
 
     // Mark the rotation of the joint along z, and add a offset of the axis along y
     iDynTree::Axis axisNew;


### PR DESCRIPTION
While running in debug, I found out that `UnitTestModelExporter` continued to fail with this assertion:

```
ModelExporterUnitTest: /home/ngenesio/robotology/robotology-superbuild/src/iDynTree/src/model/src/RevoluteJoint.cpp:234: virtual void iDynTree::RevoluteJoint::setAxis(const iDynTree::Axis&, iDynTree::LinkIndex, iDynTree::LinkIndex): Assertion `child == link2' failed.
```

That is due to this:

https://github.com/robotology/idyntree/blob/e836c8b87ab1faafa4c97d55b1f989422c743efd/src/model/src/RevoluteJoint.cpp#L225-L239

Claude Sonnet 4 solved it attaching first the links to the joint and then setting the axis in the unit test

