### PR TITLE
Remove version constraint for Eigen3 package for Eigen3 5.0.0 compat

### DIFF
--- a/cmake/iDynTreeDependencies.cmake
+++ b/cmake/iDynTreeDependencies.cmake
@@ -57,9 +57,9 @@ macro(idyntree_handle_dependency package)
   endif ()
 endmacro ()
 
-# Eigen is compulsory (minimum version 3.2.92)
+# Eigen is required
 if(NOT TARGET Eigen3::Eigen)
-  find_package(Eigen3 3.2.92 REQUIRED CONFIG)
+  find_package(Eigen3 REQUIRED CONFIG)
 endif()
 
 if(NOT TARGET LibXml2::LibXml2)


### PR DESCRIPTION
Without this fix, configuration against Eigen 5 fails with:

~~~
CMake Error at cmake/OsqpEigenDependencies.cmake:14 (find_package):
  Could not find a configuration file for package "Eigen3" that is compatible
  with requested version "3.2.92".

  The following configuration files were considered but not accepted:

    /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/eigen3/cmake/Eigen3Config.cmake, version: 5.0.0

Call Stack (most recent call first):
~~~

see https://gitlab.com/libeigen/eigen/-/issues/2972 for more details. As Eigen 3.3 was released in 2016, I think we are fine in just asking for Eigen without checking the version of it.

xref: https://github.com/conda-forge/eigen-feedstock/pull/47
xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/pull/1903