### PR TITLE
Add minimal colcon.pkg with minimal required dependencies

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,9 @@
+{
+  "name": "iDynTree",
+  "type": "cmake",
+  "dependencies": [
+    "Eigen3",
+    "LibXml2",
+    "ResolveRoboticsURICpp"
+  ]
+}


### PR DESCRIPTION
iDynTree has some complex dependecy handling logic, so the [colcon]() dependencies extraction logic can get confused, and give in output a list of dependencies like:

~~~
  dependencies:
    build: ${_NAME} ${_pkgconfig_name} Boost Doxygen Eigen3 ICUB Irrlicht LibXml2 Lua51 Matlab MeshcatCpp Octave OpenGL Orocos-KDL PkgConfig Python3 QUIET ResolveRoboticsURICpp SWIG Valgrind glfw3 ipopt orocos_kdl pybind11
    run: ${_NAME} ${_pkgconfig_name} Boost Doxygen Eigen3 ICUB Irrlicht LibXml2 Lua51 Matlab MeshcatCpp Octave OpenGL Orocos-KDL PkgConfig Python3 QUIET ResolveRoboticsURICpp SWIG Valgrind glfw3 ipopt orocos_kdl pybind11
~~~

furthermore, as the repo contains both a `CMakeLists.txt` and a `pyproject.toml`, colcon can be confused as it does not know if it should use python or CMake to build this project.

to avoid this problem, this PR adds a minimal `colcon.pkg` that:
* Specifies that the project is a cmake project
* List the minimal required dependencies

In case a user using colcon enables more dependencies via cmake options, additional dependencies can be added by all the mechanism availale in colcon (such as a `colcon.meta` file).

