### PR TITLE
Cleanup logic to set PYTHONPATH for Python tests

### DIFF
--- a/bindings/pybind11/tests/CMakeLists.txt
+++ b/bindings/pybind11/tests/CMakeLists.txt
@@ -2,14 +2,15 @@ add_test (NAME pybind11_idyntree_test
   COMMAND ${Python3_EXECUTABLE} -B -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/pybind11
 )
+
+get_filename_component(PARENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" DIRECTORY)
+
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
   set_property(TEST pybind11_idyntree_test PROPERTY
     ENVIRONMENT_MODIFICATION
-      "PYTHONPATH=path_list_append:${PROJECT_BINARY_DIR}/bindings"
-      "PYTHONPATH=path_list_append:${PROJECT_BINARY_DIR}/bindings/pybind11"
-      "PYTHONPATH=path_list_append:${PROJECT_BINARY_DIR}/bindings/python")
+      "PYTHONPATH=path_list_append:${PARENT_BINARY_DIR}")
 else()
   set_tests_properties(pybind11_idyntree_test
     PROPERTIES ENVIRONMENT
-               "PYTHONPATH=${PROJECT_BINARY_DIR}/bindings:${PROJECT_BINARY_DIR}/bindings/pybind11:${PROJECT_BINARY_DIR}/bindings/python:$ENV{PYTHONPATH}")
+               "PYTHONPATH=${PARENT_BINARY_DIR}:$ENV{PYTHONPATH}")
 endif()

--- a/bindings/pybind11/tests/test_idyntree_core.py
+++ b/bindings/pybind11/tests/test_idyntree_core.py
@@ -4,11 +4,7 @@ import sys
 from pathlib import Path
 import unittest
 
-ROOT = Path(__file__).resolve().parents[3]
-PYBIND_DIR = ROOT / "build" / "bindings" / "pybind11" / "idyntree"
-sys.path.insert(0, str(PYBIND_DIR))
-
-import pybind as iDynTree
+import idyntree.pybind as iDynTree
 import numpy as np
 
 

--- a/bindings/pybind11/tests/test_idyntree_high_level.py
+++ b/bindings/pybind11/tests/test_idyntree_high_level.py
@@ -5,11 +5,7 @@ import sys
 from pathlib import Path
 import unittest
 
-ROOT = Path(__file__).resolve().parents[3]
-PYBIND_DIR = ROOT / "build" / "bindings" / "pybind11" / "idyntree"
-sys.path.insert(0, str(PYBIND_DIR))
-
-import pybind as iDynTree
+import idyntree.pybind as iDynTree
 import numpy as np
 
 

--- a/bindings/pybind11/tests/test_idyntree_model.py
+++ b/bindings/pybind11/tests/test_idyntree_model.py
@@ -4,12 +4,7 @@ import sys
 from pathlib import Path
 import unittest
 
-ROOT = Path(__file__).resolve().parents[3]
-PYBIND_DIR = ROOT / "build" / "bindings" / "pybind11" / "idyntree"
-sys.path.insert(0, str(PYBIND_DIR))
-
-import pybind as iDynTree
-
+import idyntree.pybind as iDynTree
 
 class IDynTreeMaterialTest(unittest.TestCase):
 

--- a/bindings/pybind11/tests/test_idyntree_modelio_urdf.py
+++ b/bindings/pybind11/tests/test_idyntree_modelio_urdf.py
@@ -5,11 +5,7 @@ import tempfile
 from pathlib import Path
 import unittest
 
-ROOT = Path(__file__).resolve().parents[3]
-PYBIND_DIR = ROOT / "build" / "bindings" / "pybind11" / "idyntree"
-sys.path.insert(0, str(PYBIND_DIR))
-
-import pybind as iDynTree
+import idyntree.pybind as iDynTree
 
 SPHERICAL_COMPATIBLE_URDF = """
 <robot name="test_robot">

--- a/bindings/pybind11/tests/test_idyntree_sensors.py
+++ b/bindings/pybind11/tests/test_idyntree_sensors.py
@@ -4,12 +4,7 @@ import sys
 from pathlib import Path
 import unittest
 
-ROOT = Path(__file__).resolve().parents[3]
-PYBIND_DIR = ROOT / "build" / "bindings" / "pybind11" / "idyntree"
-sys.path.insert(0, str(PYBIND_DIR))
-
-import pybind as iDynTree
-
+import idyntree.pybind as iDynTree
 
 class IDynTreeSensorsTest(unittest.TestCase):
 

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -4,12 +4,6 @@ add_custom_command(TARGET copy_python_tests_in_build PRE_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
                    ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-set(IDYNTREE_PYTHON_TEST_PYTHONPATH
-    "PYTHONPATH=path_list_append:${CMAKE_BINARY_DIR}/bindings/python"
-    "PYTHONPATH=path_list_append:${CMAKE_BINARY_DIR}/bindings/pybind11"
-    "PYTHONPATH=path_list_append:${CMAKE_BINARY_DIR}/bindings"
-    "PYTHONPATH=path_list_append:${CMAKE_BINARY_DIR}/lib/python")
-
 add_test(NAME PythonGeometryTests COMMAND ${Python3_EXECUTABLE} geometry.py)
 add_test(NAME PythonJointTests COMMAND ${Python3_EXECUTABLE} joints.py)
 add_test(NAME PythonHelperTests COMMAND ${Python3_EXECUTABLE} helpers.py)
@@ -17,23 +11,24 @@ add_test(NAME PythonModelLoaderTests COMMAND ${Python3_EXECUTABLE} modelloader.p
 add_test(NAME PythonExtWrenchesAndJointTorquesEstimatorUnitTest COMMAND ${Python3_EXECUTABLE} ExtWrenchesAndJointTorquesEstimatorUnitTest.py)
 add_test(NAME PythonInverseKinematicsTests COMMAND ${Python3_EXECUTABLE} invkin.py)
 
+set(IDYNTREE_PYTHON_TESTS
+    PythonGeometryTests
+    PythonJointTests
+    PythonHelperTests
+    PythonModelLoaderTests
+    PythonExtWrenchesAndJointTorquesEstimatorUnitTest
+    PythonInverseKinematicsTests
+    )
+
+get_filename_component(PARENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" DIRECTORY)
+
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22")
   set_tests_properties(
-    PythonGeometryTests
-    PythonJointTests
-    PythonHelperTests
-    PythonModelLoaderTests
-    PythonExtWrenchesAndJointTorquesEstimatorUnitTest
-    PythonInverseKinematicsTests
-    PROPERTIES ENVIRONMENT_MODIFICATION "${IDYNTREE_PYTHON_TEST_PYTHONPATH}")
+    ${IDYNTREE_PYTHON_TESTS}
+    PROPERTIES ENVIRONMENT_MODIFICATION "PYTHONPATH=path_list_append:${PARENT_BINARY_DIR}")
 else()
   set_tests_properties(
-    PythonGeometryTests
-    PythonJointTests
-    PythonHelperTests
-    PythonModelLoaderTests
-    PythonExtWrenchesAndJointTorquesEstimatorUnitTest
-    PythonInverseKinematicsTests
+    ${IDYNTREE_PYTHON_TESTS}
     PROPERTIES ENVIRONMENT
-               "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python:${CMAKE_BINARY_DIR}/bindings/pybind11:${CMAKE_BINARY_DIR}/bindings:${CMAKE_BINARY_DIR}/lib/python:$ENV{PYTHONPATH}")
+               "PYTHONPATH=${PARENT_BINARY_DIR}:$ENV{PYTHONPATH}")
 endif()

--- a/bindings/python/tests/ExtWrenchesAndJointTorquesEstimatorUnitTest.py
+++ b/bindings/python/tests/ExtWrenchesAndJointTorquesEstimatorUnitTest.py
@@ -1,14 +1,9 @@
 import sys
 from pathlib import Path
 
-# Prefer the freshly built SWIG module from the build tree.
-THIS_DIR = Path(__file__).resolve().parent
-SWIG_DIR = THIS_DIR.parent / "idyntree"
-sys.path.insert(0, str(SWIG_DIR))
-
 import os
 import unittest
-import swig as iDynTree;
+import idyntree.swig as iDynTree;
 import numpy as np
 import random
 

--- a/bindings/python/tests/dyncomp.py
+++ b/bindings/python/tests/dyncomp.py
@@ -3,10 +3,6 @@
 '''
 
 import os
-# This test is mean to be executed from the build,
-# so we add in PYTHONPATH the location of iDynTree.py and _iDynTree.so
-os.environ["PYTHONPATH"] = os.environ["PYTHONPATH"] + ":../:../../../lib/python/"
-
 import unittest
 import idyntree.swig as iDynTree;
 import numpy as np

--- a/bindings/python/tests/geometry.py
+++ b/bindings/python/tests/geometry.py
@@ -6,13 +6,8 @@ import sys
 
 from pathlib import Path
 
-# Prefer the freshly built SWIG module from the build tree.
-THIS_DIR = Path(__file__).resolve().parent
-SWIG_DIR = THIS_DIR.parent / "idyntree"
-sys.path.insert(0, str(SWIG_DIR))
-
 import unittest
-import swig as iDynTree
+import idyntree.swig as iDynTree;
 import random
 
 class PositionTest(unittest.TestCase):

--- a/bindings/python/tests/helpers.py
+++ b/bindings/python/tests/helpers.py
@@ -5,14 +5,9 @@ For testing iDynTree python bindings, we rely on the unittest standard python li
 import sys
 from pathlib import Path
 
-# Prefer the freshly built SWIG module from the build tree.
-THIS_DIR = Path(__file__).resolve().parent
-SWIG_DIR = THIS_DIR.parent / "idyntree"
-sys.path.insert(0, str(SWIG_DIR))
-
 import unittest
 import numpy as np
-import swig as iDynTree
+import idyntree.swig as iDynTree;
 import random
 
 class HelpersTest(unittest.TestCase):

--- a/bindings/python/tests/invkin.py
+++ b/bindings/python/tests/invkin.py
@@ -2,13 +2,8 @@ import os
 import sys
 from pathlib import Path
 
-# Prefer the freshly built SWIG module from the build tree.
-THIS_DIR = Path(__file__).resolve().parent
-SWIG_DIR = THIS_DIR.parent / "idyntree"
-sys.path.insert(0, str(SWIG_DIR))
-
 import unittest
-import swig as iDynTree;
+import idyntree.swig as iDynTree;
 import numpy as np
 import random
 

--- a/bindings/python/tests/joints.py
+++ b/bindings/python/tests/joints.py
@@ -6,13 +6,8 @@ import sys
 
 from pathlib import Path
 
-# Prefer the freshly built SWIG module from the build tree.
-THIS_DIR = Path(__file__).resolve().parent
-SWIG_DIR = THIS_DIR.parent / "idyntree"
-sys.path.insert(0, str(SWIG_DIR))
-
 import unittest
-import swig as iDynTree
+import idyntree.swig as iDynTree;
 import random
 
 class JointTest(unittest.TestCase):

--- a/bindings/python/tests/modelloader.py
+++ b/bindings/python/tests/modelloader.py
@@ -1,14 +1,9 @@
 import sys
 from pathlib import Path
 
-# Prefer the freshly built SWIG module from the build tree.
-THIS_DIR = Path(__file__).resolve().parent
-SWIG_DIR = THIS_DIR.parent / "idyntree"
-sys.path.insert(0, str(SWIG_DIR))
-
 import unittest
 import numpy as np
-import swig as iDynTree
+import idyntree.swig as iDynTree
 import random
 
 class ModelLoaderTest(unittest.TestCase):


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree/issues/1274 .

