### PR TITLE
Fix conditional for PyPI publish action

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -137,6 +137,6 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: |
-          github.repository == 'robotology/idyntree' &&
+          github.repository == 'gbionics/idyntree' &&
           ((github.event_name == 'release' && github.event.action == 'published') ||
            (github.event_name == 'push' && github.ref == 'refs/heads/devel'))


### PR DESCRIPTION
Similarly to https://github.com/gbionics/rod/pull/73, the conditional on the CI workflow file had the wrong repository link hardcoded, so the releases were never actually published to PyPI