### PR TITLE
Fix use-after-free in `Transform::getPosition()`/`getRotation()` Python bindings

### DIFF
--- a/bindings/iDynTree.i
+++ b/bindings/iDynTree.i
@@ -250,6 +250,20 @@ namespace std {
 
 // Transformations: Rotation and Transform
 %include "iDynTree/Rotation.h"
+
+// getRotation()/getPosition() return a reference into this Transform, not a copy.
+// Chained on a temporary (e.g. getWorldTransform(f).getPosition().toNumPy()), the
+// Transform gets GC'd before the child is used, leaving it pointing at freed memory
+// (https://github.com/gbionics/idyntree/issues/1263).
+// In this way we keep the parent alive by attaching it to the child below.
+#ifdef SWIGPYTHON
+%feature("pythonappend") iDynTree::Transform::getRotation() const %{
+    val.__idyntree_owner_keepalive = self
+%}
+%feature("pythonappend") iDynTree::Transform::getPosition() const %{
+    val.__idyntree_owner_keepalive = self
+%}
+#endif
 %include "iDynTree/Transform.h"
 %include "iDynTree/TransformDerivative.h"
 %include "iDynTree/Span.h"


### PR DESCRIPTION
Fixes #1263

`getRotation()` and `getPosition()` return references into the Transform's own memory, not copies. If this gets chained e.g. `getWorldTransform(f).getPosition()`, the Transform gets garbage collected before the returned object is used, so it ends up pointing at freed memory and returning garbage values.
If we attach a reference to the parent Transform on the Rotation/Position that is returned as `__idyntree_owner_keepalive` we keep the parent alive for as long as the child object is still around.

Note that this might happen also for:

- `Axis::getDirection()` and `Axis::getOrigin()`, same as Transform, but for Axis
- `SpatialInertia::getRotationalInertiaWrtFrameOrigin()`
- `Link::getInertia()`

and probably other methods