### PR TITLE
Replaced deprecated macos-13 GitHub Actions machines to macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, macos-13, windows-latest]
+        os: [ubuntu-22.04, macos-15-intel, windows-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         # Skip Windows tests for now, see https://github.com/robotology/idyntree/issues/1251
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-15-intel]
         matlab_version: [R2022a, R2022b, R2023a]
 
     steps:


### PR DESCRIPTION
macos-13 is deprecated: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ .