### PR TITLE
Fix `FreeFloatingVel` docstrings to refer to velocities instead of accelerations

### DIFF
--- a/src/model/include/iDynTree/FreeFloatingState.h
+++ b/src/model/include/iDynTree/FreeFloatingState.h
@@ -152,27 +152,27 @@ public:
     void resize(const iDynTree::Model& model);
 
     /**
-     * Get the base acceleration.
+     * Get the base velocity.
      */
     Twist& baseVel();
 
     /**
-     * Get the vector of joint accelerations.
+     * Get the vector of joint velocities.
      */
     JointDOFsDoubleArray& jointVel();
 
     /**
-     * Get the base acceleration (const version).
+     * Get the base velocity (const version).
      */
     const Twist& baseVel() const;
 
     /**
-     * Get the vector of joint accelerations (const version).
+     * Get the vector of joint velocities (const version).
      */
     const JointDOFsDoubleArray& jointVel() const;
 
     /**
-     * Get the dimension of the joint accelerations vector.
+     * Get the dimension of the joint velocities vector.
      */
     unsigned int getNrOfDOFs() const;
 


### PR DESCRIPTION
This PR fixes the `FreeFloatingVel` docstrings which were referring to "accelerations" instead of "velocities"