### PR TITLE
Fix format, Python CI and bump version to 15.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(iDynTree VERSION 15.0.1
+project(iDynTree VERSION 15.1.0
                  LANGUAGES C CXX)
 
 # Disable in source build, unless Eclipse is used

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,7 +94,14 @@ endif()
 
 target_include_directories(${libraryname} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(${libraryname} PRIVATE Eigen3::Eigen ResolveRoboticsURICpp::ResolveRoboticsURICpp)
+target_link_libraries(${libraryname} PRIVATE Eigen3::Eigen)
+
+# Workaround for header-only ResolveRoboticsURICpp: extract include directories
+# to avoid export set issues with old CMake versions
+get_target_property(RRUC_INCLUDE_DIRS ResolveRoboticsURICpp::ResolveRoboticsURICpp INTERFACE_INCLUDE_DIRECTORIES)
+if(RRUC_INCLUDE_DIRS)
+    target_include_directories(${libraryname} PRIVATE ${RRUC_INCLUDE_DIRS})
+endif()
 
 # On Windows we need to correctly export global constants that are not inlined with the use of GenerateExportHeader
 # vtk 6.3 installs a GenerateExportHeader CMake module that shadows the official CMake module if find_package(VTK)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -102,6 +102,8 @@ get_target_property(RRUC_INCLUDE_DIRS ResolveRoboticsURICpp::ResolveRoboticsURIC
 if(RRUC_INCLUDE_DIRS)
     target_include_directories(${libraryname} PRIVATE ${RRUC_INCLUDE_DIRS})
 endif()
+# rruc uses std::filesystem, so we need C++17 support
+target_compile_features(${libraryname} PRIVATE cxx_std_17)
 
 # On Windows we need to correctly export global constants that are not inlined with the use of GenerateExportHeader
 # vtk 6.3 installs a GenerateExportHeader CMake module that shadows the official CMake module if find_package(VTK)

--- a/src/core/src/URIUtils.cpp
+++ b/src/core/src/URIUtils.cpp
@@ -17,8 +17,7 @@ std::string resolveURI(const std::string& uri, const std::vector<std::string>& p
 
     // Use ResolveRoboticsURICpp to resolve the URI
     std::string errorMessage;
-    auto resolved
-        = ResolveRoboticsURICpp::resolveRoboticsURI(uri, options, errorMessage);
+    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI(uri, options, errorMessage);
 
     // Return the resolved path if successful, otherwise return the original URI
     if (resolved.has_value())


### PR DESCRIPTION
We need anyhow a new release for fixing the Python CI, but after looking back a bit I think https://github.com/gbionics/idyntree/pull/1295 deserve at least a minor version release.