### PR TITLE
 Support package:// and model:// uri in command line tools 

### DIFF
--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -47,6 +47,7 @@
 
 //Utils
 #include "iDynTree/Utils.h"
+#include "iDynTree/URIUtils.h"
 
 // Basic math classes
 #include "iDynTree/MatrixDynSize.h"
@@ -174,6 +175,7 @@ namespace std {
 
 //Utils
 %include "iDynTree/Utils.h"
+%include "iDynTree/URIUtils.h"
 
 /* Note : always include headers following the inheritance order */
 // Basic math classes

--- a/bindings/pybind11/idyntree_core.cpp
+++ b/bindings/pybind11/idyntree_core.cpp
@@ -10,6 +10,7 @@
 #include <iDynTree/SpatialInertia.h>
 #include <iDynTree/Transform.h>
 #include <iDynTree/Twist.h>
+#include <iDynTree/URIUtils.h>
 #include <iDynTree/VectorDynSize.h>
 #include <iDynTree/VectorFixSize.h>
 #include <pybind11/operators.h>
@@ -262,6 +263,14 @@ void iDynTreeCoreBindings(pybind11::module& module)
             AngVelocity ang_vel(ang_velocity.data(), 3);
             return Twist(lin_vel, ang_vel);
         }));
+
+    // URI utility functions
+    module.def("resolve_uri",
+               &resolveURI,
+               py::arg("uri"),
+               py::arg("package_dirs") = std::vector<std::string>(),
+               "Resolve a URI (such as package:// or model://) to an absolute path on the local "
+               "file system.");
 }
 } // namespace bindings
 } // namespace iDynTree

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -40,7 +40,8 @@ set(IDYNTREE_CORE_EXP_HEADERS include/iDynTree/Axis.h
                               include/iDynTree/CubicSpline.h
                               include/iDynTree/Span.h
                               include/iDynTree/SO3Utils.h
-                              include/iDynTree/MatrixView.h)
+                              include/iDynTree/MatrixView.h
+                              include/iDynTree/URIUtils.h)
 
 
 set(IDYNTREE_CORE_EXP_SOURCES src/Axis.cpp
@@ -69,7 +70,8 @@ set(IDYNTREE_CORE_EXP_SOURCES src/Axis.cpp
                               src/SparseMatrix.cpp
                               src/Triplets.cpp
                               src/CubicSpline.cpp
-                              src/SO3Utils.cpp)
+                              src/SO3Utils.cpp
+                              src/URIUtils.cpp)
 
 SOURCE_GROUP("Source Files" FILES ${IDYNTREE_CORE_EXP_SOURCES})
 SOURCE_GROUP("Header Files" FILES ${IDYNTREE_CORE_EXP_HEADERS})

--- a/src/core/include/iDynTree/URIUtils.h
+++ b/src/core/include/iDynTree/URIUtils.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Generative Bionics S.R.L.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef IDYNTREE_URI_UTILS_H
+#define IDYNTREE_URI_UTILS_H
+
+#include <string>
+#include <vector>
+
+namespace iDynTree
+{
+
+/**
+ * Resolve a URI (such as package:// or model://) to an absolute path on the local file system.
+ *
+ * This function resolves URIs with package:// or model:// prefixes by searching for the file
+ * using the paths specified in the packageDirs vector or, if empty, in the
+ * "GZ_SIM_RESOURCE_PATH", "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH" and "AMENT_PREFIX_PATH"
+ * environmental variables.
+ *
+ * @param uri The URI to resolve (e.g., "package://MyPackage/models/model.urdf")
+ * @param packageDirs Optional vector of directories to search for packages. If empty,
+ *                    environment variables will be used.
+ * @return The absolute path to the file on the local file system. If the file cannot be
+ *         resolved, the original URI is returned.
+ *
+ * Example:
+ * If the URI is "package://iCub/robots/iCubGazeboV3/model.urdf" and the iCub package is found
+ * in "/usr/local/share/iCub", the function will return:
+ * "/usr/local/share/iCub/robots/iCubGazeboV3/model.urdf"
+ */
+std::string resolveURI(const std::string& uri, const std::vector<std::string>& packageDirs = {});
+
+} // namespace iDynTree
+
+#endif // IDYNTREE_URI_UTILS_H

--- a/src/core/src/URIUtils.cpp
+++ b/src/core/src/URIUtils.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <iDynTree/URIUtils.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <sstream>
+#include <unordered_set>
+
+namespace iDynTree
+{
+
+std::string resolveURI(const std::string& uri, const std::vector<std::string>& packageDirs)
+{
+    bool isWindows = false;
+#ifdef _WIN32
+    isWindows = true;
+#endif
+
+    std::unordered_set<std::string> pathList;
+
+    // If the user provides the packageDirs, use them instead of environment variables
+    if (!packageDirs.empty())
+    {
+        pathList = std::unordered_set<std::string>(packageDirs.begin(), packageDirs.end());
+    } else
+    {
+        // List of variables that contain <prefix>/share paths
+        std::vector<std::string> envListShare
+            = {"GZ_SIM_RESOURCE_PATH", "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH"};
+        // List of variables that contains <prefix> paths (to which /share needs to be added)
+        std::vector<std::string> envListPrefix = {"AMENT_PREFIX_PATH"};
+
+        for (size_t i = 0; i < envListShare.size(); ++i)
+        {
+            const char* env_var_value = std::getenv(envListShare[i].c_str());
+
+            if (env_var_value)
+            {
+                std::stringstream env_var_string(env_var_value);
+                std::string individualPath;
+
+                while (std::getline(env_var_string, individualPath, isWindows ? ';' : ':'))
+                {
+                    pathList.insert(individualPath);
+                }
+            }
+        }
+
+        for (size_t i = 0; i < envListPrefix.size(); ++i)
+        {
+            const char* env_var_value = std::getenv(envListPrefix[i].c_str());
+
+            if (env_var_value)
+            {
+                std::stringstream env_var_string(env_var_value);
+                std::string individualPath;
+
+                while (std::getline(env_var_string, individualPath, isWindows ? ';' : ':'))
+                {
+                    pathList.insert(individualPath + "/share");
+                }
+            }
+        }
+    }
+
+    // Helper to clean path separators
+    auto cleanPathSeparator = [isWindows](const std::string& filename) -> std::string {
+        std::string output = filename;
+        char pathSeparator = isWindows ? '\\' : '/';
+        char wrongPathSeparator = isWindows ? '/' : '\\';
+
+        for (size_t i = 0; i < output.size(); ++i)
+        {
+            if (output[i] == wrongPathSeparator)
+            {
+                output[i] = pathSeparator;
+            }
+        }
+
+        return output;
+    };
+
+    // Helper to check if a file exists
+    auto isFileExisting = [](const std::string& filename) -> bool {
+        if (FILE* file = fopen(filename.c_str(), "r"))
+        {
+            fclose(file);
+            return true;
+        } else
+        {
+            return false;
+        }
+    };
+
+    // Helper to get the file path by resolving the URI prefix
+    auto getFilePath
+        = [isFileExisting, cleanPathSeparator](const std::string& filename,
+                                               const std::string& prefixToRemove,
+                                               const std::unordered_set<std::string>& paths) {
+              // If the file already exists as specified, return it as-is
+              if (isFileExisting(filename))
+              {
+                  return filename;
+              }
+
+              // Check if the filename starts with the prefix to remove
+              if (filename.substr(0, prefixToRemove.size()) == prefixToRemove)
+              {
+                  std::string filename_noprefix = filename;
+                  filename_noprefix.erase(0, prefixToRemove.size());
+
+                  // Try each path in the list
+                  for (const std::string& path : paths)
+                  {
+                      const std::string testPath = cleanPathSeparator(path + filename_noprefix);
+                      if (isFileExisting(testPath))
+                      {
+                          return testPath;
+                      }
+                  }
+              }
+
+              // By default, return the input if resolution fails
+              return filename;
+          };
+
+    // Support both package:// and model:// URI schemes
+    // Try package:// first
+    std::string result = getFilePath(uri, "package:/", pathList);
+
+    // If package:// didn't resolve and the URI starts with model://, try that
+    if (result == uri && uri.substr(0, 8) == "model://")
+    {
+        result = getFilePath(uri, "model:/", pathList);
+    }
+
+    return result;
+}
+
+} // namespace iDynTree

--- a/src/model/src/SolidShapes.cpp
+++ b/src/model/src/SolidShapes.cpp
@@ -3,6 +3,7 @@
 
 #include <iDynTree/Model.h>
 #include <iDynTree/SolidShapes.h>
+#include <iDynTree/URIUtils.h>
 
 #include <cstdlib>
 #include <fstream>
@@ -279,115 +280,7 @@ const std::vector<std::string>& ExternalMesh::getPackageDirs() const
 
 std::string ExternalMesh::getFileLocationOnLocalFileSystem() const
 {
-    bool isWindows = false;
-#ifdef _WIN32
-    isWindows = true;
-#endif
-
-    std::unordered_set<std::string> pathList;
-
-    // if the user provides the packageDirs we do not check inside the dirs listed in the
-    // environment variables
-    if (!this->packageDirs.empty())
-    {
-        pathList
-            = std::unordered_set<std::string>(this->packageDirs.begin(), this->packageDirs.end());
-    } else
-    {
-        // List of variables that contain <prefix>/share paths
-        std::vector<std::string> envListShare
-            = {"GZ_SIM_RESOURCE_PATH", "GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH"};
-        // List of variables that contains <prefix> paths (to which /share needs to be added)
-        std::vector<std::string> envListPrefix = {"AMENT_PREFIX_PATH"};
-
-        for (size_t i = 0; i < envListShare.size(); ++i)
-        {
-            const char* env_var_value = std::getenv(envListShare[i].c_str());
-
-            if (env_var_value)
-            {
-                std::stringstream env_var_string(env_var_value);
-
-                std::string individualPath;
-
-                while (std::getline(env_var_string, individualPath, isWindows ? ';' : ':'))
-                {
-                    pathList.insert(individualPath);
-                }
-            }
-        }
-
-        for (size_t i = 0; i < envListPrefix.size(); ++i)
-        {
-            const char* env_var_value = std::getenv(envListPrefix[i].c_str());
-
-            if (env_var_value)
-            {
-                std::stringstream env_var_string(env_var_value);
-
-                std::string individualPath;
-
-                while (std::getline(env_var_string, individualPath, isWindows ? ';' : ':'))
-                {
-                    pathList.insert(individualPath + "/share");
-                }
-            }
-        }
-    }
-    auto cleanPathSeparator = [isWindows](const std::string& filename) -> std::string {
-        std::string output = filename;
-        char pathSeparator = isWindows ? '\\' : '/';
-        char wrongPathSeparator = isWindows ? '/' : '\\';
-
-        for (size_t i = 0; i < output.size(); ++i)
-        {
-            if (output[i] == wrongPathSeparator)
-            {
-                output[i] = pathSeparator;
-            }
-        }
-
-        return output;
-    };
-
-    auto isFileExisting = [](const std::string& filename) -> bool {
-        if (FILE* file = fopen(filename.c_str(), "r"))
-        {
-            fclose(file);
-            return true;
-        } else
-        {
-            return false;
-        }
-    };
-
-    auto getFilePath
-        = [isFileExisting, cleanPathSeparator](const std::string& filename,
-                                               const std::string& prefixToRemove,
-                                               const std::unordered_set<std::string>& paths) {
-              if (isFileExisting(filename))
-              {
-                  return filename;
-              }
-
-              if (filename.substr(0, prefixToRemove.size()) == prefixToRemove)
-              {
-                  std::string filename_noprefix = filename;
-                  filename_noprefix.erase(0, prefixToRemove.size());
-                  for (const std::string& path : paths)
-                  {
-                      const std::string testPath = cleanPathSeparator(path + filename_noprefix);
-                      if (isFileExisting(testPath))
-                      {
-                          return testPath;
-                      }
-                  }
-              }
-
-              return filename; // By default return the input;
-          };
-
-    return getFilePath(filename, "package:/", pathList);
+    return resolveURI(filename, packageDirs);
 }
 
 void ExternalMesh::setFilename(const std::string& filename)

--- a/src/tools/idyntree-model-info.cpp
+++ b/src/tools/idyntree-model-info.cpp
@@ -4,6 +4,7 @@
 #include <iDynTree/KinDynComputations.h>
 #include <iDynTree/Model.h>
 #include <iDynTree/ModelLoader.h>
+#include <iDynTree/URIUtils.h>
 
 #include "cmdline.h"
 
@@ -156,6 +157,10 @@ int main(int argc, char** argv)
 
     // Read model
     std::string modelPath = cmd.get<std::string>("model");
+
+    // Resolve URI (package:// or model://) to local file system path
+    modelPath = iDynTree::resolveURI(modelPath);
+
     iDynTree::ModelLoader loader;
     bool ok = loader.loadModelFromFile(modelPath);
     iDynTree::KinDynComputations model;

--- a/src/tools/idyntree-model-simplify-shapes.cpp
+++ b/src/tools/idyntree-model-simplify-shapes.cpp
@@ -5,12 +5,16 @@
 
 // To load models from file
 #include <iDynTree/ModelLoader.h>
+#include <iDynTree/URIUtils.h>
 
 // To approximate shapes of a model
 #include <iDynTree/ModelTransformersSolidShapes.h>
 
 // To write model to file
 #include <iDynTree/ModelExporter.h>
+
+// To resolve URIs
+#include <iDynTree/URIUtils.h>
 
 #include "cmdline.h"
 
@@ -42,7 +46,11 @@ int main(int argc, char** argv)
     cmd.parse_check(argc, argv);
 
     // Read model
-    const std::string& modelPath = cmd.get<std::string>("model");
+    std::string modelPath = cmd.get<std::string>("model");
+
+    // Resolve URI (package:// or model://) to local file system path
+    modelPath = iDynTree::resolveURI(modelPath);
+
     const std::string& outputModelPath = cmd.get<std::string>("output-model");
     const std::string& shapesApproximation = cmd.get<std::string>("shapes-approximation");
 

--- a/src/tools/idyntree-model-view.cpp
+++ b/src/tools/idyntree-model-view.cpp
@@ -3,6 +3,7 @@
 
 #include <iDynTree/Model.h>
 #include <iDynTree/ModelLoader.h>
+#include <iDynTree/URIUtils.h>
 
 #include <iDynTree/Visualizer.h>
 
@@ -35,8 +36,10 @@ int main(int argc, char** argv)
     addOptions(cmd);
     cmd.parse_check(argc, argv);
 
-    // Read model
-    const std::string& modelPath = cmd.get<std::string>("model");
+    // Read model and resolve URI (package:// or model://) to local file system path
+    std::string modelPath = cmd.get<std::string>("model");
+    modelPath = iDynTree::resolveURI(modelPath);
+
     iDynTree::ModelLoader mdlLoader;
     bool ok = mdlLoader.loadModelFromFile(modelPath);
 


### PR DESCRIPTION
Fix https://github.com/gbionics/idyntree/issues/942 .

This was prepared with GitHub Copilot in auto agent mode, with prompt:

> Can you please fix https://github.com/gbionics/idyntree/issues/942 ? In particular, refactor the package:// and model:// resolving code in a shared location, and add support for resolving uris for all commands that take in input a model path, thanks!

and follow up:

> Please move the URIUtils.h in the iDynTree core and use it also for solidshapes. There is not reason for putting it in model_io/codecs

and follow up:

> The bindings for findURIs for pybind11 and swig seems to be in the wrong location, can you move them in a more appropriate location now that the findURIs is in core? Furthermore, do not touch at all the autogenerated matlab bindings file, thanks!

and follow up:

> Can you keep consitency between idyntree-model-view, idyntree-model-info and idyntree-simplify-shapes so they use the same style (i.e. overwriting modelPath or defining a new variable)? Thanks!