### PR TITLE
Support using GZ_SIM_RESOURCE_PATH when evaluating model:// and package:// URIs

### DIFF
--- a/src/model/include/iDynTree/SolidShapes.h
+++ b/src/model/include/iDynTree/SolidShapes.h
@@ -243,8 +243,8 @@ public:
     /**
      * Returns the filename substituting the prefix "package://" with the corresponding absolute
      * path. The absolute path is determined by searching for the file using the paths specified in
-     * the packageDirs vector or if empty in the "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and
-     * "AMENT_PREFIX_PATH" environmental variables.
+     * the packageDirs vector or if empty in the "GZ_SIM_RESOURCE_PATH", "GAZEBO_MODEL_PATH",
+     * "ROS_PACKAGE_PATH" and "AMENT_PREFIX_PATH" environmental variables.
      */
     std::string getFileLocationOnLocalFileSystem() const;
 
@@ -256,8 +256,8 @@ public:
     /**
      * Sets the the package directories.
      * @note if not set the absolute path is determined by searching for the file using the
-     * paths specified in the "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and "AMENT_PREFIX_PATH"
-     * environmental variables.
+     * paths specified in the "GZ_SIM_RESOURCE_PATH", "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and
+     * "AMENT_PREFIX_PATH" environmental variables.
      */
     void setPackageDirs(const std::vector<std::string>& packageDirs);
 

--- a/src/model/src/SolidShapes.cpp
+++ b/src/model/src/SolidShapes.cpp
@@ -295,7 +295,8 @@ std::string ExternalMesh::getFileLocationOnLocalFileSystem() const
     } else
     {
         // List of variables that contain <prefix>/share paths
-        std::vector<std::string> envListShare = {"GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH"};
+        std::vector<std::string> envListShare
+            = {"GZ_SIM_RESOURCE_PATH", "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH"};
         // List of variables that contains <prefix> paths (to which /share needs to be added)
         std::vector<std::string> envListPrefix = {"AMENT_PREFIX_PATH"};
 

--- a/src/model_io/codecs/include/iDynTree/ModelLoader.h
+++ b/src/model_io/codecs/include/iDynTree/ModelLoader.h
@@ -130,7 +130,7 @@ public:
      * @param packageDirs a vector containing the different directories where to
      * search for model meshes
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -149,7 +149,7 @@ public:
      * @param packageDirs a vector containing the different directories where to
      * search for model meshes
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -201,7 +201,7 @@ public:
      * false otherwise.
      *
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -229,7 +229,7 @@ public:
      * false otherwise.
      *
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -321,7 +321,7 @@ public:
      * false otherwise.
      *
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -357,7 +357,7 @@ public:
      * joint types.
      *
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -389,7 +389,7 @@ public:
      * false otherwise.
      *
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should
@@ -425,7 +425,7 @@ public:
      * joint types.
      *
      * @note In case no package is specified ModelLoader will look for the meshes
-     * in `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
+     * in `GZ_SIM_RESOURCE_PATH`, `GAZEBO_MODEL_PATH`, `ROS_PACKAGE_PATH` and `AMENT_PREFIX_PATH`
      * @note If a given model searches for the meshes in
      * `package://StrangeModel/Nested/mesh.stl`, and the actual mesh is in
      * `/usr/local/share/StrangeModel/Nested/mesh.stl`, `packageDirs` should


### PR DESCRIPTION
This PR was prepared by GitHub Copilot in auto mode, with the prompt:

> Can you please fix https://github.com/gbionics/idyntree/issues/1289 ?