### PR TITLE
Fix bias acceleration for spherical joints (#1279)

### DIFF
--- a/src/model/src/SphericalJoint.cpp
+++ b/src/model/src/SphericalJoint.cpp
@@ -475,8 +475,9 @@ void SphericalJoint::computeChildVelAcc(const VectorDynSize& jntPos,
     Twist vj = Twist::Zero();
     for (int dof = 0; dof < 3; dof++)
     {
-        vj = vj + this->getMotionSubspaceVector(dof, child, parent)
-                      * jntVel(this->getDOFsOffset() + dof);
+        vj = vj
+             + this->getMotionSubspaceVector(dof, child, parent)
+                   * jntVel(this->getDOFsOffset() + dof);
     }
 
     // Compute joint acceleration contribution
@@ -506,8 +507,9 @@ void SphericalJoint::computeChildAcc(const VectorDynSize& jntPos,
     Twist vj = Twist::Zero();
     for (int dof = 0; dof < 3; dof++)
     {
-        vj = vj + this->getMotionSubspaceVector(dof, child, parent)
-                      * jntVel(this->getDOFsOffset() + dof);
+        vj = vj
+             + this->getMotionSubspaceVector(dof, child, parent)
+                   * jntVel(this->getDOFsOffset() + dof);
     }
 
     // Compute joint acceleration contribution
@@ -536,8 +538,9 @@ void SphericalJoint::computeChildBiasAcc(const VectorDynSize& jntPos,
     Twist vj = Twist::Zero();
     for (int dof = 0; dof < 3; dof++)
     {
-        vj = vj + this->getMotionSubspaceVector(dof, child, parent)
-                      * jntVel(this->getDOFsOffset() + dof);
+        vj = vj
+             + this->getMotionSubspaceVector(dof, child, parent)
+                   * jntVel(this->getDOFsOffset() + dof);
     }
 
     // Bias acceleration = parent bias + Coriolis-like term (linkVels(child) * vj)

--- a/src/model/tests/JointUnitTest.cpp
+++ b/src/model/tests/JointUnitTest.cpp
@@ -389,8 +389,8 @@ void validateJointBiasAcc(const JointType& joint,
 
     // Numerical differentiation: bias_acc = (vel_plus - vel_minus) / dt
     // This gives us the velocity-dependent acceleration term
-    Eigen::Matrix<double, 6, 1> biasAccNumericalEigen =
-        (toEigen(linkVelsPlus(child)) - toEigen(linkVelsMinus(child))) / dt;
+    Eigen::Matrix<double, 6, 1> biasAccNumericalEigen
+        = (toEigen(linkVelsPlus(child)) - toEigen(linkVelsMinus(child))) / dt;
 
     // Compare analytic and numerical bias acceleration directly using Eigen
     ASSERT_EQUAL_VECTOR_TOL(biasAccAnalytic.asVector(),


### PR DESCRIPTION
This pull request improves the computation and validation of velocity-dependent (Coriolis and centrifugal) acceleration terms for spherical joints in the dynamics codebase. The main changes ensure that the bias acceleration is correctly calculated and rigorously tested by comparing analytical results against numerical differentiation.

This PR closed issue #1279.

**Core algorithm improvements:**

* Added explicit computation of the velocity-dependent (Coriolis/centrifugal) term in the child link acceleration for spherical joints, ensuring that `linkAccs(child)` and `linkBiasAccs(child)` now include the `linkVels(child) * vj` term in all relevant methods (`computeChildPosVelAcc`, `computeChildVelAcc`, `computeChildAcc`, and `computeChildBiasAcc`). [[1]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14R428) [[2]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14L436-R438) [[3]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14R474-R482) [[4]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14L480-R492) [[5]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14R505-R513) [[6]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14L501-R523) [[7]](diffhunk://#diff-cab84b38e376c43dad01f9e20d00c9acf591035c4a369e70903b9fb6bdcb9c14L513-R544)

**Testing and validation enhancements:**

* Introduced the `validateJointBiasAcc` helper function in `JointUnitTest.cpp` to numerically validate the bias acceleration calculation for joints by comparing analytical results with finite difference approximations.
* Extended the joint test suite to call `validateJointBiasAcc` for both directions of joint attachment, ensuring comprehensive coverage for bias acceleration validation.

**Miscellaneous:**

* Added missing include for `LinkState.h` in `JointUnitTest.cpp` to support new test logic.